### PR TITLE
Install source of std.standard package to correct version sub-directory

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -126,9 +126,9 @@ all: Makefile all.$(backend) all.libghdl
 
 install: install.$(backend)
 #       Generate std.standard package VHDL source
-	$(DESTDIR)$(bindir)/ghdl$(EXEEXT) --disp-standard --std=87 > $(DESTDIR)$(VHDL_LIB_DIR)/src/std/standard.v87
-	$(DESTDIR)$(bindir)/ghdl$(EXEEXT) --disp-standard --std=93 > $(DESTDIR)$(VHDL_LIB_DIR)/src/std/standard.v93
-	$(DESTDIR)$(bindir)/ghdl$(EXEEXT) --disp-standard --std=08 > $(DESTDIR)$(VHDL_LIB_DIR)/src/std/standard.v08
+	$(DESTDIR)$(bindir)/ghdl$(EXEEXT) --disp-standard --std=87 > $(DESTDIR)$(VHDL_LIB_DIR)/src/std/v87/standard.vhdl
+	$(DESTDIR)$(bindir)/ghdl$(EXEEXT) --disp-standard --std=93 > $(DESTDIR)$(VHDL_LIB_DIR)/src/std/v93/standard.vhdl
+	$(DESTDIR)$(bindir)/ghdl$(EXEEXT) --disp-standard --std=08 > $(DESTDIR)$(VHDL_LIB_DIR)/src/std/v08/standard.vhdl
 
 uninstall: uninstall.$(backend)
 


### PR DESCRIPTION
**Description** Please explain the changes you made here.

In PR #811, the `install` target of the `Makefile` got enhanced to install the VHDL sources of the `std.standard` along with the other VHDL sources of the standard packages. Sometime over the past month, the installation location for the VHDL sources of the standard packages got changed. This PR adjusts the install paths for the `standard.vhdl` files to `lib/ghdl/src/std/v??/standard.vhdl`.

- [X] DO indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

This PR is related to PR #811 and issue #802, which facilitate using the `rust_hdl` language server for VHDL.

**When contributing to the GHDL codebase...**

- [X] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [X] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
- [X] CONSIDER adding a unit test if your PR resolves an issue.
- [X] CONSIDER modifying the docs, at least in the TODO, if your contribution is relevant to any of the content.
- [X] AVOID breaking the continuous integration build.
- [X] AVOID breaking the testsuite.

**When contributing to the docs...**

- [ ] DO make sure that the build is successful. See [ghdl/ghdl#572 (issuecomment-390466024)](https://github.com/ghdl/ghdl/issues/572#issuecomment-390466024).

**Further comments**

None.