### PR TITLE
Cygwin executable adaptations

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -375,7 +375,7 @@ install.libghdlsynth.static: libghdlsynth.a install.libghdlsynth.include
 	$(INSTALL_DATA) -p ghdlsynth.link $(DESTDIR)$(libdir)/
 
 install.libghdlsynth.shared: libghdlsynth$(SOEXT) install.libghdlsynth.include
-	$(INSTALL_DATA) -p libghdlsynth$(SOEXT) $(DESTDIR)$(libdir)/
+	$(INSTALL_PROGRAM) -p libghdlsynth$(SOEXT) $(DESTDIR)$(libdir)/
 
 ################ ghwdump #################################################
 
@@ -411,13 +411,13 @@ libghdlvpi$(SOEXT): vpi_thunk.o
 all.vpi: libghdlvpi$(SOEXT)
 
 install.vpi: all.vpi install.dirs
-	$(INSTALL_DATA) -p libghdlvpi$(SOEXT) $(DESTDIR)$(libdir)/
+	$(INSTALL_PROGRAM) -p libghdlvpi$(SOEXT) $(DESTDIR)$(libdir)/
 	$(INSTALL_DATA) -p $(GRTSRCDIR)/vpi_user.h $(DESTDIR)$(incdir)/
 
 install.vpi.local: all.vpi
 	$(MKDIR) -p include lib
 	$(INSTALL_DATA) -p $(GRTSRCDIR)/vpi_user.h include/
-	$(INSTALL_DATA) -p libghdlvpi$(SOEXT) lib/
+	$(INSTALL_PROGRAM) -p libghdlvpi$(SOEXT) lib/
 
 ################ Libraries ###############################################
 

--- a/configure
+++ b/configure
@@ -250,7 +250,8 @@ fi
 # Define default file extensions for Windows or Linux-like systems and
 # use -fPIC or not.
 case "$build" in
-    *mingw*)  SOEXT=".dll";   EXEEXT=".exe"; PIC_FLAGS="";;
+    *mingw* | *cygwin*)
+              SOEXT=".dll";   EXEEXT=".exe"; PIC_FLAGS="";;
     *darwin*) SOEXT=".dylib"; EXEEXT="";     PIC_FLAGS="";;
     *)        SOEXT=".so";    EXEEXT="";     PIC_FLAGS="-fPIC";;
 esac


### PR DESCRIPTION
Running the testsuite under Cygwin got stuck at `testsuite/gna/issue450`.

First failure was a *File not found* when linking with `-lghdlvpi`. The first commit addresses that by making sure that `SOEXT=.dll` (and other Windows-like settings) under Cygwin.

The error then changed to *Permission denied*. That is addressed by the second commit which switches to `INSTALL_PROGRAM` for anything with `SOEXT`. This makes sure that DLLs get executable permissions. Note that this change affects all platforms: Looking into `/usr/lib` under Linux (`SOEXT=.so`) as well as under MacOS X (`SOEXT=.dylib`) I see that shared libraries should get executable permissions.

Running `testsuite/gna/issue450/testsuite.sh` can now load the module `vip2.vpi`.
(Thereafter it segfaults, and a `gdb` backtrace tells me that that happens in `vpi_register_cb`. Not sure whether I can track that down, in any case that would be a separate issue.)