### PR TITLE
src/grt/Makefile.inc: grt/grt-files: Remove CR from line ends

### DIFF
--- a/src/grt/Makefile.inc
+++ b/src/grt/Makefile.inc
@@ -205,7 +205,7 @@ grt-disp-config:
 
 grt/grt-files: grt/run-bind.adb
 	sed -e "1,/-- *BEGIN/d" -e "/-- *END/,\$$d" \
-	  -e "s/   --   //" < $< > $@
+	  -e "s/   --   //" < $< | tr -d '\r' > $@
 
 # Remove local files (they are now in the libgrt library).
 # Also, remove the -shared option, in order not to build a shared library


### PR DESCRIPTION
Under Cygwin, generated `*.adb` files get CRLF line endings. These get propagated to `grt/grt-files` and later confuse the ar command for libgrt.a (because IFS does not contain CR). This breaks `make` runs.

This patch to `src/grt/Makefile.inc` unconditionally filters out CRs when generating `grt/grt-files`. Note that `tr` understanding `\r` is portable whereas in `sed` such an escape would be GNU-specific.

With this patch, `make all libs install` runs smoothly under Cygwin.