### PR TITLE
revert "configure: fix setting abs_srcdir on MSYS2/MINGW" (#911)

### DIFF
--- a/configure
+++ b/configure
@@ -146,12 +146,11 @@ fi
 case $srcdir in
   /*) abs_srcdir=$srcdir;;
   *)
-    # Use a Windows path when not on MSYS2/MINGW.
-    if [ -z "$MSYSTEM" ]; then
-      curdir=`pwd -W 2>/dev/null || pwd`
-    else
-      curdir=`pwd`
-    fi
+    # Use a Windows path on windows.
+    case "$OS" in
+      Windows_NT) curdir=`pwd -W 2>/dev/null || pwd` ;;
+      *) curdir=`pwd` ;;
+    esac
     abs_srcdir=$curdir/$srcdir
     ;;
 esac


### PR DESCRIPTION
One of the commits in #911 was not required, and does produce a failure with LLVM backend for MINGW64. This reverts commit 7b02418ec508af9e340cad5e93ab06e8f1fb84c8.

With this fix, the migration from Travis CI and AppVeyor to GitHub Actions is almost ready: https://github.com/1138-4EB/ghdl/commits/actions. See example run: https://github.com/1138-4EB/ghdl/runs/209700424. We need to decide the new distribution scheme, tho (#888).