### PR TITLE
synth: Add support for PSL cover directive

### DIFF
--- a/src/synth/ghdlsynth_gates.h
+++ b/src/synth/ghdlsynth_gates.h
@@ -58,6 +58,7 @@ enum Module_Id {
    Id_Edge = 71,
    Id_Assert = 72,
    Id_Assume = 73,
+   Id_Cover = 74,
    Id_Const_UB32 = 96,
    Id_Const_SB32 = 97,
    Id_Const_UL32 = 98,

--- a/src/synth/netlists-builders.adb
+++ b/src/synth/netlists-builders.adb
@@ -363,7 +363,7 @@ package body Netlists.Builders is
                      Outputs);
    end Create_Dff_Modules;
 
-   procedure Create_Assert_Assume (Ctxt : Context_Acc)
+   procedure Create_Assert_Assume_Cover (Ctxt : Context_Acc)
    is
       Outputs : Port_Desc_Array (1 .. 0);
    begin
@@ -378,7 +378,13 @@ package body Netlists.Builders is
          1, 0, 0);
       Set_Port_Desc (Ctxt.M_Assume, (0 => Create_Input ("cond", 1)),
                      Outputs);
-   end Create_Assert_Assume;
+
+      Ctxt.M_Cover := New_User_Module
+        (Ctxt.Design, New_Sname_Artificial (Name_Cover), Id_Cover,
+         1, 0, 0);
+      Set_Port_Desc (Ctxt.M_Cover, (0 => Create_Input ("cond", 1)),
+                     Outputs);
+   end Create_Assert_Assume_Cover;
 
    function Build_Builders (Design : Module) return Context_Acc
    is
@@ -479,7 +485,7 @@ package body Netlists.Builders is
       Create_Objects_Module (Res);
       Create_Dff_Modules (Res);
 
-      Create_Assert_Assume (Res);
+      Create_Assert_Assume_Cover (Res);
 
       return Res;
    end Build_Builders;
@@ -1145,5 +1151,16 @@ package body Netlists.Builders is
       Connect (Get_Input (Inst, 0), Cond);
       return Inst;
    end Build_Assume;
+
+   function Build_Cover (Ctxt : Context_Acc; Name : Sname; Cond : Net)
+                         return Instance
+   is
+      Inst : Instance;
+   begin
+      Inst := New_Instance (Ctxt.Parent, Ctxt.M_Cover,
+                            Name_Or_Internal (Name, Ctxt));
+      Connect (Get_Input (Inst, 0), Cond);
+      return Inst;
+   end Build_Cover;
 
 end Netlists.Builders;

--- a/src/synth/netlists-builders.ads
+++ b/src/synth/netlists-builders.ads
@@ -147,6 +147,8 @@ package Netlists.Builders is
                          return Instance;
    function Build_Assume (Ctxt : Context_Acc; Name : Sname; Cond : Net)
                          return Instance;
+   function Build_Cover (Ctxt : Context_Acc; Name : Sname; Cond : Net)
+                        return Instance;
 
    --  A simple flip-flop.
    function Build_Dff (Ctxt : Context_Acc;
@@ -204,5 +206,6 @@ private
       M_Dyn_Insert : Module;
       M_Assert : Module;
       M_Assume : Module;
+      M_Cover : Module;
    end record;
 end Netlists.Builders;

--- a/src/synth/netlists-disp_vhdl.adb
+++ b/src/synth/netlists-disp_vhdl.adb
@@ -743,6 +743,10 @@ package body Netlists.Disp_Vhdl is
             Disp_Template
               ("  \l0: assert \i0 = '1' severity warning; --  assume" & NL,
                Inst);
+         when Id_Cover =>
+            Disp_Template
+              ("  \l0: assert \i0 = '1' severity note; --  cover" & NL,
+               Inst);
          when others =>
             Disp_Instance_Gate (Inst);
       end case;

--- a/src/synth/netlists-gates.ads
+++ b/src/synth/netlists-gates.ads
@@ -148,6 +148,7 @@ package Netlists.Gates is
    --  Input signal must always be true.
    Id_Assert : constant Module_Id := 72;
    Id_Assume : constant Module_Id := 73;
+   Id_Cover : constant Module_Id := 74;
 
    --  Constants are gates with only one constant output.  There are multiple
    --  kind of constant gates: for small width, the value is stored as a

--- a/src/synth/synth-stmts.adb
+++ b/src/synth/synth-stmts.adb
@@ -1722,6 +1722,22 @@ package body Synth.Stmts is
       end if;
    end Synth_Psl_Restrict_Directive;
 
+   procedure Synth_Psl_Cover_Directive
+     (Syn_Inst : Synth_Instance_Acc; Stmt : Node)
+   is
+      Res : Net;
+      Inst : Instance;
+   begin
+      --  Build cover gate.
+      --  Note: for synthesis, we assume the next state will be correct.
+      --  (If we assume on States, then the first cycle is ignored).
+      Res := Synth_Psl_Sequence_Directive (Syn_Inst, Stmt);
+      if Res /= No_Net then
+         Inst := Build_Cover (Build_Context, Synth_Label (Stmt), Res);
+         Set_Location (Inst, Get_Location (Stmt));
+      end if;
+   end Synth_Psl_Cover_Directive;
+
    function Synth_Psl_Property_Directive
      (Syn_Inst : Synth_Instance_Acc; Stmt : Node) return Net
    is
@@ -1949,6 +1965,8 @@ package body Synth.Stmts is
                Synth_Psl_Restrict_Directive (Syn_Inst, Stmt);
             when Iir_Kind_Psl_Assume_Directive =>
                Synth_Psl_Assume_Directive (Syn_Inst, Stmt);
+            when Iir_Kind_Psl_Cover_Directive =>
+               Synth_Psl_Cover_Directive (Syn_Inst, Stmt);
             when Iir_Kind_Psl_Assert_Directive =>
                Synth_Psl_Assert_Directive (Syn_Inst, Stmt);
             when Iir_Kind_Concurrent_Assertion_Statement =>
@@ -1975,6 +1993,8 @@ package body Synth.Stmts is
                Synth_Psl_Assert_Directive (Syn_Inst, Item);
             when Iir_Kind_Psl_Assume_Directive =>
                Synth_Psl_Assume_Directive (Syn_Inst, Item);
+            when Iir_Kind_Psl_Cover_Directive =>
+               Synth_Psl_Cover_Directive (Syn_Inst, Item);
             when others =>
                Error_Kind ("synth_verification_unit", Item);
          end case;

--- a/testsuite/synth/psl01/cover1.vhdl
+++ b/testsuite/synth/psl01/cover1.vhdl
@@ -2,12 +2,12 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-entity hello is
+entity cover1 is
  port (clk, rst: std_logic;
        cnt : out unsigned(3 downto 0));
-end hello;
+end cover1;
 
-architecture behav of hello is
+architecture behav of cover1 is
  signal val : unsigned (3 downto 0);
 begin
  process(clk)
@@ -23,8 +23,5 @@ begin
  cnt <= val;
 
  --psl default clock is rising_edge(clk);
- --psl restrict {rst; (not rst)[*]};
- --psl assert always val /= 5 abort rst;
- --psl assume always val < 10;
  --psl cover {val = 10};
 end behav;

--- a/testsuite/synth/psl01/cover2.vhdl
+++ b/testsuite/synth/psl01/cover2.vhdl
@@ -2,13 +2,14 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-entity hello is
+entity cover2 is
  port (clk, rst: std_logic;
        cnt : out unsigned(3 downto 0));
-end hello;
+end cover2;
 
-architecture behav of hello is
+architecture behav of cover2 is
  signal val : unsigned (3 downto 0);
+ default clock is rising_edge(clk);
 begin
  process(clk)
  begin
@@ -22,9 +23,5 @@ begin
  end process;
  cnt <= val;
 
- --psl default clock is rising_edge(clk);
- --psl restrict {rst; (not rst)[*]};
- --psl assert always val /= 5 abort rst;
- --psl assume always val < 10;
- --psl cover {val = 10};
+ cover {val = 10};
 end behav;

--- a/testsuite/synth/psl01/testsuite.sh
+++ b/testsuite/synth/psl01/testsuite.sh
@@ -4,7 +4,7 @@
 
 GHDL_STD_FLAGS=--std=08
 
-for f in restrict1 restrict2 assume1 assume2 assert1; do
+for f in restrict1 restrict2 assume1 assume2 assert1 cover1 cover2; do
   synth -fpsl $f.vhdl -e $f > syn_$f.vhdl
   analyze syn_$f.vhdl
 done


### PR DESCRIPTION
As mentioned in https://github.com/ghdl/ghdl/issues/927 here is my first pull request to implement support for PSL cover directives with synthesis. I added two test cases to check the additions.

I'm not sure about the change in `src/synth/ghdlsynth_gates.h`as the file header says to not modify that file, as it is generated. I can remove that change if necessary.

@tgingold please check and comment if there are problems with the PR. And thanks for your suggestions.