### PR TITLE
fix(configure): ignore line ending when comparing ghdl_version and libghdl_version

### DIFF
--- a/configure
+++ b/configure
@@ -186,7 +186,7 @@ fi
 # Check the version of libghdl is correct.
 if [ "$enable_libghdl" = true ]; then
     libghdl_version="$srcdir/python/libghdl/version.py"
-    if ! echo "__version__ = '${ghdl_version}'" | cmp "$libghdl_version" ; then
+    if ! echo "__version__ = '${ghdl_version}'" | cmp -n "${#ghdl_version}" "$libghdl_version" ; then
 	echo "Sorry, the version of $libghdl_version is not correct"
 	echo "update the version to: $ghdl_version"
 	echo "or use --disable-libghdl"


### PR DESCRIPTION
On Windows (MSYS/MINGW), building after cloning the repo fails because `python/libghdl/version.py` is automatically converted to CRLF (as all other files in the repo). This PR 'fixes' the check with `cmp` in configure, so that as many bytes as the length of `ghdl_version` are compared only.