### PR TITLE
grt: optimize wave dump performance

### DIFF
--- a/src/grt/grt-avls.adb
+++ b/src/grt/grt-avls.adb
@@ -33,6 +33,7 @@ package body Grt.Avls is
          return Tree (N).Height;
       end if;
    end Get_Height;
+   pragma Inline (Get_Height);
 
    procedure Check_AVL (Tree : AVL_Tree; N : AVL_Nid)
    is
@@ -45,12 +46,11 @@ package body Grt.Avls is
       end if;
       L := Tree (N).Left;
       R := Tree (N).Right;
-      H := Get_Height (Tree, N);
+      H := Tree (N).Height;
       if L = AVL_Nil and R = AVL_Nil then
-         if Get_Height (Tree, N) /= 1 then
+         if H /= 1 then
             Internal_Error ("check_AVL(1)");
          end if;
-         return;
       elsif L = AVL_Nil then
          Check_AVL (Tree, R);
          if H /= Get_Height (Tree, R) + 1 or H > 2 then
@@ -217,7 +217,7 @@ package body Grt.Avls is
          Internal_Error ("avls.get_node");
       end if;
       Insert (Tree, Cmp, N, AVL_Root, Res);
-      Check_AVL (Tree, AVL_Root);
+      pragma Debug (Check_AVL (Tree, AVL_Root));
    end Get_Node;
 
    function Find_Node (Tree : AVL_Tree;

--- a/src/grt/grt-signals.adb
+++ b/src/grt/grt-signals.adb
@@ -248,6 +248,8 @@ package body Grt.Signals is
                               Nbr_Ports => 0,
                               Ports => null,
 
+                              Dump_Table_Idx => 0,
+
                               S => S);
 
       if Resolv /= null and then Resolv.Resolv_Ptr = System.Null_Address then
@@ -613,6 +615,8 @@ package body Grt.Signals is
 
                                      Nbr_Ports => 0,
                                      Ports => null,
+
+                                     Dump_Table_Idx => 0,
 
                                      S => (Mode_Sig => Mode_End));
 
@@ -3001,7 +3005,12 @@ package body Grt.Signals is
 
       Sig.Event := True;
       Sig.Last_Event := Current_Time;
-      Sig.Flags.RO_Event := True;
+      if not Sig.Flags.RO_Event then
+         Sig.Flags.RO_Event := True;
+         if Sig.Dump_Table_Idx /= 0 then
+            Changed_Sig_Table.Append(Sig);
+         end if;
+      end if;
 
       El := Sig.Event_List;
       while El /= null loop

--- a/src/grt/grt-signals.ads
+++ b/src/grt/grt-signals.ads
@@ -345,6 +345,8 @@ package Grt.Signals is
       Nbr_Ports : Ghdl_Index_Type;
       Ports : Signal_Arr_Ptr;
 
+      Dump_Table_Idx : Dump_Table_Index;
+
       --  Mode of the signal (in, out ...)
       --Mode_Signal : Mode_Signal_Type;
       S : Ghdl_Signal_Data;
@@ -355,6 +357,13 @@ package Grt.Signals is
      (Table_Component_Type => Ghdl_Signal_Ptr,
       Table_Index_Type => Sig_Table_Index,
       Table_Low_Bound => 0,
+      Table_Initial => 128);
+
+   -- Signals with RO_Event set. Cleared in Grt.Wave.Wave_Cycle.
+   package Changed_Sig_Table is new Grt.Table
+     (Table_Component_Type => Ghdl_Signal_Ptr,
+      Table_Index_Type => Natural,
+      Table_Low_Bound => 1,
       Table_Initial => 128);
 
    --  Read the value pointed by VALUE_PTR.  It cannot be simply deferred as

--- a/src/grt/grt-types.ads
+++ b/src/grt/grt-types.ads
@@ -175,6 +175,9 @@ package Grt.Types is
       First, Last : Sig_Table_Index;
    end record;
 
+   --  Signal index in Waves.Dump_Table.
+   type Dump_Table_Index is new Natural;
+
    --  Simple values, used for signals.
    type Mode_Type is
      (Mode_B1, Mode_E8, Mode_E32, Mode_I32, Mode_I64, Mode_F64);

--- a/src/grt/grt-waves.adb
+++ b/src/grt/grt-waves.adb
@@ -47,6 +47,7 @@ with Grt.Ghw; use Grt.Ghw;
 with Grt.Wave_Opt; use Grt.Wave_Opt;
 with Grt.Wave_Opt.File; use Grt.Wave_Opt.File;
 with Grt.Wave_Opt.Design; use Grt.Wave_Opt.Design;
+with Ada.Containers.Generic_Array_Sort;
 
 pragma Elaborate_All (Grt.Rtis_Utils);
 pragma Elaborate_All (Grt.Table);
@@ -874,6 +875,7 @@ package body Grt.Waves is
       --  If the signal number is 0, then assign a valid signal number.
       if Num = 0 then
          Nbr_Dumped_Signals := Nbr_Dumped_Signals + 1;
+         Sig.Dump_Table_Idx := Dump_Table_Index(Nbr_Dumped_Signals);
          Sig.Alink := To_Ghdl_Signal_Ptr
            (Integer_Address (Nbr_Dumped_Signals));
          Num := Nbr_Dumped_Signals;
@@ -1759,9 +1761,19 @@ package body Grt.Waves is
 
    procedure Wave_Cycle
    is
+      type Arr_Type is array (Dump_Table_Index range <>) of Ghdl_Signal_Ptr;
+
+      function Cmp (Left, Right : Ghdl_Signal_Ptr) return Boolean is
+      begin
+         return Left.Dump_Table_Idx < Right.Dump_Table_Idx;
+      end Cmp;
+
+      procedure Sort is new Ada.Containers.Generic_Array_Sort
+        (Dump_Table_Index, Ghdl_Signal_Ptr, Arr_Type, "<" => Cmp);
+
       Diff : Std_Time;
       Sig : Ghdl_Signal_Ptr;
-      Last : Natural;
+      Last : Dump_Table_Index;
    begin
       if not In_Cyc then
          Wave_Section ("CYC" & NUL);
@@ -1775,15 +1787,20 @@ package body Grt.Waves is
 
       --  Dump signals.
       Last := 0;
-      for I in Dump_Table.First .. Dump_Table.Last loop
-         Sig := Dump_Table.Table (I);
-         if Sig.Flags.RO_Event then
-            Wave_Put_ULEB128 (Ghdl_U32 (I - Last));
-            Last := I;
-            Write_Signal_Value (Sig);
-            Sig.Flags.RO_Event := False;
-         end if;
-      end loop;
+      if Changed_Sig_Table.First <= Changed_Sig_Table.Last then
+         Sort (Arr_Type (Changed_Sig_Table.Table
+                         (Changed_Sig_Table.First .. Changed_Sig_Table.Last)));
+         for I in Changed_Sig_Table.First .. Changed_Sig_Table.Last loop
+            Sig := Changed_Sig_Table.Table(I);
+            if Sig.Flags.RO_Event then
+               Wave_Put_ULEB128 (Ghdl_U32 (Sig.Dump_Table_Idx - Last));
+               Last := Sig.Dump_Table_Idx;
+               Write_Signal_Value (Sig);
+               Sig.Flags.RO_Event := False;
+            end if;
+         end loop;
+         Changed_Sig_Table.Set_Last (0);
+      end if;
       Wave_Put_Byte (0);
    end Wave_Cycle;
 


### PR DESCRIPTION
**Description**
Optimize dumping signals to GHW wave file. Instead of walking though all the signals in each cycle, an array of changed signals is maintained -- a signal is added when it changes (if it is not already present) and the whole array is cleared when the signals are dumped. The array is sorted before dumping to maintain defined order (and keep all the offsets positive).

Another commit disables structure checks in AVL tree code. This also takes a non-negligible amount of time (effectively making an Insert operation O(N) instead of O(log N)).

**Motivation**
While simulating a large design in [our project](https://gitlab.fel.cvut.cz/canbus/ctucanfd_ip_core), this improves performance significantly -- before, ~90% of CPU time was spent in `Wave_Cycle`, now it is negligible. In our case, the ratio of changed signals each cycle is around 0.001% (computed from branch taken/not taken on the condition in `Wave_Cycle`). Profiled by callgrind and perf in GCC-flavoured builds on Linux.

**Notes**
As an alternative, I considered using AVL, but this is much more efficient. What is a possible TODO is changing the hierarchy dumping code in `grt.Waves` to use the new field `Dump_Table_Idx` instead of `Alink`, but I tried to keep the changes minimal.

Changed signals are only added to the table only if they are present in the Dump_Table -- I discovered that `--read-wave-opt` works even with GHW, although the documentation for `--wave` says it does not.


Also, this is my first code in Ada, so please tell me if something should be done differently. 

**Perf outputs**
Before:
<pre>
# Children  Self  Shared Object   Symbol
# ........  ....  .............   .......
  99.44%   0.00%  libc-2.28.so    [.] __libc_start_main
  99.44%   0.00%  tb_sanity-tb    [.] _start
  99.44%   0.00%  tb_sanity-tb    [.] ghdl_main
  99.44%   0.00%  tb_sanity-tb    [.] grt__main__run
  99.44%   0.00%  tb_sanity-tb    [.] main
  99.42%   0.00%  tb_sanity-tb    [.] __ghdl_run_through_longjump
  99.42%   0.00%  tb_sanity-tb    [.] grt__main__run_simul
  99.42%   0.00%  tb_sanity-tb    [.] grt__processes__simulation
  99.42%   0.00%  tb_sanity-tb    [.] grt__processes__simulation_main_loop
  99.41%   0.09%  tb_sanity-tb    [.] grt__processes__simulation_cycle
<b>  95.14%  94.45%  tb_sanity-tb    [.] grt__waves__wave_cycle</b>
  94.85%   0.00%  tb_sanity-tb    [.] grt__hooks__call_cycle_hooks (inlined)
   2.82%   0.47%  tb_sanity-tb    [.] grt__processes__run_processes
   1.32%   0.14%  tb_sanity-tb    [.] grt__signals__update_signals
   1.06%   0.34%  tb_sanity-tb    [.] grt__signals__set_effective_value
   0.73%   0.73%  tb_sanity-tb    [.] grt__processes__resume_process
</pre>

After:
<pre>
# Children  Self  Shared Object   Symbol
# ........ .....  .............   .......
  58.91%   0.01%  tb_sanity-tb    [.] grt__processes__simulation
  55.38%   4.30%  tb_sanity-tb    [.] grt__processes__simulation_cycle
  35.39%   0.06%  tb_sanity-tb    [.] grt__fcvt__bignum_add2
  35.15%   0.00%  libc-2.28.so    [.] __libc_start_main
  35.15%   0.00%  tb_sanity-tb    [.] __ghdl_snprintf_g
  35.15%   0.00%  tb_sanity-tb    [.] _start
  35.15%   0.00%  tb_sanity-tb    [.] grt_main___elabb
  35.06%   0.11%  tb_sanity-tb    [.] grt__stats__change_counter
  34.98%   0.00%  tb_sanity-tb    [.] grt__fcvt__bignum_to_int
  34.98%   0.00%  tb_sanity-tb    [.] grt_get_times
  29.81%   0.09%  tb_sanity-tb    [.] grt__processes__simulation_init
  27.90%   3.63%  tb_sanity-tb    [.] grt__signals__update_signals
  22.34%   9.32%  tb_sanity-tb    [.] grt__signals__run_propagation
  14.16%  13.65%  tb_sanity-tb    [.] __ghdl_process_wait_add_sensitivity
  13.48%   7.63%  tb_sanity-tb    [.] lib__memory_reg__ARCH__rtl__bit_gen__reg_present_gen__B1__reg_access_proc
   8.53%   4.84%  tb_sanity-tb    [.] ieee__std_logic_1164__rising_edge
   6.54%   6.19%  tb_sanity-tb    [.] lib__control_registers_reg_map__ARCH__rtl__P0
   4.51%   0.01%  tb_sanity-tb    [.] grt__stats__Oadd
   3.77%   3.74%  tb_sanity-tb    [.] ieee__std_logic_1164__to_x01O2
&lt;snip&gt;
   0.01%   0.01%  tb_sanity-tb    [.] grt__waves__wave_put_hierarchy_1
<b>   0.01%   0.00%  tb_sanity-tb    [.] grt__waves__wave_cycle</b>
</pre>
