### PR TITLE
VPI: add support for detecting ports and their directions

### DIFF
--- a/src/grt/grt-vpi.adb
+++ b/src/grt/grt-vpi.adb
@@ -345,7 +345,7 @@ package body Grt.Vpi is
       Error : AvhpiErrorT;
    begin
       case aType is
-         when vpiNet =>
+         when vpiPort | vpiNet =>
             Rel := VhpiDecls;
          when vpiModule =>
             if Ref = null then
@@ -485,6 +485,17 @@ package body Grt.Vpi is
             Res := Vpi_Get_Size (Ref);
          when vpiVector =>
             Res := Boolean'Pos (Vpi_Get_Vector (Ref));
+         when vpiDirection =>
+            case Vhpi_Get_Mode (Ref.Ref) is
+               when VhpiInMode =>
+                   Res := vpiInput;
+               when VhpiOutMode =>
+                   Res := vpiOutput;
+               when VhpiInoutMode =>
+                   Res := vpiInout;
+               when others =>
+                   Res := vpiNoDirection;
+            end case;
          when others =>
             dbgPut_Line ("vpi_get: unknown property");
             Res := 0;
@@ -513,8 +524,16 @@ package body Grt.Vpi is
            | VhpiForGenerateK
            | VhpiCompInstStmtK =>
             return vpiModule;
-         when VhpiPortDeclK
-           | VhpiSigDeclK =>
+         when VhpiPortDeclK =>
+            declare
+               Info : Verilog_Wire_Info;
+            begin
+               Get_Verilog_Wire (Res, Info);
+               if Info.Vtype /= Vcd_Bad then
+                  return vpiPort;
+               end if;
+            end;
+         when VhpiSigDeclK =>
             declare
                Info : Verilog_Wire_Info;
             begin
@@ -547,6 +566,9 @@ package body Grt.Vpi is
                                          Ref => Res);
          when vpiNet =>
             return new struct_vpiHandle'(mType => vpiNet,
+                                         Ref => Res);
+         when vpiPort =>
+            return new struct_vpiHandle'(mType => vpiPort,
                                          Ref => Res);
          when vpiParameter =>
             return new struct_vpiHandle'(mType => vpiParameter,
@@ -592,6 +614,8 @@ package body Grt.Vpi is
          when vpiInternalScope
            | vpiModule =>
             Expected_Kind := vpiModule;
+         when vpiPort =>
+            Expected_Kind := vpiPort;
          when vpiNet =>
             Expected_Kind := vpiNet;
          when others =>
@@ -722,7 +746,7 @@ package body Grt.Vpi is
          when vpiRightRange
            | vpiLeftRange =>
             case Ref.mType is
-               when vpiNet =>
+               when vpiPort| vpiNet =>
                   Res := new struct_vpiHandle (aType);
                   Res.Ref := Ref.Ref;
                   return Res;

--- a/src/grt/grt-vpi.adb
+++ b/src/grt/grt-vpi.adb
@@ -488,13 +488,13 @@ package body Grt.Vpi is
          when vpiDirection =>
             case Vhpi_Get_Mode (Ref.Ref) is
                when VhpiInMode =>
-                   Res := vpiInput;
+                  Res := vpiInput;
                when VhpiOutMode =>
-                   Res := vpiOutput;
+                  Res := vpiOutput;
                when VhpiInoutMode =>
-                   Res := vpiInout;
+                  Res := vpiInout;
                when others =>
-                   Res := vpiNoDirection;
+                  Res := vpiNoDirection;
             end case;
          when others =>
             dbgPut_Line ("vpi_get: unknown property");

--- a/src/grt/grt-vpi.adb
+++ b/src/grt/grt-vpi.adb
@@ -627,7 +627,8 @@ package body Grt.Vpi is
          exit when Error /= AvhpiErrorOk;
 
          Kind := Vhpi_Handle_To_Vpi_Prop (Res);
-         if Kind /= vpiUndefined and then Kind = Expected_Kind then
+         if Kind /= vpiUndefined and then (Kind = Expected_Kind or
+           (Kind = vpiPort and Expected_Kind = vpiNet)) then
             return Build_vpiHandle (Res, Kind);
          end if;
       end loop;

--- a/src/grt/grt-vpi.ads
+++ b/src/grt/grt-vpi.ads
@@ -45,13 +45,13 @@ package Grt.Vpi is
    vpiModule:        constant integer := 32;
    vpiNet:           constant integer := 36;
    vpiPort:          constant integer := 44;
+   --
    vpiDirection:     constant integer := 20;
    vpiInput:         constant integer :=  1;
    vpiOutput:        constant integer :=  2;
    vpiInout:         constant integer :=  3;
    vpiMixedIO:       constant integer :=  4;
    vpiNoDirection:   constant integer :=  5;
-   
 
    vpiParameter:     constant integer := 41;
    vpiLeftRange:     constant integer := 79;

--- a/src/grt/grt-vpi.ads
+++ b/src/grt/grt-vpi.ads
@@ -44,6 +44,15 @@ package Grt.Vpi is
    -- object codes, see vpi_user.h
    vpiModule:        constant integer := 32;
    vpiNet:           constant integer := 36;
+   vpiPort:          constant integer := 44;
+   vpiDirection:     constant integer := 20;
+   vpiInput:         constant integer :=  1;
+   vpiOutput:        constant integer :=  2;
+   vpiInout:         constant integer :=  3;
+   vpiMixedIO:       constant integer :=  4;
+   vpiNoDirection:   constant integer :=  5;
+   
+
    vpiParameter:     constant integer := 41;
    vpiLeftRange:     constant integer := 79;
    vpiRightRange:    constant integer := 83;


### PR DESCRIPTION
**Description** 
The changes enable `vpi_get(vpiType, handle_to_port)` to return `vpiPort` if the signal is a port. It also enables `vpi_get(vpiDirection, handle_to_port)` to return correct port directions(`vpiInput`, `vpiOutput`, or `vpiInout`).
The changes does not change behavior for other types of signals.

:rotating_light: Before submitting your PR, please read [contribute](http://ghdl.readthedocs.io/en/latest/contribute.html#fork-modify-and-pull-request) in the [Docs](http://ghdl.readthedocs.io/en/latest/index.html), and review the following checklist:

- [ ] DO indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

**When contributing to the GHDL codebase...**

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
- [ ] CONSIDER adding a unit test if your PR resolves an issue.
- [ ] CONSIDER modifying the docs, at least in the TODO, if your contribution is relevant to any of the content.
- [ ] AVOID breaking the continuous integration build.
- [x] AVOID breaking the testsuite.

**When contributing to the docs...**

- [x] DO make sure that the build is successful. See [ghdl/ghdl#572 (issuecomment-390466024)](https://github.com/ghdl/ghdl/issues/572#issuecomment-390466024).

**Further comments**

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
