### PR TITLE
Fix UPF

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -509,7 +509,8 @@ VHDLLIB_SUBDIRS_COMMON= src/std src/std/v87 src/std/v93 src/std/v08 \
   src/synopsys src/synopsys/v08 \
   std/v87 ieee/v87 synopsys/v87 \
   std/v93 ieee/v93 synopsys/v93 \
-  std/v08 ieee/v08
+  std/v08 ieee/v08 \
+  src/openieee
 
 VHDLLIB_SUBDIRS_FULL= src/ieee src/vital95 src/vital2000 src/mentor \
   src/ieee/v87 src/ieee/v93 src/ieee2008 \

--- a/libraries/Makefile.inc
+++ b/libraries/Makefile.inc
@@ -48,6 +48,7 @@ SYNOPSYS_BSRCS := std_logic_arith.vhdl \
 SYNOPSYS_V_BSRCS := std_logic_misc.vhdl std_logic_misc-body.vhdl
 SYNOPSYS8793_BSRCS := std_logic_textio.vhdl
 MENTOR_BSRCS := mentor/std_logic_arith.vhdl mentor/std_logic_arith-body.vhdl
+UPF_SRCS := openieee/upf.vhdl openieee/upf-body.vhdl
 
 ifeq ($(enable_openieee),false)
 IEEE_SRCS := std_logic_1164.vhdl std_logic_1164-body.vhdl \
@@ -74,16 +75,16 @@ IEEE08_BSRCS := \
   ieee2008/fixed_pkg.vhdl \
   ieee2008/float_generic_pkg.vhdl ieee2008/float_generic_pkg-body.vhdl \
   ieee2008/float_pkg.vhdl \
-  ieee2008/ieee_bit_context.vhdl ieee2008/ieee_std_context.vhdl
+  ieee2008/ieee_bit_context.vhdl ieee2008/ieee_std_context.vhdl \
+  $(UPF_SRCS)
 
-IEEE87_BSRCS := $(addprefix ieee/v87/,$(IEEE_SRCS))
-IEEE93_BSRCS := $(addprefix ieee/v93/,$(IEEE_SRCS)) $(addprefix ieee/,$(MATH_SRCS))
+IEEE87_BSRCS := $(addprefix ieee/v87/,$(IEEE_SRCS)) $(UPF_SRCS)
+IEEE93_BSRCS := $(addprefix ieee/v93/,$(IEEE_SRCS)) $(addprefix ieee/,$(MATH_SRCS)) $(UPF_SRCS)
 
 else
 IEEE_SRCS := std_logic_1164.vhdl std_logic_1164-body.vhdl \
   numeric_bit.vhdl numeric_bit-body.vhdl \
   numeric_std.vhdl numeric_std-body.vhdl
-UPF_SRCS := openieee/upf.vhdl openieee/upf-body.vhdl
 MATH_SRCS := math_real.vhdl math_real-body.vhdl
 VITAL95_BSRCS :=
 VITAL2000_BSRCS :=

--- a/testsuite/sanity/006upf/test.vhdl
+++ b/testsuite/sanity/006upf/test.vhdl
@@ -1,0 +1,5 @@
+library ieee;
+use ieee.UPF.all;
+
+entity test is
+end entity;

--- a/testsuite/sanity/006upf/testsuite.sh
+++ b/testsuite/sanity/006upf/testsuite.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+analyze test.vhdl
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Package UPF was added in #889. Compilation was not correct and it was 'fixed' in https://github.com/ghdl/ghdl/commit/b814dbe04aa1658dc294b7db1f9005c497205f25.

The package was expected to be available in all cases (see https://github.com/ghdl/ghdl/pull/889#issuecomment-520115723), but it is currently only available when `--enable-openieee` is used. This PR fixes it, so UPF is always compiled.

Furthermore, a test is added to `sanity/006upf`. <strike>This shows that, even though compilation is successful, the package seems not to be properly built:

```
sanity 000hello: ok
sanity 001hello87: ok
sanity 002hello2008: ok
sanity 004all08: ok
sanity 005examples: ok
sanity 006upf: failed
analyze test.vhdl
ghdl: cannot load package "upf"
```
</strike>