### PR TITLE
style: install-ada

### DIFF
--- a/dist/macosx/install-ada.sh
+++ b/dist/macosx/install-ada.sh
@@ -22,39 +22,36 @@ rm -rf gnat
 mv gnat-gpl-2017-x86_64-darwin-bin gnat
 
 # Cleanup: remove components not needed
-rm -rf gnat/share/{themes,icons}
-rm -rf gnat/share/{man,info,doc,examples,gpr,gprconfig,gnatcoll}
-rm -rf gnat/share/gps
-rm -rf gnat/share/gdb* gnat/share/glib* gnat/share/gcc-*/python
-rm -rf gnat/etc/fonts gnat/etc/gtk*
+rm -rf gnat/share/{themes,icons} \
+       gnat/share/{man,info,doc,examples,gpr,gprconfig,gnatcoll} \
+       gnat/share/gps \
+       gnat/share/gdb* gnat/share/glib* gnat/share/gcc-*/python \
+       gnat/etc/fonts gnat/etc/gtk* \
+       gnat/include/{asis,aunit,gnat_util,gnatcoll,gpr,xmlada} \
+       gnat/include/aws* gnat/include/pycairo gnat/include/python* \
+       gnat/include/pygobject* gnat/include/gdb \
+       gnat/include/c++ \
+       gnat/lib/{aunit,gnat,gnat_util,gnatcoll,gpr,gps,xmlada} \
+       gnat/lib/aws* gnat/lib/girepository* gnat/lib/gtk* \
+       gnat/lib/python* \
+       gnat/lib/gcc/x86*/*/{gcc-include,plugin,install-tools} \
+       gnat/lib/gcc/x86*/*/rts-ios-simulator \
+       gnat/lib/gcc/x86*/*/rts-native/adalib/lib*.dSYM \
+       gnat/lib/gcc/x86*/*/rts-native/adalib/*.dylib \
+       gnat/lib/gcc/x86*/*/rts-native/adalib/lib*_pic.a \
+       gnat/libexec/gprbuild \
+       gnat/libexec/gcc/x86*/*/{plugin,install-tools}
 
-rm -f gnat/bin/aws* gnat/bin/gps* gnat/bin/gcov*
-rm -f gnat/bin/gnat2* gnat/bin/xml2* gnat/bin/gnatcoll*
-rm -f gnat/bin/gnat{doc,metric,pp,stub,prep,test,check,elim,inspect,find,kr}
-rm -f gnat/bin/gnat{xref,name}
-rm -f gnat/bin/gpr* gnat/bin/templates* gnat/bin/web* gnat/bin/wsdl*
-rm -f gnat/bin/{gdb,cpp,c++,g++} gnat/bin/x86_64-*
-
-rm -rf gnat/include/{asis,aunit,gnat_util,gnatcoll,gpr,xmlada}
-rm -rf gnat/include/aws* gnat/include/pycairo gnat/include/python*
-rm -rf gnat/include/pygobject* gnat/include/gdb
-rm -rf gnat/include/c++
-
-rm -f gnat/lib/libcc1* gnat/lib/libgomp* gnat/lib/libitm* gnat/lib/libasan*
-rm -f gnat/lib/libatomic* gnat/lib/libobjc* gnat/lib/libssp*
-rm -f gnat/lib/libstdc++* gnat/lib/libubsan* gnat/lib/libsupc++*
-rm -f gnat/lib/libxmlada*
-rm -rf gnat/lib/{aunit,gnat,gnat_util,gnatcoll,gpr,gps,xmlada}
-rm -rf gnat/lib/aws* gnat/lib/girepository* gnat/lib/gtk*
-rm -rf gnat/lib/python*
-rm -rf gnat/lib/gcc/x86*/*/{gcc-include,plugin,install-tools}
-rm -rf gnat/lib/gcc/x86*/*/rts-ios-simulator
-rm -rf gnat/lib/gcc/x86*/*/rts-native/adalib/lib*.dSYM
-rm -rf gnat/lib/gcc/x86*/*/rts-native/adalib/*.dylib
-rm -rf gnat/lib/gcc/x86*/*/rts-native/adalib/lib*_pic.a
-
-rm -rf gnat/libexec/gprbuild
-rm -rf gnat/libexec/gcc/x86*/*/{plugin,install-tools}
-rm -f gnat/libexec/gcc/x86*/*/{cc1obj,cc1plus,lto1}
+rm -f  gnat/bin/aws* gnat/bin/gps* gnat/bin/gcov* \
+       gnat/bin/gnat2* gnat/bin/xml2* gnat/bin/gnatcoll* \
+       gnat/bin/gnat{doc,metric,pp,stub,prep,test,check,elim,inspect,find,kr} \
+       gnat/bin/gnat{xref,name} \
+       gnat/bin/gpr* gnat/bin/templates* gnat/bin/web* gnat/bin/wsdl* \
+       gnat/bin/{gdb,cpp,c++,g++} gnat/bin/x86_64-* \
+       gnat/lib/libcc1* gnat/lib/libgomp* gnat/lib/libitm* gnat/lib/libasan* \
+       gnat/lib/libatomic* gnat/lib/libobjc* gnat/lib/libssp* \
+       gnat/lib/libstdc++* gnat/lib/libubsan* gnat/lib/libsupc++* \
+       gnat/lib/libxmlada* \
+       gnat/libexec/gcc/x86*/*/{cc1obj,cc1plus,lto1}
 
 touch gnat/etc/install_ok

--- a/dist/travis/travis-ci.sh
+++ b/dist/travis/travis-ci.sh
@@ -50,6 +50,11 @@ echo "travis_fold:start:fetch"
 git fetch --unshallow || true
 echo "travis_fold:end:fetch"
 
+if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+    # Install gnat compiler (use cache)
+    ./dist/macosx/install-ada.sh || exit 1
+    PATH=$PWD/gnat/bin:$PATH
+fi
 
 # Compute package name
 
@@ -86,10 +91,6 @@ echo "build cmd: $BUILD_CMD_OPTS"
 # Build
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-    # Install gnat compiler (use cache)
-    ./dist/macosx/install-ada.sh || exit 1
-    PATH=$PWD/gnat/bin:$PATH
-
     bash -c "${scriptdir}/build.sh $BUILD_CMD_OPTS"
 else
     # Assume linux


### PR DESCRIPTION
This is just some style change. On the one hand, execution of `install-ada.sh` is moved before section *Build*. This is more coherent with other platforms, where dependencies are already available when entering section *Build*. On the other hand, multiple calls to `rm` are put together.

> NOTE: this slightly affects the references in #744.