### PR TITLE
doc: announce nightly pre-release and Action setup-ghdl-ci

### DIFF
--- a/dist/msys2-mingw/llvm/PKGBUILD
+++ b/dist/msys2-mingw/llvm/PKGBUILD
@@ -19,7 +19,6 @@ build() {
   cd "${srcdir}/builddir"
   ../../../../../configure --prefix=${MINGW_PREFIX} --with-llvm-config="llvm-config --link-static" LDFLAGS="-static" --enable-libghdl --enable-synth
   make GNATMAKE="gnatmake -j$(nproc)"
-  exit
 }
 
 package() {

--- a/dist/msys2-mingw/mcode/PKGBUILD
+++ b/dist/msys2-mingw/mcode/PKGBUILD
@@ -19,7 +19,6 @@ build() {
   cd "${srcdir}/builddir"
   ../../../../../configure --prefix=${MINGW_PREFIX} LDFLAGS=-static --enable-libghdl --enable-synth
   make GNATMAKE="gnatmake -j$(nproc)"
-  exit
 }
 
 package() {

--- a/doc/getting/Releases.rst
+++ b/doc/getting/Releases.rst
@@ -6,10 +6,19 @@ Releases and sources
 .. contents:: Contents of this Page
    :local:
 
+Using package managers
+**********************
+
+Package managers of many popular distributions provide pre-built packages of GHDL. This is the case for `apt` (Debian/Ubuntu), `dnf` (Fedora/CentOS) or `pacman` (Arch Linux). Since GHDL supports three different backends and two library sets (ieee or openieee), at least six packages with different features might be available in each package manager. See differences between backends in :ref:`BUILD`.
+
 .. _RELEASE:packages:
 
 Downloading pre-built packages
 ******************************
+
+Assets from nightly GHDL builds are available at `github.com/ghdl/ghdl/releases/nightly <https://github.com/ghdl/ghdl/releases/nightly>`_. These are mostly meant to be used in Continuous Integration (CI) workflows. Precisely, `setup-ghdl-ci <https://github.com/ghdl/setup-ghdl-ci>`_ allows to easily setup nightly assets in GitHub Actions workflows.
+
+Furthermore, assets from stable builds are available for a larger set of platforms:
 
 .. TODO How to extend this directive to use `.. only:: html` and `.. only:: html` in the python code passed to it?
 

--- a/doc/helpers.py
+++ b/doc/helpers.py
@@ -162,7 +162,7 @@ def createReleasesShields(tag='latest'):
    from dateutil.parser import parse as parseTime
    releases = [['Date', 'Downloads']]
    if tag == 'latest':
-      t = d[0]
+      t = d[1] if d[0]['name'] == 'nightly' else d[0]
    for x in d:
       name = x['tag_name']
       if tag == name:
@@ -204,6 +204,12 @@ def printReleasesList(releases, latex=False):
       releases = getJSON(releases)["releases"]
 
    rs = [releases[0]]
+
+   for x, r in enumerate(releases):
+      if 'nightly' in r[1]:
+         releases.remove(r)
+         break
+
    rs.extend(releases[2:])
 
    if latex:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,6 +11,12 @@
    News
    ****
 
+   21.05.2020 - Nightly build assets available
+   ===========================================
+
+   * After each successful CI run of branch ``master``, packages are published as assets of pre-release `nightly <https://github.com/ghdl/ghdl/releases/tag/nightly>`_.
+   * GitHub Action `ghdl/setup-ghdl-ci <https://github.com/ghdl/setup-ghdl-ci>`_ was created, to allow easy installation of nightly GHDL assets in GitHub Actions workflows.
+
    09.05.2020 - New repositories and a wiki were created
    =====================================================
 
@@ -63,6 +69,8 @@
    ===================================
 
 .. only:: latex
+
+   .. rubric:: 21.05.2020 - Nightly build assets available.
 
    .. rubric:: 09.05.2020 - New repositories and a wiki were created.
 

--- a/doc/licenses.rst
+++ b/doc/licenses.rst
@@ -63,7 +63,7 @@ Jensen, Adam               FreeBSD builds
 Koch, Markus               vendor pre-compile script for Lattice (GNU/Linux)
 Koontz, David              Mac OSX builds, LRM compliance work, bugfix analyses
 Lehmann, Patrick           Windows compile scripts, vendor library pre-compile scripts (win+lin), building in MinGW, AppVeyor integration.
-Martinez-Corral, Unai      ghdl-cosim, docs, docker/CI, termux build script, building/testing on ARM
+Martinez-Corral, Unai      ghdl-cosim, setup-ghdl-ci, docs, docker/CI, termux build script, building/testing on ARM
 van Rantwijk, Joris        Debian packaging
 =========================  ============================================================
 


### PR DESCRIPTION
Nightly pre-release and Action setup-ghdl-ci are announced in the docs. Section getting/Releases is updated accordingly, and `doc/helpers.py` is fixed to ignore `nightly` in the list of regular releases.