### PR TITLE
Fixes in Vendor Compilation Scripts

### DIFF
--- a/dist/ansi_color.sh
+++ b/dist/ansi_color.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 enable_color() {
   ENABLECOLOR='-c '
   ANSI_RED="\033[31m"

--- a/libraries/vendors/compile-altera.sh
+++ b/libraries/vendors/compile-altera.sh
@@ -44,7 +44,7 @@ ScriptDir="$(dirname $0)"
 ScriptDir="$($READLINK -f $ScriptDir)"
 
 # source configuration file from GHDL's 'vendors' library directory
-. $ScriptDir/../ansi_color.sh
+. $ScriptDir/../../dist/ansi_color.sh
 . $ScriptDir/config.sh
 . $ScriptDir/shared.sh
 

--- a/libraries/vendors/compile-intel.sh
+++ b/libraries/vendors/compile-intel.sh
@@ -44,7 +44,7 @@ ScriptDir="$(dirname $0)"
 ScriptDir="$($READLINK -f $ScriptDir)"
 
 # source configuration file from GHDL's 'vendors' library directory
-. $ScriptDir/../ansi_color.sh
+. $ScriptDir/../../dist/ansi_color.sh
 . $ScriptDir/config.sh
 . $ScriptDir/shared.sh
 

--- a/libraries/vendors/compile-lattice.sh
+++ b/libraries/vendors/compile-lattice.sh
@@ -48,7 +48,7 @@ ScriptDir="$($READLINK -f $ScriptDir)"
 DeviceList="ec ecp ecp2 ecp3 ecp5u lptm lptm2 machxo machxo2 machxo3l sc scm xp xp2"
 
 # source configuration file from GHDL's 'vendors' library directory
-. $ScriptDir/../ansi_color.sh
+. $ScriptDir/../../dist/ansi_color.sh
 . $ScriptDir/config.sh
 . $ScriptDir/shared.sh
 

--- a/libraries/vendors/compile-osvvm.sh
+++ b/libraries/vendors/compile-osvvm.sh
@@ -43,7 +43,7 @@ ScriptDir="$(dirname $0)"
 ScriptDir="$($READLINK -f $ScriptDir)"
 
 # source configuration file from GHDL's 'vendors' library directory
-. $ScriptDir/../ansi_color.sh
+. $ScriptDir/../../dist/ansi_color.sh
 . $ScriptDir/config.sh
 . $ScriptDir/shared.sh
 

--- a/libraries/vendors/compile-uvvm.sh
+++ b/libraries/vendors/compile-uvvm.sh
@@ -48,8 +48,8 @@ ScriptDir="$(dirname $0)"
 ScriptDir="$($READLINK -f $ScriptDir)"
 
 # source configuration file from GHDL's 'vendors' library directory
-if [ -f $ScriptDir/../ansi_color.sh ]; then
-		. $ScriptDir/../ansi_color.sh
+if [ -f $ScriptDir/../../dist/ansi_color.sh ]; then
+		. $ScriptDir/../../dist/ansi_color.sh
 fi
 . $ScriptDir/config.sh
 . $ScriptDir/shared.sh

--- a/libraries/vendors/compile-xilinx-ise.sh
+++ b/libraries/vendors/compile-xilinx-ise.sh
@@ -44,7 +44,7 @@ ScriptDir="$(dirname $0)"
 ScriptDir="$($READLINK -f $ScriptDir)"
 
 # source configuration file from GHDL's 'vendors' library directory
-. $ScriptDir/../ansi_color.sh
+. $ScriptDir/../../dist/ansi_color.sh
 . $ScriptDir/config.sh
 . $ScriptDir/shared.sh
 

--- a/libraries/vendors/compile-xilinx-vivado.sh
+++ b/libraries/vendors/compile-xilinx-vivado.sh
@@ -44,7 +44,7 @@ ScriptDir="$(dirname $0)"
 ScriptDir="$($READLINK -f $ScriptDir)"
 
 # source configuration file from GHDL's 'vendors' library directory
-. $ScriptDir/../ansi_color.sh
+. $ScriptDir/../../dist/ansi_color.sh
 . $ScriptDir/config.sh
 . $ScriptDir/shared.sh
 

--- a/libraries/vendors/config.sh
+++ b/libraries/vendors/config.sh
@@ -1,4 +1,3 @@
-#! /bin/bash
 # EMACS settings: -*-	tab-width: 2; indent-tabs-mode: t -*-
 # vim: tabstop=2:shiftwidth=2:noexpandtab
 # kate: tab-width 2; replace-tabs off; indent-width 2;


### PR DESCRIPTION
**Description**
This patch fixes a path issue in the `vendors/compile_*` scripts, which failed as they were unable to source the `ansi_color.sh` include that was apparently relocated to the `dist/` directory. Additionally, the meaningless shebangs of the sole shell includes `ansi_color.sh` and `config.sh` were removed.