### PR TITLE
add build script for termux

### DIFF
--- a/dist/termux.sh
+++ b/dist/termux.sh
@@ -1,0 +1,15 @@
+# Build and install GHDL on termux (https://termux.com/)
+
+cd $(dirname "$0")/..
+
+curl -fsSL https://its-pointless.github.io/setup-pointless-repo.sh | bash -
+pkg install gnat-9
+setupgcc-9
+ln -s $PREFIX/lib/gcc/aarch64-linux-android/9.2.0/libgnat-9.so $PREFIX/lib/libgnat-9.so
+ln -s $PREFIX/lib/gcc/aarch64-linux-android/9.2.0/libgnarl-9.so $PREFIX/lib/libgnarl-9.so
+
+mkdir -p build-termux
+cd build-termux
+../configure --default-pic --enable-synth --with-llvm-config=llvm-config --prefix="$PREFIX"
+make
+make install


### PR DESCRIPTION
Ref #1142

In this PR, a shell script to install dependencies, build GHDL and install GHDL on [termux](https://termux.com/) is added to subdir `dist`.

<p align="center"><img src="https://user-images.githubusercontent.com/38422348/74899270-aff08300-539c-11ea-8f25-4e168fd4c739.png" alt="ghdl_termux" width="200"/></p>

Notes:

- GCC and GNAT are not available in the main repo, so its-pointless' repo is used (see https://github.com/its-pointless/gcc_termux).
- In the future, setting symlinks explicitly might not be required (see its-pointless/gcc_termux#84).
- Due to constraints regarding shebangs (see https://wiki.termux.com/wiki/Differences_from_Linux#Termux_is_not_FHS_compliant), this script should be execute explicitly: `bash dist/termux.sh`.
- The default `$PREFIX` is relevant (NOT empty, and NOT equal to `/`): https://wiki.termux.com/wiki/Differences_from_Linux#Root_file_system_is_stored_as_ordinary_application_data.

So far, I could successfully execute all of GHDL's test suites (sanity, gna, vests and synth) as well as VUnit's acceptance tests. Execution time on a octa-core 2GHz Cortex-A53 ([8-stage pipelined processor with 2-way superscalar, in-order execution pipeline](https://en.wikipedia.org/wiki/ARM_Cortex-A53)) is 4-4.5x the time on GHA. I'd say it's partially due to the clock frequency and partially because of the in-order pipeline. Also, this model is known to be among the most efficient (less powerful). Nevertheless, the battery lasted +24h even after being simulating for +5h. Hence, it should be possible to improve performance by tweaking the power saving settings. I'm curious about how will it perform on any Cortex-A7* device. 

