### PR TITLE
add sphinx_rtd_theme to requirements.txt

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,7 +1,7 @@
 #-r ../requirements.txt
 sphinx>=1.5.2
 recommonmark
+sphinx_rtd_theme
 # sphinxcontrib-textstyle>=0.2.1
 # sphinxcontrib-spelling>=2.2.0
 # changelog>=0.3.5
-


### PR DESCRIPTION
At the moment, if the documentation is built outside of RTD, the following error is shown:

``` bash
sphinx_rtd_theme is no longer a hard dependency since version 1.4.0. Please install it manually.(pip install sphinx_rtd_theme)
```

This PR adds the dependency to `requirements.txt`, so that it is automatically installed. For example:

``` bash
$(command -v winpty) docker run --rm -itv /$(pwd)://src -w //src/doc btdi/sphinx:py3-featured sh -c "\
 pip install -r requirements.txt; \
 sphinx-build -T -b html -D language=en . _build/html"
```