### PR TITLE
Support for PSL assert and assume in synthesis

### DIFF
--- a/src/synth/synth-stmts.adb
+++ b/src/synth/synth-stmts.adb
@@ -1254,6 +1254,20 @@ package body Synth.Stmts is
             return Build_Monadic
               (Build_Context, Netlists.Gates.Id_Not,
                Synth_PSL_Expression (Syn_Inst, Get_Boolean (Expr)));
+         when N_And_Bool =>
+            return Build_Dyadic
+              (Build_Context, Netlists.Gates.Id_And,
+               Synth_PSL_Expression (Syn_Inst, Get_Left (Expr)),
+               Synth_PSL_Expression (Syn_Inst, Get_Right (Expr)));
+         when N_Or_Bool =>
+            return Build_Dyadic
+              (Build_Context, Netlists.Gates.Id_Or,
+               Synth_PSL_Expression (Syn_Inst, Get_Left (Expr)),
+               Synth_PSL_Expression (Syn_Inst, Get_Right (Expr)));
+         when N_True =>
+            return Build_Const_UB32 (Build_Context, 1, 1);
+         when N_False =>
+            return Build_Const_UB32 (Build_Context, 0, 1);
          when others =>
             PSL.Errors.Error_Kind ("translate_psl_expr", Expr);
       end case;

--- a/testsuite/synth/psl01/hello.vhdl
+++ b/testsuite/synth/psl01/hello.vhdl
@@ -24,5 +24,6 @@ begin
 
  --psl default clock is clk;
  --psl restrict {rst; (not rst)[*]};
- assert val /= 5 or rst = '1' severity error;
+ --psl assert always val /= 5 or rst = '1';
+ --psl assume always val < 50;
 end behav;


### PR DESCRIPTION
This adds support for synthesis of PSL assert and assume keywords, so they can be used in SimbiYosys formal verification.

This passes my little update to the testbench, but might very well break once I start to use it for real testing. I've also not added cover yet. So it's ok to merge, but I'll likely have more changes in the coming days.