### PR TITLE
Fix for PSL next_e operator

### DIFF
--- a/src/vhdl/vhdl-sem_psl.adb
+++ b/src/vhdl/vhdl-sem_psl.adb
@@ -461,7 +461,7 @@ package body Vhdl.Sem_Psl is
             Sem_Number (Prop);
             Sem_Property (Prop);
             return Prop;
-         when N_Next_A =>
+         when N_Next_A | N_Next_E =>
             --  FIXME: range.
             Sem_Property (Prop);
             return Prop;

--- a/testsuite/gna/issue1288/issue.vhdl
+++ b/testsuite/gna/issue1288/issue.vhdl
@@ -1,0 +1,34 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+
+entity issue is
+end issue;
+
+
+architecture sim of issue is
+
+  signal clk  : std_logic := '1';
+  signal a, b : std_logic := '0';
+
+begin
+
+  clk <= not clk after 5 ns;
+
+  a <= '1' after 20 ns,
+       '0' after 30 ns,
+       '1' after 40 ns,
+       '0' after 50 ns;
+
+  b <= '1' after 50 ns,
+       '0' after 60 ns,
+       '1' after 70 ns,
+       '0' after 80 ns;
+
+  -- All is sensitive to rising edge of clk
+  -- psl default clock is rising_edge(clk);
+
+  -- This assertion holds
+  -- psl NEXT_0_a : assert always (a -> next_e[3 to 5] (b));
+
+end architecture sim;

--- a/testsuite/gna/issue1288/testsuite.sh
+++ b/testsuite/gna/issue1288/testsuite.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+analyze -fpsl issue.vhdl
+
+clean
+
+echo "Test successful"

--- a/testsuite/synth/issue1288/issue.vhdl
+++ b/testsuite/synth/issue1288/issue.vhdl
@@ -1,0 +1,94 @@
+library ieee;
+  use ieee.std_logic_1164.all;
+
+
+entity sequencer is
+  generic (
+    seq : string
+  );
+  port (
+    clk  : in  std_logic;
+    data : out std_logic
+  );
+end entity sequencer;
+
+
+architecture rtl of sequencer is
+
+  signal index : natural := seq'low;
+  signal ch    : character;
+
+  function to_bit (a : in character) return std_logic is
+    variable ret : std_logic;
+  begin
+    case a is
+      when '0' | '_' => ret := '0';
+      when '1' | '-' => ret := '1';
+      when others    => ret := 'X';
+    end case;
+    return ret;
+  end function to_bit;
+
+begin
+
+
+  process (clk) is
+  begin
+    if rising_edge(clk) then
+      if (index < seq'high) then
+        index <= index + 1;
+      end if;
+    end if;
+  end process;
+
+  ch <= seq(index);
+
+  data <= to_bit(ch);
+
+
+end architecture rtl;
+
+
+
+library ieee;
+  use ieee.std_logic_1164.all;
+
+
+entity issue is
+  port (
+    clk : in std_logic
+  );
+end entity issue;
+
+
+architecture psl of issue is
+
+  component sequencer is
+    generic (
+      seq : string
+    );
+    port (
+      clk  : in  std_logic;
+      data : out std_logic
+    );
+  end component sequencer;
+
+  signal a, b : std_logic;
+
+begin
+
+
+  --                              01234567890
+  SEQ_A : sequencer generic map ("__-_-______") port map (clk, a);
+  SEQ_B : sequencer generic map ("_____-_-___") port map (clk, b);
+
+
+
+  -- All is sensitive to rising edge of clk
+  default clock is rising_edge(clk);
+
+  -- This assertion holds
+  NEXT_EVENT_a : assert always (a -> next_e[3 to 5] (b));
+
+
+end architecture psl;

--- a/testsuite/synth/issue1288/testsuite.sh
+++ b/testsuite/synth/issue1288/testsuite.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+GHDL_STD_FLAGS=--std=08
+synth_analyze issue
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
This small PR fixes the handling of the PSL operator `next_e` as reported in bug #1288. I also added tests for simulation & synth. The CI seems to be happy, so have a look and please merge :)
