### PR TITLE
fix btdi image names

### DIFF
--- a/dist/man.sh
+++ b/dist/man.sh
@@ -9,7 +9,7 @@ set -e
 docker run --rm -it \
   -v /$(pwd):/src \
   -w //src/doc \
-  btdi/sphinx:py2-featured \
+  btdi/sphinx:featured \
   sh -c "sphinx-build -T -b man . ./_build/man"
 
 nroff -man doc/_build/man/ghdl.1

--- a/doc/make.sh
+++ b/doc/make.sh
@@ -5,7 +5,7 @@ set -e
 cd "$(dirname $0)"
 
 docker build -t ghdl/sphinx -f- . <<EOF
-FROM btdi/sphinx:py3-featured
+FROM btdi/sphinx:featured
 COPY requirements.txt /
 RUN apk add -U --no-cache make \
  && pip3 install -r /requirements.txt


### PR DESCRIPTION
The names of images that are used in `man.sh` and `make.sh` changed. This PR fixes them so that job 'man' in Travis is not broken.