### PR TITLE
use fedora28 instead of fedora26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ env:
     - IMAGE=ubuntu14+llvm-3.8
 #    - IMAGE=ubuntu18+mcode
 #    - IMAGE=ubuntu18+llvm-5.0
-    - IMAGE=fedora26+mcode
-    - IMAGE=fedora26+llvm
+    - IMAGE=fedora28+mcode
+    - IMAGE=fedora28+llvm
 
 deploy:
   provider: releases


### PR DESCRIPTION
As commented by @CraigNoble in gitter, 2018-05-29 was the End-of-life for Fedora 26: https://en.wikipedia.org/wiki/Fedora_version_history#Version_history

This PR skips Fedora 27 and jumps to Fedora 28.