### PR TITLE
fix(dist/travis/build.sh): ensure that CONFIG_OPTS arguments are sepa…

### DIFF
--- a/dist/travis/build.sh
+++ b/dist/travis/build.sh
@@ -86,36 +86,35 @@ case "$BLD" in
         travis_finish "configure_gcc"
     ;;
     mcode)
-        CONFIG_OPTS+=""
         CXX=""
     ;;
     llvm)
         CXX="clang"
-        CONFIG_OPTS+="--with-llvm-config CXX=$CXX"
+        CONFIG_OPTS=" --with-llvm-config CXX=$CXX"
     ;;
     llvm-3.5)
         CXX="clang++"
-        CONFIG_OPTS+="--with-llvm-config=llvm-config-3.5 CXX=$CXX"
+        CONFIG_OPTS+=" --with-llvm-config=llvm-config-3.5 CXX=$CXX"
     ;;
     llvm-3.8)
         CXX="clang++-3.8"
-        CONFIG_OPTS+="--with-llvm-config=llvm-config-3.8 CXX=$CXX"
+        CONFIG_OPTS+=" --with-llvm-config=llvm-config-3.8 CXX=$CXX"
     ;;
     llvm-3.9)
         CXX="clang++-3.9"
-        CONFIG_OPTS+="--with-llvm-config=llvm-config-3.9 CXX=$CXX"
+        CONFIG_OPTS+=" --with-llvm-config=llvm-config-3.9 CXX=$CXX"
     ;;
     llvm-4.0)
         CXX="clang++-4.0"
-        CONFIG_OPTS+="--with-llvm-config=llvm-config-4.0 CXX=$CXX"
+        CONFIG_OPTS+=" --with-llvm-config=llvm-config-4.0 CXX=$CXX"
     ;;
     llvm-5.0)
         CXX="clang++-5.0"
-        CONFIG_OPTS+="--with-llvm-config=llvm-config-5.0 CXX=$CXX"
+        CONFIG_OPTS+=" --with-llvm-config=llvm-config-5.0 CXX=$CXX"
     ;;
     llvm-6.0)
         CXX="clang++-6.0"
-        CONFIG_OPTS+="--with-llvm-config=llvm-config-6.0 CXX=$CXX"
+        CONFIG_OPTS+=" --with-llvm-config=llvm-config-6.0 CXX=$CXX"
     ;;
     *)
         echo "$ANSI_RED[GHDL - build] Unknown build $BLD $ANSI_NOCOLOR"


### PR DESCRIPTION
This is to ensure that additional CONFIG_OPTS passed as in #835 are properly separated. See: https://travis-ci.com/ghdl/docker/jobs/207173211