### PR TITLE
Integer literals are 64 bits

### DIFF
--- a/src/synth/synth-context.adb
+++ b/src/synth/synth-context.adb
@@ -358,9 +358,11 @@ package body Synth.Context is
                   Value2net (Val, 1, V, Res);
                   return Res;
                end;
-            elsif Val.Typ.Drange.W <= 32 then
-               return Build_Const_UB32
-                 (Build_Context, Uns32 (Val.Scal), Val.Typ.Drange.W);
+            elsif Val.Scal <= Int64(Uns32'Last) then
+               return Build_Const_UB32 (
+                 Build_Context,
+                 Uns32 (Val.Scal),
+                 Width'min(32, Val.Typ.Drange.W));
             else
                raise Internal_Error;
             end if;


### PR DESCRIPTION
It appears that integer literals are always 64 bits, which causes issues.

Attached is the most simple fix, which just synthesizes them into 32 bits if they fit.
An alternative solution would be to support 64 bits constants, which is a bit more work.
Another variation on this theme is to set width to something like `ceil(log2(Val.Scal))`.

But there is a deeper issue here. When using ranged integers, the width of the ranged integer does not match the width of the integer literal. This causes an error in dyadic functions that expect their arguments to be the same size.

So I think the correct solution might actually be to narrow the literal to the minimum width, and make operators extend the smaller of the two.