### PR TITLE
Support for 2008 unary reduce operators

### DIFF
--- a/src/synth/netlists-disp_vhdl.adb
+++ b/src/synth/netlists-disp_vhdl.adb
@@ -707,6 +707,19 @@ package body Netlists.Disp_Vhdl is
                     ("  \o0 <= \i1; -- reduce or" & NL, Inst);
                end if;
             end;
+         when Id_Red_And =>
+            declare
+               Iw : constant Width := Get_Width (Get_Input_Net (Inst, 0));
+            begin
+               if Iw > 1 then
+                  Disp_Template
+                    ("  \o0 <= '1' when \i0 = (\n0 downto 0 => '1') else '0';"
+                       & NL, Inst, (0 => Iw - 1));
+               else
+                  Disp_Template
+                    ("  \o0 <= \i1; -- reduce or" & NL, Inst);
+               end if;
+            end;
          when Id_Assert =>
             Disp_Template ("  assert \i0 = '1' severity error;" & NL, Inst);
          when Id_Assume =>

--- a/src/synth/synth-disp_vhdl.adb
+++ b/src/synth/synth-disp_vhdl.adb
@@ -92,7 +92,8 @@ package body Synth.Disp_Vhdl is
             Put_Line (";");
             Idx := Idx + 1;
          when Iir_Kind_Array_Type_Definition =>
-            if Btype = Vhdl.Ieee.Std_Logic_1164.Std_Logic_Vector_Type then
+            if Btype = Vhdl.Ieee.Std_Logic_1164.Std_Logic_Vector_Type
+            or Btype = Vhdl.Ieee.Std_Logic_1164.Std_Ulogic_Vector_Type then
                --  Nothing to do.
                Put ("  wrap_" & Pfx & " <= " & Pfx);
                if Desc.W = 1 then

--- a/src/synth/synth-expr.adb
+++ b/src/synth/synth-expr.adb
@@ -1265,6 +1265,17 @@ package body Synth.Expr is
          Set_Location (N, Loc);
          return Create_Value_Net (N, Create_Res_Bound (Operand, Op));
       end Synth_Vec_Monadic;
+
+      function Synth_Vec_Reduce_Monadic (Id : Reduce_Module_Id)
+         return Value_Acc
+      is
+         Op: constant Net := Get_Net (Operand);
+         N : Net;
+      begin
+         N := Build_Reduce (Build_Context, Id, Op);
+         Set_Location (N, Loc);
+         return Create_Value_Net (N, Operand.Typ.Vec_El);
+      end Synth_Vec_Reduce_Monadic;
    begin
       Operand := Synth_Expression (Syn_Inst, Operand_Expr);
       case Def is
@@ -1279,6 +1290,10 @@ package body Synth.Expr is
          when Iir_Predefined_Ieee_Numeric_Std_Neg_Uns
            | Iir_Predefined_Ieee_Numeric_Std_Neg_Sgn =>
             return Synth_Vec_Monadic (Id_Neg);
+         when Iir_Predefined_Ieee_1164_Vector_And_Reduce =>
+            return Synth_Vec_Reduce_Monadic(Id_Red_And);
+         when Iir_Predefined_Ieee_1164_Vector_Or_Reduce =>
+            return Synth_Vec_Reduce_Monadic(Id_Red_Or);
          when others =>
             Error_Msg_Synth
               (+Loc,

--- a/src/vhdl/vhdl-ieee-std_logic_1164.adb
+++ b/src/vhdl/vhdl-ieee-std_logic_1164.adb
@@ -277,11 +277,24 @@ package body Vhdl.Ieee.Std_Logic_1164 is
                   end case;
                   Set_Implicit_Definition (Decl, Predefined);
                end;
-            elsif Is_Vector_Function (Decl)
-              and then Get_Identifier (Decl) = Name_Not
-            then
-               Set_Implicit_Definition
-                 (Decl, Iir_Predefined_Ieee_1164_Vector_Not);
+            elsif Is_Vector_Function (Decl) then
+               declare
+                  Predefined : Iir_Predefined_Functions;
+               begin
+                  case Get_Identifier (Decl) is
+                     when Name_Not =>
+                        Predefined := Iir_Predefined_Ieee_1164_Vector_Not;
+                     when Name_And =>
+                        Predefined :=
+                           Iir_Predefined_Ieee_1164_Vector_And_Reduce;
+                     when Name_Or =>
+                        Predefined :=
+                           Iir_Predefined_Ieee_1164_Vector_Or_Reduce;
+                     when others =>
+                        Predefined := Iir_Predefined_None;
+                  end case;
+                  Set_Implicit_Definition (Decl, Predefined);
+               end;
             end if;
          end if;
       end loop;

--- a/src/vhdl/vhdl-nodes.ads
+++ b/src/vhdl/vhdl-nodes.ads
@@ -4901,6 +4901,10 @@ package Vhdl.Nodes is
       Iir_Predefined_Ieee_1164_Vector_Xnor,
       Iir_Predefined_Ieee_1164_Vector_Not,
 
+      -- VHDL-2008 unary logic operators
+      Iir_Predefined_Ieee_1164_Vector_And_Reduce,
+      Iir_Predefined_Ieee_1164_Vector_Or_Reduce,
+
       --  Numeric_Std.
       --  Abbreviations:
       --  Uns: Unsigned, Sgn: Signed, Nat: Natural, Int: Integer.

--- a/testsuite/synth/unary01/test.vhdl
+++ b/testsuite/synth/unary01/test.vhdl
@@ -1,0 +1,14 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity test is
+  port (a, b : in std_logic_vector(7 downto 0);
+        o, p : out std_logic);
+end test;
+
+architecture behav of test is
+begin
+  o <= or a;
+  p <= and b;
+end behav;

--- a/testsuite/synth/unary01/testsuite.sh
+++ b/testsuite/synth/unary01/testsuite.sh
@@ -1,0 +1,11 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+GHDL_STD_FLAGS=--std=08
+
+synth test.vhdl -e test > syn_test.vhdl
+analyze syn_test.vhdl
+clean
+
+echo "Test successful"


### PR DESCRIPTION
In VHDL-2008 there is support for unary logic operations, stuff like `and foo`. This was already supported in the parser and used in synthesizing PSL assumptions, so now I connected the dots.

For now it only supports AND/OR on std_logic_vector. I'll add support for signed/unsigned and xor and other operations later. Probably after dinner :)