### PR TITLE
WIP: Synthesis of PSL stable() function.

### DIFF
--- a/src/vhdl/vhdl-prints.adb
+++ b/src/vhdl/vhdl-prints.adb
@@ -2288,6 +2288,21 @@ package body Vhdl.Prints is
       Disp_Token (Ctxt, Tok_Right_Paren);
    end Disp_Psl_Prev;
 
+   procedure Disp_Psl_Stable (Ctxt : in out Ctxt_Class; Call : Iir)
+   is
+      Expr : Iir;
+   begin
+      Disp_Token (Ctxt, Tok_Stable);
+      Disp_Token (Ctxt, Tok_Left_Paren);
+      Print (Ctxt, Get_Expression (Call));
+      Expr := Get_Clock_Expression (Call);
+      if Expr /= Null_Iir then
+         Disp_Token (Ctxt, Tok_Comma);
+         Print (Ctxt, Expr);
+      end if;
+      Disp_Token (Ctxt, Tok_Right_Paren);
+   end Disp_Psl_Stable;
+
    procedure Disp_Psl_Declaration (Ctxt : in out Ctxt_Class; Stmt : Iir)
    is
       Decl : constant PSL_Node := Get_Psl_Declaration (Stmt);
@@ -4751,6 +4766,8 @@ package body Vhdl.Prints is
 
          when Iir_Kind_Psl_Prev =>
             Disp_Psl_Prev (Ctxt, Expr);
+         when Iir_Kind_Psl_Stable =>
+            Disp_Psl_Stable (Ctxt, Expr);
 
          when Iir_Kinds_Type_And_Subtype_Definition =>
             Disp_Type (Ctxt, Expr);

--- a/src/vhdl/vhdl-sem_expr.adb
+++ b/src/vhdl/vhdl-sem_expr.adb
@@ -415,7 +415,8 @@ package body Vhdl.Sem_Expr is
            | Iir_Kind_Type_Conversion
            | Iir_Kind_Function_Call =>
             return Expr;
-         when Iir_Kind_Psl_Endpoint_Declaration =>
+         when Iir_Kind_Psl_Endpoint_Declaration
+           | Iir_Kind_Psl_Stable =>
             return Expr;
          when Iir_Kind_Simple_Name
            | Iir_Kind_Parenthesis_Name
@@ -4827,6 +4828,9 @@ package body Vhdl.Sem_Expr is
 
          when Iir_Kind_Psl_Prev =>
             return Sem_Psl.Sem_Prev_Builtin (Expr, A_Type);
+
+         when Iir_Kind_Psl_Stable =>
+            return Sem_Psl.Sem_Stable_Builtin (Expr);
 
          when Iir_Kind_Error =>
             --  Always ok.

--- a/src/vhdl/vhdl-sem_psl.adb
+++ b/src/vhdl/vhdl-sem_psl.adb
@@ -123,6 +123,41 @@ package body Vhdl.Sem_Psl is
       return Call;
    end Sem_Prev_Builtin;
 
+   function Sem_Stable_Builtin (Call : Iir) return Iir
+   is
+      use Vhdl.Sem_Expr;
+      use Vhdl.Std_Package;
+      Expr  : Iir;
+      Clock : Iir;
+      First : Boolean;
+   begin
+      Expr := Get_Expression (Call);
+      First := Is_Expr_Not_Analyzed (Expr);
+      Expr := Sem_Expression (Expr, Null_Iir);
+      if Expr /= Null_Iir then
+         Set_Expression (Call, Expr);
+         Set_Type (Call, Vhdl.Std_Package.Boolean_Type_Definition);
+         Set_Expr_Staticness (Call, None);
+      end if;
+
+      if First then
+         --  Analyze count and clock only once.
+         Clock := Get_Clock_Expression (Call);
+         if Clock /= Null_Iir then
+            Clock := Sem_Expression_Wildcard (Clock, Wildcard_Psl_Bit_Type);
+            Set_Clock_Expression (Call, Clock);
+         else
+            if Current_Psl_Default_Clock = Null_Iir then
+               Error_Msg_Sem (+Call, "no clock for PSL stable builtin");
+            else
+               Set_Default_Clock (Call, Current_Psl_Default_Clock);
+            end if;
+         end if;
+      end if;
+
+      return Call;
+   end Sem_Stable_Builtin;
+
    --  Convert VHDL and/or/not nodes to PSL nodes.
    function Convert_Bool (Expr : Iir) return PSL_Node
    is

--- a/src/vhdl/vhdl-sem_psl.ads
+++ b/src/vhdl/vhdl-sem_psl.ads
@@ -23,6 +23,7 @@ package Vhdl.Sem_Psl is
    function Is_Psl_Bitvector_Type (Atype : Iir) return Boolean;
 
    function Sem_Prev_Builtin (Call : Iir; Atype : Iir) return Iir;
+   function Sem_Stable_Builtin (Call : Iir) return Iir;
 
    procedure Sem_Psl_Declaration (Stmt : Iir);
    procedure Sem_Psl_Endpoint_Declaration (Stmt : Iir);

--- a/testsuite/synth/issue662/psl_prev.vhdl
+++ b/testsuite/synth/issue662/psl_prev.vhdl
@@ -1,12 +1,12 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-entity issue is
+entity psl_prev is
   port (clk, a, b : std_logic);
-end entity issue;
+end entity psl_prev;
 
 
-architecture psl of issue is
+architecture psl of psl_prev is
 begin
   -- All is sensitive to rising edge of clk
   default clock is rising_edge(clk);

--- a/testsuite/synth/issue662/psl_stable.vhdl
+++ b/testsuite/synth/issue662/psl_stable.vhdl
@@ -1,0 +1,23 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity psl_stable is
+  port (clk, a, b, c : in std_logic;
+        d         : in std_logic_vector(3 downto 0)
+  );
+end entity psl_stable;
+
+
+architecture psl of psl_stable is
+begin
+
+  -- All is sensitive to rising edge of clk
+  default clock is rising_edge(clk);
+
+  -- This assertion holds
+  STABLE_0_a : assert always {not a; a} |=> (stable(c) until_ b);
+
+  -- This assertion holds
+  STABLE_1_a : assert always {not a; a} |=> (stable(d) until_ b);
+
+end architecture psl;

--- a/testsuite/synth/issue662/tb_psl_prev.vhdl
+++ b/testsuite/synth/issue662/tb_psl_prev.vhdl
@@ -1,11 +1,11 @@
 library ieee;
   use ieee.std_logic_1164.all;
 
-entity tb_issue is
-end entity tb_issue;
+entity tb_psl_prev is
+end entity tb_psl_prev;
 
 
-architecture psl of tb_issue is
+architecture psl of tb_psl_prev is
   procedure seq (s : string; signal clk : std_logic; signal o : out std_logic)
   is
   begin
@@ -24,7 +24,7 @@ architecture psl of tb_issue is
   signal clk   : std_logic := '1';
 
 begin
-  dut: entity work.issue port map (clk, a, b);
+  dut: entity work.psl_prev port map (clk, a, b);
 
   clk <= not clk after 500 ps;
 

--- a/testsuite/synth/issue662/tb_psl_stable.vhdl
+++ b/testsuite/synth/issue662/tb_psl_stable.vhdl
@@ -1,0 +1,68 @@
+library ieee;
+  use ieee.std_logic_1164.all;
+
+entity tb_psl_stable is
+end entity tb_psl_stable;
+
+
+architecture psl of tb_psl_stable is
+
+  procedure seq (s : string; signal clk : std_logic; signal o : out std_logic)
+  is
+  begin
+    for i in s'range loop
+      wait until rising_edge(clk);
+      case s(i) is
+        when '0' | '_' => o <= '0';
+        when '1' | '-' => o <= '1';
+        when others    => o <= 'X';
+      end case;
+    end loop;
+    wait;
+  end seq;
+
+  procedure hseq (s : string; signal clk : std_logic; signal o : out std_logic_vector(3 downto 0))
+  is
+  begin
+    for i in s'range loop
+      wait until rising_edge(clk);
+      case s(i) is
+        when '0' | '_' => o <= x"0";
+        when '1'       => o <= x"1";
+        when '2'       => o <= x"2";
+        when '3'       => o <= x"3";
+        when '4'       => o <= x"4";
+        when '5'       => o <= x"5";
+        when '6'       => o <= x"6";
+        when '7'       => o <= x"7";
+        when '8'       => o <= x"8";
+        when '9'       => o <= x"9";
+        when 'a' | 'A' => o <= x"A";
+        when 'b' | 'B' => o <= x"B";
+        when 'c' | 'C' => o <= x"C";
+        when 'd' | 'D' => o <= x"D";
+        when 'e' | 'E' => o <= x"E";
+        when 'f' | 'F' | '-' => o <= x"F";
+        when others => o <= x"X";
+      end case;
+    end loop;
+    wait;
+  end hseq;
+
+  signal a, b, c : std_logic := '0';
+  signal d       : std_logic_vector(3 downto 0) := x"0";
+  signal clk     : std_logic := '1';
+
+begin
+
+  dut: entity work.psl_stable port map (clk, a, b, c, d);
+
+  clk <= not clk after 500 ps;
+
+  --             012345678901234
+  SEQ_A :  seq ("_--__---____--_", clk, a);
+  SEQ_B :  seq ("__-____-_____-_", clk, b);
+  SEQ_C :  seq ("_--__________-_", clk, c);
+  SEQ_D : hseq ("011006660000000", clk, d);
+
+end architecture psl;

--- a/testsuite/synth/issue662/testsuite.sh
+++ b/testsuite/synth/issue662/testsuite.sh
@@ -3,10 +3,13 @@
 . ../../testenv.sh
 
 GHDL_STD_FLAGS=--std=08
-synth_analyze issue
-analyze tb_issue.vhdl
-elab_simulate_failure tb_issue --stop-time=20ns --asserts=disable-at-0 --assert-level=error
-elab_simulate tb_issue --stop-time=10ns --asserts=disable-at-0 --assert-level=error
+
+for test in psl_prev psl_stable; do
+  synth_analyze $test
+  analyze tb_${test}.vhdl
+  elab_simulate_failure tb_${test} --stop-time=20ns --asserts=disable-at-0 --assert-level=error
+  elab_simulate tb_${test} --stop-time=10ns --asserts=disable-at-0 --assert-level=error
+done
 
 clean
 


### PR DESCRIPTION
**Description**
I want to add synthesis of PSL built-in `stable()` function. See #662 for the Issue which tracks support of PSL built-in functions in GHDL.

As I'm not an expert of the GHDL code base, I can't get it completely right. I've looked after the changes which were done for PSL `prev()` synthesis and tried to add similar changes for PSL `stable()`. However, the function which synthesizes the `stable()` function don't compiles. Honestly, I'm confused about the many types and sub types declared and when to use which one.

GNAT complains about this funtion in  `src/synth/synth-expr.adb`:

```ada
   function Synth_Psl_Stable (Syn_Inst : Synth_Instance_Acc; Call : Node)
                              return Valtyp
   is
      Ctxt      : constant Context_Acc := Get_Build (Syn_Inst);
      Clock     : Node;
      Dff       : Net;
      Clk       : Valtyp;
      Expr      : Valtyp;
      Clk_Net   : Net;
      CurVal    : Valtyp;
      OldVal    : Valtyp;
      Res       : Valtyp;
   begin
      Expr := Synth_Expression (Syn_Inst, Get_Expression (Call));

      Clock := Get_Clock_Expression (Call);
      if Clock /= Null_Node then
         Clk := Synth_Expression (Syn_Inst, Clock);
         Clk_Net := Get_Net (Ctxt, Clk);
      else
         Clock := Get_Default_Clock (Call);
         pragma Assert (Clock /= Null_Node);
         Clk_Net := Synth_PSL_Expression (Syn_Inst, Get_Psl_Boolean (Clock));
      end if;

      CurVal := Get_Value(Expr);
      Dff := Get_Net (Ctxt, Expr);
      Dff := Build_Dff (Ctxt, Clk_Net, Dff);
      Set_Location (Dff, Call);
      OldVal := Get_Value(Dff);
      
      Res := Create_Value_Memory (Get_Type (Get_Type_Mark (Expr)));
      Write_Discrete (Res, Get_Value (CurVal = OldVal));
      return Res;
   end Synth_Psl_Stable;
```

I'm sure that the comparing of old and current value is too naive, I get following compile error:

```
x86_64-linux-gnu-gcc-8 -c -I./ -I./src -I./src/vhdl -I./src/synth -I./src/grt -I./src/psl -I./src/vhdl/translate -I./src/ghdldrv -I./src/ortho -I./src/ortho/llvm4-nodebug -I./src/synth -I./src/ghdldrv -gnaty3befhkmr -gnatwa -gnatwC -gnatf -g -gnata -gnatwe -I- /root/ghdl/src/synth/synth-expr.adb
synth-expr.adb:1905:19: "Mem" is undefined
synth-expr.adb:1919:17: no candidate interpretations match the actuals:
synth-expr.adb:1919:17: missing argument for parameter "Obj" in call to "Get_Value" declared at synth-context.ads:114
synth-expr.adb:1919:27: expected type "Node_Type" defined at vhdl-nodes_priv.ads:23
synth-expr.adb:1919:27: found type "Valtyp" defined at synth-values.ads:93
synth-expr.adb:1919:27:   ==> in call to "Get_Value" at vhdl-nodes.ads:7295
synth-expr.adb:1923:17: no candidate interpretations match the actuals:
synth-expr.adb:1923:17: missing argument for parameter "Obj" in call to "Get_Value" declared at synth-context.ads:114
synth-expr.adb:1923:27: expected type "Node_Type" defined at vhdl-nodes_priv.ads:23
synth-expr.adb:1923:27: found private type "Net" defined at netlists.ads:113
synth-expr.adb:1923:27:   ==> in call to "Get_Value" at vhdl-nodes.ads:7295
synth-expr.adb:1924:01: (style) trailing spaces not permitted
synth-expr.adb:1927:14: no candidate interpretations match the actuals:
synth-expr.adb:1927:35:   ==> in call to "Create_Value_Memory" at synth-values.ads:123
synth-expr.adb:1927:35:   ==> in call to "Create_Value_Memory" at synth-values.ads:122
synth-expr.adb:1927:60: expected type "Node_Type" defined at vhdl-nodes_priv.ads:23
synth-expr.adb:1927:60: found type "Valtyp" defined at synth-values.ads:93
synth-expr.adb:1927:60:   ==> in call to "Get_Type_Mark" at vhdl-nodes.ads:8771
synth-expr.adb:1928:28: no candidate interpretations match the actuals:
synth-expr.adb:1928:28: missing argument for parameter "Obj" in call to "Get_Value" declared at synth-context.ads:114
synth-expr.adb:1928:46: expected type "Node_Type" defined at vhdl-nodes_priv.ads:23
synth-expr.adb:1928:46: found type "Standard.Boolean"
synth-expr.adb:1928:46:   ==> in call to "Get_Value" at vhdl-nodes.ads:7295
gnatmake: "/root/ghdl/src/synth/synth-expr.adb" compilation error
make: *** [Makefile:344: ghdl_llvm] Error 4

```


@tgingold Maybe you can have a look and give some hints?
