### PR TITLE
ci: adjust pkg tag in ci-run.sh

### DIFF
--- a/dist/ci-run.sh
+++ b/dist/ci-run.sh
@@ -135,7 +135,7 @@ vertag() {
     echo $1 | cut -c2-
   else
     # Regular tag (like snapshots), nothing to change.
-    echo "$2"
+    echo "$1"
   fi
 }
 
@@ -163,7 +163,7 @@ buildCmdOpts () {
   # Compute package name
   case "$GITHUB_REF" in
     *tags*)
-      PKG_TAG="$(vertag "`echo "$GITHUB_REF" | sed 's#^refs/tags/\(.*\)#\1#g'`" "$GITHUB_REF")"
+      PKG_TAG="$(vertag "`echo "$GITHUB_REF" | sed 's#^refs/tags/\(.*\)#\1#g'`")"
     ;;
     *heads*|*pull*)
       PKG_TAG="`notag`"
@@ -172,7 +172,7 @@ buildCmdOpts () {
       if [ -z "$TRAVIS_TAG" ]; then
         PKG_TAG="`notag`"
       else
-        PKG_TAG="`vertag "$TRAVIS_TAG" "$TRAVIS_TAG"`"
+        PKG_TAG="`vertag "$TRAVIS_TAG"`"
       fi
     ;;
     *)


### PR DESCRIPTION
This PR fixes the extraction of tag names on GitHub Actions workflows. The bug was shown when tag `nightly` was pushed some hours ago: https://github.com/ghdl/ghdl/actions/runs/110635016

The fact that building tag `nightly` fails is not relevant, because the tag itself is a placeholder only. Actual assets are produced and pushed from branch master. Still, it is good to have this fixed for future releases/tags.