### PR TITLE
ci: use eine/tip to provide nightly releases

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,5 +1,9 @@
 name: 'doc'
-on: [push, pull_request]
+
+on:
+  push:
+  pull_request:
+
 jobs:
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,8 @@
 name: 'push'
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
 
 env:
   CI: true
@@ -14,17 +16,26 @@ jobs:
     - run: |
         TASK=buster+mcode ./dist/ci-run.sh -c --gpl --no-synth
 
-  linux:
+  lin:
     strategy:
       fail-fast: false
       max-parallel: 3
       matrix:
-        task: [ mcode, llvm-7, gcc-8.3.0 ]
+        task: [
+          { backend: mcode, version: '' },
+          { backend: llvm,  version: '-5.0' },
+          { backend: gcc,   version: '-8.3.0' }
+        ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: |
-        TASK=buster+${{ matrix.task }} ./dist/ci-run.sh -c
+    - name: Build and test GHDL in containers
+      run: |
+        TASK=ubuntu18+${{ matrix.task.backend }}${{ matrix.task.version }} ./dist/ci-run.sh -c
+        mv ghdl-*-ubuntu18-*.tgz ghdl-gha-ubuntu-${{ matrix.task.backend }}.tgz
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ghdl-gha-ubuntu-*.tgz
 
   osx:
     runs-on: macOS-latest
@@ -34,7 +45,8 @@ jobs:
         brew update
         brew install p7zip
         ./dist/macosx/install-ada.sh
-    - run: |
+    - name: Build and test GHDL
+      run: |
         PATH=$PWD/gnat/bin:$PATH
         ./dist/ci-run.sh -c
       env:
@@ -68,16 +80,36 @@ jobs:
       shell: msys2 {0}
       run: |
         ./dist/msys2-mingw/run.sh -b
-#    - uses: actions/upload-artifact@v2
-#      with:
-#         name: ${{ matrix.task.installs }}-${{ matrix.task.pkg }}-pkg
-#         path: ./dist/msys2-mingw/${{ matrix.task.pkg }}/mingw-*ghdl*.pkg.tar.zst
+        cp ./dist/msys2-mingw/${{ matrix.task.pkg }}/mingw-*ghdl*.pkg.tar.zst ghdl-gha-${{ matrix.installs }}-${{ matrix.task }}.zst
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.task.installs }}-${{ matrix.task.pkg }}-builddir
+        path: ./dist/msys2-mingw/${{ matrix.task.pkg }}/src/
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.task.installs }}-${{ matrix.task.pkg }}-builddir
+        path: ./dist/msys2-mingw/${{ matrix.task.pkg }}/pkg/
+    - uses: actions/upload-artifact@v2
+      with:
+         path: ./dist/msys2-mingw/${{ matrix.task.pkg }}/mingw-*ghdl*.pkg.tar.zst
     - name: Test package
       shell: msys2 {0}
       run: |
         ./dist/msys2-mingw/run.sh -t
       env:
         MSYSTEM: ${{ matrix.task.installs }}
+
+  nightly:
+    needs: [ lin, win ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v2
+    - if: github.ref == 'ref/head/master' && github.event_name != 'pull_request'
+      uses: eine/tip@master
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag: 'nightly'
+        files: artifact/*
 
 #---
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  except:
+    - nightly
+
 os: linux
 dist: xenial
 services: docker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ version: '{branch}-{build}'
 # Branches to build
 branches:
   except:
+    - nightly
     - travis
 
 # =============================================================================


### PR DESCRIPTION
Close #1320

This is a proposal for providing "nightly" builds to be used in GitHub Actions workflows. Currently, docker images are provided, which can be used on Linux (`ubuntu-latest`). But, using latest GHDL on `windows-latest` or `macos-latest` requires users to build it themselves. At the same time, artifacts for all (Linux, Windows and macOS) are created in each run of the default workflow in this repo. The proposal is to keep these artifacts in a fixed location, so users can retrieve them easily. It is complemented with a GitHub Action, which can make setup easier.

---

- Currently, Debian docker images are used to test each of the backends on Linux. However, in ghdl/docker Ubuntu 18 images are available too. Since `ubuntu-latest` environment in GitHub Actions is Ubuntu 18, in this PR the default containers are changed from Debian Buster to Ubuntu 18. Then, the same packages that are used for testing are uploaded. These same packages can be extracted and used in `ubuntu-latest` environments.
- Currently, Windows jobs produce MSYS2 packages, which are tested. These same artifacts are uploaded.
- Since GitHub's API does not provide unauthenticated access to artifacts, there is no easy programatic way for users to retrieve the latest uploaded items. As an alternative, the proposal is to use a pre-release (named `nightly` or `tip`). Action [eine/tip](https://github.com/eine/tip) allows to update the assets in an existing release. In this PR, *tip* is used to upload all artifacts and to force-push the nightly/tip tag.
  - Since *tip* is executed after jobs `lin` and `win`, the assets in the nightly pre-release will only be updated when all jobs are succesful.
  - Artifacts generated in each job will be available through GitHub Actions for 90 days, regardles of *tip* succeeding/failing.
  - The proposal is to execute *tip* on pushes to `master` only. Neither PRs nor other branches will trigger the job.

<strike>Because of the failing MINGW64 job in master, merging this PR now will have no effect. In order to test it, I disabled the testsuite in my fork. This is the log: https://github.com/umarcor/ghdl/runs/676868947?check_suite_focus=true</strike>

---

The complement for users to install these artifacts "idiomatically" is [umarcor/setup-ghdl](https://github.com/umarcor/setup-ghdl). *setup-ghdl* is a GitHub Action written in JavaScript, which allows to retrieve GHDL, extract it and add it to the PATH. See [README](https://github.com/umarcor/setup-ghdl#readme). Personally, I don't really like writing the Action in JavaScript. I'd prefer to use Python as in *tip*. Unfortunately, JavaScript is the only language supported in GitHub Actions, which can be executed on any of the host platforms. Docker Actions are limited to `ubuntu-latest` environments. For this reason, *tip* is executed in a separate job (at the end), instead of using it as a replacement of *actions/upload-artifact*.

Since a pre-release with a fixed name is used, artifacts are available in a fixed URL. For example: https://github.com/umarcor/ghdl/releases/download/nightly/ghdl-gha-ubuntu-mcode.tgz. Hence, *setup-ghdl* is not really required. However, the purpose is to later enhance the Action in order to support installing stable releases too (ATM, v0.37). In fact, I'd like to propose moving the Action to **ghdl/setup-ghdl**.

Currently, all three backends are provided for `ubuntu-latest`. For `windows-latest`, either MINGW64-llvm or MINGW32-mcode are available. See example executions: https://github.com/umarcor/setup-ghdl/actions/runs/105369782. I'd like to add packages for macOS too.

Due to MSYS2 not being installed by default yet, Action [eine/setup-msys2](https://github.com/eine/setup-msys2) needs to be used on Windows workflows: https://github.com/umarcor/setup-ghdl#windows-latest. In fact, *setup-msys2* is already used in this repo to test GHDL on Windows. Nevertheless, in the following weeks MSYS2 is expected to be available by default: https://github.com/actions/virtual-environments/issues/30#issuecomment-627237467. I will likely update both the Action and the workflows.

Overall, the main use case of these nightly builds and Action *setup-ghdl* is ghdl-cosim. Currently, latest docker images are used on Linux, but Windows tests are limited to the latest stable release: https://github.com/ghdl/ghdl-cosim/runs/678518104?check_suite_focus=true#step:3:2. Nevertheless, the same artifacts/assets can be used by any Ubuntu or Windows (MSYS2) user.
