### PR TITLE
Add synth testsuite to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,11 @@ script: ./dist/travis/travis-ci.sh
 # above) is executed in parallel in stage 'test'.
 env:
   matrix:
-    - IMAGE=stretch+mcode
-    - IMAGE=stretch+mcode
+    - IMAGE=buster+mcode
+    - IMAGE=buster+mcode
       EXTRA=gpl
     - IMAGE=buster+mcode
       EXTRA=synth
-#    - IMAGE=buster+mcode+gpl
     - IMAGE=ubuntu14+mcode
     - IMAGE=ubuntu14+llvm-3.8
 #    - IMAGE=ubuntu18+mcode

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ env:
     - IMAGE=ubuntu14+llvm-3.8
 #    - IMAGE=ubuntu18+mcode
 #    - IMAGE=ubuntu18+llvm-5.0
-    - IMAGE=fedora28+mcode
-    - IMAGE=fedora28+llvm
+    - IMAGE=fedora29+mcode
+    - IMAGE=fedora29+llvm
 
 deploy:
   - &deploy-docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
     # Optionally, more macos jobs can be added. See list of available versions at https://docs.travis-ci.com/user/reference/osx/#macos-version
 #   - <<: *osx
 #     osx_image: xcode10
-    - env: IMAGE=""
+    - env: IMAGE="man"
       script: ./dist/travis/man.sh
       deploy:
         - <<: *deploy-docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,17 @@ dist: xenial
 services: docker
 language: minimal
 install: skip
-script: "./dist/travis/travis-ci.sh"
+script: ./dist/travis/travis-ci.sh
 
 # For each linux build, a different job/instance (with the constraints
 # above) is executed in parallel in stage 'test'.
 env:
   matrix:
     - IMAGE=stretch+mcode
-    - IMAGE=stretch+mcode+gpl
-#    - IMAGE=buster+mcode
+    - IMAGE=stretch+mcode
+      EXTRA=gpl
+    - IMAGE=buster+mcode
+      EXTRA=synth
 #    - IMAGE=buster+mcode+gpl
     - IMAGE=ubuntu14+mcode
     - IMAGE=ubuntu14+llvm-3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,8 @@ env:
       EXTRA=synth
     - IMAGE=ubuntu14+mcode
     - IMAGE=ubuntu14+llvm-3.8
-#    - IMAGE=ubuntu18+mcode
-#    - IMAGE=ubuntu18+llvm-5.0
-    - IMAGE=fedora29+mcode
-    - IMAGE=fedora29+llvm
+    - IMAGE=fedora30+mcode
+    - IMAGE=fedora30+llvm
 
 deploy:
   - &deploy-docker

--- a/dist/travis/build.sh
+++ b/dist/travis/build.sh
@@ -18,16 +18,18 @@ for arg in "$@"; do
       "--build"|"-build")   set -- "$@" "-b";;
       "--pkg"|"-pkg")       set -- "$@" "-p";;
       "--gpl"|"-gpl")       set -- "$@" "-g";;
+      "--synth"|"-synth")   set -- "$@" "-s";;
     *) set -- "$@" "$arg"
   esac
 done
 # Parse args
-while getopts ":b:p:cg" opt; do
+while getopts ":b:p:cgs" opt; do
   case $opt in
     c) enable_color;;
     b) BLD=$OPTARG ;;
     p) PKG_NAME=$OPTARG;;
     g) ISGPL=true;;
+    s) ISSYNTH=true;;
     \?) printf "$ANSI_RED[GHDL - build] Invalid option: -$OPTARG $ANSI_NOCOLOR\n" >&2
         exit 1 ;;
     :)  printf "$ANSI_RED[GHDL - build] Option -$OPTARG requires an argument. $ANSI_NOCOLOR\n" >&2
@@ -65,6 +67,10 @@ export prefix="$CDIR/install-$BLD"
 mkdir "$prefix"
 mkdir "build-$BLD"
 cd "build-$BLD"
+
+if [ "x$ISSYNTH" = "xtrue" ]; then
+  CONFIG_OPTS+=" --enable-synth"
+fi
 
 case "$BLD" in
     gcc*)

--- a/dist/travis/travis-ci.sh
+++ b/dist/travis/travis-ci.sh
@@ -49,7 +49,7 @@ fi
 
 # Get build command options
 travis_start "opts" "$ANSI_YELLOW[GHDL - build] Get build command options $ANSI_NOCOLOR"
-buildCmdOpts
+buildCmdOpts "$EXTRA"
 echo "build cmd: $BUILD_CMD_OPTS"
 travis_finish "opts"
 
@@ -71,16 +71,6 @@ else
     cp version.tmp src/version.in
     travis_finish "version"
 
-    GHDL_IMAGE_TAG=`echo $IMAGE | sed -e 's/+/-/g'`
-
-    case $IMAGE in
-      *gcc*)
-        BUILD_IMAGE_TAG="$(echo $IMAGE | sed 's#\(.*\)+gcc.*#\1-gcc#g')"
-      ;;
-      *)
-        BUILD_IMAGE_TAG="$GHDL_IMAGE_TAG"
-      ;;
-    esac
 
     travis_start "pull" "$ANSI_YELLOW[GHDL - build] Docker pull ghdl/build:$BUILD_IMAGE_TAG $ANSI_NOCOLOR"
     docker pull ghdl/build:$BUILD_IMAGE_TAG


### PR DESCRIPTION
In this PR:

- Option `--synth` is added to `dist/travis/build.sh` and `dist/travis/test.sh`.
- A Debian Buster mcode job is added, where GHDL is buit with `--enable-synth` and the synth testsuite is executed.
- Fedora jobs are updated from 28 to 30.
- Debian jobs are updated from Stretch to Buster.