### PR TITLE
doc: add '.. program:: ghdl' directive

### DIFF
--- a/doc/examples/quick_start/DLXModelSuite.rst
+++ b/doc/examples/quick_start/DLXModelSuite.rst
@@ -1,3 +1,4 @@
+.. program:: ghdl
 .. _QuickStart:DLX:
 
 Working with non-trivial designs

--- a/doc/examples/quick_start/README.rst
+++ b/doc/examples/quick_start/README.rst
@@ -1,3 +1,4 @@
+.. program:: ghdl
 .. _USING:QuickStart:
 
 Quick Start Guide

--- a/doc/examples/quick_start/adder/README.rst
+++ b/doc/examples/quick_start/adder/README.rst
@@ -1,3 +1,4 @@
+.. program:: ghdl
 .. _QuickStart:adder:
 
 `Full adder` module and testbench

--- a/doc/examples/quick_start/heartbeat/README.rst
+++ b/doc/examples/quick_start/heartbeat/README.rst
@@ -1,3 +1,4 @@
+.. program:: ghdl
 .. _QuickStart:heartbeat:
 
 `Heartbeat` module

--- a/doc/examples/quick_start/hello/README.rst
+++ b/doc/examples/quick_start/hello/README.rst
@@ -1,3 +1,4 @@
+.. program:: ghdl
 .. _QuickStart:hello:
 
 `Hello world` program

--- a/doc/using/CommandReference.rst
+++ b/doc/using/CommandReference.rst
@@ -1,3 +1,4 @@
+.. program:: ghdl
 .. _REF:Command:
 
 Command Reference

--- a/doc/using/Foreign.rst
+++ b/doc/using/Foreign.rst
@@ -1,3 +1,4 @@
+.. program:: ghdl
 .. FOREIGN:
 
 Interfacing to other languages

--- a/doc/using/ImplementationOfVHDL.rst
+++ b/doc/using/ImplementationOfVHDL.rst
@@ -1,3 +1,4 @@
+.. program:: ghdl
 .. _REF:ImplVHDL:
 
 Implementation of VHDL

--- a/doc/using/ImplementationOfVITAL.rst
+++ b/doc/using/ImplementationOfVITAL.rst
@@ -1,3 +1,4 @@
+.. program:: ghdl
 .. _REF:ImplVITAL:
 
 ****************************
@@ -28,7 +29,7 @@ requirements of VITAL: VITAL 1995 requires the models follow the VHDL
 1987 standard, while VITAL 2000 requires the models follow VHDL 1993.
 
 The VITAL 2000 packages were slightly modified so that they conform to
-the VHDL 1993 standard (a few functions are made pure and a few 
+the VHDL 1993 standard (a few functions are made pure and a few
 impure).
 
 .. _vhdl_restrictions_for_vital:

--- a/doc/using/InvokingGHDL.rst
+++ b/doc/using/InvokingGHDL.rst
@@ -1,3 +1,4 @@
+.. program:: ghdl
 .. _USING:Invoking:
 
 Invoking GHDL

--- a/doc/using/Simulation.rst
+++ b/doc/using/Simulation.rst
@@ -1,3 +1,4 @@
+.. program:: ghdl
 .. _USING:Simulation:
 
 Simulation and runtime


### PR DESCRIPTION
As suggested by @Paebbels ([November 12, 2019 12:55 AM](https://gitter.im/ghdl1/Lobby?at=5dc9f4f635889012b1efe572)), `.. program:: ghdl` directives that were removed in #1003 are added again.