### PR TITLE
fix: skip testsuite/sanity/005examples when 'doc' not found

### DIFF
--- a/testsuite/sanity/005examples/testsuite.sh
+++ b/testsuite/sanity/005examples/testsuite.sh
@@ -8,6 +8,12 @@ if ! python -V > /dev/null 2>&1; then
   exit 0
 fi
 
+# Skip the test if ../../../doc is not available.
+if [ ! -d ../../../doc ]; then
+  echo "test skipped, '../../../doc' not found"
+  exit 0
+fi
+
 # Extract examples
 python extract_vhdl.py hello.vhdl heartbeat.vhdl adder.vhdl adder_tb.vhdl < ../../../doc/using/QuickStartGuide.rst
 


### PR DESCRIPTION
This is a work around #915 until we guess how to properly move the examples out of `doc`.