### PR TITLE
ci: update installation of GNAT GPL on macOS

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,7 +31,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - run: |
+        brew update
+        brew install p7zip
         ./dist/macosx/install-ada.sh
+    - run: |
         PATH=$PWD/gnat/bin:$PATH
         ./dist/ci-run.sh -c
       env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,7 +30,10 @@ jobs:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v1
-    - run: ./dist/ci-run.sh -c
+    - run: |
+        ./dist/macosx/install-ada.sh
+        PATH=$PWD/gnat/bin:$PATH
+        ./dist/ci-run.sh -c
       env:
         TASK: macosx+mcode
         GITHUB_OS: ${{ runner.os }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,12 @@ jobs:
       os: osx
       language: c
       osx_image: xcode9.4
-      install: true
+      env: TASK=macosx+mcode
       cache:
         directories:
           - gnat
-      env: TASK=macosx+mcode
+      install: ./dist/macosx/install-ada.sh
+      before_script: PATH=$PWD/gnat/bin:$PATH
     # Optionally, more macos jobs can be added. See list of available versions at https://docs.travis-ci.com/user/reference/osx/#macos-version
 #   - <<: *osx
 #     osx_image: xcode10

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,11 @@ jobs:
           - gnat
       install: ./dist/macosx/install-ada.sh
       before_script: PATH=$PWD/gnat/bin:$PATH
+      addons:
+        homebrew:
+          packages:
+            - p7zip
+          update: true
     # Optionally, more macos jobs can be added. See list of available versions at https://docs.travis-ci.com/user/reference/osx/#macos-version
 #   - <<: *osx
 #     osx_image: xcode9.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
     - &osx
       os: osx
       language: c
-      osx_image: xcode9.4
+      osx_image: xcode10
       env: TASK=macosx+mcode
       cache:
         directories:
@@ -48,7 +48,7 @@ jobs:
       before_script: PATH=$PWD/gnat/bin:$PATH
     # Optionally, more macos jobs can be added. See list of available versions at https://docs.travis-ci.com/user/reference/osx/#macos-version
 #   - <<: *osx
-#     osx_image: xcode10
+#     osx_image: xcode9.4
     - env: TASK="man"
       script: ./dist/man.sh
       deploy:

--- a/dist/ci-run.sh
+++ b/dist/ci-run.sh
@@ -388,14 +388,6 @@ ci_run () {
   git fetch --unshallow || true
   gend
 
-  if [ "x$IS_MACOS" = "xtrue" ]; then
-      gstart "[CI] Install gnat compiler (use cache) and set CPATH" "$ANSI_BLUE"
-      ./dist/macosx/install-ada.sh || exit 1
-      PATH=$PWD/gnat/bin:$PATH
-      export CPATH="$CPATH:`xcrun --show-sdk-path`/usr/include"
-      gend
-  fi
-
   # Get build command options
   gstart "[CI] Get build command options" "$ANSI_BLUE"
   buildCmdOpts "$TASK"
@@ -406,7 +398,10 @@ ci_run () {
 
   RUN="docker run --rm -t -e CI -e TRAVIS -v `pwd`:/work -w /work"
   if [ "x$IS_MACOS" = "xtrue" ]; then
-      CC=clang CONFIG_OPTS="--disable-libghdl" bash -c "${scriptdir}/ci-run.sh $BUILD_CMD_OPTS build"
+      export CPATH="$CPATH:`xcrun --show-sdk-path`/usr/include"
+      CC=clang \
+      CONFIG_OPTS="--disable-libghdl" \
+      bash -c "${scriptdir}/ci-run.sh $BUILD_CMD_OPTS build"
   else
       # Assume linux
 
@@ -435,7 +430,9 @@ ci_run () {
   # Test
 
   if [ "x$IS_MACOS" = "xtrue" ]; then
-      CC=clang prefix="`cd ./install-mcode; pwd`" ./testsuite/testsuite.sh sanity gna vests
+      CC=clang \
+      prefix="`cd ./install-mcode; pwd`" \
+      ./testsuite/testsuite.sh sanity gna vests
   else
       # Build ghdl/ghdl:$GHDL_IMAGE_TAG image
       build_img_ghdl

--- a/dist/macosx/install-ada.sh
+++ b/dist/macosx/install-ada.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -e gnat/etc/install_ok ]; then
+if [ -e gnat/etc/install_ok ] && [ "x$(cat gnat/etc/install_ok)" = "x2019" ]; then
     echo "gnatgpl already installed"
     exit 0
 fi
@@ -10,16 +10,20 @@ fi
 echo "Download and install gnat-gpl"
 set -x
 
-# Download from libre.adacore.com
-tarfile=gnat-gpl-2017-x86_64-darwin-bin.tar.gz
-wget -O $tarfile https://community.download.adacore.com/v1/7bbc77bd9c3c03fdb93699bce67b458f95d049a9?filename=gnat-gpl-2017-x86_64-darwin-bin.tar.gz
+# Remove old gnat directory
+if [ -d gnat ]; then
+    rm -rf gnat
+fi
 
-# untar
-tar xf $tarfile
+# Download from community.adacore.com and extract
+wget -O dmgfile https://community.download.adacore.com/v1/5a7801fc686e86de838cfaf7071170152d81254d?filename=gnat-community-2019-20190517-x86_64-darwin-bin.dmg
+7z x dmgfile
+installer="gnat-community-2019-20190517-x86_64-darwin-bin/gnat-community-2019-20190517-x86_64-darwin-bin.app/Contents/MacOS/gnat-community-2019-20190517-x86_64-darwin-bin"
 
-# Remove old gnat directory and install manually
-rm -rf gnat
-mv gnat-gpl-2017-x86_64-darwin-bin gnat
+# Install
+mkdir -p gnat
+chmod +x $installer
+./$installer PREFIX=gnat
 
 # Cleanup: remove components not needed
 rm -rf gnat/share/{themes,icons} \
@@ -40,9 +44,8 @@ rm -rf gnat/share/{themes,icons} \
        gnat/lib/gcc/x86*/*/rts-native/adalib/*.dylib \
        gnat/lib/gcc/x86*/*/rts-native/adalib/lib*_pic.a \
        gnat/libexec/gprbuild \
-       gnat/libexec/gcc/x86*/*/{plugin,install-tools}
-
-rm -f  gnat/bin/aws* gnat/bin/gps* gnat/bin/gcov* \
+       gnat/libexec/gcc/x86*/*/{plugin,install-tools} \
+       gnat/bin/aws* gnat/bin/gps* gnat/bin/gcov* \
        gnat/bin/gnat2* gnat/bin/xml2* gnat/bin/gnatcoll* \
        gnat/bin/gnat{doc,metric,pp,stub,prep,test,check,elim,inspect,find,kr} \
        gnat/bin/gnat{xref,name} \
@@ -54,4 +57,4 @@ rm -f  gnat/bin/aws* gnat/bin/gps* gnat/bin/gcov* \
        gnat/lib/libxmlada* \
        gnat/libexec/gcc/x86*/*/{cc1obj,cc1plus,lto1}
 
-touch gnat/etc/install_ok
+echo "2019" > gnat/etc/install_ok


### PR DESCRIPTION
Close #1071 

This PR contains a few non-critical updates to the macOS environments in CI:

- GNAT GPL is updated to 2019. Unlike 2017, this version is only available as a DMG file, not as a tarball. Hence, `7z` is used to extract it, instead of `tar`.
- Xcode in Travis is updated to 10.
- Instead of executing the installation of GNAT GPL in the ci run script, it is done in the YAML files of the CI services. The motivation for this is that it is a dependency that is required in the system, rather than a piece of GHDL. On other platforms, dependencies are handled outside of the build scripts.