### PR TITLE
grt: handle argc=0 and argv/=null in ghdl_main (#1206)

### DIFF
--- a/src/grt/ghdl_main.adb
+++ b/src/grt/ghdl_main.adb
@@ -44,19 +44,17 @@ is
    function To_Argv_Type is new Ada.Unchecked_Conversion
      (Source => System.Address, Target => Grt.Options.Argv_Type);
 
-   My_Argv : Grt.Options.Argv_Type := To_Argv_Type (Argv);
-   Progname : Ghdl_C_String;
+   Args : Grt.Options.Argv_Type := To_Argv_Type (Argv);
+   Progname : Ghdl_C_String := null;
 begin
    --  Ada elaboration.
    Grt_Init;
 
    --  Set the options.
-   if Argc > 0 then
-      Progname := My_Argv (0);
-   else
-      Progname := null;
+   if not (Argc = 0 and Args = null) then
+     Progname := Args (0);
    end if;
-   Grt.Main.Run_Options (Progname, Argc, My_Argv);
+   Grt.Main.Run_Options (Progname, Argc, Args);
 
    --  Initialize, elaborate and simulate.
    Grt.Main.Run;

--- a/testsuite/gna/issue1206/main_notnull.c
+++ b/testsuite/gna/issue1206/main_notnull.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+extern int ghdl_main(int argc, char** argv);
+
+int main(int argc, char** argv) {
+  printf("ghdl_main: %d\n", ghdl_main(argc, argv));
+  return 0;
+}

--- a/testsuite/gna/issue1206/testsuite.sh
+++ b/testsuite/gna/issue1206/testsuite.sh
@@ -1,15 +1,23 @@
 #! /bin/sh
 
+cd $(dirname "$0")
+
 . ../../testenv.sh
 
 if $GHDL --help | grep -q -e --link; then
     if [ -z $CC ]; then
-	CC="gcc"
+        CC="gcc"
     fi
 
-    $CC -c main.c
     analyze hello.vhdl
-    elab -Wl,main.o hello
+    elab -Wl,main.c hello
+    run ./hello
+
+    clean
+    rm -f main.o
+
+    analyze hello.vhdl
+    elab -Wl,main_notnull.c hello
     run ./hello
 
     clean


### PR DESCRIPTION
The fix fox #1206 applied in https://github.com/ghdl/ghdl/commit/7a211109152e82843a59ba70b0a080ce91b9b495 was required because it had been broken in https://github.com/ghdl/ghdl/commit/2fc3356ae0d34dae87eb22c94f4b5eaa1873695b 10 days ago. The behaviour now is the same that it was for 15 years.

However, I think it is not completely correct. The underlaying issue is not argc being zero, but argv being null. Currently, if `argc=0` and `argv={"progname"}`, GHDL will ignore `progname`, set it to `null` and use `Default_Progname` instead. This PR changes it so that `Argv(0)` is preserved if `Argv/=null`.

BTW, I replaced:

```sh
$CC -c main.c
analyze hello.vhdl
elab -Wl,main.o hello
```

with

```sh
analyze hello.vhdl
elab -Wl,main.c hello
```

@tgingold, is there any relevant difference between these?

---

At first, I tried to test this with mcode backend, as I thought that VHPIDIRECT is supported with any backend. However, I found that the test won't work, because mcode backend does not support `-Wl,main.o` or `-Wl,main.c` as an argument. @tgingold, can you please clarify? Is it required to use command run for mcode? Should GCC be used instead?