### PR TITLE
update .readthedocs.yml to version 2

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,19 @@
-#formats:
-#  - pdf
-requirements_file: doc/requirements.txt
+version: 2
+
+formats: # Use 'all' to include all formats
+  - htmlzip
+  - pdf
+#  - epub
+
 python:
-  version: 3
+  version: 3.7
+  install:
+    - requirements: doc/requirements.txt
+
+build:
+  image: latest
+
+sphinx:
+  builder: html
+  configuration: doc/conf.py
+  fail_on_warning: false


### PR DESCRIPTION
This PR updates `.readthedoc.yml` to version 2. See:

- https://blog.readthedocs.com/configuration-file-v2/
- https://docs.readthedocs.io/en/latest/config-file/v2
  - https://docs.readthedocs.io/en/latest/config-file/v2#migrating-from-v1

