### PR TITLE
ci(msys2): define deps in PKGBUILD, cleanup run.sh

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -94,10 +94,12 @@ jobs:
         path: ./dist/msys2-mingw/${{ matrix.task.pkg }}/pkg/
     - uses: actions/upload-artifact@v2
       with:
-         path: ./dist/msys2-mingw/${{ matrix.task.pkg }}/mingw-*ghdl*.pkg.tar.zst
+        path: ./dist/msys2-mingw/${{ matrix.task.pkg }}/mingw-*ghdl*.pkg.tar.zst
     - name: Test package
       run: |
-        ./dist/msys2-mingw/run.sh -t
+        env | grep MSYSTEM
+        env | grep MINGW
+        GHDL=ghdl ./testsuite/testsuite.sh
       env:
         MSYSTEM: ${{ matrix.task.installs }}
 

--- a/dist/msys2-mingw/llvm/PKGBUILD
+++ b/dist/msys2-mingw/llvm/PKGBUILD
@@ -3,16 +3,10 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=ci
 pkgrel=1
-pkgdesc="GHDL: the open-source analyzer, compiler and simulator for VHDL (LLVM backend) (mingw-w64)"
+pkgdesc="GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL (LLVM backend) (mingw-w64)"
 arch=('any')
-#depends=()
-makedepends=("${MINGW_PACKAGE_PREFIX}-clang" "${MINGW_PACKAGE_PREFIX}-gcc-ada")
-#source=(
-#  "ghdl::git://github.com/ghdl/ghdl.git#branch=master"
-#)
-#sha512sums=(
-#  'SKIP'
-#)
+depends=('zlib-devel' "${MINGW_PACKAGE_PREFIX}-clang")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-ada")
 
 build() {
   mkdir "${srcdir}/builddir"

--- a/dist/msys2-mingw/mcode/PKGBUILD
+++ b/dist/msys2-mingw/mcode/PKGBUILD
@@ -3,16 +3,10 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=ci
 pkgrel=1
-pkgdesc="GHDL: the open-source analyzer, compiler and simulator for VHDL (mcode backend) (mingw-w64)"
+pkgdesc="GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL (mcode backend) (mingw-w64)"
 arch=('any')
-#depends=()
+depends=('zlib-devel')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-gcc-ada")
-#source=(
-#  "ghdl::git://github.com/ghdl/ghdl.git#branch=master"
-#)
-#sha512sums=(
-#  'SKIP'
-#)
 
 build() {
   mkdir "${srcdir}/builddir"


### PR DESCRIPTION
With this PR dependencies of MSYS2 packages are defined in PKGBUILD files, instead of installing them in the `run.sh` script. Then, scripts are simplified.