### PR TITLE
Update travis macos job to use xcode9.4 (current default)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,19 +45,20 @@ deploy:
 
 jobs:
   include:
-    # Additional jobs are described in stage 'test' for the macos build.
+    # One additional job is described in stage 'test' for the macos build.
     # The constraints above are used, except explicitly overriden.
     - &osx
       os: osx
       language: c
-      osx_image: xcode9.3
+      osx_image: xcode9.4
       install: true
       cache:
         directories:
           - gnat
       env: IMAGE=macosx+mcode
-#    - <<: *osx
-#      osx_image: xcode8.3
+    # Optionally, more macos jobs can be added. See list of available versions at https://docs.travis-ci.com/user/reference/osx/#macos-version
+#   - <<: *osx
+#     osx_image: xcode10
     - env: IMAGE=""
       script: ./dist/travis/man.sh
       deploy:


### PR DESCRIPTION
Follow up on #574. Related to #744.

Defaults in Travis CI are now macOS 10.13 and Xcode 9.4.1. See:

- https://docs.travis-ci.com/user/reference/osx/#macos-version
- https://blog.travis-ci.com/2018-07-19-xcode9-4-default-announce

> In order to streamline our image catalog, minor 9 versions other than xcode9.2 and 9.latest will be deprecated when 10.0 is released (date TBA). If you are using xcode9, xcode9.1 , and xcode9.3, please plan to move to xcode9.2 or xcode9.4 as soon as you are able.

This PR updates `.travis.yml` to use the default environment. as `xcode9.3` is being deprecated.