### PR TITLE
Add dummy UPF package

### DIFF
--- a/libraries/Makefile.inc
+++ b/libraries/Makefile.inc
@@ -54,7 +54,8 @@ MENTOR_BSRCS := mentor/std_logic_arith.vhdl mentor/std_logic_arith_body.vhdl
 ifeq ($(enable_openieee),false)
 IEEE_SRCS := ieee/std_logic_1164.vhdl ieee/std_logic_1164_body.vhdl \
   ieee/numeric_bit.vhdl ieee/numeric_bit-body.vhdl \
-  ieee/numeric_std.vhdl ieee/numeric_std-body.vhdl
+  ieee/numeric_std.vhdl ieee/numeric_std-body.vhdl \
+  ieee/upf.vhdl ieee/upf-body.vhdl
 MATH_SRCS := ieee/math_real.vhdl ieee/math_real-body.vhdl \
   ieee/math_complex.vhdl ieee/math_complex-body.vhdl
 VITAL95_BSRCS := vital95/vital_timing.vhdl vital95/vital_timing_body.vhdl \
@@ -76,7 +77,8 @@ IEEE08_BSRCS := \
   ieee2008/fixed_pkg.vhdl \
   ieee2008/float_generic_pkg.vhdl ieee2008/float_generic_pkg-body.vhdl \
   ieee2008/float_pkg.vhdl \
-  ieee2008/ieee_bit_context.vhdl ieee2008/ieee_std_context.vhdl
+  ieee2008/ieee_bit_context.vhdl ieee2008/ieee_std_context.vhdl \
+  ieee2008/upf.vhdl ieee2008/upf-body.vhdl
 else
 IEEE_SRCS := openieee/std_logic_1164.vhdl openieee/std_logic_1164-body.vhdl \
   openieee/numeric_bit.vhdl openieee/numeric_bit-body.vhdl \

--- a/libraries/ieee/upf-body.vhdl
+++ b/libraries/ieee/upf-body.vhdl
@@ -1,0 +1,26 @@
+package body upf is
+
+  function supply_on (
+    constant supply_name : string;
+    constant voltage     : real)
+    return boolean is
+  begin
+    return true;
+  end supply_on;
+
+  function supply_partial_on (
+    constant supply_name : string;
+    constant voltage     : real)
+    return boolean is
+  begin
+    return true;
+  end supply_partial_on;
+
+  function supply_off (
+    constant supply_name : string)
+    return boolean is
+  begin
+    return true;
+  end supply_off;
+
+end package body upf;

--- a/libraries/ieee/upf-body.vhdl
+++ b/libraries/ieee/upf-body.vhdl
@@ -23,4 +23,4 @@ package body upf is
     return true;
   end supply_off;
 
-end package body upf;
+end upf;

--- a/libraries/ieee/upf.vhdl
+++ b/libraries/ieee/upf.vhdl
@@ -1,0 +1,19 @@
+-- modelled according to IEEE Std 1801-2015, 11.2
+
+package upf is
+
+  function supply_on (
+    constant supply_name : string;
+    constant voltage     : real)
+    return boolean;
+
+  function supply_partial_on (
+    constant supply_name : string;
+    constant voltage     : real)
+    return boolean;
+
+  function supply_off (
+    constant supply_name : string)
+    return boolean;
+
+end package upf;

--- a/libraries/ieee/upf.vhdl
+++ b/libraries/ieee/upf.vhdl
@@ -16,4 +16,4 @@ package upf is
     constant supply_name : string)
     return boolean;
 
-end package upf;
+end upf;

--- a/libraries/ieee2008/upf-body.vhdl
+++ b/libraries/ieee2008/upf-body.vhdl
@@ -1,0 +1,26 @@
+package body upf is
+
+  function supply_on (
+    constant supply_name : string;
+    constant voltage     : real)
+    return boolean is
+  begin
+    return true;
+  end supply_on;
+
+  function supply_partial_on (
+    constant supply_name : string;
+    constant voltage     : real)
+    return boolean is
+  begin
+    return true;
+  end supply_partial_on;
+
+  function supply_off (
+    constant supply_name : string)
+    return boolean is
+  begin
+    return true;
+  end supply_off;
+
+end package body upf;

--- a/libraries/ieee2008/upf.vhdl
+++ b/libraries/ieee2008/upf.vhdl
@@ -1,0 +1,19 @@
+-- modelled according to IEEE Std 1801-2015, 11.2
+
+package upf is
+
+  function supply_on (
+    constant supply_name : string;
+    constant voltage     : real)
+    return boolean;
+
+  function supply_partial_on (
+    constant supply_name : string;
+    constant voltage     : real)
+    return boolean;
+
+  function supply_off (
+    constant supply_name : string)
+    return boolean;
+
+end package upf;


### PR DESCRIPTION
The UPF package allow power aware testbenches to control the supply voltages of the power domains of a design. Now ghdl isn't power aware, but it would still be useful to have a dummy UPF package that allows testbenches to be shared without modification across different simulators.

Unfortunately, there doesn't seem to be a formal specification of this VHDL UPF package. There is a system verilog specification in IEEE Standard 1801-2015, Chapter 11.2. This SV definition has been translated to VHDL by the commercial hdl simulation vendors, unfortunately not in a very compatible way.

This package provides a dummy implementation of the portable subset of UPF.