### PR TITLE
synth: add support for comp. equal of two signed

### DIFF
--- a/src/synth/synth-oper.adb
+++ b/src/synth/synth-oper.adb
@@ -519,6 +519,10 @@ package body Synth.Oper is
             --  "=" (Unsigned, Unsigned) [resize]
             return Synth_Compare_Uns_Uns (Id_Eq);
 
+         when Iir_Predefined_Ieee_Numeric_Std_Eq_Sgn_Sgn =>
+            --  "=" (Signed, Signed) [resize]
+            return Synth_Compare_Sgn_Sgn (Id_Eq);
+
          when Iir_Predefined_Ieee_Numeric_Std_Ne_Uns_Uns
            | Iir_Predefined_Ieee_Std_Logic_Unsigned_Ne_Slv_Slv =>
             --  "/=" (Unsigned, Unsigned) [resize]


### PR DESCRIPTION
This PR adds handling of comparing two signed vectors, for example:

```vhdl
library ieee;
use ieee.std_logic_1164.all;
use ieee.numeric_std.all;

entity test is
  port (
    a, b  : in  signed(7 downto 0);
    eq   : out std_logic
  );
end entity test;

architecture rtl of test is
begin

  eq <= '1' when a = b else '0';

end architecture rtl;
```

Without this addition, we got an error like 
`synth_dyadic_operation: unhandled IIR_PREDEFINED_IEEE_NUMERIC_STD_EQ_SGN_SGN`

With the addition, this compare is mapped to `Id_Eq`. I would like to add compare of signed to Integer also, but for that a new function `Synth_Sresize (Val : Value_Acc; W : Width; Loc : Node)` is needed which isn't that trivial (for me ;)).
