### PR TITLE
ci: fix envvar name to run synth tests

### DIFF
--- a/dist/travis/travis-ci.sh
+++ b/dist/travis/travis-ci.sh
@@ -98,7 +98,7 @@ else
       tests="$tests gna"
     fi
     tests="$tests vests"
-    if [ "x$ISEXTRA" = "xsynth" ]; then
+    if [ "x$EXTRA" = "xsynth" ]; then
       tests="$tests synth"
     fi
     $RUN "ghdl/ghdl:$GHDL_IMAGE_TAG" bash -c "GHDL=ghdl ${scriptdir}/../../testsuite/testsuite.sh $tests"


### PR DESCRIPTION
The name of the envvar that is checked to decide whether to run the synth test suite is not correct. `ISEXTRA` is checked, and it should be `EXTRA`. As a result, currently issues with the synth test suite are not being checked: https://travis-ci.org/ghdl/ghdl/jobs/614170911#L1270

Actually, this PR fails because there is currently some issue with `master`: https://travis-ci.org/1138-4EB/ghdl/jobs/614291974#L1836