### PR TITLE
Fixes to libraries/vendors

### DIFF
--- a/libraries/vendors/README.md
+++ b/libraries/vendors/README.md
@@ -68,11 +68,11 @@ The vendor library compile scripts need to know where the used / latest vendor
 tool chain is installed. Therefore, the script implement a default installation
 directory search as well as environment variable checks. If a vendor tool could
 not be detected or the script choses the wrong vendor library source directory,
-then it's possible to provide the path via `--source` or `-Source`.
+then it's possible to provide the path via `--src` or `-Source`.
 
 The generated output is stored relative to the current working directory. The
 scripts create a sub-directory for each vendor. The default output directory can
-be overwritten by the parameter `--output` or `-Output`.
+be overwritten by the parameter `--out` or `-Output`.
 
 To compile all source files with GHDL, the simulator executable is searched in
 `PATH`. The found default GHDL executable can be overwritten by setting the

--- a/libraries/vendors/compile-altera.sh
+++ b/libraries/vendors/compile-altera.sh
@@ -44,7 +44,7 @@ ScriptDir="$(dirname $0)"
 ScriptDir="$($READLINK -f $ScriptDir)"
 
 # source configuration file from GHDL's 'vendors' library directory
-. $ScriptDir/../ansi_color.sh
+. $ScriptDir/../../dist/ansi_color.sh
 . $ScriptDir/config.sh
 . $ScriptDir/shared.sh
 

--- a/libraries/vendors/compile-intel.sh
+++ b/libraries/vendors/compile-intel.sh
@@ -44,7 +44,7 @@ ScriptDir="$(dirname $0)"
 ScriptDir="$($READLINK -f $ScriptDir)"
 
 # source configuration file from GHDL's 'vendors' library directory
-. $ScriptDir/../ansi_color.sh
+. $ScriptDir/../../dist/ansi_color.sh
 . $ScriptDir/config.sh
 . $ScriptDir/shared.sh
 

--- a/libraries/vendors/compile-lattice.sh
+++ b/libraries/vendors/compile-lattice.sh
@@ -48,7 +48,7 @@ ScriptDir="$($READLINK -f $ScriptDir)"
 DeviceList="ec ecp ecp2 ecp3 ecp5u lptm lptm2 machxo machxo2 machxo3l sc scm xp xp2"
 
 # source configuration file from GHDL's 'vendors' library directory
-. $ScriptDir/../ansi_color.sh
+. $ScriptDir/../../dist/ansi_color.sh
 . $ScriptDir/config.sh
 . $ScriptDir/shared.sh
 

--- a/libraries/vendors/compile-osvvm.sh
+++ b/libraries/vendors/compile-osvvm.sh
@@ -43,7 +43,7 @@ ScriptDir="$(dirname $0)"
 ScriptDir="$($READLINK -f $ScriptDir)"
 
 # source configuration file from GHDL's 'vendors' library directory
-. $ScriptDir/../ansi_color.sh
+. $ScriptDir/../../dist/ansi_color.sh
 . $ScriptDir/config.sh
 . $ScriptDir/shared.sh
 

--- a/libraries/vendors/compile-uvvm.sh
+++ b/libraries/vendors/compile-uvvm.sh
@@ -44,7 +44,7 @@ ScriptDir="$(dirname $0)"
 ScriptDir="$($READLINK -f $ScriptDir)"
 
 # source configuration file from GHDL's 'vendors' library directory
-. $ScriptDir/../ansi_color.sh
+. $ScriptDir/../../dist/ansi_color.sh
 . $ScriptDir/config.sh
 . $ScriptDir/shared.sh
 

--- a/libraries/vendors/compile-xilinx-ise.sh
+++ b/libraries/vendors/compile-xilinx-ise.sh
@@ -44,7 +44,7 @@ ScriptDir="$(dirname $0)"
 ScriptDir="$($READLINK -f $ScriptDir)"
 
 # source configuration file from GHDL's 'vendors' library directory
-. $ScriptDir/../ansi_color.sh
+. $ScriptDir/../../dist/ansi_color.sh
 . $ScriptDir/config.sh
 . $ScriptDir/shared.sh
 

--- a/libraries/vendors/compile-xilinx-vivado.sh
+++ b/libraries/vendors/compile-xilinx-vivado.sh
@@ -44,7 +44,7 @@ ScriptDir="$(dirname $0)"
 ScriptDir="$($READLINK -f $ScriptDir)"
 
 # source configuration file from GHDL's 'vendors' library directory
-. $ScriptDir/../ansi_color.sh
+. $ScriptDir/../../dist/ansi_color.sh
 . $ScriptDir/config.sh
 . $ScriptDir/shared.sh
 

--- a/libraries/vendors/config.sh
+++ b/libraries/vendors/config.sh
@@ -44,8 +44,8 @@ declare -A InstallationDirectories
 InstallationDirectories[AlteraQuartus]=""     # "/opt/altera/16.0/quartus"
 InstallationDirectories[IntelQuartus]=""      # "/opt/intelFPGA/17.1/quartus"
 InstallationDirectories[LatticeDiamond]=""    # "/usr/local/diamond/3.7_x64"
-InstallationDirectories[OSVVM]=""	   					# "~/git/github/osvvm"
-InstallationDirectories[UVVM]=""	   					# "~/git/github/uvvm_all"
+InstallationDirectories[OSVVM]=""	   					# "~/git/github/OSVVM"
+InstallationDirectories[UVVM]=""	   					# "~/git/github/UVVM"
 InstallationDirectories[XilinxISE]=""	  		  # "/opt/Xilinx/14.7/ISE_DS/ISE"
 InstallationDirectories[XilinxVivado]=""      # "/opt/Xilinx/Vivado/2017.4"
 


### PR DESCRIPTION
I made small quality of life changes to the libraries/vendors. Fixed path to ansi_color.sh, renamed git folders of OSVVM and UVVM in the comments and changed flags for source and output in the README.md so that they are equal as in scripts.