### PR TITLE
netlists: Handle sdiv and udiv

### DIFF
--- a/src/synth/netlists-disp_vhdl.adb
+++ b/src/synth/netlists-disp_vhdl.adb
@@ -940,6 +940,12 @@ package body Netlists.Disp_Vhdl is
          when Id_Srem =>
             Disp_Template
               ("  \o0 <= std_logic_vector (\si0 rem \si1);" & NL, Inst);
+         when Id_Sdiv =>
+            Disp_Template
+              ("  \o0 <= std_logic_vector (\si0 / \si1);" & NL, Inst);
+         when Id_Udiv =>
+            Disp_Template
+              ("  \o0 <= std_logic_vector (\ui0 / \ui1);" & NL, Inst);
          when Id_Lsl =>
             Disp_Template
               ("  \o0 <= std_logic_vector "


### PR DESCRIPTION
I hit an issue with vhdl that uses divides when using `ghdl --synth`.