### PR TITLE
Install `std.standard` package VHDL source during `make install` phase

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -125,6 +125,10 @@ LIBVHDL_FLAGS_TO_PASS=\
 all: Makefile all.$(backend) all.libghdl.$(enable_python)
 
 install: install.$(backend)
+#       Generate std.standard package VHDL source
+	$(DESTDIR)$(bindir)/ghdl$(EXEEXT) --disp-standard --std=87 > $(DESTDIR)$(VHDL_LIB_DIR)/src/std/standard.v87
+	$(DESTDIR)$(bindir)/ghdl$(EXEEXT) --disp-standard --std=93 > $(DESTDIR)$(VHDL_LIB_DIR)/src/std/standard.v93
+	$(DESTDIR)$(bindir)/ghdl$(EXEEXT) --disp-standard --std=08 > $(DESTDIR)$(VHDL_LIB_DIR)/src/std/standard.v08
 
 check: check.$(backend)
 


### PR DESCRIPTION
**Description**

This PR extends the Makefile's `install` target to install the `std.standard` package VHDL source.
The `std.standard` package VHDL source is generated with `ghdl --disp-standard --std=<87|93|08>` and redirected to `$PREFIX/lib/ghdl/src/std/standard.v<87|93|08>`.

This fixes issue #802.

- [X] DO indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

**When contributing to the GHDL codebase...**

- [X] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [X] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
- [X] CONSIDER adding a unit test if your PR resolves an issue: N/A
- [X] CONSIDER modifying the docs, at least in the TODO, if your contribution is relevant to any of the content: N/A
- [X] AVOID breaking the continuous integration build.
- [X] AVOID breaking the testsuite.

**When contributing to the docs...**

- [ ] DO make sure that the build is successful. See [ghdl/ghdl#572 (issuecomment-390466024)](https://github.com/ghdl/ghdl/issues/572#issuecomment-390466024).

**Further comments**

None

:heart: Thank you!
