### PR TITLE
fix gnat-gpl download URL (osx)

### DIFF
--- a/dist/macosx/install-ada.sh
+++ b/dist/macosx/install-ada.sh
@@ -12,9 +12,9 @@ set -x
 
 # Download from libre.adacore.com
 tarfile=gnat-gpl-2017-x86_64-darwin-bin.tar.gz
-curl -o $tarfile http://mirrors.cdn.adacore.com/art/591c9045c7a447af2deed24e
+wget -O $tarfile https://community.download.adacore.com/v1/7bbc77bd9c3c03fdb93699bce67b458f95d049a9?filename=gnat-gpl-2017-x86_64-darwin-bin.tar.gz
 
-# un tar
+# untar
 tar xf $tarfile
 
 # Remove old gnat directory and install manually


### PR DESCRIPTION
Apparently, AdaCore changed the URLs of the tarballs, and osx builds are failing, unless GNAT GPL is already cached in the CI system. This PR updates the URL to fix it. I had to use `wget` instead of `curl`, because I couldn't guess how to make the latter work.