### PR TITLE
disable backtrace on android

### DIFF
--- a/src/grt/config/jumps.c
+++ b/src/grt/config/jumps.c
@@ -29,7 +29,7 @@
 #include <signal.h>
 #include <fcntl.h>
 
-#if defined (__linux__) || defined (__APPLE__)
+#if ( defined (__linux__) || defined (__APPLE__) ) && !defined (__ANDROID__)
 #define HAVE_BACKTRACE 1
 #include <sys/ucontext.h>
 #endif


### PR DESCRIPTION
This PR disables backtrace on Android, since that feature is not included in the Bionic C library. This allows to follow a regular build procedure to have GHDL available on smartphones and tablets!
