### PR TITLE
doc: update list of supported LLVM versions

### DIFF
--- a/doc/building/llvm/GNULinux-GNAT.rst
+++ b/doc/building/llvm/GNULinux-GNAT.rst
@@ -3,7 +3,7 @@
 LLVM Backend on GNU/Linux with GCC/GNAT
 #######################################
 
-.. HINT:: You need to install LLVM (usually depends on ``libedit``, see :ghdlsharp:`29`). The supported versions are 3.5 til 5.0, but debugging is only supported with LLVM 3.5.
+.. HINT:: You need to install LLVM (usually depends on ``libedit``, see :ghdlsharp:`29`). Debugging is only supported with LLVM 3.5.
 
 * First configure GHDL with the proper arg ``./configure --with-llvm-config``. If ``llvm-config`` is not in your path, you can specify it: ``./configure --with-llvm-config=LLVM_INSTALL/bin/llvm-config``.
 

--- a/doc/building/llvm/index.rst
+++ b/doc/building/llvm/index.rst
@@ -7,13 +7,7 @@ LLVM Backend
 
 * GCC (Gnu Compiler Collection)
 * GNAT (Ada compiler for GCC)
-* LLVM (Low-Level-Virtual Machine) and CLANG (Compiler front-end for LLVM)
-
-  * 3.5
-  * 3.8
-  * 3.9
-  * 4.0
-  * 5.0
+* LLVM (Low-Level-Virtual Machine) and CLANG (Compiler front-end for LLVM): 3.5, 3.8, 3.9, 4.0, 5.0, 6.0, 7.0 or 8.0
 
 .. rubric:: Supported platforms
 


### PR DESCRIPTION
As commented in [#859](https://github.com/ghdl/ghdl/issues/859#issuecomment-509022726).

@tgingold, is it worth opening an issue to track debug support on versions >3.5?