### PR TITLE
Allow building GHDL mcode on FreeBSD

### DIFF
--- a/configure
+++ b/configure
@@ -368,7 +368,7 @@ fi
 # Generate ortho_code-x86-flags
 if test $backend = mcode; then
   case "$build" in
-    *darwin*) ortho_flags="Flags_Macosx${mcode64}" ;;
+    *darwin* | *freebsd* ) ortho_flags="Flags_Macosx${mcode64}" ;;
     *mingw32*) ortho_flags="Flags_Windows${mcode64}" ;;
     *linux*) ortho_flags="Flags_Linux${mcode64}" ;;
     *) echo "Unsupported $build build for mcode"; exit 1;;

--- a/src/grt/Makefile.inc
+++ b/src/grt/Makefile.inc
@@ -56,7 +56,7 @@ else
     GRT_EXTRA_LIB=-ldl -lm $(GRT_ELF_OPTS)
   endif
   ifeq ($(filter-out netbsd freebsd% dragonfly%,$(osys)),)
-    GRT_EXTRA_LIB=-lm $(GRT_ELF_OPTS)
+    GRT_EXTRA_LIB=-lm
   endif
   ifeq ($(filter-out solaris%,$(osys)),)
     GRT_EXTRA_LIB=-ldl -lm

--- a/src/ortho/mcode/memsegs_c.c
+++ b/src/ortho/mcode/memsegs_c.c
@@ -28,7 +28,7 @@
    set rights.
 */
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || !defined(MREMAP_MAYMOVE)
 #define MAP_ANONYMOUS MAP_ANON
 #else
 #define HAVE_MREMAP


### PR DESCRIPTION
These commits enables building of GHDL (mcode) on FreeBSD 12.1. Each of the three commits fixes one individual build failure. This pull request also fixes #501.

The exact configure and build commands for the successful build is:
```
MAKE=gmake ../configure CC=cc GNATMAKE=/usr/local/gcc6-aux/bin/gnatmake --prefix=/opt/ghdl-mcode
gmake
```

System information:
```
$ uname -a
FreeBSD cl 12.1-RELEASE-p1 FreeBSD 12.1-RELEASE-p1 GENERIC  amd64
$ cc -v
FreeBSD clang version 8.0.1 (tags/RELEASE_801/final 366581) (based on LLVM 8.0.1)
Target: x86_64-unknown-freebsd12.1
Thread model: posix
InstalledDir: /usr/bin
```