### PR TITLE
add some version to grt.ver (#800)

### DIFF
--- a/src/grt/grt.ver
+++ b/src/grt/grt.ver
@@ -1,4 +1,4 @@
-{
+ANY {
   global:
 vpi_chk_error;
 vpi_control;


### PR DESCRIPTION
Close #800 and Close #640.

As commented in #800, this PR adds a version (`ANY`) to `grt.ver`, so it is possible to add other visible symbols to the binary generated with `ghdl -e [args] -Wl,-Wl,--version-script=custom.ver`.