### PR TITLE
PowerShell Windows installation fix

### DIFF
--- a/dist/windows/InstallerTemplate.ps1
+++ b/dist/windows/InstallerTemplate.ps1
@@ -205,13 +205,13 @@ if ($Install)
 	New-Item -ItemType Directory -Path "$InstallPath"						-ErrorAction SilentlyContinue	| Out-Null
 
 	# writing ZIP file to disk
-	$TempFilePath =									[System.IO.Path]::GetTempFileName()
+	$TempFilePath =	[System.IO.Path]::GetTempFileName().TrimEnd("tmp") + "zip"
 	Write-Host "  Writing temporary ZIP file: $TempFilePath"
 	$CompressedFileContentAsBytes =	[System.Convert]::FromBase64String($CompressedFileContentInBase64)
 	[System.IO.File]::WriteAllBytes("$TempFilePath", $CompressedFileContentAsBytes)
 	
 	Write-Host "  Extracting ZIP file to: $InstallPath"
-	Expand-Archive "$TempFilePath" -OutputPath $InstallPath -Force -ShowProgress
+	Expand-Archive "$TempFilePath" -DestinationPath $InstallPath -Force
 
 	Remove-Item $TempFilePath
 	

--- a/dist/windows/InstallerTemplate.ps1
+++ b/dist/windows/InstallerTemplate.ps1
@@ -211,7 +211,7 @@ if ($Install)
 	[System.IO.File]::WriteAllBytes("$TempFilePath", $CompressedFileContentAsBytes)
 	
 	Write-Host "  Extracting ZIP file to: $InstallPath"
-	Expand-Archive "$TempFilePath" -DestinationPath $InstallPath -Force
+	Microsoft.PowerShell.Archive\Expand-Archive "$TempFilePath" -DestinationPath $InstallPath -Force
 
 	Remove-Item $TempFilePath
 	


### PR DESCRIPTION
**Description**
Fixes the installation process in vanilla PowerShell on Windows 10. Creates temporary zip file because Expand-Archive expects a file with .zip extension. Also call `Expand-Archive` with correct syntax (for bulitin PS version).

**Fixed issues**
* [PowerShell installation fail on Windows 10 (x64) [1803]](https://github.com/ghdl/ghdl/issues/678)
* [PowerShell installation failed](https://github.com/ghdl/ghdl/issues/457)