### PR TITLE
Show error on wait without condition

### DIFF
--- a/src/synth/synth-stmts.adb
+++ b/src/synth/synth-stmts.adb
@@ -1925,6 +1925,10 @@ package body Synth.Stmts is
 
       --  Handle the condition as an if.
       Cond := Get_Condition_Clause (Stmt);
+      if Cond = 0 then
+         Error_Msg_Synth (+Stmt, "expect wait condition");
+         return;
+      end if;
       Cond_Val := Synth_Expression (C.Inst, Cond);
 
       Push_Phi;

--- a/src/synth/synth-stmts.adb
+++ b/src/synth/synth-stmts.adb
@@ -1925,7 +1925,7 @@ package body Synth.Stmts is
 
       --  Handle the condition as an if.
       Cond := Get_Condition_Clause (Stmt);
-      if Cond = 0 then
+      if Cond = Null_Node then
          Error_Msg_Synth (+Stmt, "expect wait condition");
          return;
       end if;


### PR DESCRIPTION
Currently GHDL can synth a `wait` statement only if it is the first statement in a process and has a clock condition. This PR just adds a check that there is an actual condition.

#903: The latest Microwatt uses a `wait` without condition at the end of a debug process. Not sure if this should be supported and how.