### PR TITLE
Build GHDL and libs with -fPIC

### DIFF
--- a/dist/travis/build.sh
+++ b/dist/travis/build.sh
@@ -145,7 +145,7 @@ echo "travis_fold:start:make"
 travis_time_start
 printf "$ANSI_YELLOW[GHDL - build] Make $ANSI_NOCOLOR\n"
 set +e
-make -j$(nproc) 2>make_err.log
+make LIB_CFLAGS="$LIB_CFLAGS" OPT_FLAGS="$OPT_FLAGS" -j$(nproc) 2>make_err.log
 tail -1000 make_err.log
 set -e
 travis_time_finish


### PR DESCRIPTION
This PR forces `-fPIC` to be used when building GHDL, which involves all the libraries in `$prefix/lib/*`. This is required in order to compile VHDL sources to C objects that can then be used to build foreign applications: https://github.com/ghdl/ghdl/issues/640#issuecomment-418470167.

I don't know if this is the best solution for the problem I am trying to solve. I'd be open to any suggestion to avoid making this a fixed setting. However, I am unsure about how to pass this option when calling either `configure` or `make`.