### PR TITLE
fix version.tmp in travis-ci

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -147,11 +147,14 @@ include $(srcdir)/src/grt/Makefile.inc
 version.tmp: $(srcdir)/src/version.in force
 #	Create version.tmp from version.in, using git date/hash
 	if ! test -d $(srcdir)/.git \
-	   || ! desc=`cd $(srcdir); git describe --dirty`; then \
-	  desc="tarball"; \
-        fi; \
-	$(SED) -e "s/[(].*[)]/($$desc)/" \
-               -e "s/@VER@/$(ghdl_version)/" < $< > $@; \
+	  || ! desc=`cd $(srcdir); git describe --dirty`; then \
+	    desc="tarball"; \
+	fi; \
+	cp $< $@; \
+	if [ "$$desc" != "tarball" ]; then \
+	  sed -i.bak -e "s/[(].*[)]/($$desc)/" $@;  \
+	fi;  \
+	sed -i.bak -e "s/@VER@/@ghdl_version@/" $@; \
 
 version.ads: version.tmp
 #	Change version.ads only if version.tmp has been modified to avoid

--- a/dist/linux/travis-ci.sh
+++ b/dist/linux/travis-ci.sh
@@ -100,9 +100,8 @@ else
     # This is a little bit hack-ish, as it assumes that 'git' is not
     # available in docker (otherwise it will describe as -dirty
     # because this modifies the source file version.in).
-    ghdl_version_line=`grep -e '^ghdl_version' configure`
-    make -f Makefile.in srcdir=. $ghdl_version_line version.tmp
-    cp version.tmp src/version.in
+    make -f Makefile.in srcdir=. version.tmp
+    sed -e "s/@ghdl_version@/@VER@/" < version.tmp > src/version.in
 
     # Run build in docker
     IMAGE_TAG=`echo $IMAGE | sed -e 's/+/-/g'`


### PR DESCRIPTION
Close #554.

@tgingold , the [fix](https://github.com/ghdl/ghdl/commit/ba14e9da2a0ca776e6be758f5b0fa49f6090e838) you pushed produces an acceptable solution (`GHDL 0.36-dev (tarball) [Dunoon edition]`, [840](https://travis-ci.org/ghdl/ghdl/jobs/366221639)), but not the one we got earlier ([834](https://travis-ci.org/ghdl/ghdl/jobs/354693488)). Because travis builds are exported as docker images, it is desirable to have the `describe --dirty` string/tag.

This PR makes the `"s/[(].*[)]/($$desc)/"` to be conditional: `(.*)` is only replaced if `$desc` is not "empty" (word `tarball`, which is the default in `src/version.in`, is considered the keyword for empty). So:

- When lines 103-104 of the travis-ci.sh are executed, field `Ghdl_Release` in `version.in` is changed, but `Ghdl_Ver` is left untouched.
- Then, inside each container/build, field `Ghdl_Ver` is changed, but `Ghdl_Release` is left untouched.

Besides, if `configure` and `make` are executed locally (with `git` available), both fields, `Ghdl_Ver` and `Ghdl_Release` will be changed at the same time. Shall git not be available, the output will be `GHDL 0.36-dev (tarball) [Dunoon edition]`.