### PR TITLE
fix 'occured' typo

### DIFF
--- a/doc/building/PrecompileVendorPrimitives.rst
+++ b/doc/building/PrecompileVendorPrimitives.rst
@@ -248,7 +248,7 @@ Selectable Options for the Bash Scripts:
      -n --no-warnings	     Don't show warnings. Report errors only.
      -s --skip-existing    Skip already compiled files (an *.o file exists).
      -S --skip-largefiles  Don't compile large entities like DSP and PCIe primitives.
-     -H --halt-on-error    Stop compiling if an error occured.
+     -H --halt-on-error    Stop compiling if an error occurred.
 
 * `compile-altera.sh`
 

--- a/doc/ghdl.texi
+++ b/doc/ghdl.texi
@@ -4413,7 +4413,7 @@ Common parameters to most scripts:
 -n --no-warnings        Don't show warnings. Report errors only.
 -s --skip-existing    Skip already compiled files (an *.o file exists).
 -S --skip-largefiles  Don't compile large entities like DSP and PCIe primitives.
--H --halt-on-error    Stop compiling if an error occured.
+-H --halt-on-error    Stop compiling if an error occurred.
 @end example
 
 @item 

--- a/libraries/vendors/README.md
+++ b/libraries/vendors/README.md
@@ -211,7 +211,7 @@ $InstallationDirectory = @{
         -n --no-warnings	    Don't show warnings. Report errors only.
         -s --skip-existing    Skip already compiled files (an *.o file exists).
         -S --skip-largefiles  Don't compile large entities like DSP and PCIe primitives.
-        -H --halt-on-error    Stop compiling if an error occured.
+        -H --halt-on-error    Stop compiling if an error occurred.
  - `compile-altera.sh`
     Selectable libraries:
 

--- a/src/bug.adb
+++ b/src/bug.adb
@@ -66,7 +66,7 @@ package body Bug is
       New_Line (Standard_Error);
       Put_Line
         (Standard_Error,
-         "******************** GHDL Bug occured ****************************");
+         "******************** GHDL Bug occurred ***************************");
       Put_Line
         (Standard_Error,
          "Please report this bug on https://github.com/ghdl/ghdl/issues");

--- a/src/grt/grt-lib.ads
+++ b/src/grt/grt-lib.ads
@@ -61,7 +61,7 @@ package Grt.Lib is
    procedure Ghdl_Direction_Check_Failed (Filename : Ghdl_C_String;
                                           Line: Ghdl_I32);
 
-   --  Program error has occured:
+   --  Program error has occurred:
    --  * configuration of an already configured block.
    procedure Ghdl_Program_Error (Filename : Ghdl_C_String;
                                  Line : Ghdl_I32;

--- a/src/grt/grt-main.adb
+++ b/src/grt/grt-main.adb
@@ -194,7 +194,7 @@ package body Grt.Main is
       if Expect_Failure then
          if Status >= 0 then
             Expect_Failure := False;
-            Error ("error expected, but none occured");
+            Error ("error expected, but none occurred");
          end if;
       else
          if Status < 0 then

--- a/src/grt/grt-processes.adb
+++ b/src/grt/grt-processes.adb
@@ -931,8 +931,8 @@ package body Grt.Processes is
 
       --  f) The following actions occur in the indicated order:
       --     2) For each process P, if P is currently sensitive to a signal S
-      --        and if an event has occured on S in this simulation cycle, then
-      --        P resumes.
+      --        and if an event has occurred on S in this simulation cycle,
+      --        then P resumes.
       if Current_Time = Process_First_Timeout then
          --  There are processes to awake.
          Tn := Last_Time;

--- a/src/grt/grt-signals.ads
+++ b/src/grt/grt-signals.ads
@@ -282,7 +282,7 @@ package Grt.Signals is
       --  If set, the signal is dumped in a GHW file.
       Is_Dumped : Boolean;
 
-      --  Set when an event occured.
+      --  Set when an event occurred.
       --  Only reset by GHW file dumper.
       RO_Event : Boolean;
 

--- a/src/vhdl/sem_expr.adb
+++ b/src/vhdl/sem_expr.adb
@@ -4773,7 +4773,7 @@ package body Sem_Expr is
          Res := Sem_Expression_Ov (Cond, Null_Iir);
 
          if Res = Null_Iir then
-            --  Error occured.
+            --  Error occurred.
             return Res;
          end if;
 

--- a/testsuite/gna/bug037/bugreport.txt
+++ b/testsuite/gna/bug037/bugreport.txt
@@ -79,7 +79,7 @@ Implementing 9-bit wide adder: ARCH=pai, BLOCKING=desc[4,5], SKIPPING=ppn_ks
 Implementing 9-bit wide adder: ARCH=pai, BLOCKING=desc[4,5], SKIPPING=ppn_bk
 Implementing 9-bit wide adder: ARCH=pai, BLOCKING=desc[4,5], SKIPPING=ppn_bk
 
-******************** GHDL Bug occured ****************************
+******************** GHDL Bug occurred ****************************
 Please report this bug on https://github.com/tgingold/ghdl/issues
 GHDL release: GHDL 0.34dev (commit: 2016-01-20;  git branch: paebbels/llvm';  hash: 3a8fd5b) [Dunoon edition]
 Compiled with GNAT Version: GPL 2015 (20150428-49)

--- a/testsuite/gna/issue25/1_SecondaryUnit.vhdl
+++ b/testsuite/gna/issue25/1_SecondaryUnit.vhdl
@@ -3,7 +3,7 @@
 --	.\1_SecondaryUnit.vhd:19:42: can't match physical literal with type physical type "t_angel"
 --	are_trees_equal: cannot handle IIR_KIND_UNIT_DECLARATION (*std_standard*:1:1)
 --	
---	******************** GHDL Bug occured ****************************
+--	******************** GHDL Bug occurred ****************************
 --	Please report this bug on https://github.com/tgingold/ghdl/issues
 --	GHDL release: GHDL 0.34dev (commit: 2016-01-20;  git branch: paebbels/llvm';  hash: 3a8fd5b) [Dunoon edition]
 --	Compiled with GNAT Version: GPL 2015 (20150428-49)

--- a/testsuite/gna/issue38/bugreport_aliasprotected.vhdl
+++ b/testsuite/gna/issue38/bugreport_aliasprotected.vhdl
@@ -32,7 +32,7 @@
 --
 -- Issue 2:
 --	Calling an aliases to a shared variable's method causes an exception in GHDL:
---		******************** GHDL Bug occured ****************************
+--		******************** GHDL Bug occurred ****************************
 --		Please report this bug on https://github.com/tgingold/ghdl/issues
 --		GHDL release: GHDL 0.34dev (commit: 2016-01-27;  git branch: paebbels/master';  hash: d424eb8) [Dunoon edition]
 --		Compiled with GNAT Version: GPL 2015 (20150428-49)

--- a/testsuite/gna/issue42/bugreport_attribute.vhdl
+++ b/testsuite/gna/issue42/bugreport_attribute.vhdl
@@ -32,7 +32,7 @@
 --		.\attribute.vhdl:64:53: (location of 'image attribute)
 --		finish_sem_name: cannot handle IIR_KIND_OVERLOAD_LIST (??:??:??)
 --		
---		******************** GHDL Bug occured ****************************
+--		******************** GHDL Bug occurred ****************************
 --		Please report this bug on https://github.com/tgingold/ghdl/issues
 --		GHDL release: GHDL 0.34dev (commit: 2016-02-11;  git branch: paebbels/master';  hash: f24fdfb) [Dunoon edition]
 --		Compiled with GNAT Version: GPL 2015 (20150428-49)


### PR DESCRIPTION
This PR is to replace `occured` with `occurred`. I don't know why some blank lines are changed too.