### PR TITLE
Partially fix vpi_get_vlog_info

### DIFF
--- a/src/grt/grt-vpi.adb
+++ b/src/grt/grt-vpi.adb
@@ -55,6 +55,7 @@ with Grt.Rtis_Types;
 with Grt.Std_Logic_1164; use Grt.Std_Logic_1164;
 with Grt.Callbacks; use Grt.Callbacks;
 with Grt.Vstrings; use Grt.Vstrings;
+with Version;
 
 package body Grt.Vpi is
    --  The VPI interface requires libdl (dlopen, dlsym) to be linked in.
@@ -65,7 +66,8 @@ package body Grt.Vpi is
    --errNoString:      constant String := "grt-vcd.adb: no string" & NUL;
 
    Product : constant String := "GHDL" & NUL;
-   Version : constant String := "0.1" & NUL;
+   GhdlVersion : constant String :=
+      Version.Ghdl_Ver & " " & Version.Ghdl_Release & NUL;
 
    --  If true, emit traces
    Flag_Trace : Boolean := False;
@@ -1568,7 +1570,7 @@ package body Grt.Vpi is
       info.all := (Argc => 0,
                    Argv => Null_Address,
                    Product => To_Ghdl_C_String (Product'Address),
-                   Version => To_Ghdl_C_String (Version'Address));
+                   Version => To_Ghdl_C_String (GhdlVersion'Address));
       return 0;
    end vpi_get_vlog_info;
 

--- a/src/grt/grt-vpi.adb
+++ b/src/grt/grt-vpi.adb
@@ -1571,7 +1571,7 @@ package body Grt.Vpi is
                    Argv => Null_Address,
                    Product => To_Ghdl_C_String (Product'Address),
                    Version => To_Ghdl_C_String (GhdlVersion'Address));
-      return 0;
+      return 1;
    end vpi_get_vlog_info;
 
    -- vpiHandle vpi_handle_by_index(vpiHandle ref, int index)


### PR DESCRIPTION
This PR implements some of the missing functionality in the `vpi_get_vlog_info` VPI method: the version returned by the function now follows the release version, and the function returns `1` indicating success. While functionality is still missing, argc = `0` and argv = `NULL` is valid, so returning failure is not necessary.

This leaves one last bit of missing functionality in this function: returning argc and argv to C. While I'd like to see this implemented, I'm not familiar enough with Ada to do so.

This PR partially fixes #1396. 