### PR TITLE
configure: Fall back to `pwd` if `pwd -W` does not work

### DIFF
--- a/configure
+++ b/configure
@@ -124,9 +124,10 @@ case $srcdir in
     *)
         # Use a Windows path on windows.
         case "$OS" in
-            Windows_NT) abs_srcdir="`pwd -W`/$srcdir" ;;
-            *) abs_srcdir=`pwd`/$srcdir ;;
+            Windows_NT) curdir=`pwd -W 2>/dev/null || pwd` ;;
+            *) curdir=`pwd` ;;
         esac
+        abs_srcdir=$curdir/$srcdir
         ;;
 esac
 
@@ -346,7 +347,6 @@ fi
 # Also update dist/windows/mcode/default_paths.ads if you change this
 # template.
 echo "Generate default_paths.ads"
-curdir=`pwd`
 sed -e "s%@COMPILER_GCC@%ghdl1-gcc$EXEEXT%" \
     -e "s%@COMPILER_DEBUG@%ghdl1-debug$EXEEXT%" \
     -e "s%@COMPILER_MCODE@%ghdl1-mcode$EXEEXT%" \


### PR DESCRIPTION
This enables configure runs under Cygwin.

The patch also (re)moves an unused `` curdir=`pwd` ``.