### PR TITLE
Add PSL prev() function to allowed expressions

### DIFF
--- a/src/vhdl/vhdl-sem_expr.adb
+++ b/src/vhdl/vhdl-sem_expr.adb
@@ -416,6 +416,7 @@ package body Vhdl.Sem_Expr is
            | Iir_Kind_Function_Call =>
             return Expr;
          when Iir_Kind_Psl_Endpoint_Declaration
+           | Iir_Kind_Psl_Prev
            | Iir_Kind_Psl_Stable
            | Iir_Kind_Psl_Rose
            | Iir_Kind_Psl_Fell =>

--- a/testsuite/synth/issue662/psl_fell.vhdl
+++ b/testsuite/synth/issue662/psl_fell.vhdl
@@ -17,7 +17,7 @@ begin
   FELL_0_a : assert always {a; not a} |-> fell(a);
 
   -- This assertion holds
-  FELL_1_a : assert always (fell(a) -> (prev(a) = '1' and a = '0'));
+  FELL_1_a : assert always (fell(a) -> (prev(a) and not a));
 
   -- This assertion should fail at cycle 11
   FELL_2_a : assert always fell(a) -> b;

--- a/testsuite/synth/issue662/psl_rose.vhdl
+++ b/testsuite/synth/issue662/psl_rose.vhdl
@@ -17,7 +17,7 @@ begin
   ROSE_0_a : assert always {not a; a} |-> rose(a);
 
   -- This assertion holds
-  ROSE_1_a : assert always (rose(a) -> (prev(a) = '0' and a = '1'));
+  ROSE_1_a : assert always (rose(a) -> (not prev(a) and a));
 
   -- This assertion should fail at cycle 11
   ROSE_2_a : assert always rose(a) -> b;

--- a/testsuite/synth/issue662/psl_stable.vhdl
+++ b/testsuite/synth/issue662/psl_stable.vhdl
@@ -14,10 +14,16 @@ begin
   -- All is sensitive to rising edge of clk
   default clock is rising_edge(clk);
 
-  -- This assertion holds
+  -- This assertion should fail at cycle 13
   STABLE_0_a : assert always {not a; a} |=> (stable(c) until_ b);
 
   -- This assertion holds
   STABLE_1_a : assert always {not a; a} |=> (stable(d) until_ b);
+
+  -- This assertion should fail at cycle 13
+  STABLE_2_a : assert always {not a; a} |=> (c = prev(c) until_ b);
+
+  -- This assertion holds
+  STABLE_3_a : assert always {not a; a} |=> (d = prev(d) until_ b);
 
 end architecture psl;


### PR DESCRIPTION
Small fix:

I added prev() to list of allowed expressions in `Check_Is_Expression()` function in `src/vhdl/vhdl-sem_exp.adb`. Furthermore I adjusted the test cases which use `prev()`.