### PR TITLE
ci(msys2): update eine/setup-msys2 to v1, set default shell

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -72,7 +72,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-    - uses: eine/setup-msys2@v0
+    - uses: eine/setup-msys2@v1
       with:
         msystem: MSYS
         update: true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -68,6 +68,9 @@ jobs:
     env:
       MINGW_INSTALLS: ${{ matrix.task.installs }}
       TARGET: ${{ matrix.task.pkg }}
+    defaults:
+      run:
+        shell: msys2 {0}
     steps:
     - uses: eine/setup-msys2@v0
       with:
@@ -75,9 +78,9 @@ jobs:
         update: true
         install: base-devel git
     - run: git config --global core.autocrlf input
+      shell: bash
     - uses: actions/checkout@v2
     - name: Build and (hopefully) install package
-      shell: msys2 {0}
       run: |
         ./dist/msys2-mingw/run.sh -b
         cp ./dist/msys2-mingw/${{ matrix.task.pkg }}/mingw-*ghdl*.pkg.tar.zst ghdl-gha-${{ matrix.installs }}-${{ matrix.task }}.zst
@@ -93,7 +96,6 @@ jobs:
       with:
          path: ./dist/msys2-mingw/${{ matrix.task.pkg }}/mingw-*ghdl*.pkg.tar.zst
     - name: Test package
-      shell: msys2 {0}
       run: |
         ./dist/msys2-mingw/run.sh -t
       env:


### PR DESCRIPTION
The most meaningful change in this PR is that update setup-msys2 from v0 to v1 reduces startup of Windows jobs from 10-12 min to 1-2 min (see https://github.com/eine/setup-msys2/issues/23#issuecomment-639837574).

Apart from that, `defaults` at job level are used to set the shell to `msys2`. This reduces verbosity slightly.