### PR TITLE
openieee: add dummy UPF package

### DIFF
--- a/libraries/Makefile.inc
+++ b/libraries/Makefile.inc
@@ -82,7 +82,8 @@ IEEE93_BSRCS := $(addprefix ieee/v93/,$(IEEE_SRCS)) $(addprefix ieee/,$(MATH_SRC
 else
 IEEE_SRCS := std_logic_1164.vhdl std_logic_1164-body.vhdl \
   numeric_bit.vhdl numeric_bit-body.vhdl \
-  numeric_std.vhdl numeric_std-body.vhdl
+  numeric_std.vhdl numeric_std-body.vhdl \
+  upf.vhdl upf-body.vhdl
 MATH_SRCS := math_real.vhdl math_real-body.vhdl
 VITAL95_BSRCS :=
 VITAL2000_BSRCS :=

--- a/libraries/openieee/upf-body.vhdl
+++ b/libraries/openieee/upf-body.vhdl
@@ -1,0 +1,26 @@
+package body upf is
+
+  function supply_on (
+    constant supply_name : string;
+    constant voltage     : real)
+    return boolean is
+  begin
+    return true;
+  end supply_on;
+
+  function supply_partial_on (
+    constant supply_name : string;
+    constant voltage     : real)
+    return boolean is
+  begin
+    return true;
+  end supply_partial_on;
+
+  function supply_off (
+    constant supply_name : string)
+    return boolean is
+  begin
+    return true;
+  end supply_off;
+
+end upf;

--- a/libraries/openieee/upf.vhdl
+++ b/libraries/openieee/upf.vhdl
@@ -1,0 +1,19 @@
+-- modelled according to IEEE Std 1801-2015, 11.2
+
+package upf is
+
+  function supply_on (
+    constant supply_name : string;
+    constant voltage     : real)
+    return boolean;
+
+  function supply_partial_on (
+    constant supply_name : string;
+    constant voltage     : real)
+    return boolean;
+
+  function supply_off (
+    constant supply_name : string)
+    return boolean;
+
+end upf;


### PR DESCRIPTION
Close #436.
Ref #888.

This PR is an update/rework of #436. As requested by @tgingold, the ieee and ieee2008 versions look the same, so sources are added once only. Furthermore, they are added to openieee. As a result, patching the makefile is not required.

/cc @tsailer