### PR TITLE
travis-ci: pass CONFIG_OPTS to docker containers

### DIFF
--- a/dist/travis/travis-ci.sh
+++ b/dist/travis/travis-ci.sh
@@ -55,7 +55,7 @@ travis_finish "opts"
 
 # Build
 
-RUN="docker run --rm -t -e TRAVIS=$TRAVIS -v $(pwd):/work -w /work"
+RUN="docker run --rm -t -e TRAVIS=$TRAVIS -e CONFIG_OPTS="$CONFIG_OPTS" -v $(pwd):/work -w /work"
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
     bash -c "${scriptdir}/build.sh $BUILD_CMD_OPTS"


### PR DESCRIPTION
Related to #805, this PR allows to pass CONFIG_OPTS to `travis-ci.sh`, which is then passed to docker containers. This will be used in ghdl/docker, so that all the ready-to-use docker images are built with `--default-pic`.