### PR TITLE
log stderr of make to a file and use tail to show last 1000 lines

### DIFF
--- a/dist/travis/build.sh
+++ b/dist/travis/build.sh
@@ -140,7 +140,10 @@ echo "travis_fold:end:configure"
 echo "travis_fold:start:make"
 travis_time_start
 printf "$ANSI_YELLOW[GHDL - build] Make $ANSI_NOCOLOR\n"
-make -j$(nproc)
+set +e
+make -j$(nproc) 2>make_err.log
+tail -1000 make_err.log
+set -e
 travis_time_finish
 echo "travis_fold:end:make"
 


### PR DESCRIPTION
When GHDL is built with GCC backend, and the target version of GCC is not the same as the version of the GCC used in the build, the process logs so heavily that the 4MB in travis-ci is reached. This results in the build being broken (see last two lines in https://api.travis-ci.com/v3/job/127969859/log.txt). Moreover, if all the make output is saved to a file, the build fails because no output is received in 10 minutes and travis thinks that it is stalled.

This PR logs stderr to a file (not stdout). When make is done, the last 1000 lines of the file are shown. This allows the build to finish successfully.