### PR TITLE
Expose source location to ghdlsynth

### DIFF
--- a/src/synth/ghdlsynth.h
+++ b/src/synth/ghdlsynth.h
@@ -118,6 +118,9 @@ namespace GhdlSynth {
 
   GHDLSYNTH_ADA_WRAPPER_WWD(get_input_net, Net, Instance, Port_Idx);
 
+  typedef char* chars_ptr;
+  GHDLSYNTH_ADA_WRAPPER_DW(get_source, chars_ptr, Instance);
+
   extern "C" unsigned int ghdlsynth__ghdl_synth(int argc, const char **argv);
   inline Module ghdl_synth(int argc, const char **argv) {
     Module res;

--- a/src/synth/netlists-utils.adb
+++ b/src/synth/netlists-utils.adb
@@ -19,6 +19,8 @@
 --  MA 02110-1301, USA.
 
 with Netlists.Gates; use Netlists.Gates;
+with Netlists.Locations; use Netlists.Locations;
+with Vhdl.Disp_Tree;
 
 package body Netlists.Utils is
    function Get_Nbr_Inputs (Inst : Instance) return Port_Nbr
@@ -95,6 +97,17 @@ package body Netlists.Utils is
    begin
       return Get_Driver (Get_Input (Inst, Idx));
    end Get_Input_Net;
+
+   function Get_Source (Inst : Instance) return chars_ptr is
+      loc : constant Location_Type := Get_Location(Inst);
+      img : constant String := Vhdl.Disp_Tree.Image_Location_Type(loc);
+   begin
+      if loc = No_Location then
+         return New_String("");
+      else
+         return New_String(img);
+      end if;
+   end Get_Source;
 
    function Is_Const (Id : Module_Id) return Boolean is
    begin

--- a/src/synth/netlists-utils.ads
+++ b/src/synth/netlists-utils.ads
@@ -18,6 +18,8 @@
 --  Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
 --  MA 02110-1301, USA.
 
+with Interfaces.C.Strings; use Interfaces.C.Strings;
+
 package Netlists.Utils is
    function Get_Nbr_Inputs (Inst : Instance) return Port_Nbr;
    function Get_Nbr_Outputs (Inst : Instance) return Port_Nbr;
@@ -35,6 +37,8 @@ package Netlists.Utils is
    function Get_Output_Width (M : Module; I : Port_Idx) return Width;
 
    function Get_Input_Net (Inst : Instance; Idx : Port_Idx) return Net;
+
+   function Get_Source (Inst : Instance) return chars_ptr;
 
    --  Return True iff ID describe a constant.
    function Is_Const (Id : Module_Id) return Boolean;


### PR DESCRIPTION
Adds a `Get_Source` utility function needed for https://github.com/tgingold/ghdlsynth-beta/pull/35