### PR TITLE
Remove redundant use-clauses for gcc 8.1 compatibility

### DIFF
--- a/src/ghdldrv/ghdlrun.adb
+++ b/src/ghdldrv/ghdlrun.adb
@@ -231,9 +231,6 @@ package body Ghdlrun is
 
    procedure Run
    is
-      use Interfaces;
-      --use Ortho_Code.Binary;
-
       function Conv is new Ada.Unchecked_Conversion
         (Source => Address, Target => Elaborate_Acc);
       Err : Boolean;

--- a/src/grt/grt-processes.adb
+++ b/src/grt/grt-processes.adb
@@ -1160,7 +1160,6 @@ package body Grt.Processes is
 
    function Simulation return Integer
    is
-      use Grt.Options;
       Status : Integer;
    begin
       Status := Simulation_Init;

--- a/src/ortho/mcode/ortho_code-decls.adb
+++ b/src/ortho/mcode/ortho_code-decls.adb
@@ -637,7 +637,6 @@ package body Ortho_Code.Decls is
    procedure Disp_Decl (Indent : Natural; Decl : O_Dnode)
    is
       use Ada.Text_IO;
-      use Ortho_Ident;
       use Ortho_Code.Debug.Int32_IO;
 
       procedure Disp_Decl_Type (Decl : O_Dnode)

--- a/src/ortho/mcode/ortho_code-dwarf.adb
+++ b/src/ortho/mcode/ortho_code-dwarf.adb
@@ -819,7 +819,6 @@ package body Ortho_Code.Dwarf is
 
    procedure Emit_Record_Type (Atype : O_Tnode; Decl : O_Dnode)
    is
-      use Ortho_Code.Types;
       procedure Finish_Gen_Abbrev is
       begin
          Gen_Abbrev_Tuple (DW_AT_Byte_Size, DW_FORM_Udata);
@@ -851,7 +850,6 @@ package body Ortho_Code.Dwarf is
 
    procedure Emit_Union_Type (Atype : O_Tnode; Decl : O_Dnode)
    is
-      use Ortho_Code.Types;
       procedure Finish_Gen_Abbrev is
       begin
          Gen_Abbrev_Tuple (DW_AT_Byte_Size, DW_FORM_Udata);
@@ -958,7 +956,6 @@ package body Ortho_Code.Dwarf is
    procedure Emit_Type (Atype : O_Tnode)
    is
       use Ortho_Code.Types;
-      use Ada.Text_IO;
       Kind : OT_Kind;
       Decl : O_Dnode;
    begin

--- a/src/ortho/mcode/ortho_code-x86-abi.adb
+++ b/src/ortho/mcode/ortho_code-x86-abi.adb
@@ -293,7 +293,6 @@ package body Ortho_Code.X86.Abi is
 
    procedure Disp_Irm_Code (Stmt : O_Enode)
    is
-      use Ortho_Code.Debug.Int32_IO;
       use Ada.Text_IO;
       Reg : O_Reg;
       Kind : OE_Kind;
@@ -640,8 +639,6 @@ package body Ortho_Code.X86.Abi is
 
    procedure Disp_Subprg (Subprg : O_Dnode)
    is
-      use Ada.Text_IO;
-
       Stmt : O_Enode;
    begin
       Disp_Subprg_Decl (Get_Body_Decl (Subprg));

--- a/src/ortho/mcode/ortho_code-x86-emits.adb
+++ b/src/ortho/mcode/ortho_code-x86-emits.adb
@@ -1383,7 +1383,6 @@ package body Ortho_Code.X86.Emits is
 
    procedure Emit_Call (Stmt : O_Enode)
    is
-      use Ortho_Code.Decls;
       Subprg : constant O_Dnode := Get_Call_Subprg (Stmt);
       Sym : constant Symbol := Get_Decl_Symbol (Subprg);
       Mode : constant Mode_Type := Get_Expr_Mode (Stmt);
@@ -3098,7 +3097,6 @@ package body Ortho_Code.X86.Emits is
    procedure Emit_Var_Decl (Decl : O_Dnode)
    is
       use Decls;
-      use Types;
       Sym : Symbol;
    begin
       Sym := Create_Symbol (Get_Decl_Ident (Decl), False);
@@ -3125,7 +3123,6 @@ package body Ortho_Code.X86.Emits is
    procedure Emit_Const_Decl (Decl : O_Dnode)
    is
       use Decls;
-      use Types;
       Sym : Symbol;
    begin
       Set_Current_Section (Sect_Rodata);

--- a/src/ortho/mcode/ortho_jit.adb
+++ b/src/ortho/mcode/ortho_jit.adb
@@ -23,7 +23,7 @@ with Ada.Text_IO;
 
 with Binary_File; use Binary_File;
 with Binary_File.Memory;
-with Ortho_Mcode; use Ortho_Mcode;
+with Ortho_Mcode;
 with Ortho_Mcode.Jit;
 with Ortho_Code.Flags; use Ortho_Code.Flags;
 with Ortho_Code.Debug;


### PR DESCRIPTION
I had to remove some additional redundant use-clauses in order to get GHDL to compile with GCC 8.1. The compiled GHDL seems to work fine for me, but I'm not familiar with ADA or the GHDL internals so please review carefully for any breakage.

This is related to issue #568