### PR TITLE
Add man pages job to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,16 +31,17 @@ env:
     - IMAGE=fedora28+llvm
 
 deploy:
-  provider: releases
-  skip_cleanup: true
-  api_key:
-    secure: ji6LXOmD5V2N+ELHZr4oJsmxPhedk+8W6jfCqQdEbewQ42N+fKOq3lgqJni7ZdfpZaulB9OHPTApv3bwOjXjtN9rfBGmq//U9CwvzHmUeomdQv6WQOVevaWSXl3DNL9fk3yKynyFrsv4pvr45L8GIjaHLggKcYhNFPJ2rrnJlDoFT9MqQNpmP7Bg/LnwVQiv+ZDPkLlMWQzrXzLamdQILARPQka+kCdXl/sHH6OKvLgRvu9yvyXYSSfbyAHP+THISS5gDciizSBeWGlU75kgj/N+mkV+8NvtTTfEIgG8y49WJz6aBooTmRzk/jZW1dKMbDR6c5bpTmRvMZSzeSBuAR6WLhr6HevgCPi/1fX1y3pkVSrgBUF5KcxPgWCZp0I05QjaJOdvQDl1hH4TlVwpT18lM2+cWrui9fS7spnk/AuNKX882C5QWWRy28lIPasCVnwfeKX8a9KAwY9OqVOenoLC1yx7NJOGfH1bjuSYYxyR4XgLiGTHKALAuknCyD9QL0o378IwqxHMcsN0Gsd+GndMu0/b8GvSqfzDpV1XknqabQFwkZLs+Yydw0snfBUzXw9TfOk78IiPYEgXAxsQKBAkK7qvO36HIxLlSQXglXU1D4IDtQYDUel6vKll4pgu0WMxStQCbj51yDVJKvRhzwiBNC6Pwgzt2JTrpwM/T/U=
-  file: "ghdl-*.tgz"
-  file_glob: true
-  on:
-    repo: ghdl/ghdl
-    all_branches: true
-    tags: true
+  - &deploy-docker
+    provider: releases
+    skip_cleanup: true
+    api_key:
+      secure: ji6LXOmD5V2N+ELHZr4oJsmxPhedk+8W6jfCqQdEbewQ42N+fKOq3lgqJni7ZdfpZaulB9OHPTApv3bwOjXjtN9rfBGmq//U9CwvzHmUeomdQv6WQOVevaWSXl3DNL9fk3yKynyFrsv4pvr45L8GIjaHLggKcYhNFPJ2rrnJlDoFT9MqQNpmP7Bg/LnwVQiv+ZDPkLlMWQzrXzLamdQILARPQka+kCdXl/sHH6OKvLgRvu9yvyXYSSfbyAHP+THISS5gDciizSBeWGlU75kgj/N+mkV+8NvtTTfEIgG8y49WJz6aBooTmRzk/jZW1dKMbDR6c5bpTmRvMZSzeSBuAR6WLhr6HevgCPi/1fX1y3pkVSrgBUF5KcxPgWCZp0I05QjaJOdvQDl1hH4TlVwpT18lM2+cWrui9fS7spnk/AuNKX882C5QWWRy28lIPasCVnwfeKX8a9KAwY9OqVOenoLC1yx7NJOGfH1bjuSYYxyR4XgLiGTHKALAuknCyD9QL0o378IwqxHMcsN0Gsd+GndMu0/b8GvSqfzDpV1XknqabQFwkZLs+Yydw0snfBUzXw9TfOk78IiPYEgXAxsQKBAkK7qvO36HIxLlSQXglXU1D4IDtQYDUel6vKll4pgu0WMxStQCbj51yDVJKvRhzwiBNC6Pwgzt2JTrpwM/T/U=
+    file: "ghdl-*.tgz"
+    file_glob: true
+    on:
+      repo: ghdl/ghdl
+      all_branches: true
+      tags: true
 
 jobs:
   include:
@@ -57,3 +58,8 @@ jobs:
       env: IMAGE=macosx+mcode
 #    - <<: *osx
 #      osx_image: xcode8.3
+    - env: IMAGE=""
+      script: ./dist/travis/man.sh
+      deploy:
+        - <<: *deploy-docker
+        file: "doc/_build/man/ghdl.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,4 +62,4 @@ jobs:
       script: ./dist/travis/man.sh
       deploy:
         - <<: *deploy-docker
-        file: "doc/_build/man/ghdl.1"
+          file: "doc/_build/man/ghdl.1"

--- a/dist/travis/man.sh
+++ b/dist/travis/man.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+rm -rf doc/_build/man/*
+
+set -e
+
+docker run --rm -it \
+  -v /$(pwd):/src \
+  -w //src/doc \
+  btdi/sphinx:py2-featured \
+  sh -c "sphinx-build -T -b man . ./_build/man"
+
+nroff -man doc/_build/man/ghdl.1

--- a/dist/travis/travis-ci.sh
+++ b/dist/travis/travis-ci.sh
@@ -29,6 +29,7 @@ scriptdir=$(dirname $0)
 . "$scriptdir/../ansi_color.sh"
 #disable_color
 
+
 # Display env (to debug)
 
 echo -en "travis_fold:start:travis_env\r"
@@ -47,7 +48,6 @@ echo "travis_fold:start:fetch"
 # The command 'git describe' (used for version) needs the history. Get it.
 # But the following command fails if the repository is complete.
 git fetch --unshallow || true
-
 echo "travis_fold:end:fetch"
 
 


### PR DESCRIPTION
Close #622.

This PR adds a parallel job in the Travis matrix, to build man pages for GHDL. When a release is tagged, file `ghdl.1` is added to the release artifacts, so it is pushed to GitHub along with the tarballs for different distributions.

Even though the file is only pushed to GitHub when a release is tagged, the content can be seen in every Travis build. See e.g. https://travis-ci.org/1138-4EB/ghdl/builds/475993763 and https://travis-ci.org/1138-4EB/ghdl/jobs/475993771