### PR TITLE
WIP: Synthesis of PSL built-in fell() function.

### DIFF
--- a/src/synth/synth-expr.adb
+++ b/src/synth/synth-expr.adb
@@ -1882,7 +1882,7 @@ package body Synth.Expr is
    begin
       Expr := Synth_Expression (Syn_Inst, Get_Expression (Call));
 
-      Clk_Net := Synth_Psl_Function_Clock(Syn_Inst, Call, Ctxt);
+      Clk_Net := Synth_Psl_Function_Clock (Syn_Inst, Call, Ctxt);
 
       if Count /= Null_Node then
          Count_Val := Synth_Expression (Syn_Inst, Count);
@@ -1913,7 +1913,7 @@ package body Synth.Expr is
    begin
       Expr := Synth_Expression (Syn_Inst, Get_Expression (Call));
 
-      Clk_Net := Synth_Psl_Function_Clock(Syn_Inst, Call, Ctxt);
+      Clk_Net := Synth_Psl_Function_Clock (Syn_Inst, Call, Ctxt);
 
       DffCurr := Get_Net (Ctxt, Expr);
       Set_Location (DffCurr, Call);
@@ -1928,7 +1928,7 @@ package body Synth.Expr is
    end Synth_Psl_Stable;
 
    function Synth_Psl_Rose (Syn_Inst : Synth_Instance_Acc; Call : Node)
-                              return Valtyp
+                            return Valtyp
    is
       Ctxt    : constant Context_Acc := Get_Build (Syn_Inst);
       DffCurr : Net;
@@ -1940,7 +1940,7 @@ package body Synth.Expr is
    begin
       Expr := Synth_Expression (Syn_Inst, Get_Expression (Call));
 
-      Clk_Net := Synth_Psl_Function_Clock(Syn_Inst, Call, Ctxt);
+      Clk_Net := Synth_Psl_Function_Clock (Syn_Inst, Call, Ctxt);
 
       DffCurr := Get_Net (Ctxt, Expr);
       Set_Location (DffCurr, Call);
@@ -1957,6 +1957,36 @@ package body Synth.Expr is
       return Create_Value_Net (Res, Boolean_Type);
 
    end Synth_Psl_Rose;
+
+   function Synth_Psl_Fell (Syn_Inst : Synth_Instance_Acc; Call : Node)
+                            return Valtyp
+   is
+      Ctxt       : constant Context_Acc := Get_Build (Syn_Inst);
+      DffCurr    : Net;
+      NotDffCurr : Net;
+      Dff        : Net;
+      Clk_Net    : Net;
+      Expr       : Valtyp;
+      Res        : Net;
+   begin
+      Expr := Synth_Expression (Syn_Inst, Get_Expression (Call));
+
+      Clk_Net := Synth_Psl_Function_Clock(Syn_Inst, Call, Ctxt);
+
+      DffCurr := Get_Net (Ctxt, Expr);
+      Set_Location (DffCurr, Call);
+      Dff := Build_Dff (Ctxt, Clk_Net, DffCurr);
+      Set_Location (Dff, Call);
+
+      NotDffCurr := Build_Monadic (Ctxt, Id_Not, DffCurr);
+      Set_Location (NotDffCurr, Call);
+
+      Res := Build_Dyadic (Ctxt, Id_And, Dff, NotDffCurr);
+      Set_Location (Res, Call);
+
+      return Create_Value_Net (Res, Boolean_Type);
+
+   end Synth_Psl_Fell;
 
    subtype And_Or_Module_Id is Module_Id range Id_And .. Id_Or;
 
@@ -2302,6 +2332,8 @@ package body Synth.Expr is
             return Synth_Psl_Stable (Syn_Inst, Expr);
          when Iir_Kind_Psl_Rose =>
             return Synth_Psl_Rose(Syn_Inst, Expr);
+         when Iir_Kind_Psl_Fell =>
+            return Synth_Psl_Fell(Syn_Inst, Expr);
          when Iir_Kind_Overflow_Literal =>
             Error_Msg_Synth (+Expr, "out of bound expression");
             return No_Valtyp;

--- a/src/vhdl/vhdl-prints.adb
+++ b/src/vhdl/vhdl-prints.adb
@@ -2318,6 +2318,21 @@ package body Vhdl.Prints is
       Disp_Token (Ctxt, Tok_Right_Paren);
    end Disp_Psl_Rose;
 
+   procedure Disp_Psl_Fell (Ctxt : in out Ctxt_Class; Call : Iir)
+   is
+      Expr : Iir;
+   begin
+      Disp_Token (Ctxt, Tok_Fell);
+      Disp_Token (Ctxt, Tok_Left_Paren);
+      Print (Ctxt, Get_Expression (Call));
+      Expr := Get_Clock_Expression (Call);
+      if Expr /= Null_Iir then
+         Disp_Token (Ctxt, Tok_Comma);
+         Print (Ctxt, Expr);
+      end if;
+      Disp_Token (Ctxt, Tok_Right_Paren);
+   end Disp_Psl_Fell;
+
    procedure Disp_Psl_Declaration (Ctxt : in out Ctxt_Class; Stmt : Iir)
    is
       Decl : constant PSL_Node := Get_Psl_Declaration (Stmt);
@@ -4785,6 +4800,8 @@ package body Vhdl.Prints is
             Disp_Psl_Stable (Ctxt, Expr);
          when Iir_Kind_Psl_Rose =>
             Disp_Psl_Rose (Ctxt, Expr);
+         when Iir_Kind_Psl_Fell =>
+            Disp_Psl_Fell (Ctxt, Expr);
 
          when Iir_Kinds_Type_And_Subtype_Definition =>
             Disp_Type (Ctxt, Expr);

--- a/src/vhdl/vhdl-sem_expr.adb
+++ b/src/vhdl/vhdl-sem_expr.adb
@@ -417,7 +417,8 @@ package body Vhdl.Sem_Expr is
             return Expr;
          when Iir_Kind_Psl_Endpoint_Declaration
            | Iir_Kind_Psl_Stable
-           | Iir_Kind_Psl_Rose =>
+           | Iir_Kind_Psl_Rose
+           | Iir_Kind_Psl_Fell =>
             return Expr;
          when Iir_Kind_Simple_Name
            | Iir_Kind_Parenthesis_Name
@@ -4835,6 +4836,9 @@ package body Vhdl.Sem_Expr is
 
          when Iir_Kind_Psl_Rose =>
             return Sem_Psl.Sem_Rose_Builtin (Expr);
+
+         when Iir_Kind_Psl_Fell =>
+            return Sem_Psl.Sem_Fell_Builtin (Expr);
 
          when Iir_Kind_Error =>
             --  Always ok.

--- a/src/vhdl/vhdl-sem_psl.adb
+++ b/src/vhdl/vhdl-sem_psl.adb
@@ -193,6 +193,41 @@ package body Vhdl.Sem_Psl is
       return Call;
    end Sem_Rose_Builtin;
 
+   function Sem_Fell_Builtin (Call : Iir) return Iir
+   is
+      use Vhdl.Sem_Expr;
+      use Vhdl.Std_Package;
+      Expr  : Iir;
+      Clock : Iir;
+      First : Boolean;
+   begin
+      Expr := Get_Expression (Call);
+      First := Is_Expr_Not_Analyzed (Expr);
+      Expr := Sem_Expression (Expr, Null_Iir);
+      if Expr /= Null_Iir then
+         Set_Expression (Call, Expr);
+         Set_Type (Call, Vhdl.Std_Package.Boolean_Type_Definition);
+         Set_Expr_Staticness (Call, None);
+      end if;
+
+      if First then
+         --  Analyze clock only once.
+         Clock := Get_Clock_Expression (Call);
+         if Clock /= Null_Iir then
+            Clock := Sem_Expression_Wildcard (Clock, Wildcard_Psl_Bit_Type);
+            Set_Clock_Expression (Call, Clock);
+         else
+            if Current_Psl_Default_Clock = Null_Iir then
+               Error_Msg_Sem (+Call, "no clock for PSL fell builtin");
+            else
+               Set_Default_Clock (Call, Current_Psl_Default_Clock);
+            end if;
+         end if;
+      end if;
+
+      return Call;
+   end Sem_Fell_Builtin;
+
    --  Convert VHDL and/or/not nodes to PSL nodes.
    function Convert_Bool (Expr : Iir) return PSL_Node
    is

--- a/src/vhdl/vhdl-sem_psl.ads
+++ b/src/vhdl/vhdl-sem_psl.ads
@@ -25,6 +25,7 @@ package Vhdl.Sem_Psl is
    function Sem_Prev_Builtin (Call : Iir; Atype : Iir) return Iir;
    function Sem_Stable_Builtin (Call : Iir) return Iir;
    function Sem_Rose_Builtin (Call : Iir) return Iir;
+   function Sem_Fell_Builtin (Call : Iir) return Iir;
 
    procedure Sem_Psl_Declaration (Stmt : Iir);
    procedure Sem_Psl_Endpoint_Declaration (Stmt : Iir);

--- a/testsuite/synth/issue662/psl_fell.vhdl
+++ b/testsuite/synth/issue662/psl_fell.vhdl
@@ -1,0 +1,25 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity psl_fell is
+  port (clk, a, b : in std_logic
+  );
+end entity psl_fell;
+
+
+architecture psl of psl_fell is
+begin
+
+  -- All is sensitive to rising edge of clk
+  default clock is rising_edge(clk);
+
+  -- This assertion holds
+  FELL_0_a : assert always {a; not a} |-> fell(a);
+
+  -- This assertion holds
+  FELL_1_a : assert always (fell(a) -> (prev(a) = '1' and a = '0'));
+
+  -- This assertion should fail at cycle 11
+  FELL_2_a : assert always fell(a) -> b;
+
+end architecture psl;

--- a/testsuite/synth/issue662/tb_psl_fell.vhdl
+++ b/testsuite/synth/issue662/tb_psl_fell.vhdl
@@ -1,0 +1,37 @@
+library ieee;
+  use ieee.std_logic_1164.all;
+
+entity tb_psl_fell is
+end entity tb_psl_fell;
+
+
+architecture psl of tb_psl_fell is
+
+  procedure seq (s : string; signal clk : std_logic; signal o : out std_logic)
+  is
+  begin
+    for i in s'range loop
+      wait until rising_edge(clk);
+      case s(i) is
+        when '0' | '_' => o <= '0';
+        when '1' | '-' => o <= '1';
+        when others    => o <= 'X';
+      end case;
+    end loop;
+    wait;
+  end seq;
+
+  signal a, b : std_logic := '0';
+  signal clk  : std_logic := '1';
+
+begin
+
+  dut: entity work.psl_fell port map (clk, a, b);
+
+  clk <= not clk after 500 ps;
+
+  --             012345678901234
+  SEQ_A :  seq ("--_--___---__--", clk, a);
+  SEQ_B :  seq ("__-__-______-__", clk, b);
+
+end architecture psl;

--- a/testsuite/synth/issue662/testsuite.sh
+++ b/testsuite/synth/issue662/testsuite.sh
@@ -4,7 +4,7 @@
 
 GHDL_STD_FLAGS=--std=08
 
-for test in psl_prev psl_stable psl_rose; do
+for test in psl_prev psl_stable psl_rose psl_fell; do
   synth_analyze $test
   analyze tb_${test}.vhdl
   elab_simulate_failure tb_${test} --stop-time=20ns --asserts=disable-at-0 --assert-level=error


### PR DESCRIPTION
Next one. Similar additions as for `rose()`. But this time I get an error when synthesizing my example which states that the declaration of fell cannot be found. Is there something left to add on the parser side?

```
$  ghdl --synth --std=08 psl_fell.vhdl -e psl_fell
psl_fell.vhdl:17:43:error: no declaration for "fell"
*std_standard*:1:1:error: type of expression must be boolean
psl_fell.vhdl:20:29:error: no declaration for "fell"
*std_standard*:1:1:error: type of expression must be boolean
psl_fell.vhdl:23:28:error: no declaration for "fell"
*std_standard*:1:1:error: type of expression must be boolean
```