### PR TITLE
py: adjust blank lines to PEP 8 for vhdl_langserver

### DIFF
--- a/python/libghdl/__init__.py
+++ b/python/libghdl/__init__.py
@@ -5,6 +5,7 @@ from os.path import dirname, join, exists, normpath
 from shutil import which
 from libghdl.version import __version__
 
+
 def _to_char_p(arg):
     return ctypes.c_char_p(arg), len(arg)
 
@@ -82,6 +83,7 @@ libghdl.libghdl__set_hooks_for_analysis()
 # Set the prefix in order to locate the vhdl libraries.
 libghdl.libghdl__set_exec_prefix(
     *_to_char_p(dirname(dirname(_libghdl_path)).encode('utf-8')))
+
 
 def set_option(opt):
     "Set option OPT.  Return true iff the option is known and handled"

--- a/python/vhdl_langserver/document.py
+++ b/python/vhdl_langserver/document.py
@@ -14,6 +14,7 @@ from . import symbols, references
 
 log = logging.getLogger(__name__)
 
+
 class Document(object):
     # The encoding used for the files.
     # Unfortunately this is not fully reliable.  The client can read the

--- a/python/vhdl_langserver/lsp.py
+++ b/python/vhdl_langserver/lsp.py
@@ -12,8 +12,10 @@ except ImportError:
 
 log = logging.getLogger('ghdl-ls')
 
+
 class ProtocolError(Exception):
     pass
+
 
 class LSPConn:
     def __init__(self, reader, writer):
@@ -31,6 +33,7 @@ class LSPConn:
     def write(self, out):
         self.writer.write(out.encode())
         self.writer.flush()
+
 
 def path_from_uri(uri):
     # Convert file uri to path (strip html like head part)
@@ -193,6 +196,7 @@ class LanguageProtocolServer(object):
 #  Standard defines and object types
 #
 
+
 class JSONErrorCodes(object):
     # Defined by JSON RPC
     ParseError = -32700
@@ -237,16 +241,19 @@ class DiagnosticSeverity(object):
     Information = 3
     Hint = 4
 
+
 class TextDocumentSyncKind(object):
     NONE = 0,
     FULL = 1
     INCREMENTAL = 2
+
 
 class MessageType(object):
     Error = 1
     Warning = 2
     Info = 3
     Log = 4
+
 
 class SymbolKind(object):
     File = 1
@@ -268,6 +275,7 @@ class SymbolKind(object):
     Boolean = 17
     Array = 18
 
+
 @attr.s
 class HoverInfo(object):
     language = attr.ib()
@@ -286,6 +294,7 @@ class Completion(object):
 class Position(object):
     line = attr.ib()
     character = attr.ib()
+
 
 @attr.s
 class Range(object):

--- a/python/vhdl_langserver/lsptools.py
+++ b/python/vhdl_langserver/lsptools.py
@@ -3,6 +3,7 @@ import argparse
 import json
 from . import lsp
 
+
 def lsp2json():
     "Utility that transforms lsp log file to a JSON list"
     conn = lsp.LSPConn(sys.stdin.buffer, sys.stdout.buffer)
@@ -15,6 +16,7 @@ def lsp2json():
         res.append(json.loads(req))
     print(json.dumps(res, indent=2))
 
+
 def json2lsp():
     "Utility that transform a JSON list to an lsp file"
     res = json.load(sys.stdin)
@@ -22,6 +24,7 @@ def json2lsp():
     ls = lsp.LanguageProtocolServer(None, conn)
     for req in res:
         ls.write_output(req)
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -34,6 +37,7 @@ def main():
     parser_j2l.set_defaults(func=json2lsp)
     args = parser.parse_args()
     args.func()
+
 
 if __name__ == "__main__":
     main()

--- a/python/vhdl_langserver/main.py
+++ b/python/vhdl_langserver/main.py
@@ -15,6 +15,7 @@ from . import vhdl_ls
 
 logger = logging.getLogger('ghdl-ls')
 
+
 class LSPConnTrace(object):
     """Wrapper class to save in and out packets"""
     def __init__(self, basename, conn):
@@ -46,6 +47,7 @@ def rotate_log_files(basename, num):
             os.rename(oldfile, '{}.{}'.format(basename, i))
     if os.path.isfile(basename):
         os.rename(basename, '{}.0'.format(basename))
+
 
 def main():
     parser = argparse.ArgumentParser(

--- a/python/vhdl_langserver/references.py
+++ b/python/vhdl_langserver/references.py
@@ -6,6 +6,7 @@ import libghdl.thin.name_table as name_table
 
 log = logging.getLogger(__name__)
 
+
 def find_def_chain(first, loc):
     n1 = first
     while n1 != nodes.Null_Iir:
@@ -80,6 +81,7 @@ def find_def(n, loc):
                         return res
 
     return None
+
 
 def goto_definition(n, loc):
     "Return the declaration (as a node) under :param loc: or None"

--- a/python/vhdl_langserver/symbols.py
+++ b/python/vhdl_langserver/symbols.py
@@ -67,15 +67,18 @@ SYMBOLS_MAP = {
     nodes.Iir_Kind.Configuration_Specification: {'kind': None},
 }
 
+
 def location_to_position(fe, loc):
     assert loc != files_map.No_Location
     line = files_map.Location_File_To_Line(loc, fe)
     off = files_map.Location_File_Line_To_Offset(loc, fe, line)
     return {'line': line - 1, 'character': off}
 
+
 def get_symbols_chain(fe, n):
     res = [get_symbols(fe, el) for el in pyutils.chain_iter(n)]
     return [e for e in res if e is not None]
+
 
 def get_symbols(fe, n):
     if n == nodes.Null_Iir:

--- a/python/vhdl_langserver/workspace.py
+++ b/python/vhdl_langserver/workspace.py
@@ -21,11 +21,13 @@ from . import document, symbols
 
 log = logging.getLogger(__name__)
 
+
 class ProjectError(Exception):
     "Exception raised in case of unrecoverable error in the project file."
     def __init__(self, msg):
         super().__init__()
         self.msg = msg
+
 
 class Workspace(object):
     def __init__(self, root_uri, server):
@@ -192,7 +194,6 @@ class Workspace(object):
         except ProjectError as e:
             self._server.show_message(lsp.MessageType.Error,
                 "error in project file: {}".format(e.msg))
-
 
     def read_files_from_project(self):
         try:
@@ -430,7 +431,6 @@ class Workspace(object):
                 'entity': name,
                 'generics': create_interfaces(nodes.Get_Generic_Chain(ent)),
                 'ports': create_interfaces(nodes.Get_Port_Chain(ent))}
-
 
     def compute_anti_dependences(self):
         """Return a dictionnary of anti dependencies for design unit"""


### PR DESCRIPTION
Why?
1. Conform to PEP 8.
2. Easier to read.
3. Make tools, such as PyCharm, not complain.
