### PR TITLE
Add option for compiling Wishbone VIP for UVVM framework.

### DIFF
--- a/libraries/vendors/compile-uvvm.sh
+++ b/libraries/vendors/compile-uvvm.sh
@@ -65,6 +65,7 @@ uvvm_vips="bitvis_vip_sbi
  bitvis_vip_i2c
  bitvis_vip_spi
  bitvis_vip_uart
+ bitvis_vip_wishbone
 
  bitvis_vip_clock_generator
  bitvis_vip_scoreboard
@@ -134,6 +135,10 @@ while [[ $# > 0 ]]; do
 		;;
 		--uvvm-vip-uart)
 		COMPILE_vip_uart=TRUE
+		NO_COMMAND=0
+		;;
+		--uvvm-vip-wishbone)
+		COMPILE_vip_wishbone=TRUE
 		NO_COMMAND=0
 		;;
 		--uvvm-vip-clock_generator)
@@ -216,6 +221,7 @@ if [ "$HELP" == "TRUE" ]; then
 	echo "     --uvvm-vip-sbi"
 	echo "     --uvvm-vip-spi"
 	echo "     --uvvm-vip-uart"
+	echo "     --uvvm-vip-wishbone"
 	echo "     --uvvm-vip-clock_generator"
 	echo "     --uvvm-vip-scoreboard"
 	echo ""


### PR DESCRIPTION
Wishbone VIP is located in [UVVM_Community_VIPs](https://github.com/UVVM/UVVM_Community_VIPs) repository. To compile it needs to be copied to [UVVM](https://github.com/UVVM/UVVM) directory. Why and how is explained in this issue [UVVM_Community_VIPs issue 2](https://github.com/UVVM/UVVM_Community_VIPs/issues/2).
When it is not copied, and you compile with `--all` flag, compilation of standard VIPs from [UVVM](https://github.com/UVVM/UVVM) repository success, so this commit does not break anything.