### PR TITLE
ci: enable libghdl on macOS, add LLVM job

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -161,6 +161,14 @@ jobs:
     - name: '🧰 Checkout'
       uses: actions/checkout@v2
 
+    - name: '💾 Cache gnat'
+      id: cache-gnat
+      uses: actions/cache@v2
+      with:
+        path: gnat
+        key: ${{ runner.os }}-gnat
+
+    # Although we cache this, we let the script run to check if the cache is valid (without conditions)
     - name: '⚙️ Dependencies (brew)'
       run: ./scripts/macosx/install-ada.sh
 

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -154,8 +154,16 @@ jobs:
 #
 
   osx:
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        include: [
+          { backend: mcode },
+          { backend: brew-llvm }
+        ]
     runs-on: macOS-latest
-    name: '🍎 macOS · mcode'
+    name: '🍎 macOS · ${{ matrix.backend }}'
     steps:
 
     - name: '🧰 Checkout'
@@ -176,15 +184,15 @@ jobs:
       run: |
         PATH=$PWD/gnat/bin:$PATH
         ./scripts/ci-run.sh -c
-        mv ghdl-*.tgz ghdl-osx-mcode.tgz
+        mv ghdl-*.tgz ghdl-osx-${{ matrix.backend }}.tgz
       env:
-        TASK: macosx+mcode
+        TASK: macosx+${{ matrix.backend }}
         GITHUB_OS: ${{ runner.os }}
 
     - name: '📤 Upload artifact: package'
       uses: actions/upload-artifact@v2
       with:
-        path: ghdl-osx-mcode.tgz
+        path: ghdl-osx-${{ matrix.backend }}.tgz
 
 #
 # Windows Build

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -139,7 +139,7 @@ jobs:
     - name: '🧰 Checkout'
       uses: actions/checkout@v2
 
-    - name: Build and test GHDL in containers
+    - name: '🛳️ Build and test GHDL in containers'
       run: |
         TASK=ubuntu${{ matrix.os }}+${{ matrix.backend }} ./scripts/ci-run.sh -c
         mv ghdl-*-ubuntu${{ matrix.os }}-*.tgz ghdl-gha-ubuntu-${{ matrix.os }}.04-$(echo ${{ matrix.backend }} | sed 's#-.*##g').tgz
@@ -179,7 +179,7 @@ jobs:
     - name: '⚙️ Dependencies (brew)'
       run: ./scripts/macosx/install-ada.sh
 
-    - name: Build and test GHDL
+    - name: '🚧 Build and test GHDL'
       run: |
         PATH=$PWD/gnat/bin:$PATH
         ./scripts/ci-run.sh -c
@@ -227,7 +227,8 @@ jobs:
           git
           mingw-w64-${{ matrix.arch }}-toolchain
 
-    - run: git config --global core.autocrlf input
+    - name: '⚙️ git config'
+      run: git config --global core.autocrlf input
       shell: bash
 
     - name: '🧰 Checkout'
@@ -236,7 +237,7 @@ jobs:
         # The command 'git describe' (used for version) needs the history.
         fetch-depth: 0
 
-    - name: Build package
+    - name: '🚧 Build package'
       run: |
         cd scripts/msys2-${{ matrix.pkg }}
         makepkg-mingw --noconfirm --noprogressbar -sCLf
@@ -293,7 +294,8 @@ jobs:
           mingw-w64-${{ matrix.sys.arch }}-gcc
           mingw-w64-${{ matrix.sys.arch }}-python-pip
 
-    - run: git config --global core.autocrlf input
+    - name: '⚙️ git config'
+      run: git config --global core.autocrlf input
       shell: bash
 
     - name: '🧰 Checkout'
@@ -302,12 +304,12 @@ jobs:
     - name: '📥 Download artifact: package'
       uses: actions/download-artifact@v2
 
-    - name: Install package and Python dependencies
+    - name: '🚧 Install package and Python dependencies'
       run: |
         pacman --noconfirm -U artifact/mingw-w64-${{ matrix.sys.arch }}-ghdl-${{ matrix.sys.pkg }}-*.zst
         pip3 install -r testsuite/requirements.txt
 
-    - name: Test package
+    - name: '🚧 Test package'
       run: GHDL=ghdl ./testsuite/testsuite.sh ${{ matrix.suite }}
 
 #
@@ -370,7 +372,8 @@ jobs:
         update: true
         install: mingw-w64-x86_64-python-pip
 
-    - run: git config --global core.autocrlf input
+    - name: '⚙️ git config'
+      run: git config --global core.autocrlf input
       shell: bash
 
     - name: '🧰 Checkout'
@@ -379,14 +382,13 @@ jobs:
     - name: '📥 Download artifact: package'
       uses: actions/download-artifact@v2
 
-    - name: Install package and Python dependencies
+    - name: '🚧 Install package and Python dependencies'
       run: |
         pacman --noconfirm -U artifact/mingw-w64-x86_64-ghdl-llvm-*.zst
         pip3 install -r testsuite/requirements.txt
 
-    - name: Run tests to generate coverage report
-      run: |
-        PYTHONPATH=$(pwd) python3 -m pytest -rA --cov=.. --cov-config=.coveragerc testsuite/pyunit
+    - name: '🚧 Run tests to generate coverage report'
+      run: PYTHONPATH=$(pwd) python3 -m pytest -rA --cov=.. --cov-config=.coveragerc testsuite/pyunit
 
     - name: Generate XML coverage report
       if: always()

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -158,10 +158,9 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        include: [
-          { backend: mcode },
-          { backend: brew-llvm }
-        ]
+        backend:
+        - mcode
+        - llvm
     runs-on: macOS-latest
     name: '🍎 macOS · ${{ matrix.backend }}'
     steps:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -426,9 +426,6 @@ jobs:
 #---
 
 # TODO:
-# - Cache
-#  - 'gnat' directory in macOS job
-#
 # - Re-package a MINGW/MSYS2 package to provide a 'standalone' tarball/zipfile.
 #  - https://github.com/ghdl/ghdl/issues/318#issuecomment-286246287
 #

--- a/scripts/ci-run.sh
+++ b/scripts/ci-run.sh
@@ -294,11 +294,6 @@ build () {
           CXX="clang++-$llvmver"
           CONFIG_OPTS+=" --with-llvm-config=llvm-config-$llvmver CXX=$CXX"
       ;;
-      brew-llvm)
-          llvmprefix=`brew --prefix llvm`
-          CXX="clang++"
-          CONFIG_OPTS+=" --with-llvm-config=$llvmprefix/bin/llvm-config CXX=$CXX"
-      ;;
       *)
           printf "$ANSI_RED[GHDL - build] Unknown build $BACK $ANSI_NOCOLOR\n"
           exit 1;;
@@ -401,7 +396,8 @@ ci_run () {
 
   RUN="docker run --rm -t -e CI -e TRAVIS -v `pwd`:/work -w /work"
   if [ "x$IS_MACOS" = "xtrue" ]; then
-      export CPATH="$CPATH:`xcrun --show-sdk-path`/usr/include"
+      export CPATH="$CPATH:$(xcrun --show-sdk-path)/usr/include"
+      export PATH="$PATH:$(brew --prefix llvm)/bin"
       CC=clang bash -c "${scriptdir}/ci-run.sh $BUILD_CMD_OPTS build"
   else
       # Assume linux
@@ -429,8 +425,8 @@ ci_run () {
 
   if [ "x$IS_MACOS" = "xtrue" ]; then
       CC=clang \
-      prefix="`pwd`/install-$BACK/usr/local" \
-      ./testsuite/testsuite.sh sanity gna vests vpi
+      prefix="$(pwd)/install-$(echo "$TASK" | cut -d+ -f2)/usr/local" \
+      ./testsuite/testsuite.sh sanity gna vests vpi synth
   else
       # Build ghdl/ghdl:$GHDL_IMAGE_TAG image
       build_img_ghdl

--- a/scripts/ci-run.sh
+++ b/scripts/ci-run.sh
@@ -397,9 +397,7 @@ ci_run () {
   RUN="docker run --rm -t -e CI -e TRAVIS -v `pwd`:/work -w /work"
   if [ "x$IS_MACOS" = "xtrue" ]; then
       export CPATH="$CPATH:`xcrun --show-sdk-path`/usr/include"
-      CC=clang \
-      CONFIG_OPTS="--disable-libghdl" \
-      bash -c "${scriptdir}/ci-run.sh $BUILD_CMD_OPTS build"
+      CC=clang bash -c "${scriptdir}/ci-run.sh $BUILD_CMD_OPTS build"
   else
       # Assume linux
 

--- a/scripts/ci-run.sh
+++ b/scripts/ci-run.sh
@@ -294,6 +294,11 @@ build () {
           CXX="clang++-$llvmver"
           CONFIG_OPTS+=" --with-llvm-config=llvm-config-$llvmver CXX=$CXX"
       ;;
+      brew-llvm)
+          llvmprefix=`brew --prefix llvm`
+          CXX="clang++"
+          CONFIG_OPTS+=" --with-llvm-config=$llvmprefix/bin/llvm-config CXX=$CXX"
+      ;;
       *)
           printf "$ANSI_RED[GHDL - build] Unknown build $BACK $ANSI_NOCOLOR\n"
           exit 1;;
@@ -424,7 +429,7 @@ ci_run () {
 
   if [ "x$IS_MACOS" = "xtrue" ]; then
       CC=clang \
-      prefix="`cd ./install-mcode; pwd`/usr/local" \
+      prefix="`pwd`/install-$BACK/usr/local" \
       ./testsuite/testsuite.sh sanity gna vests vpi
   else
       # Build ghdl/ghdl:$GHDL_IMAGE_TAG image

--- a/scripts/ci-run.sh
+++ b/scripts/ci-run.sh
@@ -424,9 +424,10 @@ ci_run () {
   # Test
 
   if [ "x$IS_MACOS" = "xtrue" ]; then
+      pip3 install -r testsuite/requirements.txt
       CC=clang \
       prefix="$(pwd)/install-$(echo "$TASK" | cut -d+ -f2)/usr/local" \
-      ./testsuite/testsuite.sh sanity gna vests vpi synth
+      ./testsuite/testsuite.sh
   else
       # Build ghdl/ghdl:$GHDL_IMAGE_TAG image
       build_img_ghdl

--- a/scripts/macosx/install-ada.sh
+++ b/scripts/macosx/install-ada.sh
@@ -24,36 +24,4 @@ mkdir -p gnat
 chmod +x $installer
 ./$installer PREFIX=gnat
 
-# Cleanup: remove components not needed
-rm -rf gnat/share/{themes,icons} \
-       gnat/share/{man,info,doc,examples,gpr,gprconfig,gnatcoll} \
-       gnat/share/gps \
-       gnat/share/gdb* gnat/share/glib* gnat/share/gcc-*/python \
-       gnat/etc/fonts gnat/etc/gtk* \
-       gnat/include/{asis,aunit,gnat_util,gnatcoll,gpr,xmlada} \
-       gnat/include/aws* gnat/include/pycairo gnat/include/python* \
-       gnat/include/pygobject* gnat/include/gdb \
-       gnat/include/c++ \
-       gnat/lib/{aunit,gnat,gnat_util,gnatcoll,gpr,gps,xmlada} \
-       gnat/lib/aws* gnat/lib/girepository* gnat/lib/gtk* \
-       gnat/lib/python* \
-       gnat/lib/gcc/x86*/*/{gcc-include,plugin,install-tools} \
-       gnat/lib/gcc/x86*/*/rts-ios-simulator \
-       gnat/lib/gcc/x86*/*/rts-native/adalib/lib*.dSYM \
-       gnat/lib/gcc/x86*/*/rts-native/adalib/*.dylib \
-       gnat/lib/gcc/x86*/*/rts-native/adalib/lib*_pic.a \
-       gnat/libexec/gprbuild \
-       gnat/libexec/gcc/x86*/*/{plugin,install-tools} \
-       gnat/bin/aws* gnat/bin/gps* gnat/bin/gcov* \
-       gnat/bin/gnat2* gnat/bin/xml2* gnat/bin/gnatcoll* \
-       gnat/bin/gnat{doc,metric,pp,stub,prep,test,check,elim,inspect,find,kr} \
-       gnat/bin/gnat{xref,name} \
-       gnat/bin/gpr* gnat/bin/templates* gnat/bin/web* gnat/bin/wsdl* \
-       gnat/bin/{gdb,cpp,c++,g++} gnat/bin/x86_64-* \
-       gnat/lib/libcc1* gnat/lib/libgomp* gnat/lib/libitm* gnat/lib/libasan* \
-       gnat/lib/libatomic* gnat/lib/libobjc* gnat/lib/libssp* \
-       gnat/lib/libstdc++* gnat/lib/libubsan* gnat/lib/libsupc++* \
-       gnat/lib/libxmlada* \
-       gnat/libexec/gcc/x86*/*/{cc1obj,cc1plus,lto1}
-
 echo "2019" > gnat/etc/install_ok

--- a/scripts/macosx/install-ada.sh
+++ b/scripts/macosx/install-ada.sh
@@ -15,7 +15,7 @@ if [ -d gnat ]; then
 fi
 
 # Download from community.adacore.com and extract
-wget -O dmgfile https://community.download.adacore.com/v1/5a7801fc686e86de838cfaf7071170152d81254d?filename=gnat-community-2019-20190517-x86_64-darwin-bin.dmg
+wget -q --show-progress --progress=bar:force:noscroll -O dmgfile https://community.download.adacore.com/v1/5a7801fc686e86de838cfaf7071170152d81254d?filename=gnat-community-2019-20190517-x86_64-darwin-bin.dmg
 7z x dmgfile
 installer="gnat-community-2019-20190517-x86_64-darwin-bin/gnat-community-2019-20190517-x86_64-darwin-bin.app/Contents/MacOS/gnat-community-2019-20190517-x86_64-darwin-bin"
 


### PR DESCRIPTION
As commented in [#848](https://github.com/ghdl/ghdl/issues/848#issuecomment-510205566), this PR removes `--disable-libghdl` from the Mac OS job in Travis.