### PR TITLE
Cyclone 1,2,3 support for compile-altera.sh

### DIFF
--- a/libraries/vendors/compile-altera.sh
+++ b/libraries/vendors/compile-altera.sh
@@ -513,7 +513,63 @@ if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_ARRIA" == "TRUE" ] && [ $SKIP_LARGE_F
 
 	GHDLCompilePackages
 fi
+# compile Cyclone library
+if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_CYCLONE" == "TRUE" ]; then
+	Library="cyclone"
+	Files=(
+		cyclone_atoms.vhd
+		cyclone_components.vhd
+	)
 
+	# append absolute source path
+	SourceFiles=()
+	for File in ${Files[@]}; do
+		#Don't put nonexisting files.
+		if [ -f "$SourceDirectory/$File" ]; then
+			SourceFiles+=("$SourceDirectory/$File")
+		fi
+	done
+
+	GHDLCompilePackages
+fi
+# compile CycloneII library
+if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_CYCLONE" == "TRUE" ]; then
+	Library="cycloneii"
+	Files=(
+		cycloneii_atoms.vhd
+		cycloneii_components.vhd
+	)
+
+	# append absolute source path
+	SourceFiles=()
+	for File in ${Files[@]}; do
+		#Don't put nonexisting files.
+		if [ -f "$SourceDirectory/$File" ]; then
+			SourceFiles+=("$SourceDirectory/$File")
+		fi
+	done
+
+	GHDLCompilePackages
+fi
+# compile Cyclone IIIlibrary
+if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_CYCLONE" == "TRUE" ]; then
+	Library="cycloneiii"
+	Files=(
+		cycloneiii_atoms.vhd
+		cycloneiii_components.vhd
+	)
+
+	# append absolute source path
+	SourceFiles=()
+	for File in ${Files[@]}; do
+		#Don't put nonexisting files.
+		if [ -f "$SourceDirectory/$File" ]; then
+			SourceFiles+=("$SourceDirectory/$File")
+		fi
+	done
+
+	GHDLCompilePackages
+fi
 # compile CycloneIV library
 if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_CYCLONE" == "TRUE" ]; then
 	Library="cycloneiv"
@@ -583,7 +639,9 @@ if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_CYCLONE" == "TRUE" ]; then
 	# append absolute source path
 	SourceFiles=()
 	for File in ${Files[@]}; do
-		SourceFiles+=("$SourceDirectory/$File")
+		if [ -f "$SourceDirectory/$File" ]; then
+			SourceFiles+=("$SourceDirectory/$File")
+		fi
 	done
 
 	GHDLCompilePackages

--- a/libraries/vendors/compile-altera.sh
+++ b/libraries/vendors/compile-altera.sh
@@ -524,9 +524,12 @@ if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_CYCLONE" == "TRUE" ]; then
 	# append absolute source path
 	SourceFiles=()
 	for File in ${Files[@]}; do
+		FullPath="$SourceDirectory/$File"
 		#Don't put nonexisting files.
-		if [ -f "$SourceDirectory/$File" ]; then
-			SourceFiles+=("$SourceDirectory/$File")
+		if [ -f $FullPath ]; then
+			SourceFiles+=($FullPath)
+		elif [ $SUPPRESS_WARNINGS -eq 0 ] ; then
+			echo -e "${ANSI_YELLOW}File ${FullPath} not found.${ANSI_NOCOLOR}"
 		fi
 	done
 
@@ -543,15 +546,18 @@ if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_CYCLONE" == "TRUE" ]; then
 	# append absolute source path
 	SourceFiles=()
 	for File in ${Files[@]}; do
+		FullPath="$SourceDirectory/$File"
 		#Don't put nonexisting files.
-		if [ -f "$SourceDirectory/$File" ]; then
-			SourceFiles+=("$SourceDirectory/$File")
+		if [ -f $FullPath ]; then
+			SourceFiles+=($FullPath)
+		elif [ $SUPPRESS_WARNINGS -eq 0 ] ; then
+			echo -e "${ANSI_YELLOW}File ${FullPath} not found.${ANSI_NOCOLOR}"
 		fi
 	done
 
 	GHDLCompilePackages
 fi
-# compile Cyclone IIIlibrary
+# compile Cyclone III library
 if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_CYCLONE" == "TRUE" ]; then
 	Library="cycloneiii"
 	Files=(
@@ -562,9 +568,12 @@ if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_CYCLONE" == "TRUE" ]; then
 	# append absolute source path
 	SourceFiles=()
 	for File in ${Files[@]}; do
+		FullPath="$SourceDirectory/$File"
 		#Don't put nonexisting files.
-		if [ -f "$SourceDirectory/$File" ]; then
-			SourceFiles+=("$SourceDirectory/$File")
+		if [ -f $FullPath ]; then
+			SourceFiles+=($FullPath)
+		elif [ $SUPPRESS_WARNINGS -eq 0 ] ; then
+			echo -e "${ANSI_YELLOW}File ${FullPath} not found.${ANSI_NOCOLOR}"
 		fi
 	done
 
@@ -639,8 +648,12 @@ if [ $STOPCOMPILING -eq 0 ] && [ "$COMPILE_CYCLONE" == "TRUE" ]; then
 	# append absolute source path
 	SourceFiles=()
 	for File in ${Files[@]}; do
-		if [ -f "$SourceDirectory/$File" ]; then
-			SourceFiles+=("$SourceDirectory/$File")
+		FullPath="$SourceDirectory/$File"
+		#Don't put nonexisting files.
+		if [ -f $FullPath ]; then
+			SourceFiles+=($FullPath)
+		elif [ $SUPPRESS_WARNINGS -eq 0 ] ; then
+			echo -e "${ANSI_YELLOW}File ${FullPath} not found.${ANSI_NOCOLOR}"
 		fi
 	done
 


### PR DESCRIPTION
Quartus 13 is last version which supported older devices. Also first
supported version of script.

TODO: Port support to Windows, maybe add more file existence testing.

**Description** Please explain the changes you made here.
This patch adds support for older cyclone devices. It imports clean quartus version 13 and 17 sim_lib. 

--------------
Closes #303
