### PR TITLE
Remove dependency on Get-DriveInfo for powershell compile scripts

### DIFF
--- a/libraries/vendors/compile-altera.ps1
+++ b/libraries/vendors/compile-altera.ps1
@@ -132,8 +132,8 @@ function Get-AlteraQuartusDirectory
 	{	return $QUARTUS_ROOTDIR + "\" + (Get-VendorToolSourceDirectory)		}
 	else
 	{	$EnvSourceDir = ""
-		foreach ($Drive in Get-DriveInfo)
-		{	$Path = $Drive.Name + "Altera"
+		foreach ($Drive in gdr -PSProvider 'FileSystem')
+		{	$Path = $Drive.Name + ":\" + "Altera"
 			if (Test-Path $Path -PathType Container)
 			{	foreach ($Major in 16..13)
 				{	foreach ($Minor in 3..0)

--- a/libraries/vendors/compile-altera.ps1
+++ b/libraries/vendors/compile-altera.ps1
@@ -132,7 +132,7 @@ function Get-AlteraQuartusDirectory
 	{	return $QUARTUS_ROOTDIR + "\" + (Get-VendorToolSourceDirectory)		}
 	else
 	{	$EnvSourceDir = ""
-		foreach ($Drive in gdr -PSProvider 'FileSystem')
+		foreach ($Drive in Get-PSDrive -PSProvider 'FileSystem')
 		{	$Path = $Drive.Name + ":\" + "Altera"
 			if (Test-Path $Path -PathType Container)
 			{	foreach ($Major in 16..13)

--- a/libraries/vendors/compile-intel.ps1
+++ b/libraries/vendors/compile-intel.ps1
@@ -135,8 +135,8 @@ function Get-AlteraQuartusDirectory
 	{	return $QUARTUS_ROOTDIR + "\" + (Get-VendorToolSourceDirectory)		}
 	else
 	{	$EnvSourceDir = ""
-		foreach ($Drive in Get-DriveInfo)
-		{	$Path = $Drive.Name + "Altera"
+		foreach ($Drive in gdr -PSProvider 'FileSystem')
+		{	$Path = $Drive.Name + ":\" + "Altera"
 			if (Test-Path $Path -PathType Container)
 			{	foreach ($Major in 16..13)
 				{	foreach ($Minor in 3..0)

--- a/libraries/vendors/compile-intel.ps1
+++ b/libraries/vendors/compile-intel.ps1
@@ -135,7 +135,7 @@ function Get-AlteraQuartusDirectory
 	{	return $QUARTUS_ROOTDIR + "\" + (Get-VendorToolSourceDirectory)		}
 	else
 	{	$EnvSourceDir = ""
-		foreach ($Drive in gdr -PSProvider 'FileSystem')
+		foreach ($Drive in Get-PSDrive -PSProvider 'FileSystem')
 		{	$Path = $Drive.Name + ":\" + "Altera"
 			if (Test-Path $Path -PathType Container)
 			{	foreach ($Major in 16..13)

--- a/libraries/vendors/compile-lattice.ps1
+++ b/libraries/vendors/compile-lattice.ps1
@@ -157,7 +157,7 @@ function Get-LatticeDiamondDirectory
 	{	return $FOUNDRY + "\..\" + (Get-VendorToolSourceDirectory)		}
 	else
 	{	$EnvSourceDir = ""
-		foreach ($Drive in gdr -PSProvider 'FileSystem')
+		foreach ($Drive in Get-PSDrive -PSProvider 'FileSystem')
 		{	$Path = $Drive.Name + ":\" + "Lattice\Diamond"
 			if (Test-Path $Path -PathType Container)
 			{	foreach ($Major in 4..3)

--- a/libraries/vendors/compile-lattice.ps1
+++ b/libraries/vendors/compile-lattice.ps1
@@ -157,8 +157,8 @@ function Get-LatticeDiamondDirectory
 	{	return $FOUNDRY + "\..\" + (Get-VendorToolSourceDirectory)		}
 	else
 	{	$EnvSourceDir = ""
-		foreach ($Drive in Get-DriveInfo)
-		{	$Path = $Drive.Name + "Lattice\Diamond"
+		foreach ($Drive in gdr -PSProvider 'FileSystem')
+		{	$Path = $Drive.Name + ":\" + "Lattice\Diamond"
 			if (Test-Path $Path -PathType Container)
 			{	foreach ($Major in 4..3)
 				{	foreach ($Minor in 9..0)

--- a/libraries/vendors/compile-xilinx-ise.ps1
+++ b/libraries/vendors/compile-xilinx-ise.ps1
@@ -127,8 +127,8 @@ function Get-XilinxISEDirectory
 	{	return $XILINX + "\" + (Get-VendorToolSourceDirectory)		}
 	else
 	{	$EnvSourceDir = ""
-		foreach ($Drive in Get-DriveInfo)
-		{	$Path = $Drive.Name + "Xilinx"
+		foreach ($Drive in gdr -PSProvider 'FileSystem')
+		{	$Path = $Drive.Name + ":\" + "Xilinx"
 			if (Test-Path $Path -PathType Container)
 			{	foreach ($Major in 14..12)
 				{	foreach ($Minor in 7..1)

--- a/libraries/vendors/compile-xilinx-ise.ps1
+++ b/libraries/vendors/compile-xilinx-ise.ps1
@@ -127,7 +127,7 @@ function Get-XilinxISEDirectory
 	{	return $XILINX + "\" + (Get-VendorToolSourceDirectory)		}
 	else
 	{	$EnvSourceDir = ""
-		foreach ($Drive in gdr -PSProvider 'FileSystem')
+		foreach ($Drive in Get-PSDrive -PSProvider 'FileSystem')
 		{	$Path = $Drive.Name + ":\" + "Xilinx"
 			if (Test-Path $Path -PathType Container)
 			{	foreach ($Major in 14..12)

--- a/libraries/vendors/compile-xilinx-vivado.ps1
+++ b/libraries/vendors/compile-xilinx-vivado.ps1
@@ -113,7 +113,7 @@ function Get-XilinxVivadoDirectory
 	{	return $XILINX_VIVADO + "\" + (Get-VendorToolSourceDirectory)		}
 	else
 	{	$EnvSourceDir = ""
-		foreach ($Drive in gdr -PSProvider 'FileSystem')
+		foreach ($Drive in Get-PSDrive -PSProvider 'FileSystem')
 		{	$Path = $Drive.Name + ":\" + "Xilinx\Vivado"
 			if (Test-Path $Path -PathType Container)
 			{	foreach ($Major in 2018..2014)

--- a/libraries/vendors/compile-xilinx-vivado.ps1
+++ b/libraries/vendors/compile-xilinx-vivado.ps1
@@ -113,8 +113,8 @@ function Get-XilinxVivadoDirectory
 	{	return $XILINX_VIVADO + "\" + (Get-VendorToolSourceDirectory)		}
 	else
 	{	$EnvSourceDir = ""
-		foreach ($Drive in Get-DriveInfo)
-		{	$Path = $Drive.Name + "Xilinx\Vivado"
+		foreach ($Drive in gdr -PSProvider 'FileSystem')
+		{	$Path = $Drive.Name + ":\" + "Xilinx\Vivado"
 			if (Test-Path $Path -PathType Container)
 			{	foreach ($Major in 2018..2014)
 				{	foreach ($Minor in 4..1)


### PR DESCRIPTION
Ran into an issue when compiling vendor libraries on Windows 7, decided to write a fix for it. Tested using the compile-xilinx-ise.ps1 script on Windows 7 with Powershell 4.0.

Error was:
```
Get-DriveInfo : The term 'Get-DriveInfo' is not recognized as the name of a cmdlet, function, script file, or operable
program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At C:\Users\craign\Documents\ghdl\libraries\vendors\compile-xilinx-ise.ps1:130 char:22
+         foreach ($Drive in Get-DriveInfo)
+                            ~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (Get-DriveInfo:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException

[ERROR]: Xilinx ISE is not configured in '\config.psm1'.
  Use adv. options '-Source' and '-Output' or configure 'config.psm1'.
[DEBUG]: HARD EXIT
```