### PR TITLE
use DESTDIR instead of --prefix

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -264,7 +264,7 @@ copy-sources.gcc: version.ads
 
 # To build vhdl libs using a non-installed ghdl, define GHDL_GCC_BIN to the
 # path of ghdl and GHDL1_GCC_BIN to path of ghdl1
-GHDL_GCC_BIN=$(bindir)/ghdl$(EXEEXT)
+GHDL_GCC_BIN=$(DESTDIR)$(bindir)/ghdl$(EXEEXT)
 GHDL1_GCC_BIN=  # --GHDL1=/path/to/ghdl1
 
 libs.vhdl.gcc:

--- a/dist/ci-run.sh
+++ b/dist/ci-run.sh
@@ -248,8 +248,8 @@ build () {
   #--- Configure
 
   CDIR=`pwd`
-  export prefix="$CDIR/install-$BACK"
-  mkdir "$prefix"
+  INSTALL_DIR="$CDIR/install-$BACK"
+  mkdir "$INSTALL_DIR"
   mkdir "build-$BACK"
   cd "build-$BACK"
 
@@ -271,14 +271,14 @@ build () {
           gend
 
           gstart "[GHDL - build] Configure ghdl"
-          run_cmd ../configure --with-gcc=gcc-srcs --prefix="$prefix" $CONFIG_OPTS
+          run_cmd ../configure --with-gcc=gcc-srcs $CONFIG_OPTS
           gend
           gstart "[GHDL - build] Copy sources"
           make copy-sources
           mkdir gcc-objs; cd gcc-objs
           gend
           gstart "[GHDL - build] Configure gcc"
-          run_cmd ../gcc-srcs/configure --prefix="$prefix" --enable-languages=c,vhdl --disable-bootstrap --disable-lto --disable-multilib --disable-libssp --disable-libgomp --disable-libquadmath "`gcc -v 2>&1 | grep -o -- --enable-default-pie`"
+          run_cmd ../gcc-srcs/configure --enable-languages=c,vhdl --disable-bootstrap --disable-lto --disable-multilib --disable-libssp --disable-libgomp --disable-libquadmath "`gcc -v 2>&1 | grep -o -- --enable-default-pie`"
           gend
       ;;
       mcode)
@@ -304,7 +304,7 @@ build () {
 
   if [ ! "`echo $BACK | grep gcc`" ]; then
       gstart "[GHDL - build] Configure"
-      run_cmd ../configure "--prefix=$prefix" $CONFIG_OPTS
+      run_cmd ../configure $CONFIG_OPTS
       gend
   fi
 
@@ -318,17 +318,17 @@ build () {
   gend
 
   gstart "[GHDL - build] Install"
-  make install
+  make DESTDIR="$INSTALL_DIR" install
   cd ..
   gend
 
   if [ "`echo $BACK | grep gcc`" ]; then
       gstart "[GHDL - build] Make ghdllib"
-      make ghdllib
+      make DESTDIR="$INSTALL_DIR" ghdllib
       gend
 
       gstart "[GHDL - build] Install ghdllib"
-      make install
+      make DESTDIR="$INSTALL_DIR" install
       cd ..
       gend
   fi
@@ -336,7 +336,7 @@ build () {
   #--- package
 
   gstart "[GHDL - build] Create package ${ANSI_DARKCYAN}${PKG_NAME}.tgz"
-  tar -zcvf "${PKG_NAME}.tgz" -C "$prefix" .
+  tar -zcvf "${PKG_NAME}.tgz" -C "$INSTALL_DIR/usr/local" .
   gend
 
   #--- build tools versions
@@ -432,7 +432,7 @@ ci_run () {
 
   if [ "x$IS_MACOS" = "xtrue" ]; then
       CC=clang \
-      prefix="`cd ./install-mcode; pwd`" \
+      prefix="`cd ./install-mcode; pwd`/usr/local" \
       ./testsuite/testsuite.sh sanity gna vests
   else
       # Build ghdl/ghdl:$GHDL_IMAGE_TAG image


### PR DESCRIPTION
Currently, GHDL is built in CI jobs by setting `prefix`|`--prefix` to a local subdir (`./install-<BACKEND>`):

https://github.com/ghdl/ghdl/blob/501193da2ca0f6ad0f5c514eb793a7e3a3224887/dist/ci-run.sh#L251

In ghdlsynth-beta, instead of setting `prefix`, it defaults to `/usr/local` and `DESTDIR` is used:

https://github.com/tgingold/ghdlsynth-beta/blob/910073d647e55d133494429d8c3a4bacffc32428/ci.sh#L36-L38

Since GHDL is built daily with `--enable-synth` in ghdl/docker (see https://github.com/ghdl/docker/actions?query=workflow%3Adaily), I think it'd be good to reuse image `ghdl/pkg:buster-mcode`. That would reduce the CI job of ghdlsynth-beta to building `ghdl_yosys.so` and running the tests.

Unfortunately, `ghdl_yosys.so` looks for GHDL in the `prefix`. As a result, it fails when searching the libraries (`std`): https://github.com/eine/ghdlsynth-beta/commit/662c49a92cb3e843da90dcc984b92444e1b60735/checks?check_suite_id=408813253#step:3:297

A possible solution would be to enhance `ghdl_yosys.so` so that GHDL is searched in the PATH. Alternatively, I'd like to change the build procedure here, to use DESTDIR instead of `--prefix`.

The changes in this PR work for mcode and LLVM backends, but not for GCC. Precisely, it fails when building `ghdllib`: https://github.com/eine/ghdl/runs/397759378#step:3:10709. @tgingold, any hint?