### PR TITLE
add option llvm-6.0 to travis build script

### DIFF
--- a/dist/travis/build.sh
+++ b/dist/travis/build.sh
@@ -123,6 +123,10 @@ case "$BLD" in
 	      CXX="clang++-5.0"
 	      config_opts="--with-llvm-config=llvm-config-5.0 CXX=$CXX"
     ;;
+    llvm-6.0)
+	      CXX="clang++-6.0"
+	      config_opts="--with-llvm-config=llvm-config-6.0 CXX=$CXX"
+    ;;
     *)
 	      echo "$ANSI_RED[GHDL - build] Unknown build $BLD $ANSI_NOCOLOR"
 	      exit 1;;


### PR DESCRIPTION
ATM, LLVM 6.0 is supported in the main configure file in the root, but not in the travis build script.