### PR TITLE
Update xcode version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ jobs:
       stage: test
       os: osx
       language: c
-      osx_image: xcode7.3
+      osx_image: xcode9.3
       install: true
       cache:
         directories:
@@ -81,7 +81,5 @@ jobs:
       env: IMAGE=macosx+mcode
       deploy:
         - <<: *deploy-releases
-    - <<: *osx
-      osx_image: xcode8.3
-    - <<: *osx
-      osx_image: xcode9.3
+#    - <<: *osx
+#      osx_image: xcode8.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,9 +67,10 @@ jobs:
       script: if echo "$TRAVIS_COMMIT_MESSAGE" | grep -F -q "[ci images]"; then ./dist/linux/create.sh; fi;
       deploy:
         - <<: *deploy-docker
-    # A single additional job is described in stage 'test' for the macos build.
+    # Additional jobs are described in stage 'test' for the macos build.
     # The constraints above are used, except explicitly overriden.
-    - stage: test
+    - &osx
+      stage: test
       os: osx
       language: c
       osx_image: xcode7.3
@@ -80,3 +81,7 @@ jobs:
       env: IMAGE=macosx+mcode
       deploy:
         - <<: *deploy-releases
+    - <<: *osx
+      osx_image: xcode8.3
+    - <<: *osx
+      osx_image: xcode9.3


### PR DESCRIPTION
We are currently testing only `xcode7.3`. Travis supports `xcode6.4` to `xcode9.3`, the default being `xcode8.3`: https://docs.travis-ci.com/user/languages/objective-c/#Supported-Xcode-versions.

This PR adds `xcode8.3` and `xcode9.3` jobs to the travis matrix, just to test that all of them work. However, I think that we should choose one. 8.3? 9.3?

