### PR TITLE
Add tests of synth/sim for #1292 and #1295

### DIFF
--- a/testsuite/gna/issue1295/psl_next_event_a.vhdl
+++ b/testsuite/gna/issue1295/psl_next_event_a.vhdl
@@ -1,0 +1,98 @@
+library ieee;
+  use ieee.std_logic_1164.all;
+
+
+entity sequencer is
+  generic (
+    seq : string
+  );
+  port (
+    clk  : in  std_logic;
+    data : out std_logic
+  );
+end entity sequencer;
+
+
+architecture rtl of sequencer is
+
+  signal index : natural := seq'low;
+  signal ch    : character;
+
+  function to_bit (a : in character) return std_logic is
+    variable ret : std_logic;
+  begin
+    case a is
+      when '0' | '_' => ret := '0';
+      when '1' | '-' => ret := '1';
+      when others    => ret := 'X';
+    end case;
+    return ret;
+  end function to_bit;
+
+begin
+
+
+  process (clk) is
+  begin
+    if rising_edge(clk) then
+      if (index < seq'high) then
+        index <= index + 1;
+      end if;
+    end if;
+  end process;
+
+  ch <= seq(index);
+
+  data <= to_bit(ch);
+
+
+end architecture rtl;
+
+
+library ieee;
+  use ieee.std_logic_1164.all;
+
+
+entity psl_next_event_a is
+end entity psl_next_event_a;
+
+
+architecture psl of psl_next_event_a is
+  signal clk : std_logic := '0';
+
+  component sequencer is
+    generic (
+      seq : string
+    );
+    port (
+      clk  : in  std_logic;
+      data : out std_logic
+    );
+  end component sequencer;
+
+  signal a, b, c : std_logic;
+
+begin
+
+  --                              012345678901234
+  SEQ_A : sequencer generic map ("_-______________-____") port map (clk, a);
+  SEQ_B : sequencer generic map ("--___--__----________") port map (clk, b);
+  SEQ_C : sequencer generic map ("_____-___---_____----") port map (clk, c);
+
+
+  -- All is sensitive to rising edge of clk
+  default clock is rising_edge(clk);
+
+  -- This assertion holds
+  assert_NEXT_EVENT_a : assert always ((a and b) -> next_event_a(c)[1 to 4](b));
+
+  process
+  begin
+    for i in 1 to 2*20 loop
+      wait for 1 ns;
+      clk <= not clk;
+    end loop;
+    wait;
+  end process;
+
+end architecture psl;

--- a/testsuite/gna/issue1295/testsuite.sh
+++ b/testsuite/gna/issue1295/testsuite.sh
@@ -1,0 +1,11 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+export GHDL_STD_FLAGS=--std=08
+analyze psl_next_event_a.vhdl
+elab_simulate psl_next_event_a
+
+clean
+
+echo "Test successful"

--- a/testsuite/synth/issue1292/issue.vhdl
+++ b/testsuite/synth/issue1292/issue.vhdl
@@ -1,0 +1,94 @@
+library ieee;
+  use ieee.std_logic_1164.all;
+
+
+entity sequencer is
+  generic (
+    seq : string
+  );
+  port (
+    clk  : in  std_logic;
+    data : out std_logic
+  );
+end entity sequencer;
+
+
+architecture rtl of sequencer is
+
+  signal index : natural := seq'low;
+  signal ch    : character;
+
+  function to_bit (a : in character) return std_logic is
+    variable ret : std_logic;
+  begin
+    case a is
+      when '0' | '_' => ret := '0';
+      when '1' | '-' => ret := '1';
+      when others    => ret := 'X';
+    end case;
+    return ret;
+  end function to_bit;
+
+begin
+
+
+  process (clk) is
+  begin
+    if rising_edge(clk) then
+      if (index < seq'high) then
+        index <= index + 1;
+      end if;
+    end if;
+  end process;
+
+  ch <= seq(index);
+
+  data <= to_bit(ch);
+
+
+end architecture rtl;
+
+
+
+library ieee;
+  use ieee.std_logic_1164.all;
+
+
+entity issue is
+  port (
+    clk : in std_logic
+  );
+end entity issue;
+
+
+architecture psl of issue is
+
+  component sequencer is
+    generic (
+      seq : string
+    );
+    port (
+      clk  : in  std_logic;
+      data : out std_logic
+    );
+  end component sequencer;
+
+  signal a, b, c : std_logic;
+
+begin
+
+
+  --                              012345678901234
+  SEQ_A : sequencer generic map ("_-______-______") port map (clk, a);
+  SEQ_B : sequencer generic map ("___-__-___-__-_") port map (clk, b);
+  SEQ_C : sequencer generic map ("______-___-____") port map (clk, c);
+
+
+  -- All is sensitive to rising edge of clk
+  default clock is rising_edge(clk);
+
+  -- This assertion holds
+  NEXT_EVENT_a : assert always (a -> next_event_e(b)[1 to 2](c));
+
+
+end architecture psl;

--- a/testsuite/synth/issue1292/testsuite.sh
+++ b/testsuite/synth/issue1292/testsuite.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+GHDL_STD_FLAGS=--std=08
+synth_analyze issue
+
+clean
+
+echo "Test successful"

--- a/testsuite/synth/issue1295/issue.vhdl
+++ b/testsuite/synth/issue1295/issue.vhdl
@@ -1,0 +1,94 @@
+library ieee;
+  use ieee.std_logic_1164.all;
+
+
+entity sequencer is
+  generic (
+    seq : string
+  );
+  port (
+    clk  : in  std_logic;
+    data : out std_logic
+  );
+end entity sequencer;
+
+
+architecture rtl of sequencer is
+
+  signal index : natural := seq'low;
+  signal ch    : character;
+
+  function to_bit (a : in character) return std_logic is
+    variable ret : std_logic;
+  begin
+    case a is
+      when '0' | '_' => ret := '0';
+      when '1' | '-' => ret := '1';
+      when others    => ret := 'X';
+    end case;
+    return ret;
+  end function to_bit;
+
+begin
+
+
+  process (clk) is
+  begin
+    if rising_edge(clk) then
+      if (index < seq'high) then
+        index <= index + 1;
+      end if;
+    end if;
+  end process;
+
+  ch <= seq(index);
+
+  data <= to_bit(ch);
+
+
+end architecture rtl;
+
+
+
+library ieee;
+  use ieee.std_logic_1164.all;
+
+
+entity issue is
+  port (
+    clk : in std_logic
+  );
+end entity issue;
+
+
+architecture psl of issue is
+
+  component sequencer is
+    generic (
+      seq : string
+    );
+    port (
+      clk  : in  std_logic;
+      data : out std_logic
+    );
+  end component sequencer;
+
+  signal a, b, c : std_logic;
+
+begin
+
+
+  --                              012345678901234
+  SEQ_A : sequencer generic map ("_-______________-____") port map (clk, a);
+  SEQ_B : sequencer generic map ("--___--__----________") port map (clk, b);
+  SEQ_C : sequencer generic map ("_____-___---_____----") port map (clk, c);
+
+
+  -- All is sensitive to rising edge of clk
+  default clock is rising_edge(clk);
+
+  -- This assertion holds
+  assert_NEXT_EVENT_a : assert always ((a and b) -> next_event_a(c)[1 to 4](b));
+
+
+end architecture psl;

--- a/testsuite/synth/issue1295/testsuite.sh
+++ b/testsuite/synth/issue1295/testsuite.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+GHDL_STD_FLAGS=--std=08
+synth_analyze issue
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
This PR adds tests for the PSL next_event_e & next_event_a operators. Both were recently fixed, see issue #1292. This closes issue #1295.

CI seems to be happy, so please merge :)