### PR TITLE
add .github (issue templates)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing to GHDL
+
+GHDL is a free and open source software brought to you with :heart: by [@tgingold](https://github.com/tgingold) and [contributors](https://github.com/ghdl/ghdl/graphs/contributors). So, first off, thanks for taking the time to contribute. We need all the help we can get :thumbsup:
+
+- Found a bug? See how to [report a bug](http://ghdl.readthedocs.io/en/latest/contribute.html#reporting-bugs) and open a [Bug report](https://github.com/ghdl/ghdl/issues/new?template=bug_report.md).
+- Got a feature idea? See how to [request enhancements](http://ghdl.readthedocs.io/en/latest/contribute.html#requesting-enhancements) and open a [Feature request](https://github.com/ghdl/ghdl/issues/new?template=feature_request.md).
+- Want to contribute modifications to the codebase? See how to [contribute modifications](http://ghdl.readthedocs.io/en/latest/contribute.html#fork-modify-and-pull-request) and open a [Pull Request (PR)](https://github.com/ghdl/ghdl/compare/).
+- Spread the word. Talk to your friends and colleagues about how awesome GHDL is!
+- Want to add VHDL design examples? Talk to us on [gitter.im/ghdl1/Lobby](https://gitter.im/ghdl1/Lobby).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,59 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+**Description**
+A clear and concise description of what the issue is about.
+
+**Expected behaviour**
+What you expected to happen, and what is happening instead.
+
+**Context**
+Please paste the `GHDL Bug occurred` log block here. Also, provide the following information:
+
+- OS:
+- Origin:
+  - [ ] Package manager. Repo:
+  - [ ] Released binaries. Tarball:
+  - [ ] Built from sources. Commit SHA:
+
+**Additional context**
+Add any other context about the problem here. If applicable, add screenshots to help explain your problem.
+
+**How to reproduce?**
+Tell us how to reproduce this issue. Please provide a Minimal Working Example (MWE), that is compatible with [issue-runner](https://github.com/1138-4EB/issue-runner). With sample code it's easier to reproduce the bug and it's much faster to fix it. For example:
+
+```
+#>> ent.vhd
+entity ent is
+end entity;
+
+architecture a of ent is
+begin
+  process begin
+    report "Hello world" severity note;
+  end process;
+end;
+
+#>> sim.sh
+ghdl -a ent.vhd
+ghdl --elab-run ent
+
+#>> run.sh
+docker run --rm -tv /$(pwd):/src -w //src ghdl/ghdl:buster-mcode sh -c ./sim.sh
+
+#>> end
+```
+
+Note that `run.sh` is used to execute `sim.sh` inside a docker container. Please, put your commands in `sim.sh` and just copy `run.sh` from the example. Using `ghdl/ghdl:*` docker images to run the MWEs ensures that the latest available GHDL is used.
+
+**Files**
+A list of relevant files for this issue. Large files can be uploaded one-by-one or in a tarball/zipfile. See [1138-4EB/issue-runner#parser](https://github.com/1138-4EB/issue-runner#parser).
+
+**Checklist**
+Before submitting your issue, please review the following checklist:
+
+- [ ] Add `GHDL Bug occurred` log block
+- [ ] Add a MWE
+- [ ] Try the latest version

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+---
+
+**Is your feature request related to a problem? Please describe.**
+Add a clear and concise description of what the problem is. E.g. *I'm always frustrated when [...]*
+
+**Describe the solution you'd like**
+Add a clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+Add a clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+**Description** Please explain the changes you made here.
+If the feature changes current behaviour, explain why your solution is better.
+
+:rotating_light: Before submitting your PR, please read [contribute](http://ghdl.readthedocs.io/en/latest/contribute.html#fork-modify-and-pull-request) in the [Docs](http://ghdl.readthedocs.io/en/latest/index.html), and review the following checklist:
+
+- [ ] DO indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).
+
+**When contributing to the GHDL codebase...**
+
+- [ ] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
+- [ ] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
+- [ ] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
+- [ ] CONSIDER adding a unit test if your PR resolves an issue.
+- [ ] CONSIDER modifying the docs, at least in the TODO, if your contribution is relevant to any of the content.
+- [ ] AVOID breaking the continuous integration build.
+- [ ] AVOID breaking the testsuite.
+
+**When contributing to the docs...**
+
+- [ ] DO make sure that the build is successful. See [ghdl/ghdl#572 (issuecomment-390466024)](https://github.com/ghdl/ghdl/issues/572#issuecomment-390466024).
+
+**Further comments**
+
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.
+
+:heart: Thank you!

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -1,3 +1,0 @@
-First off, thanks for taking the time to contribute!
-
-Either to [report a bug](http://ghdl.readthedocs.io/en/doc-gcc/contribute.html#reporting-bugs), [request enhancements](http://ghdl.readthedocs.io/en/doc-gcc/contribute.html#requesting-enhancements) or to [contribute modifications](http://ghdl.readthedocs.io/en/doc-gcc/contribute.html#fork-modify-and-pull-request), please read [Contributing](http://ghdl.readthedocs.io/en/doc-gcc/contribute.html) in the [Docs](http://ghdl.readthedocs.io/en/doc-gcc/index.html).

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -36,7 +36,7 @@ Reporting bugs
    * If the executable created from your VHDL sources crashes, this may be a bug at runtime or the code itself may be wrong. However, since VHDL has a notion of pointers, an erroneous VHDL program (using invalid pointers for example) may crash.
    * If a compiler message is not clear enough, please tell us. The error messages can be improved, but we have not enough experience with them.
 
-Please, report issues of this kind through |SHIELD:issues-new|, as this allows us to categorize issues into groups and
+Please, report issues of this kind through |SHIELD:bug-report|, as this allows us to categorize issues into groups and
 assign developers to them. You can track the issue’s state and see how it’s getting solved.
 
 .. IMPORTANT::
@@ -65,7 +65,7 @@ assign developers to them. You can track the issue’s state and see how it’s 
 Requesting enhancements
 =======================
 
-|SHIELD:issues-new| |SHIELD:gitter|
+|SHIELD:feature-request| |SHIELD:gitter|
 
 All enhancements and feature requests are welcome. Please `open a new issue <https://github.com/ghdl/ghdl/issues/new>`_ to report any, so you can track the request's status and implementation. Depending on the complexity of the request, you may want to `chat on Gitter <https://gitter.im/ghdl/ghdl1>`_, to polish it before opening an issue.
 
@@ -85,7 +85,7 @@ Fork, modify and pull-request
 =============================
 
 .. TIP::
-   * Before starting any modification, you might want to have a look at |SHIELD:issues-pr| and |SHIELD:issues-pr-closed|, to check which other contributions are being made or have been made. If you observe that the modifications you are about to start might conflict with any other, please |SHIELD:gitter| or open a |SHIELD:issues-new| to coordinate.
+   * Before starting any modification, you might want to have a look at |SHIELD:issues-pr| and |SHIELD:issues-pr-closed|, to check which other contributions are being made or have been made. If you observe that the modifications you are about to start might conflict with any other, please |SHIELD:gitter| or open a |SHIELD:new-pr| to coordinate.
    * See section :ref:`BUILD:dir_structure` to faster find the location of the sources you need to modify, and/or to know where to place new ones.
 
 Contributing source code/documentation via `Git <https://git-scm.com/>`_ is very easy. Although we don't provide direct

--- a/doc/shields.inc
+++ b/doc/shields.inc
@@ -37,6 +37,18 @@
    :target: https://github.com/ghdl/ghdl/issues/new
    :alt: Open new issue at GitHub
 
+.. |SHIELD:new-pr| image:: https://img.shields.io/badge/new-pull--request-yellowgreen.svg?style=flat
+   :target: https://github.com/ghdl/ghdl/compare/
+   :alt: Open new Pull Request (PR) at GitHub
+
+.. |SHIELD:bug-report| image:: https://img.shields.io/badge/new-bug--report-yellowgreen.svg?style=flat
+   :target: https://github.com/ghdl/ghdl/issues/new?template=bug_report.md
+   :alt: Open new bug report at GitHub
+
+.. |SHIELD:feature-request| image:: https://img.shields.io/badge/new-feature--request-yellowgreen.svg?style=flat
+   :target: https://github.com/ghdl/ghdl/issues/new?template=feature_request.md
+   :alt: Open new feature request at GitHub
+
 .. |SHIELD:issues-open| image:: https://img.shields.io/github/issues/ghdl/ghdl.svg
    :target: https://github.com/ghdl/ghdl/issues
    :alt: Open issues


### PR DESCRIPTION
As commented in #579, this PR adds 'Bug report' and 'Feature request' issue templates. After this is merged, when a user creates a new issue three options will be available: the two I mentioned and the regular one (empty). In the 'Bug report' template I added a reference to [1138-4EB/issue-runner](https://github.com/1138-4EB/issue-runner) and I provided a very basic example. Also:

- A 'Pull request' template is added.
- The docs are updated with new shields (`new bug report`, `new feature request` and `new pull request`).
- `CONTRIBUTING` is moved to `.github`, extension `.md` is added and the content is updated.