### PR TITLE
add :z to the docker bind argument

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -42,7 +42,7 @@ ghdl -a ent.vhd
 ghdl --elab-run ent
 
 #>> run.sh
-docker run --rm -tv /$(pwd):/src -w //src ghdl/ghdl:buster-mcode sh -c ./sim.sh
+docker run --rm -tv /$(pwd):/src:z -w //src ghdl/ghdl:buster-mcode sh -c ./sim.sh
 
 #>> end
 ```


### PR DESCRIPTION
I had only tried the issue-runner on Windows hosts, where bind mount permissions are not so relevant. Today I tried it in Fedora and I realized that option `:z` must be used, because of selinux. This PR just adds it.

See https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label