### PR TITLE
Add gcc

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -217,7 +217,7 @@ copy-sources.gcc: version.ads
 	 5.*)      gcc_ortho_lang=ortho-lang-5.c ;; \
 	 6 | 6.*)  gcc_ortho_lang=ortho-lang-6.c ;; \
 	 7.*)      gcc_ortho_lang=ortho-lang-7.c ;; \
-	 8.*)      gcc_ortho_lang=ortho-lang-7.c ;; \
+	 8.*)      gcc_ortho_lang=ortho-lang-8.c ;; \
 	 *) echo "Mismatch gcc version from $(gcc_src_dir)"; \
 	    echo "Need gcc version 4.9.x, 5.x, 6.x, 7.x or 8.x"; \
 	    exit 1 ;; \


### PR DESCRIPTION
This PR updates `build.sh` to allow building GHDL with GCC backend using the same procedure that we are using for mcode and LLVM. For example:

```
- IMAGE=stretch+gcc-5.5.0
- IMAGE=fedora26+gcc-6.4.0
- IMAGE=buster+gcc-7.2.0
- IMAGE=fedora28+gcc-8.1.0
```

BTW, the type mentioned [here](https://github.com/ghdl/ghdl/commit/ef5f47fad76e12050a8a1cfbbedb89e5d2af31af#r29237687) is fixed.