### PR TITLE
python: fix document URI creation on Windows

### DIFF
--- a/python/vhdl_langserver/workspace.py
+++ b/python/vhdl_langserver/workspace.py
@@ -78,7 +78,7 @@ class Workspace(object):
         # Create the document.
         # Common case: an error message was reported in a non-open document.
         #  Create a document so that it could be reported to the client.
-        doc_uri = 'file://' + os.path.normpath(abspath)
+        doc_uri = lsp.path_to_uri(os.path.normpath(abspath))
         return self._create_document(doc_uri, sfe)
 
     def create_document_from_uri(self, doc_uri, source=None, version=None):


### PR DESCRIPTION
On Windows, a URI has to begin with file:/// (3 slashes!).
Now, the correct implementation from lsp.py is used to create the URIs.

