### PR TITLE
add wait statement to bug_report reproduction example

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,6 +33,7 @@ architecture a of ent is
 begin
   process begin
     report "Hello world" severity note;
+    wait;
   end process;
 end;
 


### PR DESCRIPTION
As suggested by @keesj in Gitter, this PR adds a `wait` statement to the `ent.vhd` example in the `bug_report.md` template.