### PR TITLE
Add Version_String to bug message

### DIFF
--- a/src/bug.adb
+++ b/src/bug.adb
@@ -71,15 +71,11 @@ package body Bug is
         ("Please report this bug on https://github.com/ghdl/ghdl/issues");
       Put_Line_Err ("GHDL release: " & Ghdl_Ver & ' ' & Ghdl_Release);
       Put_Line_Err ("Compiled with " & Get_Gnat_Version);
+      if Version.Version_String /= null then
+         Put_Line_Err (Version.Version_String.all);
+      end if;
       Put_Line_Err ("Target: " & Standard'Target_Name);
       Put_Line_Err (GNAT.Directory_Operations.Get_Current_Dir);
-      --Put_Line
-      --  ("Program name: " & Command_Name);
-      --Put_Line
-      --  ("Program arguments:");
-      --for I in 1 .. Argument_Count loop
-      --   Put_Line ("  " & Argument (I));
-      --end loop;
       Put_Line_Err ("Command line:");
       Put_Err (Command_Name);
       for I in 1 .. Argument_Count loop

--- a/src/ghdldrv/ghdl_gcc.adb
+++ b/src/ghdldrv/ghdl_gcc.adb
@@ -21,12 +21,13 @@ with Ghdldrv;
 with Ghdlprint;
 with Ghdlvpi;
 with Ghdlxml;
+with Version; use Version;
 
 procedure Ghdl_Gcc is
 begin
    --  Manual elaboration so that the order is known (because it is the order
    --  used to display help).
-   Ghdlmain.Version_String := new String'("GCC back-end code generator");
+   Version.Version_String := new String'("GCC back-end code generator");
    Ghdldrv.Backend := Ghdldrv.Backend_Gcc;
    Ghdldrv.Register_Commands;
    Ghdllocal.Register_Commands;

--- a/src/ghdldrv/ghdl_jit.adb
+++ b/src/ghdldrv/ghdl_jit.adb
@@ -22,12 +22,13 @@ with Ghdlrun;
 with Ghdlvpi;
 with Ghdlxml;
 with Ortho_Jit;
+with Version; use Version;
 
 procedure Ghdl_Jit is
 begin
    --  Manual elaboration so that the order is known (because it is the order
    --  used to display help).
-   Ghdlmain.Version_String :=
+   Version.Version_String :=
      new String'(Ortho_Jit.Get_Jit_Name & " code generator");
    Ghdlrun.Register_Commands;
    Ghdllocal.Register_Commands;

--- a/src/ghdldrv/ghdl_llvm.adb
+++ b/src/ghdldrv/ghdl_llvm.adb
@@ -21,12 +21,13 @@ with Ghdlprint;
 with Ghdldrv;
 with Ghdlvpi;
 with Ghdlxml;
+with Version; use Version;
 
 procedure Ghdl_Llvm is
 begin
    --  Manual elaboration so that the order is known (because it is the order
    --  used to display help).
-   Ghdlmain.Version_String := new String'("llvm code generator");
+   Version.Version_String := new String'("llvm code generator");
    Ghdldrv.Backend := Ghdldrv.Backend_Llvm;
    Ghdldrv.Register_Commands;
    Ghdllocal.Register_Commands;

--- a/src/ghdldrv/ghdl_simul.adb
+++ b/src/ghdldrv/ghdl_simul.adb
@@ -20,14 +20,14 @@ with Ghdllocal;
 with Ghdlprint;
 with Ghdlxml;
 with Ghdlsimul;
-
+with Version; use Version;
 with Ghdlsynth;
 
 procedure Ghdl_Simul is
 begin
    --  Manual elaboration so that the order is known (because it is the order
    --  used to display help).
-   Ghdlmain.Version_String := new String'("interpretation");
+   Version.Version_String := new String'("interpretation");
    Ghdlsimul.Register_Commands;
    Ghdlsynth.Register_Commands;
    Ghdllocal.Register_Commands;

--- a/src/ghdldrv/ghdlcomp.adb
+++ b/src/ghdldrv/ghdlcomp.adb
@@ -30,7 +30,7 @@ with Errorout; use Errorout;
 with Libraries;
 with Vhdl.Std_Package;
 with Files_Map;
-with Version;
+with Version; use Version;
 
 package body Ghdlcomp is
 
@@ -812,8 +812,8 @@ package body Ghdlcomp is
       Put (' ');
       Put (Version.Ghdl_Release);
       Put (" - ");
-      if Version_String /= null then
-         Put (Version_String.all);
+      if Version.Version_String /= null then
+         Put (Version.Version_String.all);
       end if;
       New_Line;
       Put_Line ("# Command used to generate this makefile:");

--- a/src/ghdldrv/ghdldrv.adb
+++ b/src/ghdldrv/ghdldrv.adb
@@ -34,7 +34,7 @@ with System;
 with Ghdlmain; use Ghdlmain;
 with Ghdllocal; use Ghdllocal;
 with Errorout;
-with Version;
+with Version; use Version;
 with Options;
 
 package body Ghdldrv is
@@ -1786,8 +1786,8 @@ package body Ghdldrv is
       Put (' ');
       Put (Version.Ghdl_Release);
       Put (" - ");
-      if Version_String /= null then
-         Put (Version_String.all);
+      if Version.Version_String /= null then
+         Put (Version.Version_String.all);
       end if;
       New_Line;
       Put_Line ("# Command used to generate this makefile:");

--- a/src/ghdldrv/ghdlmain.adb
+++ b/src/ghdldrv/ghdlmain.adb
@@ -19,7 +19,7 @@ with Ada.Command_Line;
 with Ada.Command_Line.Response_File;
 
 with Simple_IO;
-with Version;
+with Version; use Version;
 with Bug;
 with Options;
 with Types; use Types;
@@ -230,9 +230,9 @@ package body Ghdlmain is
       Put (' ');
       Put_Line (Version.Ghdl_Release);
       Put_Line (" Compiled with " & Bug.Get_Gnat_Version);
-      if Version_String /= null then
+      if Version.Version_String /= null then
          Put (" ");
-         Put (Version_String.all);
+         Put (Version.Version_String.all);
       end if;
       New_Line;
       Put_Line ("Written by Tristan Gingold.");

--- a/src/ghdldrv/ghdlmain.ads
+++ b/src/ghdldrv/ghdlmain.ads
@@ -80,12 +80,6 @@ package Ghdlmain is
 
    procedure Main;
 
-   --  Additionnal one-line message displayed by the --version command,
-   --  if defined.
-   --  Used to customize.
-   type String_Cst_Acc is access constant String;
-   Version_String : String_Cst_Acc := null;
-
    --  Registers all commands in this package.
    procedure Register_Commands;
 end Ghdlmain;

--- a/src/ghdldrv/ghdlprint.adb
+++ b/src/ghdldrv/ghdlprint.adb
@@ -32,7 +32,7 @@ with Vhdl.Tokens;
 with Vhdl.Scanner;
 with Vhdl.Parse;
 with Vhdl.Canon;
-with Version;
+with Version; use Version;
 with Vhdl.Xrefs;
 with Vhdl.Sem_Lib; use Vhdl.Sem_Lib;
 with Ghdlmain; use Ghdlmain;

--- a/src/version.in
+++ b/src/version.in
@@ -2,4 +2,10 @@ package Version is
    Ghdl_Ver : constant String := "@VER@";
    Ghdl_Release : constant String :=
       "(tarball) [Dunoon edition]";
+
+   --  Additionnal one-line message displayed by the --version command,
+   --  if defined.
+   --  Used to customize.
+   type String_Cst_Acc is access constant String;
+   Version_String : String_Cst_Acc := null;
 end Version;


### PR DESCRIPTION
As commented in [#757](https://github.com/ghdl/ghdl/issues/757#issuecomment-465747978), this is an attempt at adding `Version_String` (which contains the name of the backend) to the 'Bug occurred' message block. To do so, `Version_String` is defined in package `Version`, instead of `Ghdlmain`.

Regarding the suggestion by @Paebbels, I think it is not straighforward to retrieve the version of the backed from ADA, because the strings are hardcode (e.g. `"llvm code generator"`). I believe it would be neccesary for `configure` to add the info to `version.in`, just as we do for `Ghdl_Ver` and `Ghdl_Release`. @tgingold, what do you think?

> Note: in this PR some commented lines from `bug.adb` are removed, because they seemed to be redundant.