### PR TITLE
ghwdump should handle zero-length signals

### DIFF
--- a/src/grt/ghwlib.c
+++ b/src/grt/ghwlib.c
@@ -1313,7 +1313,7 @@ ghw_disp_hie (struct ghw_handler *h, struct ghw_hie *top)
 	    ghw_disp_subtype_indication (h, hie->u.sig.type);
 	    printf (":");
 	    k = 0;
-	    assert (sigs[0] != GHW_NO_SIG);
+
 	    while (1)
 	      {
 		/* First signal of the range.  */

--- a/testsuite/gna/issue1326/mytestbench.vhdl
+++ b/testsuite/gna/issue1326/mytestbench.vhdl
@@ -1,0 +1,17 @@
+library ieee ;
+
+entity mytestbench is
+end mytestbench;
+
+architecture arch of mytestbench is
+  signal zero_length_array : bit_vector(-1 downto 0);
+begin
+
+  -- Just here so we get a meaningful dump.
+  main_process: process
+  begin
+    wait for 10 ns;
+    wait;
+  end process;      
+
+end arch; 

--- a/testsuite/gna/issue1326/testsuite.sh
+++ b/testsuite/gna/issue1326/testsuite.sh
@@ -1,0 +1,18 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+analyze mytestbench.vhdl
+elab mytestbench
+
+simulate mytestbench --wave=dump.ghw | tee mytestbench.out
+
+gcc ../../../src/grt/ghwdump.c ../../../src/grt/ghwlib.c -I../../../src/grt/ -o ghwdump
+
+# We're just checking that ghwdump doesn't crash on a zero length signal.
+./ghwdump -ths dump.ghw > dump.txt
+
+rm -f mytestbench.out ghwdump dump.txt dump.ghw
+clean
+
+echo "Test passed"


### PR DESCRIPTION
This adds a test that checks that ghwdump doesn't crash on a signal of zero length.
The solution in the pull request just removes the offending assertion in ghwlib.c.

Presumably there is a good reason that this assertion was there, and a better solution is required.

The error message when the assertion is present is:
```
ghwdump: ../../../src/grt/ghwlib.c:1317: ghw_disp_hie: Assertion `sigs[0] != GHW_NO_SIG' failed.
```