### PR TITLE
add synthesis support for logic operators on numeric types

### DIFF
--- a/src/synth/synth-disp_vhdl.adb
+++ b/src/synth/synth-disp_vhdl.adb
@@ -25,6 +25,7 @@ with Name_Table;
 with Vhdl.Prints;
 with Vhdl.Std_Package;
 with Vhdl.Ieee.Std_Logic_1164;
+with Vhdl.Ieee.Numeric;
 with Vhdl.Errors; use Vhdl.Errors;
 with Vhdl.Utils; use Vhdl.Utils;
 
@@ -100,6 +101,15 @@ package body Synth.Disp_Vhdl is
                   Put (" (" & Pfx & "'left)");
                end if;
                Put_Line (";");
+               Idx := Idx + 1;
+            elsif Btype = Vhdl.Ieee.Numeric.Numeric_Std_Unsigned_Type then
+               Put ("  wrap_" & Pfx & " <= std_logic_vector(" & Pfx);
+               if Desc.W = 1 then
+                  --  This is an array of length 1.  A scalar is used in the
+                  --  netlist.
+                  Put (" (" & Pfx & "'left)");
+               end if;
+               Put_Line (");");
                Idx := Idx + 1;
             else
                Error_Kind ("disp_in_converter(arr)", Ptype);

--- a/src/synth/synth-disp_vhdl.adb
+++ b/src/synth/synth-disp_vhdl.adb
@@ -102,7 +102,8 @@ package body Synth.Disp_Vhdl is
                end if;
                Put_Line (";");
                Idx := Idx + 1;
-            elsif Btype = Vhdl.Ieee.Numeric.Numeric_Std_Unsigned_Type then
+            elsif Btype = Vhdl.Ieee.Numeric.Numeric_Std_Unsigned_Type
+               or Btype = Vhdl.Ieee.Numeric.Numeric_Std_Signed_Type then
                Put ("  wrap_" & Pfx & " <= std_logic_vector(" & Pfx);
                if Desc.W = 1 then
                   --  This is an array of length 1.  A scalar is used in the

--- a/src/synth/synth-expr.adb
+++ b/src/synth/synth-expr.adb
@@ -933,12 +933,30 @@ package body Synth.Expr is
            | Iir_Predefined_Ieee_1164_Scalar_Xnor =>
             return Synth_Bit_Dyadic (Id_Xnor);
 
-         when Iir_Predefined_Ieee_1164_Vector_And =>
+         when Iir_Predefined_Ieee_1164_Vector_And
+            | Iir_Predefined_Ieee_Numeric_Std_And_Uns_Uns
+            | Iir_Predefined_Ieee_Numeric_Std_And_Sgn_Sgn =>
             return Synth_Vec_Dyadic (Id_And);
-         when Iir_Predefined_Ieee_1164_Vector_Or =>
+         when Iir_Predefined_Ieee_1164_Vector_Or
+            | Iir_Predefined_Ieee_Numeric_Std_Or_Uns_Uns
+            | Iir_Predefined_Ieee_Numeric_Std_Or_Sgn_Sgn =>
             return Synth_Vec_Dyadic (Id_Or);
-         when Iir_Predefined_Ieee_1164_Vector_Xor =>
+         when Iir_Predefined_Ieee_1164_Vector_Nand
+            | Iir_Predefined_Ieee_Numeric_Std_Nand_Uns_Uns
+            | Iir_Predefined_Ieee_Numeric_Std_Nand_Sgn_Sgn =>
+            return Synth_Vec_Dyadic (Id_Nand);
+         when Iir_Predefined_Ieee_1164_Vector_Nor
+            | Iir_Predefined_Ieee_Numeric_Std_Nor_Uns_Uns
+            | Iir_Predefined_Ieee_Numeric_Std_Nor_Sgn_Sgn =>
+            return Synth_Vec_Dyadic (Id_Nor);
+         when Iir_Predefined_Ieee_1164_Vector_Xor
+            | Iir_Predefined_Ieee_Numeric_Std_Xor_Uns_Uns
+            | Iir_Predefined_Ieee_Numeric_Std_Xor_Sgn_Sgn =>
             return Synth_Vec_Dyadic (Id_Xor);
+         when Iir_Predefined_Ieee_1164_Vector_Xnor
+            | Iir_Predefined_Ieee_Numeric_Std_Xnor_Uns_Uns
+            | Iir_Predefined_Ieee_Numeric_Std_Xnor_Sgn_Sgn =>
+            return Synth_Vec_Dyadic (Id_Xnor);
 
          when Iir_Predefined_Enum_Equality =>
             if Is_Bit_Type (Left_Type) then

--- a/src/synth/synth-expr.adb
+++ b/src/synth/synth-expr.adb
@@ -1236,7 +1236,9 @@ package body Synth.Expr is
             return null;
          when Iir_Predefined_Ieee_1164_Scalar_Not =>
             return Synth_Bit_Monadic (Id_Not);
-         when Iir_Predefined_Ieee_1164_Vector_Not =>
+         when Iir_Predefined_Ieee_1164_Vector_Not
+            | Iir_Predefined_Ieee_Numeric_Std_Not_Uns
+            | Iir_Predefined_Ieee_Numeric_Std_Not_Sgn =>
             return Synth_Vec_Monadic (Id_Not);
          when Iir_Predefined_Ieee_Numeric_Std_Neg_Uns
            | Iir_Predefined_Ieee_Numeric_Std_Neg_Sgn =>

--- a/src/vhdl/vhdl-ieee-numeric.adb
+++ b/src/vhdl/vhdl-ieee-numeric.adb
@@ -188,6 +188,85 @@ package body Vhdl.Ieee.Numeric is
       Pkg_Bit =>
         (others => Iir_Predefined_None));
 
+   Not_Patterns : constant Unary_Pattern_Type :=
+     (Pkg_Std =>
+        (Type_Unsigned => Iir_Predefined_Ieee_Numeric_Std_Not_Uns,
+         Type_Signed => Iir_Predefined_Ieee_Numeric_Std_Not_Sgn),
+      Pkg_Bit =>
+        (others => Iir_Predefined_None));
+
+   And_Patterns : constant Binary_Pattern_Type :=
+     (Pkg_Std =>
+        (Type_Unsigned =>
+           (Arg_Vect_Vect => Iir_Predefined_Ieee_Numeric_Std_And_Uns_Uns,
+            others        => Iir_Predefined_None),
+         Type_Signed =>
+           (Arg_Vect_Vect => Iir_Predefined_Ieee_Numeric_Std_And_Sgn_Sgn,
+            others        => Iir_Predefined_None)),
+      Pkg_Bit =>
+        (others =>
+           (others => Iir_Predefined_None)));
+
+   Or_Patterns : constant Binary_Pattern_Type :=
+     (Pkg_Std =>
+        (Type_Unsigned =>
+           (Arg_Vect_Vect => Iir_Predefined_Ieee_Numeric_Std_Or_Uns_Uns,
+            others        => Iir_Predefined_None),
+         Type_Signed =>
+           (Arg_Vect_Vect => Iir_Predefined_Ieee_Numeric_Std_Or_Sgn_Sgn,
+            others        => Iir_Predefined_None)),
+      Pkg_Bit =>
+        (others =>
+           (others => Iir_Predefined_None)));
+
+   Nand_Patterns : constant Binary_Pattern_Type :=
+     (Pkg_Std =>
+        (Type_Unsigned =>
+           (Arg_Vect_Vect => Iir_Predefined_Ieee_Numeric_Std_Nand_Uns_Uns,
+            others        => Iir_Predefined_None),
+         Type_Signed =>
+           (Arg_Vect_Vect => Iir_Predefined_Ieee_Numeric_Std_Nand_Sgn_Sgn,
+            others        => Iir_Predefined_None)),
+      Pkg_Bit =>
+        (others =>
+           (others => Iir_Predefined_None)));
+
+   Nor_Patterns : constant Binary_Pattern_Type :=
+     (Pkg_Std =>
+        (Type_Unsigned =>
+           (Arg_Vect_Vect => Iir_Predefined_Ieee_Numeric_Std_Nor_Uns_Uns,
+            others        => Iir_Predefined_None),
+         Type_Signed =>
+           (Arg_Vect_Vect => Iir_Predefined_Ieee_Numeric_Std_Nor_Sgn_Sgn,
+            others        => Iir_Predefined_None)),
+      Pkg_Bit =>
+        (others =>
+           (others => Iir_Predefined_None)));
+
+   Xor_Patterns : constant Binary_Pattern_Type :=
+     (Pkg_Std =>
+        (Type_Unsigned =>
+           (Arg_Vect_Vect => Iir_Predefined_Ieee_Numeric_Std_Xor_Uns_Uns,
+            others        => Iir_Predefined_None),
+         Type_Signed =>
+           (Arg_Vect_Vect => Iir_Predefined_Ieee_Numeric_Std_Xor_Sgn_Sgn,
+            others        => Iir_Predefined_None)),
+      Pkg_Bit =>
+        (others =>
+           (others => Iir_Predefined_None)));
+
+   Xnor_Patterns : constant Binary_Pattern_Type :=
+     (Pkg_Std =>
+        (Type_Unsigned =>
+           (Arg_Vect_Vect => Iir_Predefined_Ieee_Numeric_Std_Xnor_Uns_Uns,
+            others        => Iir_Predefined_None),
+         Type_Signed =>
+           (Arg_Vect_Vect => Iir_Predefined_Ieee_Numeric_Std_Xnor_Sgn_Sgn,
+            others        => Iir_Predefined_None)),
+      Pkg_Bit =>
+        (others =>
+           (others => Iir_Predefined_None)));
+
    Error : exception;
 
    procedure Extract_Declarations (Pkg_Decl : Iir_Package_Declaration;
@@ -436,6 +515,18 @@ package body Vhdl.Ieee.Numeric is
                         Handle_Binary (Gt_Patterns);
                      when Name_Op_Greater_Equal =>
                         Handle_Binary (Ge_Patterns);
+                     when Name_And =>
+                        Handle_Binary (And_Patterns);
+                     when Name_Or =>
+                        Handle_Binary (Or_Patterns);
+                     when Name_Nand =>
+                        Handle_Binary (Nand_Patterns);
+                     when Name_Nor =>
+                        Handle_Binary (Nor_Patterns);
+                     when Name_Xor =>
+                        Handle_Binary (Xor_Patterns);
+                     when Name_Xnor =>
+                        Handle_Binary (Xnor_Patterns);
                      when Name_To_Bstring
                        | Name_To_Ostring
                        | Name_To_Hstring =>
@@ -454,6 +545,8 @@ package body Vhdl.Ieee.Numeric is
                   case Get_Identifier (Decl) is
                      when Name_Op_Minus =>
                         Handle_Unary (Neg_Patterns);
+                     when Name_Not =>
+                        Handle_Unary (Not_Patterns);
                      when Name_To_Integer =>
                         Handle_To_Integer;
                      when others =>

--- a/src/vhdl/vhdl-nodes.ads
+++ b/src/vhdl/vhdl-nodes.ads
@@ -4931,6 +4931,27 @@ package Vhdl.Nodes is
       Iir_Predefined_Ieee_Numeric_Std_Ne_Sgn_Int,
       Iir_Predefined_Ieee_Numeric_Std_Ne_Int_Sgn,
 
+      Iir_Predefined_Ieee_Numeric_Std_Not_Uns,
+      Iir_Predefined_Ieee_Numeric_Std_Not_Sgn,
+
+      Iir_Predefined_Ieee_Numeric_Std_And_Uns_Uns,
+      Iir_Predefined_Ieee_Numeric_Std_And_Sgn_Sgn,
+
+      Iir_Predefined_Ieee_Numeric_Std_Or_Uns_Uns,
+      Iir_Predefined_Ieee_Numeric_Std_Or_Sgn_Sgn,
+
+      Iir_Predefined_Ieee_Numeric_Std_Nand_Uns_Uns,
+      Iir_Predefined_Ieee_Numeric_Std_Nand_Sgn_Sgn,
+
+      Iir_Predefined_Ieee_Numeric_Std_Nor_Uns_Uns,
+      Iir_Predefined_Ieee_Numeric_Std_Nor_Sgn_Sgn,
+
+      Iir_Predefined_Ieee_Numeric_Std_Xor_Uns_Uns,
+      Iir_Predefined_Ieee_Numeric_Std_Xor_Sgn_Sgn,
+
+      Iir_Predefined_Ieee_Numeric_Std_Xnor_Uns_Uns,
+      Iir_Predefined_Ieee_Numeric_Std_Xnor_Sgn_Sgn,
+
       --  Unary functions for numeric_std
       Iir_Predefined_Ieee_Numeric_Std_Neg_Uns,
       Iir_Predefined_Ieee_Numeric_Std_Neg_Sgn,

--- a/testsuite/synth/psl01/hello.vhdl
+++ b/testsuite/synth/psl01/hello.vhdl
@@ -22,8 +22,8 @@ begin
  end process;
  cnt <= val;
 
- --psl default clock is clk;
+ --psl default clock is rising_edge(clk);
  --psl restrict {rst; (not rst)[*]};
- --psl assert always val /= 5 or rst = '1';
- --psl assume always val < 50;
+ --psl assert always val /= 5 abort rst;
+ --psl assume always val < 10;
 end behav;


### PR DESCRIPTION
This makes it so you can do logic operators on `unsigned` ans `signed` without an explicit cast.
I'm not sure if there is any meaning in having them as separate IIR, but it's what the rest of the code does too.
I don't think we're handling mixed `signed` and `unsigned` operations, but who in their right mind does that anyway.

Example:
```vhdl
entity alu is
  port (
    a : in unsigned(7 downto 0);
    b : in unsigned(7 downto 0);
    y : out unsigned(7 downto 0)
  );
end alu;

architecture rtl of alu is
begin
  y <= a and b;
end rtl;
```

p.s. I accidentally committed a change to the psl testcase. I can revert and make a new pr for that if it bothers you. I don't even think `hello.vhdl` is used any more.