### PR TITLE
Add port width utility function for yosys

### DIFF
--- a/src/synth/ghdlsynth.h
+++ b/src/synth/ghdlsynth.h
@@ -112,6 +112,8 @@ namespace GhdlSynth {
   GHDLSYNTH_ADA_WRAPPER_DW(get_id, Module_Id, Instance);
   GHDLSYNTH_ADA_WRAPPER_WWD(get_input_name, Sname, Module, Port_Idx);
   GHDLSYNTH_ADA_WRAPPER_WWD(get_output_name, Sname, Module, Port_Idx);
+  GHDLSYNTH_ADA_WRAPPER_DWD(get_input_width, Width, Module, Port_Idx);
+  GHDLSYNTH_ADA_WRAPPER_DWD(get_output_width, Width, Module, Port_Idx);
   GHDLSYNTH_ADA_WRAPPER_BW(has_one_connection, Net);
 
   GHDLSYNTH_ADA_WRAPPER_WWD(get_input_net, Net, Instance, Port_Idx);

--- a/src/synth/ghdlsynth_gates.h
+++ b/src/synth/ghdlsynth_gates.h
@@ -64,4 +64,7 @@ enum Module_Id {
    Id_Const_SB128 = 69,
    Id_Const_UL32 = 70,
    Id_Const_SL32 = 71,
+   Id_Const_Z = 72,
+   Id_Const_0 = 73,
+   Id_Concatn = 80,
 };

--- a/src/synth/netlists-utils.adb
+++ b/src/synth/netlists-utils.adb
@@ -76,6 +76,16 @@ package body Netlists.Utils is
       return Get_Output_Desc (M, I).Name;
    end Get_Output_Name;
 
+   function Get_Input_Width (M : Module; I : Port_Idx) return Width is
+   begin
+      return Get_Input_Desc (M, I).W;
+   end Get_Input_Width;
+
+   function Get_Output_Width (M : Module; I : Port_Idx) return Width is
+   begin
+      return Get_Output_Desc (M, I).W;
+   end Get_Output_Width;
+
    function Get_Input_Net (Inst : Instance; Idx : Port_Idx) return Net is
    begin
       return Get_Driver (Get_Input (Inst, Idx));

--- a/src/synth/netlists-utils.ads
+++ b/src/synth/netlists-utils.ads
@@ -31,6 +31,9 @@ package Netlists.Utils is
    function Get_Input_Name (M : Module; I : Port_Idx) return Sname;
    function Get_Output_Name (M : Module; I : Port_Idx) return Sname;
 
+   function Get_Input_Width (M : Module; I : Port_Idx) return Width;
+   function Get_Output_Width (M : Module; I : Port_Idx) return Width;
+
    function Get_Input_Net (Inst : Instance; Idx : Port_Idx) return Net;
 
    --  Return True iff ID describe a constant.


### PR DESCRIPTION
To create a black box cell in yosys I need to get the width of the port. I don't think this is exposed in another way, so I added an utility function.

This change is required for https://github.com/tgingold/ghdlsynth-beta/pull/25

p.s. Somehow the gates were also outdated again, because when running make it added 3 new entries.