### PR TITLE
preserve externally set OPT_FLAGS, ADA_FLAGS and/or LIB_CFLAGS

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -60,9 +60,9 @@ VHDL_LIB_DIR=$(prefix)/$(libdirsuffix)
 
 ifeq "$(enable_checks)" "true"
  # Debug + checks
- OPT_FLAGS=-g
- ADA_FLAGS=-gnata
- LIB_CFLAGS=
+ OPT_FLAGS+=-g
+ ADA_FLAGS+=-gnata
+ LIB_CFLAGS+=
 else
  # Optimize + no checks
  ADA_FLAGS+=-gnatpn


### PR DESCRIPTION
I didn't dive into the details, but it happens that, during a regular build with `OPT_FLAGS="-fPIC" LIB_CFLAGS="-fPIC" ./dist/travis/build.sh -b llvm -p ghdl-llvm-fPIC`, the makefile in `src/grt/Makefile.inc` is executed twice. The first time, `GRT_FLAGS` is `-g`, and the second time `GRT_FLAGS` is `$OPT_FLAGS` (as expected after #670). In order to build binaries that are dynamically loadable (#803), it is required for `GRT_FLAGS` to always contain `-fPIC`.

Currently, externally defined variable `OPT_FLAGS` is not preserved when `"$(enable_checks)" "true"`. This PR changes it, so that it is always preserved. I applied the same change to ` ADA_FLAGS` and `LIB_CFLAGS`, although I didn't find it to be a requirement.