### PR TITLE
rework 'version.tmp'

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -4,6 +4,6 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: build doc
       run: ./doc/make.sh

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -61,6 +61,8 @@ jobs:
       with:
         msystem: MSYS
         update: true
+        install: base-devel git
+    - run: git config --global core.autocrlf input
     - uses: actions/checkout@v2
     - name: Build and (hopefully) install package
       shell: msys2 {0}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,7 @@ jobs:
   gpl:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - run: |
         TASK=buster+mcode ./dist/ci-run.sh -c --gpl --no-synth
 
@@ -22,14 +22,14 @@ jobs:
         task: [ mcode, llvm-7, gcc-8.3.0 ]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - run: |
         TASK=buster+${{ matrix.task }} ./dist/ci-run.sh -c
 
   osx:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - run: |
         brew update
         brew install p7zip
@@ -61,7 +61,7 @@ jobs:
       with:
         msystem: MSYS
         update: true
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Build and (hopefully) install package
       shell: msys2 {0}
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ testsuite/get_entities
 
 # Generated files on windows.
 /build/
+/dist/msys2-mingw/**/logpipe.*
+/dist/msys2-mingw/**/*.log
 
 # Generated directories on Linux
 lib/

--- a/Makefile.in
+++ b/Makefile.in
@@ -56,6 +56,7 @@ CP=cp
 MV=mv
 SED=sed
 GRT_RANLIB=ranlib
+GHDL_DESC?=tarball
 
 VHDL_LIB_DIR=$(prefix)/$(libdirsuffix)
 
@@ -162,14 +163,9 @@ GRTSRCDIR=$(abs_srcdir)/src/grt
 include $(srcdir)/src/grt/Makefile.inc
 
 version.tmp: $(srcdir)/src/version.in force
-#	Create version.tmp from version.in, using git date/hash
-	if test -d $(srcdir)/.git \
-	   && desc=`cd $(srcdir); git describe --dirty`; then \
-          sub="s/[(].*[)]/($$desc)/"; \
-	else \
-	  sub="s/tarball/tarball/"; \
-        fi; \
-	$(SED) -e "$$sub" -e "s/@VER@/$(ghdl_version)/" < $< > $@; \
+#	Create version.tmp from version.in, using git date/hash, or envvar GHDL_DESC. Defaults to 'tarball'.
+	if test -d $(srcdir)/.git && desc=`cd $(srcdir); git describe --dirty`; then GHDL_DESC="$$desc"; fi; \
+	$(SED) -e "s/[(].*[)]/($$GHDL_DESC)/" -e "s/@VER@/$(ghdl_version)/" < $< > $@; \
 
 version.ads: version.tmp
 #	Change version.ads only if version.tmp has been modified to avoid

--- a/dist/ci-run.sh
+++ b/dist/ci-run.sh
@@ -402,21 +402,12 @@ ci_run () {
   else
       # Assume linux
 
-      gstart "[CI] Build version.tmp and replace version.in with it (so that the version is correctly set)" "$ANSI_BLUE"
-      # This is a little bit hack-ish, as it assumes that 'git' is not
-      # available in docker (otherwise it will describe as -dirty
-      # because this modifies the source file version.in).
-      ghdl_version_line=`grep -e '^ghdl_version' configure`
-      make -f Makefile.in srcdir=. $ghdl_version_line version.tmp
-      cp version.tmp src/version.in
-      gend
-
       gstart "[CI] Docker pull ghdl/build:$BUILD_IMAGE_TAG" "$ANSI_BLUE"
       docker pull ghdl/build:$BUILD_IMAGE_TAG
       gend
 
       printf "$ANSI_BLUE[CI] Build ghdl in docker image ghdl/build:$BUILD_IMAGE_TAG\n"
-      $RUN -e CONFIG_OPTS="$CONFIG_OPTS" "ghdl/build:$BUILD_IMAGE_TAG" bash -c "${scriptdir}/ci-run.sh $BUILD_CMD_OPTS build"
+      $RUN -e GHDL_DESC="$(git describe --dirty)@${BUILD_IMAGE_TAG}" -e CONFIG_OPTS="$CONFIG_OPTS" "ghdl/build:$BUILD_IMAGE_TAG" bash -c "${scriptdir}/ci-run.sh $BUILD_CMD_OPTS build"
   fi
 
   if [ ! -f build_ok ]; then

--- a/dist/msys2-mingw/llvm/PKGBUILD
+++ b/dist/msys2-mingw/llvm/PKGBUILD
@@ -19,6 +19,7 @@ build() {
   cd "${srcdir}/builddir"
   ../../../../../configure --prefix=${MINGW_PREFIX} --with-llvm-config="llvm-config --link-static" LDFLAGS="-static" --enable-libghdl --enable-synth
   make GNATMAKE="gnatmake -j$(nproc)"
+  exit
 }
 
 package() {

--- a/dist/msys2-mingw/mcode/PKGBUILD
+++ b/dist/msys2-mingw/mcode/PKGBUILD
@@ -19,6 +19,7 @@ build() {
   cd "${srcdir}/builddir"
   ../../../../../configure --prefix=${MINGW_PREFIX} LDFLAGS=-static --enable-libghdl --enable-synth
   make GNATMAKE="gnatmake -j$(nproc)"
+  exit
 }
 
 package() {

--- a/dist/msys2-mingw/run.sh
+++ b/dist/msys2-mingw/run.sh
@@ -93,10 +93,12 @@ build () {
 
   gstart 'Build package'
     dos2unix PKGBUILD
-    makepkg-mingw -sCLfc --noconfirm --noprogressbar
+    makepkg-mingw --noconfirm --noprogressbar -sCLf --noarchive
   gend
 
-  ls -la
+  gstart 'Archive package'
+    makepkg-mingw --noconfirm --noprogressbar -R
+  gend
 
   gstart 'Install package'
     pacman --noconfirm -U "mingw-w64-${TARBALL_ARCH}-ghdl-${TARGET}-ci"-*-any.pkg.tar.zst

--- a/dist/msys2-mingw/run.sh
+++ b/dist/msys2-mingw/run.sh
@@ -58,7 +58,7 @@ cd $(dirname $0)
 
 build () {
   gstart 'Install common build dependencies'
-    pacman -S --noconfirm base-devel git
+    pacman -S --noconfirm base-devel
   gend
 
   if [ -z "$TARGET" ]; then
@@ -66,6 +66,12 @@ build () {
     exit 1
   fi
   cd "$TARGET"
+
+  gstart "Fetch --unshallow"
+  # The command 'git describe' (used for version) needs the history. Get it.
+  # But the following command fails if the repository is complete.
+  git fetch --unshallow || true
+  gend
 
   MINGW_INSTALLS="$(echo "$MINGW_INSTALLS" | tr '[:upper:]' '[:lower:]')"
 
@@ -92,7 +98,6 @@ build () {
   gend
 
   gstart 'Build package'
-    dos2unix PKGBUILD
     makepkg-mingw --noconfirm --noprogressbar -sCLf --noarchive
   gend
 


### PR DESCRIPTION
This PR includes multiple enhancements to how `version.tmp` is generated:

- <strike>Instead of being a make target, `version.tmp` is generated in `configure`</strike>.
- <strike>Instead of requiring `make` to override the version description</strike>, environment variable `GHDL_DESC` is supported <strike>by `configure`</strike>. The precedence is as follows:
  - If this is a cloned repo and git exists, `git describe --dirty`.
  - If `GHDL_DESC` is defined, use it.
  - Default to `tarball`.
- The new environment variable is used in `dist/ci-run.sh` for customizing the description of the packages built in CI: `GHDL_DESC="$(git describe --dirty)@${BUILD_IMAGE_TAG}"`.
- Updating actions/checkout to v2 revealed that Windows build scripts have the same "unshallow" issue as Linux builds. It is fixed here.
- Either with v1 or v2 of actions/checkout, clones on Windows produce a "dirty" description. Note that this is independent from previous changes. To work around it, in this PR autocrlf is set to `input` on Windows jobs.