### PR TITLE
update bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,23 +9,10 @@ A clear and concise description of what the issue is about.
 **Expected behaviour**
 What you expected to happen, and what is happening instead.
 
-**Context**
-Please paste the `GHDL Bug occurred` log block here. Also, provide the following information:
-
-- OS:
-- Origin:
-  - [ ] Package manager. Repo:
-  - [ ] Released binaries. Tarball:
-  - [ ] Built from sources. Commit SHA:
-
-**Additional context**
-Add any other context about the problem here. If applicable, add screenshots to help explain your problem.
-
 **How to reproduce?**
-Tell us how to reproduce this issue. Please provide a Minimal Working Example (MWE), that is compatible with [issue-runner](https://github.com/1138-4EB/issue-runner). With sample code it's easier to reproduce the bug and it's much faster to fix it. For example:
+Tell us how to reproduce this issue. Please provide a Minimal Working Example (MWE). With sample code it's easier to reproduce the bug and it's much faster to fix it. For example:
 
-```
-#>> ent.vhd
+```vhd :file: ent.vhd
 entity ent is
 end entity;
 
@@ -36,25 +23,34 @@ begin
     wait;
   end process;
 end;
-
-#>> sim.sh
-ghdl -a ent.vhd
-ghdl --elab-run ent
-
-#>> run.sh
-docker run --rm -tv /$(pwd):/src:z -w //src ghdl/ghdl:buster-mcode sh -c ./sim.sh
-
-#>> end
 ```
 
-Note that `run.sh` is used to execute `sim.sh` inside a docker container. Please, put your commands in `sim.sh` and just copy `run.sh` from the example. Using `ghdl/ghdl:*` docker images to run the MWEs ensures that the latest available GHDL is used.
+```sh :image: ghdl/ghdl:buster-mcode
+ghdl -a ent.vhd
+ghdl --elab-run ent
+```
 
-**Files**
-A list of relevant files for this issue. Large files can be uploaded one-by-one or in a tarball/zipfile. See [1138-4EB/issue-runner#parser](https://github.com/1138-4EB/issue-runner#parser).
+> NOTE: `:file:` and `:image:` identifiers are specific to [issue-runner](https://github.com/1138-4EB/issue-runner). We suggest to use these, since it allows continuous integration workflows to automatically test the MWE. Using `ghdl/ghdl:*` docker images to run the MWEs ensures that the latest available GHDL is used.
 
-**Checklist**
-Before submitting your issue, please review the following checklist:
+> NOTE: Large files can be uploaded one-by-one or in a tarball/zipfile.
 
-- [ ] Add `GHDL Bug occurred` log block
-- [ ] Add a MWE
-- [ ] Try the latest version
+**Context**
+Please, provide the following information:
+
+- OS:
+- Origin:
+  - [ ] Package manager: `version`
+  - [ ] Released binaries: `tarball_url`
+  - [ ] Built from sources: `commit SHA`
+
+If a `GHDL Bug occurred` block is shown in the log, please paste it here:
+
+```
+******************** GHDL Bug occurred ***************************
+Please report this bug on https://github.com/ghdl/ghdl/issues
+...
+******************************************************************
+```
+
+**Additional context**
+Add any other context about the problem here. If applicable, add screenshots to help explain your problem.


### PR DESCRIPTION
In this PR the bug report template is updated. I've rewritten [issue-runner](https://github.com/1138-4EB/issue-runner) in golang, and now a different format is supported. It is no longer necessary to define all the sources in the same code block. Now, each file is defined in a different code block, which allows language highlighting to work properly.

At the same time, I moved contex-related questions to the bottom. If/when MWEs are automatically tested through a GitHub Action, it will be handy to have this info in the same place.