### PR TITLE
Update travis dist from trusty to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os: linux
 dist: xenial
-sudo: required
 services: docker
 language: minimal
 install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,10 @@
-branches:
-  except:
-    - appveyor
-
 os: linux
-dist: trusty
+dist: xenial
 sudo: required
 services: docker
 language: minimal
 install: skip
 script: "./dist/travis/travis-ci.sh"
-
-addons:
-  apt:
-    packages:
-      - docker-ce
 
 # For each linux build, a different job/instance (with the constraints
 # above) is executed in parallel in stage 'test'.


### PR DESCRIPTION
Ubuntu Xenial 16.04 is available as the base image in Travis: https://blog.travis-ci.com/2018-11-08-xenial-release. The default in Travis is still Ubuntu Trusty 14.04: https://docs.travis-ci.com/user/reference/overview/#linux. However, switching to Xenial is recommended for users coming from some deprecated virtualization environments: https://docs.travis-ci.com/user/reference/overview/#deprecated-virtualization-environments.

Both 14.04 and 16.04 are LTS releases. Although 14.04 is not deprecated yet, the Enf of Life (EOL) is scheduled for april: https://www.ubuntu.com/about/release-cycle. Therefore, we can expect Travis to switch the default from trusty to xenial in Q3 (see https://blog.travis-ci.com/2017-04-17-precise-EOL and https://docs.travis-ci.com/user/precise-to-trusty-migration-guide/), at least for non-enterprise environments (https://blog.travis-ci.com/2018-11-30-announcing-xenial-build-environment-for-enterprise). 

This PR updates Travis to use `xenial` instead of `trusty` as the base image for all the GNU/Linux jobs. Note that this has no impact at all in the environments where GHDL is build and tested, because those are containers on top of the host.

---

Moreover, until now package `docker-ce` was explicitly installed. We required this some months ago, because we did use features which were only available in latest docker releases: 
https://docs.travis-ci.com/user/docker/#installing-a-newer-docker-version. Precisely, we used [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/), which required docker 17.05. However, on the one hand, we are not using that feature anymore (in this repo, we are using it in ghdl/docker). On the other hand, the default docker version in Travis' `trusty` image has been updated to docker 17.09 (https://travis-ci.org/1138-4EB/ghdl/jobs/485193793). As a result, we don't need to explicitly update docker anymore. For the sake of completeness:

|  | trusty | xenial |
|--|--------|--------|
|docker | 17.09.0-ce | [18.06.0-ce](https://docs.travis-ci.com/user/reference/xenial/#docker) |
|docker-ce | 18.06.1-ce | not tested |

---

Key `sudo` is deprecated now: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration.

---

Last, I think that explicitly excluding branch `appveyor` is not required anymore. The branch has not been updated in about a year and a half.