### PR TITLE
Fix build for libghdlsynth.so targets with gcc/gnat 8.3

### DIFF
--- a/src/synth/synth-stmts.adb
+++ b/src/synth/synth-stmts.adb
@@ -677,7 +677,6 @@ package body Synth.Stmts is
       Inter_Chain : Iir;
       Assoc_Chain : Iir)
    is
-      use Simul.Annotations;
       Inter : Iir;
       Assoc : Iir;
       Assoc_Inter : Iir;

--- a/src/vhdl/simulate/simul-execution.adb
+++ b/src/vhdl/simulate/simul-execution.adb
@@ -584,7 +584,6 @@ package body Simul.Execution is
 
    procedure Assert_Std_Ulogic_Dc (Loc : Iir)
    is
-      use Grt.Std_Logic_1164;
    begin
       Execute_Failed_Assertion
         ("assertion",

--- a/src/vhdl/simulate/simul-simulation-main.adb
+++ b/src/vhdl/simulate/simul-simulation-main.adb
@@ -34,7 +34,6 @@ with Grt.Main;
 with Simul.Debugger; use Simul.Debugger;
 with Simul.Debugger.AMS;
 with Grt.Errors;
-with Grt.Rtis;
 with Grt.Processes;
 with Grt.Signals;
 with Areapools; use Areapools;
@@ -1033,7 +1032,6 @@ package body Simul.Simulation.Main is
                                  Sig : Iir_Value_Literal_Acc;
                                  Val : Iir_Value_Literal_Acc)
    is
-      use Grt.Rtis;
       use Grt.Signals;
 
       procedure Create_Signal (Val : Iir_Value_Literal_Acc;


### PR DESCRIPTION
**Description** 
When following the instructions at https://github.com/tgingold/ghdlsynth-beta, compilation of the libghdlsynth.so target failed for me because of gnat warnings being treated as errors.
These errors all boiled down to 'use' or 'with' clauses that were considered being 'without effect', therefore this PR removes them.
This happens on a relatively up-to-date system using gcc/gnat 8.3.
