### PR TITLE
Add configure option '--default-pic' to enable '-fPIC' by default

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -80,7 +80,7 @@ OPT_FLAGS+=-fprofile-arcs -ftest-coverage
 endif
 
 GNATFLAGS=-gnaty3befhkmr -gnatwa -gnatf $(OPT_FLAGS) $(ADA_FLAGS)
-GRT_FLAGS=$(OPT_FLAGS)
+GRT_FLAGS=$(OPT_FLAGS) $(PIC_FLAGS)
 
 WARN_CFLAGS=-Wall
 

--- a/configure
+++ b/configure
@@ -6,12 +6,12 @@
 # the terms of the GNU General Public License as published by the Free
 # Software Foundation; either version 2, or (at your option) any later
 # version.
-# 
+#
 # GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 # for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with GHDL; see the file COPYING.  If not, write to the Free
 # Software Foundation, 59 Temple Place - Suite 330, Boston, MA
@@ -45,6 +45,7 @@ enable_werror=true
 enable_checks=true
 enable_openieee=unknown
 enable_python=false
+default_pie=false
 EXEEXT=
 SOEXT=.so
 PIC_FLAGS=-fPIC
@@ -106,6 +107,7 @@ for opt do
 		--disable-openieee)     enable_openieee=false;;
 		--enable-python)        enable_python=true;;
 		--disable-python)       enable_python=false;;
+		--enable-default-pie)   default_pie=true;;
 		--enable-coverage)      build_mode="coverage";;
 		-h|-help|--help)        show_help=yes;;
 		*)
@@ -279,9 +281,7 @@ libghdl_version=`echo $ghdl_version | sed -e 's/[-.]/_/g'`
 # Check if gcc was configured with --enable-default-pie.  In that case -fPIC
 # should be added.
 if gcc -v 2>&1 | grep -q enable-default-pie; then
-	default_pie="yes"
-else
-	default_pie="no"
+	default_pie="true"
 fi
 
 # Create subdirectories

--- a/configure
+++ b/configure
@@ -45,7 +45,7 @@ enable_werror=true
 enable_checks=true
 enable_openieee=unknown
 enable_python=false
-default_pie=false
+default_pic=false
 EXEEXT=
 SOEXT=.so
 PIC_FLAGS=-fPIC
@@ -107,7 +107,7 @@ for opt do
 		--disable-openieee)     enable_openieee=false;;
 		--enable-python)        enable_python=true;;
 		--disable-python)       enable_python=false;;
-		--enable-default-pie)   default_pie=true;;
+		--default-pic)          default_pic=true;;
 		--enable-coverage)      build_mode="coverage";;
 		-h|-help|--help)        show_help=yes;;
 		*)
@@ -281,6 +281,10 @@ libghdl_version=`echo $ghdl_version | sed -e 's/[-.]/_/g'`
 # Check if gcc was configured with --enable-default-pie.  In that case -fPIC
 # should be added.
 if gcc -v 2>&1 | grep -q enable-default-pie; then
+	default_pie="true"
+fi
+
+if [ "x$default_pic" = "xtrue" ]; then
 	default_pie="true"
 fi
 

--- a/dist/travis/build.sh
+++ b/dist/travis/build.sh
@@ -29,9 +29,9 @@ while getopts ":b:p:cg" opt; do
     p) PKG_NAME=$OPTARG;;
     g) ISGPL=true;;
     \?) printf "$ANSI_RED[GHDL - build] Invalid option: -$OPTARG $ANSI_NOCOLOR\n" >&2
-	exit 1 ;;
+        exit 1 ;;
     :)  printf "$ANSI_RED[GHDL - build] Option -$OPTARG requires an argument. $ANSI_NOCOLOR\n" >&2
-	exit 1 ;;
+        exit 1 ;;
   esac
 done
 
@@ -86,45 +86,45 @@ case "$BLD" in
         travis_finish "configure_gcc"
     ;;
     mcode)
-	      config_opts=""
+        CONFIG_OPTS+=""
         CXX=""
     ;;
     llvm)
-	      CXX="clang"
-	      config_opts="--with-llvm-config CXX=$CXX"
+        CXX="clang"
+        CONFIG_OPTS+="--with-llvm-config CXX=$CXX"
     ;;
     llvm-3.5)
-	      CXX="clang++"
-	      config_opts="--with-llvm-config=llvm-config-3.5 CXX=$CXX"
+        CXX="clang++"
+        CONFIG_OPTS+="--with-llvm-config=llvm-config-3.5 CXX=$CXX"
     ;;
     llvm-3.8)
-	      CXX="clang++-3.8"
-	      config_opts="--with-llvm-config=llvm-config-3.8 CXX=$CXX"
+        CXX="clang++-3.8"
+        CONFIG_OPTS+="--with-llvm-config=llvm-config-3.8 CXX=$CXX"
     ;;
     llvm-3.9)
-	      CXX="clang++-3.9"
-	      config_opts="--with-llvm-config=llvm-config-3.9 CXX=$CXX"
+        CXX="clang++-3.9"
+        CONFIG_OPTS+="--with-llvm-config=llvm-config-3.9 CXX=$CXX"
     ;;
     llvm-4.0)
-	      CXX="clang++-4.0"
-	      config_opts="--with-llvm-config=llvm-config-4.0 CXX=$CXX"
+        CXX="clang++-4.0"
+        CONFIG_OPTS+="--with-llvm-config=llvm-config-4.0 CXX=$CXX"
     ;;
     llvm-5.0)
-	      CXX="clang++-5.0"
-	      config_opts="--with-llvm-config=llvm-config-5.0 CXX=$CXX"
+        CXX="clang++-5.0"
+        CONFIG_OPTS+="--with-llvm-config=llvm-config-5.0 CXX=$CXX"
     ;;
     llvm-6.0)
-	      CXX="clang++-6.0"
-	      config_opts="--with-llvm-config=llvm-config-6.0 CXX=$CXX"
+        CXX="clang++-6.0"
+        CONFIG_OPTS+="--with-llvm-config=llvm-config-6.0 CXX=$CXX"
     ;;
     *)
-	      echo "$ANSI_RED[GHDL - build] Unknown build $BLD $ANSI_NOCOLOR"
-	      exit 1;;
+        echo "$ANSI_RED[GHDL - build] Unknown build $BLD $ANSI_NOCOLOR"
+        exit 1;;
 esac
 
 if [ ! "$(echo $BLD | grep gcc)" ]; then
-    echo "../configure --prefix=$prefix $config_opts"
-    ../configure "--prefix=$prefix" $config_opts
+    echo "../configure --prefix=$prefix $CONFIG_OPTS"
+    ../configure "--prefix=$prefix" $CONFIG_OPTS
 fi
 
 travis_finish "configure" -notime

--- a/src/ghdldrv/default_paths.ads.in
+++ b/src/ghdldrv/default_paths.ads.in
@@ -38,5 +38,5 @@ package Default_Paths is
      "@POST_PROCESSOR@";
 
    Shared_Library_Extension : constant String := "@SOEXT@";
-   Default_Pie : constant Boolean := "@default_pie@" = String'("yes");
+   Default_Pie : constant Boolean := "@default_pie@" = String'("true");
 end Default_Paths;


### PR DESCRIPTION
Currently, GHDL can be built as:

``` bash
OPT_FLAGS="-fPIC" \
LIB_CFLAGS="-fPIC" \
./dist/travis/build.sh -b llvm -p ghdl-llvm-fPIC
```

Then, sources must be analyzed with `-fPIC` in order to generate a PIE binary. E.g., in VUnit:

```
ui.set_compile_option("ghdl.flags", ['-fPIC'])
ui.set_sim_option("ghdl.elab_flags", ['-fPIC', '-Wl,-pie'])
```

---

This PR allows to simplify the commands above to:

``` bash
CONFIG_OPTS="--enable-default-pie " \
./dist/travis/build.sh -b llvm -p ghdl-llvm-fPIC
```

and

``` python
ui.set_sim_option("ghdl.elab_flags", ['-Wl,-pie'])
```

I.e., if GHDL is built with `--enable-default-pie`, `-fPIC` is implicitly added (by default) to any `ghdl -a` or `ghdl -e` command.

This PR sets the default of variable `default_pie` in `configure` to `false`. It is enabled automatically if gcc was built with `enable-default-pie`, as it is now. The new feature is that it can be explicitly set through `--enable-default-pie`.

However, this alone is not enough to achieve the desired result. `PIC_FLAGS` must be added to `GRT_FLAGS`, in order to force all the objects in `libghdl.a` to be position independent.

Note that I changed the values of `default_pie` from `no|yes` to `false|true`, for coherency.