### PR TITLE
Better support for ranged integers and integer literals.

### DIFF
--- a/src/synth/netlists-builders.adb
+++ b/src/synth/netlists-builders.adb
@@ -434,6 +434,16 @@ package body Netlists.Builders is
       Create_Compare_Module (Design, Res.M_Compare (Id_Uge),
                              Get_Identifier ("uge"), Id_Uge);
 
+      Create_Compare_Module (Design, Res.M_Compare (Id_Slt),
+                             Get_Identifier ("slt"), Id_Slt);
+      Create_Compare_Module (Design, Res.M_Compare (Id_Sle),
+                             Get_Identifier ("sle"), Id_Sle);
+
+      Create_Compare_Module (Design, Res.M_Compare (Id_Sgt),
+                             Get_Identifier ("sgt"), Id_Sgt);
+      Create_Compare_Module (Design, Res.M_Compare (Id_Sge),
+                             Get_Identifier ("sge"), Id_Sge);
+
       Create_Concat_Modules (Res);
       Create_Const_Modules (Res);
 

--- a/src/synth/netlists-disp_vhdl.adb
+++ b/src/synth/netlists-disp_vhdl.adb
@@ -623,16 +623,16 @@ package body Netlists.Disp_Vhdl is
             Disp_Template
               ("  \o0 <= std_logic_vector (resize (\ui0 * \ui1, \n0));" & NL,
                Inst, (0 => Get_Width (Get_Output (Inst, 0))));
-         when Id_Ult =>
+         when Id_Ult | Id_Slt =>
             Disp_Template ("  \o0 <= '1' when \ui0 < \ui1 else '0';" & NL,
                            Inst);
-         when Id_Ule =>
+         when Id_Ule | Id_Sle =>
             Disp_Template ("  \o0 <= '1' when \ui0 <= \ui1 else '0';" & NL,
                            Inst);
-         when Id_Ugt =>
+         when Id_Ugt | Id_Sgt =>
             Disp_Template ("  \o0 <= '1' when \ui0 > \ui1 else '0';" & NL,
                            Inst);
-         when Id_Uge =>
+         when Id_Uge | Id_Sge =>
             Disp_Template ("  \o0 <= '1' when \ui0 >= \ui1 else '0';" & NL,
                            Inst);
          when Id_Eq =>

--- a/src/synth/netlists-disp_vhdl.adb
+++ b/src/synth/netlists-disp_vhdl.adb
@@ -623,17 +623,29 @@ package body Netlists.Disp_Vhdl is
             Disp_Template
               ("  \o0 <= std_logic_vector (resize (\ui0 * \ui1, \n0));" & NL,
                Inst, (0 => Get_Width (Get_Output (Inst, 0))));
-         when Id_Ult | Id_Slt =>
+         when Id_Ult =>
             Disp_Template ("  \o0 <= '1' when \ui0 < \ui1 else '0';" & NL,
                            Inst);
-         when Id_Ule | Id_Sle =>
+         when Id_Ule =>
             Disp_Template ("  \o0 <= '1' when \ui0 <= \ui1 else '0';" & NL,
                            Inst);
-         when Id_Ugt | Id_Sgt =>
+         when Id_Ugt =>
             Disp_Template ("  \o0 <= '1' when \ui0 > \ui1 else '0';" & NL,
                            Inst);
-         when Id_Uge | Id_Sge =>
+         when Id_Uge =>
             Disp_Template ("  \o0 <= '1' when \ui0 >= \ui1 else '0';" & NL,
+                           Inst);
+         when Id_Slt =>
+            Disp_Template ("  \o0 <= '1' when \si0 < \si1 else '0';" & NL,
+                           Inst);
+         when Id_Sle =>
+            Disp_Template ("  \o0 <= '1' when \si0 <= \si1 else '0';" & NL,
+                           Inst);
+         when Id_Sgt =>
+            Disp_Template ("  \o0 <= '1' when \si0 > \si1 else '0';" & NL,
+                           Inst);
+         when Id_Sge =>
+            Disp_Template ("  \o0 <= '1' when \si0 >= \si1 else '0';" & NL,
                            Inst);
          when Id_Eq =>
             Disp_Template ("  \o0 <= '1' when \i0 = \i1 else '0';" & NL, Inst);

--- a/src/synth/synth-context.adb
+++ b/src/synth/synth-context.adb
@@ -358,9 +358,11 @@ package body Synth.Context is
                   Value2net (Val, 1, V, Res);
                   return Res;
                end;
-            elsif Val.Typ.Drange.W <= 32 then
-               return Build_Const_UB32
-                 (Build_Context, Uns32 (Val.Scal), Val.Typ.Drange.W);
+            elsif Val.Scal <= Int64(Uns32'Last) then
+               return Build_Const_UB32 (
+                 Build_Context,
+                 Uns32 (Val.Scal),
+                 Width'min(32, Val.Typ.Drange.W));
             else
                raise Internal_Error;
             end if;

--- a/src/synth/synth-context.adb
+++ b/src/synth/synth-context.adb
@@ -358,11 +358,9 @@ package body Synth.Context is
                   Value2net (Val, 1, V, Res);
                   return Res;
                end;
-            elsif Val.Scal <= Int64(Uns32'Last) then
-               return Build_Const_UB32 (
-                 Build_Context,
-                 Uns32 (Val.Scal),
-                 Width'min(32, Val.Typ.Drange.W));
+            elsif Val.Typ.Drange.W <= 32 then
+               return Build_Const_UB32
+                 (Build_Context, Uns32 (Val.Scal), Val.Typ.Drange.W);
             else
                raise Internal_Error;
             end if;

--- a/src/synth/synth-expr.adb
+++ b/src/synth/synth-expr.adb
@@ -1040,6 +1040,27 @@ package body Synth.Expr is
             else
                return Synth_Compare (Id_Sle);
             end if;
+         when Iir_Predefined_Integer_Less =>
+            if Is_Const (Left) and then Is_Const (Right) then
+               return Create_Value_Discrete
+                 (Boolean'Pos (Left.Scal < Right.Scal), Boolean_Type);
+            else
+               return Synth_Compare (Id_Slt);
+            end if;
+         when Iir_Predefined_Integer_Greater_Equal =>
+            if Is_Const (Left) and then Is_Const (Right) then
+               return Create_Value_Discrete
+                 (Boolean'Pos (Left.Scal >= Right.Scal), Boolean_Type);
+            else
+               return Synth_Compare (Id_Sge);
+            end if;
+         when Iir_Predefined_Integer_Greater =>
+            if Is_Const (Left) and then Is_Const (Right) then
+               return Create_Value_Discrete
+                 (Boolean'Pos (Left.Scal > Right.Scal), Boolean_Type);
+            else
+               return Synth_Compare (Id_Sgt);
+            end if;
          when Iir_Predefined_Integer_Equality =>
             if Is_Const (Left) and then Is_Const (Right) then
                return Create_Value_Discrete


### PR DESCRIPTION
I have some code like the following that I'm trying to get to work

```vhdl
signal counter : integer range 0 to 63;
--[...]
if counter < 2 then
--[...]
counter <= counter - 1;
```

So first problem is that integer literals seem to be 64 bits.
The logic that makes `Const_UB32` just checks for the width and then fails.
But for small constants, it should be safe to use, so I changed the check to just check if the constant fits in 32 bits.

The next problem is that the comparison then tries to compare a 6-bit value with a 32-bit value, and gives an error. I am not sure how to resolve this, probably one of the values needs to be extended, or the literal needs to match the range. **UNSOLVED** So I changed my code to define constants with the correct range.

```vhdl
  constant two : integer range 0 to 63 := 2;
```

Which leads to the next problem, that a bunch of operators are not defined. Ok, I know how to do this by now.

That lead to the next problem, where `Iir_Predefined_Integer_Minus` uses `Synth_Vec_Dyadic (Id_Sub)` which calls `Create_Res_Bound` which crashes with `CONSTRAINT_ERROR : synth-expr.adb:651 discriminant check failed`. It seems from the debugger that it expects an entirely different value type. I googled it, but this goes beyond my current Ada knowledge, so **UNRESOLVED**.

But with these changes, comparing ranged integer literals works. What does not work is comparing a ranged integer with a literal, and subtracting ranged integers.