### PR TITLE
ghdl-ls: Fix exception crashing language server

### DIFF
--- a/python/vhdl_langserver/lsp.py
+++ b/python/vhdl_langserver/lsp.py
@@ -113,7 +113,20 @@ class LanguageProtocolServer(object):
         if fmethod:
             if params is None:
                 params = {}
-            response = fmethod(**params)
+            try:
+                response = fmethod(**params)
+            except Exception as e:
+                log.exception(
+                    "Caught exception while handling %s with params %s:",
+                    method, params
+                )
+                self.show_message(
+                    MessageType.Error,
+                    ("Caught exception while handling {}, " +
+                     "see VHDL language server output for details.").format(
+                        method)
+                )
+                response = None
             if tid is None:
                 # If this was just a notification, discard it
                 return None

--- a/python/vhdl_langserver/symbols.py
+++ b/python/vhdl_langserver/symbols.py
@@ -1,3 +1,4 @@
+import logging
 import libghdl.thin.name_table as name_table
 import libghdl.thin.files_map as files_map
 import libghdl.thin.vhdl.pyutils as pyutils
@@ -6,6 +7,8 @@ import libghdl.thin.vhdl.nodes_meta as nodes_meta
 import libghdl.thin.vhdl.elocations as elocations
 
 from . import lsp
+
+log = logging.getLogger(__name__)
 
 SYMBOLS_MAP = {
     nodes.Iir_Kind.Package_Declaration: {'kind': lsp.SymbolKind.Package, 'detail': '(declaration)'},
@@ -78,7 +81,8 @@ def get_symbols(fe, n):
         return get_symbols(fe, nodes.Get_Library_Unit(n))
     m = SYMBOLS_MAP.get(k, None)
     if m is None:
-        raise AssertionError("get_symbol: unhandled {}".format(pyutils.kind_image(k)))
+        log.error("get_symbol: unhandled {}".format(pyutils.kind_image(k)))
+        return None
     kind = m['kind']
     if kind is None:
         return None

--- a/python/vhdl_langserver/symbols.py
+++ b/python/vhdl_langserver/symbols.py
@@ -1,4 +1,3 @@
-import logging
 import libghdl.thin.name_table as name_table
 import libghdl.thin.files_map as files_map
 import libghdl.thin.vhdl.pyutils as pyutils
@@ -7,8 +6,6 @@ import libghdl.thin.vhdl.nodes_meta as nodes_meta
 import libghdl.thin.vhdl.elocations as elocations
 
 from . import lsp
-
-log = logging.getLogger(__name__)
 
 SYMBOLS_MAP = {
     nodes.Iir_Kind.Package_Declaration: {'kind': lsp.SymbolKind.Package, 'detail': '(declaration)'},
@@ -81,8 +78,7 @@ def get_symbols(fe, n):
         return get_symbols(fe, nodes.Get_Library_Unit(n))
     m = SYMBOLS_MAP.get(k, None)
     if m is None:
-        log.error("get_symbol: unhandled {}".format(pyutils.kind_image(k)))
-        return None
+        raise AssertionError("get_symbol: unhandled {}".format(pyutils.kind_image(k)))
     kind = m['kind']
     if kind is None:
         return None


### PR DESCRIPTION
Previously, the language server crashed on unhandled symbols with an exception. As ignoring unhandled symbols should be fine, logging this as an error to the logger results in a much better user experience.

This fixes #1410.
