### PR TITLE
termux: setting symlinks explicitly is not required now

### DIFF
--- a/dist/termux.sh
+++ b/dist/termux.sh
@@ -5,8 +5,6 @@ cd $(dirname "$0")/..
 curl -fsSL https://its-pointless.github.io/setup-pointless-repo.sh | bash -
 pkg install gnat-9
 setupgcc-9
-ln -s $PREFIX/lib/gcc/aarch64-linux-android/9.2.0/libgnat-9.so $PREFIX/lib/libgnat-9.so
-ln -s $PREFIX/lib/gcc/aarch64-linux-android/9.2.0/libgnarl-9.so $PREFIX/lib/libgnarl-9.so
 
 mkdir -p build-termux
 cd build-termux


### PR DESCRIPTION
Now that its-pointless/gcc_termux#84 is fixed, some symbolic links don't need to be created explicitly.