### PR TITLE
fix filter to generate GRT_EXTRA_LIB on arm-linux-gnueabihf

### DIFF
--- a/src/grt/Makefile.inc
+++ b/src/grt/Makefile.inc
@@ -52,7 +52,7 @@ ifeq ($(filter-out mingw32 mingw64,$(osys)),)
   GRT_EXTRA_LIB=-ldbghelp
 else
   GRT_TARGET_OBJS=jumps.o times.o
-  ifeq ($(filter-out linux,$(osys)),)
+  ifeq ($(filter-out linux%,$(osys)),)
     GRT_EXTRA_LIB=-ldl -lm $(GRT_ELF_OPTS)
   endif
   ifeq ($(filter-out netbsd freebsd% dragonfly%,$(osys)),)


### PR DESCRIPTION
This PR allows `src/grt/Makefile.inc` to add `GRT_EXTRA_LIB` arguments on `linux-gnueabihf` platforms, by adding `%` to the filter. See https://github.com/ghdl/ghdl/issues/640#issuecomment-428574760.