### PR TITLE
fix(makefile): conf.py does not exist anymore

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -402,7 +402,6 @@ uninstall.libghdl:
 libghdl-py.tgz:
 	[ -d pythonb ] || $(MKDIR) pythonb
 	$(CP) -r $(srcdir)/python/libghdl $(srcdir)/python/setup.py pythonb
-	$(CP) config.py pythonb/libghdl/
 	tar -zcvf $@ -C pythonb .
 
 ################ ghdlsynth library ######################################


### PR DESCRIPTION
See https://travis-ci.com/ghdl/docker/jobs/210330285

Maybe the rule itself can be removed, since generating a tarball for libghdl is not required now.