### PR TITLE
Add and use 'black' Python formatter

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,6 +10,24 @@ env:
 jobs:
 
 #
+# Format
+#
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - run: python -m pip install black
+
+    - run: python -m black --check python
+
+#
 # GPL
 #
 
@@ -19,8 +37,7 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - run: |
-        TASK=buster+mcode ./dist/ci-run.sh -c --gpl --no-synth
+    - run: TASK=buster+mcode ./dist/ci-run.sh -c --gpl --no-synth
 
 #
 # GNU/Linux

--- a/configure
+++ b/configure
@@ -192,7 +192,7 @@ fi
 if [ "$enable_libghdl" = true ]; then
     libghdl_version="$srcdir/python/libghdl/version.py"
     # Extract content between single quotes in version.py, to avoid false positives due to LF/CRLF mismatch.
-    if [ "$ghdl_version" != "`sed "s/.*'\(.*\)'.*/\1/g" $libghdl_version`" ]; then
+    if [ "$ghdl_version" != "`sed 's/.*"\(.*\)".*/\1/g' $libghdl_version`" ]; then
       echo "Sorry, the version of $libghdl_version is not correct"
       echo "update the version to: $ghdl_version"
       echo "or use --disable-libghdl"

--- a/python/libghdl/__init__.py
+++ b/python/libghdl/__init__.py
@@ -12,11 +12,9 @@ def _to_char_p(arg):
 
 def _get_libghdl_name():
     """Get the name of the libghdl library (with version and extension)"""
-    ver = __version__.replace('-', '_').replace('.', '_')
-    ext = {'win32': 'dll',
-           'cygwin': 'dll',
-           'darwin': 'dylib'}.get(sys.platform, 'so')
-    return 'libghdl-' + ver + '.' + ext
+    ver = __version__.replace("-", "_").replace(".", "_")
+    ext = {"win32": "dll", "cygwin": "dll", "darwin": "dylib"}.get(sys.platform, "so")
+    return "libghdl-" + ver + "." + ext
 
 
 def _check_libghdl_libdir(libdir, basename):
@@ -33,14 +31,14 @@ def _check_libghdl_libdir(libdir, basename):
 def _check_libghdl_bindir(bindir, basename):
     if bindir is None:
         return None
-    return _check_libghdl_libdir(normpath(join(bindir, '..', 'lib')), basename)
+    return _check_libghdl_libdir(normpath(join(bindir, "..", "lib")), basename)
 
 
 def _get_libghdl_path():
     """Locate the directory where the shared library is"""
     basename = _get_libghdl_name()
     # Try GHDL_PREFIX
-    r = os.environ.get('GHDL_PREFIX')
+    r = os.environ.get("GHDL_PREFIX")
     if r is not None:
         # GHDL_PREFIX is the prefix of the vhdl libraries, so remove the
         # last path component.
@@ -48,11 +46,11 @@ def _get_libghdl_path():
         if r is not None:
             return r
     # Try VUNIT_GHDL_PATH (path of the ghdl binary when using VUnit).
-    r = _check_libghdl_bindir (os.environ.get('VUNIT_GHDL_PATH'), basename)
+    r = _check_libghdl_bindir(os.environ.get("VUNIT_GHDL_PATH"), basename)
     if r is not None:
         return r
     # Try GHDL (name/path of the ghdl binary)
-    r = os.environ.get('GHDL', 'ghdl')
+    r = os.environ.get("GHDL", "ghdl")
     r = which(r)
     if r is not None:
         r = _check_libghdl_bindir(dirname(r), basename)
@@ -64,12 +62,12 @@ def _get_libghdl_path():
     if r is not None:
         return r
     # Try when running from the build directory
-    r = normpath(join(dirname(__file__), '..', '..', 'lib'))
+    r = normpath(join(dirname(__file__), "..", "..", "lib"))
     r = _check_libghdl_libdir(r, basename)
     if r is not None:
         return r
     # Failed.
-    raise Exception('Cannot find libghdl {}'.format(basename))
+    raise Exception("Cannot find libghdl {}".format(basename))
 
 
 # Load the shared library
@@ -82,7 +80,8 @@ libghdl.libghdl__set_hooks_for_analysis()
 
 # Set the prefix in order to locate the vhdl libraries.
 libghdl.libghdl__set_exec_prefix(
-    *_to_char_p(dirname(dirname(_libghdl_path)).encode('utf-8')))
+    *_to_char_p(dirname(dirname(_libghdl_path)).encode("utf-8"))
+)
 
 
 def set_option(opt):

--- a/python/libghdl/thin/errorout.py
+++ b/python/libghdl/thin/errorout.py
@@ -3,7 +3,6 @@ from libghdl import libghdl
 Enable_Warning = libghdl.errorout__enable_warning
 
 
-
 class Msgid:
     Msgid_Note = 0
     Warnid_Library = 1

--- a/python/libghdl/thin/errorout_memory.py
+++ b/python/libghdl/thin/errorout_memory.py
@@ -1,13 +1,16 @@
 from libghdl import libghdl
 from ctypes import c_int8, c_int32, c_char_p, Structure
 
+
 class Error_Message(Structure):
-    _fields_ = [("id", c_int8),
-                ("group", c_int8),
-                ("file", c_int32),
-                ("line", c_int32),
-                ("offset", c_int32),
-                ("length", c_int32)]
+    _fields_ = [
+        ("id", c_int8),
+        ("group", c_int8),
+        ("file", c_int32),
+        ("line", c_int32),
+        ("offset", c_int32),
+        ("length", c_int32),
+    ]
 
 
 # Values for group:

--- a/python/libghdl/thin/files_map.py
+++ b/python/libghdl/thin/files_map.py
@@ -1,7 +1,7 @@
 from libghdl import libghdl
 from ctypes import c_void_p
 
-EOT = b'\x04'
+EOT = b"\x04"
 
 No_Source_File_Entry = 0
 
@@ -13,8 +13,7 @@ Location_File_To_Pos = libghdl.files_map__location_file_to_pos
 
 Location_File_To_Line = libghdl.files_map__location_file_to_line
 
-Location_File_Line_To_Offset = \
-    libghdl.files_map__location_file_line_to_offset
+Location_File_Line_To_Offset = libghdl.files_map__location_file_line_to_offset
 
 Location_File_Line_To_Col = libghdl.files_map__location_file_line_to_col
 

--- a/python/libghdl/thin/flags.py
+++ b/python/libghdl/thin/flags.py
@@ -8,7 +8,7 @@ Flag_Elocations = c_bool.in_dll(libghdl, "flags__flag_elocations")
 Verbose = c_bool.in_dll(libghdl, "flags__verbose")
 
 Flag_Elaborate_With_Outdated = c_bool.in_dll(
-    libghdl, "flags__flag_elaborate_with_outdated")
+    libghdl, "flags__flag_elaborate_with_outdated"
+)
 
-Flag_Force_Analysis = c_bool.in_dll(
-    libghdl, "flags__flag_force_analysis")
+Flag_Force_Analysis = c_bool.in_dll(libghdl, "flags__flag_force_analysis")

--- a/python/libghdl/thin/libraries.py
+++ b/python/libghdl/thin/libraries.py
@@ -3,8 +3,7 @@ from ctypes import c_int32
 
 Get_Libraries_Chain = libghdl.libraries__get_libraries_chain
 
-Add_Design_Unit_Into_Library = \
-    libghdl.libraries__add_design_unit_into_library
+Add_Design_Unit_Into_Library = libghdl.libraries__add_design_unit_into_library
 
 # Use .value
 Library_Location = c_int32.in_dll(libghdl, "libraries__library_location")

--- a/python/libghdl/thin/name_table.py
+++ b/python/libghdl/thin/name_table.py
@@ -8,7 +8,9 @@ Get_Name_Ptr.restype = c_char_p
 
 _Get_Identifier_With_Len = libghdl.name_table__get_identifier_with_len
 
+
 def Get_Identifier(s):
     return _Get_Identifier_With_Len(c_char_p(s), len(s))
+
 
 Null_Identifier = 0

--- a/python/libghdl/thin/vhdl/canon.py
+++ b/python/libghdl/thin/vhdl/canon.py
@@ -2,13 +2,13 @@ from libghdl import libghdl
 from ctypes import c_bool
 
 Flag_Concurrent_Stmts = c_bool.in_dll(
-    libghdl, "vhdl__canon__canon_flag_concurrent_stmts")
+    libghdl, "vhdl__canon__canon_flag_concurrent_stmts"
+)
 
-Flag_Configurations = c_bool.in_dll(
-    libghdl, "vhdl__canon__canon_flag_configurations")
+Flag_Configurations = c_bool.in_dll(libghdl, "vhdl__canon__canon_flag_configurations")
 
-Flag_Associations = c_bool.in_dll(
-    libghdl, "vhdl__canon__canon_flag_associations")
+Flag_Associations = c_bool.in_dll(libghdl, "vhdl__canon__canon_flag_associations")
 
-Extract_Sequential_Statement_Chain_Sensitivity = \
+Extract_Sequential_Statement_Chain_Sensitivity = (
     libghdl.vhdl__canon__canon_extract_sequential_statement_chain_sensitivity
+)

--- a/python/libghdl/thin/vhdl/ieee.py
+++ b/python/libghdl/thin/vhdl/ieee.py
@@ -2,20 +2,19 @@ from libghdl import libghdl
 from ctypes import c_int
 
 Std_Logic_1164_Pkg = c_int.in_dll(
-    libghdl, "vhdl__ieee__std_logic_1164__std_logic_1164_pkg")
+    libghdl, "vhdl__ieee__std_logic_1164__std_logic_1164_pkg"
+)
 
 # Get value
-Std_Logic_Type = c_int.in_dll(
-    libghdl, "vhdl__ieee__std_logic_1164__std_logic_type")
+Std_Logic_Type = c_int.in_dll(libghdl, "vhdl__ieee__std_logic_1164__std_logic_type")
 
 # Get value
 Std_Logic_Vector_Type = c_int.in_dll(
-    libghdl, "vhdl__ieee__std_logic_1164__std_logic_vector_type")
+    libghdl, "vhdl__ieee__std_logic_1164__std_logic_vector_type"
+)
 
 # Get value
-Rising_Edge = c_int.in_dll(
-    libghdl, "vhdl__ieee__std_logic_1164__rising_edge")
+Rising_Edge = c_int.in_dll(libghdl, "vhdl__ieee__std_logic_1164__rising_edge")
 
 # Get value
-Falling_Edge = c_int.in_dll(
-    libghdl, "vhdl__ieee__std_logic_1164__falling_edge")
+Falling_Edge = c_int.in_dll(libghdl, "vhdl__ieee__std_logic_1164__falling_edge")

--- a/python/libghdl/thin/vhdl/lists.py
+++ b/python/libghdl/thin/vhdl/lists.py
@@ -3,10 +3,10 @@ from ctypes import c_int32, c_bool, POINTER, Structure
 
 List_Type = c_int32
 
+
 class Iterator(Structure):
-    _fields_ = [("chunk", c_int32),
-                ("chunk_idx", c_int32),
-                ("remain", c_int32)]
+    _fields_ = [("chunk", c_int32), ("chunk_idx", c_int32), ("remain", c_int32)]
+
 
 Iterate = libghdl.vhdl__lists__iterate
 Iterate.argstype = [List_Type]

--- a/python/libghdl/thin/vhdl/nodes.py
+++ b/python/libghdl/thin/vhdl/nodes.py
@@ -10,7 +10,6 @@ Iir_Flist_Others = 1
 Iir_Flist_All = 2
 
 
-
 class Iir_Kind:
     Unused = 0
     Error = 1
@@ -330,23 +329,27 @@ class Iir_Kind:
 class Iir_Kinds:
     Variable_Assignment_Statement = [
         Iir_Kind.Variable_Assignment_Statement,
-        Iir_Kind.Conditional_Variable_Assignment_Statement]
+        Iir_Kind.Conditional_Variable_Assignment_Statement,
+    ]
 
     Denoting_Name = [
         Iir_Kind.Character_Literal,
         Iir_Kind.Simple_Name,
         Iir_Kind.Selected_Name,
         Iir_Kind.Operator_Symbol,
-        Iir_Kind.Reference_Name]
+        Iir_Kind.Reference_Name,
+    ]
 
     Case_Choice = [
         Iir_Kind.Choice_By_Range,
         Iir_Kind.Choice_By_Expression,
-        Iir_Kind.Choice_By_Others]
+        Iir_Kind.Choice_By_Others,
+    ]
 
     Array_Type_Definition = [
         Iir_Kind.Array_Type_Definition,
-        Iir_Kind.Array_Subtype_Definition]
+        Iir_Kind.Array_Subtype_Definition,
+    ]
 
     Library_Unit = [
         Iir_Kind.Entity_Declaration,
@@ -358,31 +361,35 @@ class Iir_Kinds:
         Iir_Kind.Vprop_Declaration,
         Iir_Kind.Vunit_Declaration,
         Iir_Kind.Package_Body,
-        Iir_Kind.Architecture_Body]
+        Iir_Kind.Architecture_Body,
+    ]
 
     Array_Choice = [
         Iir_Kind.Choice_By_Range,
         Iir_Kind.Choice_By_Expression,
         Iir_Kind.Choice_By_Others,
-        Iir_Kind.Choice_By_None]
+        Iir_Kind.Choice_By_None,
+    ]
 
     Subprogram_Declaration = [
         Iir_Kind.Function_Declaration,
-        Iir_Kind.Procedure_Declaration]
+        Iir_Kind.Procedure_Declaration,
+    ]
 
     Subtype_Attribute = [
         Iir_Kind.Base_Attribute,
         Iir_Kind.Subtype_Attribute,
-        Iir_Kind.Element_Attribute]
+        Iir_Kind.Element_Attribute,
+    ]
 
     Scalar_Subtype_Definition = [
         Iir_Kind.Physical_Subtype_Definition,
         Iir_Kind.Floating_Subtype_Definition,
         Iir_Kind.Integer_Subtype_Definition,
-        Iir_Kind.Enumeration_Subtype_Definition]
+        Iir_Kind.Enumeration_Subtype_Definition,
+    ]
 
-    Subnature_Definition = [
-        Iir_Kind.Array_Subnature_Definition]
+    Subnature_Definition = [Iir_Kind.Array_Subnature_Definition]
 
     Literal = [
         Iir_Kind.Integer_Literal,
@@ -390,22 +397,26 @@ class Iir_Kinds:
         Iir_Kind.Null_Literal,
         Iir_Kind.String_Literal8,
         Iir_Kind.Physical_Int_Literal,
-        Iir_Kind.Physical_Fp_Literal]
+        Iir_Kind.Physical_Fp_Literal,
+    ]
 
     Nature_Indication = [
         Iir_Kind.Scalar_Nature_Definition,
         Iir_Kind.Record_Nature_Definition,
         Iir_Kind.Array_Nature_Definition,
-        Iir_Kind.Array_Subnature_Definition]
+        Iir_Kind.Array_Subnature_Definition,
+    ]
 
     Process_Statement = [
         Iir_Kind.Sensitized_Process_Statement,
-        Iir_Kind.Process_Statement]
+        Iir_Kind.Process_Statement,
+    ]
 
     Nature_Definition = [
         Iir_Kind.Scalar_Nature_Definition,
         Iir_Kind.Record_Nature_Definition,
-        Iir_Kind.Array_Nature_Definition]
+        Iir_Kind.Array_Nature_Definition,
+    ]
 
     Object_Declaration = [
         Iir_Kind.Object_Alias_Declaration,
@@ -424,12 +435,10 @@ class Iir_Kinds:
         Iir_Kind.Interface_Variable_Declaration,
         Iir_Kind.Interface_Signal_Declaration,
         Iir_Kind.Interface_File_Declaration,
-        Iir_Kind.Interface_Quantity_Declaration]
+        Iir_Kind.Interface_Quantity_Declaration,
+    ]
 
-    Clause = [
-        Iir_Kind.Library_Clause,
-        Iir_Kind.Use_Clause,
-        Iir_Kind.Context_Reference]
+    Clause = [Iir_Kind.Library_Clause, Iir_Kind.Use_Clause, Iir_Kind.Context_Reference]
 
     Type_And_Subtype_Definition = [
         Iir_Kind.Access_Type_Definition,
@@ -449,16 +458,16 @@ class Iir_Kinds:
         Iir_Kind.Enumeration_Type_Definition,
         Iir_Kind.Integer_Type_Definition,
         Iir_Kind.Floating_Type_Definition,
-        Iir_Kind.Physical_Type_Definition]
+        Iir_Kind.Physical_Type_Definition,
+    ]
 
     External_Name = [
         Iir_Kind.External_Constant_Name,
         Iir_Kind.External_Signal_Name,
-        Iir_Kind.External_Variable_Name]
+        Iir_Kind.External_Variable_Name,
+    ]
 
-    Dereference = [
-        Iir_Kind.Dereference,
-        Iir_Kind.Implicit_Dereference]
+    Dereference = [Iir_Kind.Dereference, Iir_Kind.Implicit_Dereference]
 
     Primary_Unit = [
         Iir_Kind.Entity_Declaration,
@@ -468,55 +477,63 @@ class Iir_Kinds:
         Iir_Kind.Package_Instantiation_Declaration,
         Iir_Kind.Vmode_Declaration,
         Iir_Kind.Vprop_Declaration,
-        Iir_Kind.Vunit_Declaration]
+        Iir_Kind.Vunit_Declaration,
+    ]
 
     Record_Choice = [
         Iir_Kind.Choice_By_Others,
         Iir_Kind.Choice_By_None,
-        Iir_Kind.Choice_By_Name]
+        Iir_Kind.Choice_By_Name,
+    ]
 
     Functions_And_Literals = [
         Iir_Kind.Enumeration_Literal,
-        Iir_Kind.Function_Declaration]
+        Iir_Kind.Function_Declaration,
+    ]
 
     Verification_Unit = [
         Iir_Kind.Vmode_Declaration,
         Iir_Kind.Vprop_Declaration,
-        Iir_Kind.Vunit_Declaration]
+        Iir_Kind.Vunit_Declaration,
+    ]
 
-    Secondary_Unit = [
-        Iir_Kind.Package_Body,
-        Iir_Kind.Architecture_Body]
+    Secondary_Unit = [Iir_Kind.Package_Body, Iir_Kind.Architecture_Body]
 
     Package_Declaration = [
         Iir_Kind.Package_Declaration,
-        Iir_Kind.Package_Instantiation_Declaration]
+        Iir_Kind.Package_Instantiation_Declaration,
+    ]
 
     Psl_Builtin = [
         Iir_Kind.Psl_Prev,
         Iir_Kind.Psl_Stable,
         Iir_Kind.Psl_Rose,
-        Iir_Kind.Psl_Fell]
+        Iir_Kind.Psl_Fell,
+    ]
 
     Generate_Statement = [
         Iir_Kind.If_Generate_Statement,
         Iir_Kind.Case_Generate_Statement,
-        Iir_Kind.For_Generate_Statement]
+        Iir_Kind.For_Generate_Statement,
+    ]
 
     Composite_Subtype_Definition = [
         Iir_Kind.Array_Subtype_Definition,
-        Iir_Kind.Record_Subtype_Definition]
+        Iir_Kind.Record_Subtype_Definition,
+    ]
 
     Choice = [
         Iir_Kind.Choice_By_Range,
         Iir_Kind.Choice_By_Expression,
         Iir_Kind.Choice_By_Others,
         Iir_Kind.Choice_By_None,
-        Iir_Kind.Choice_By_Name]
+        Iir_Kind.Choice_By_Name,
+    ]
 
     If_Case_Generate_Statement = [
         Iir_Kind.If_Generate_Statement,
-        Iir_Kind.Case_Generate_Statement]
+        Iir_Kind.Case_Generate_Statement,
+    ]
 
     Simple_Concurrent_Statement = [
         Iir_Kind.Sensitized_Process_Statement,
@@ -530,7 +547,8 @@ class Iir_Kinds:
         Iir_Kind.Psl_Assert_Directive,
         Iir_Kind.Psl_Assume_Directive,
         Iir_Kind.Psl_Cover_Directive,
-        Iir_Kind.Psl_Restrict_Directive]
+        Iir_Kind.Psl_Restrict_Directive,
+    ]
 
     Non_Alias_Object_Declaration = [
         Iir_Kind.File_Declaration,
@@ -542,26 +560,28 @@ class Iir_Kinds:
         Iir_Kind.Interface_Constant_Declaration,
         Iir_Kind.Interface_Variable_Declaration,
         Iir_Kind.Interface_Signal_Declaration,
-        Iir_Kind.Interface_File_Declaration]
+        Iir_Kind.Interface_File_Declaration,
+    ]
 
     Entity_Aspect = [
         Iir_Kind.Entity_Aspect_Entity,
         Iir_Kind.Entity_Aspect_Configuration,
-        Iir_Kind.Entity_Aspect_Open]
+        Iir_Kind.Entity_Aspect_Open,
+    ]
 
-    Subprogram_Body = [
-        Iir_Kind.Function_Body,
-        Iir_Kind.Procedure_Body]
+    Subprogram_Body = [Iir_Kind.Function_Body, Iir_Kind.Procedure_Body]
 
     Source_Quantity_Declaration = [
         Iir_Kind.Spectrum_Quantity_Declaration,
-        Iir_Kind.Noise_Quantity_Declaration]
+        Iir_Kind.Noise_Quantity_Declaration,
+    ]
 
     Specification = [
         Iir_Kind.Attribute_Specification,
         Iir_Kind.Disconnection_Specification,
         Iir_Kind.Step_Limit_Specification,
-        Iir_Kind.Configuration_Specification]
+        Iir_Kind.Configuration_Specification,
+    ]
 
     Dyadic_Operator = [
         Iir_Kind.And_Operator,
@@ -595,7 +615,8 @@ class Iir_Kinds:
         Iir_Kind.Division_Operator,
         Iir_Kind.Modulus_Operator,
         Iir_Kind.Remainder_Operator,
-        Iir_Kind.Exponentiation_Operator]
+        Iir_Kind.Exponentiation_Operator,
+    ]
 
     Expression_Attribute = [
         Iir_Kind.Left_Type_Attribute,
@@ -642,7 +663,8 @@ class Iir_Kinds:
         Iir_Kind.High_Array_Attribute,
         Iir_Kind.Low_Array_Attribute,
         Iir_Kind.Length_Array_Attribute,
-        Iir_Kind.Ascending_Array_Attribute]
+        Iir_Kind.Ascending_Array_Attribute,
+    ]
 
     Monadic_Operator = [
         Iir_Kind.Identity_Operator,
@@ -656,7 +678,8 @@ class Iir_Kinds:
         Iir_Kind.Reduction_Nand_Operator,
         Iir_Kind.Reduction_Nor_Operator,
         Iir_Kind.Reduction_Xor_Operator,
-        Iir_Kind.Reduction_Xnor_Operator]
+        Iir_Kind.Reduction_Xnor_Operator,
+    ]
 
     Interface_Declaration = [
         Iir_Kind.Interface_Constant_Declaration,
@@ -668,7 +691,8 @@ class Iir_Kinds:
         Iir_Kind.Interface_Type_Declaration,
         Iir_Kind.Interface_Package_Declaration,
         Iir_Kind.Interface_Function_Declaration,
-        Iir_Kind.Interface_Procedure_Declaration]
+        Iir_Kind.Interface_Procedure_Declaration,
+    ]
 
     Array_Attribute = [
         Iir_Kind.Left_Array_Attribute,
@@ -678,7 +702,8 @@ class Iir_Kinds:
         Iir_Kind.Length_Array_Attribute,
         Iir_Kind.Ascending_Array_Attribute,
         Iir_Kind.Range_Array_Attribute,
-        Iir_Kind.Reverse_Range_Array_Attribute]
+        Iir_Kind.Reverse_Range_Array_Attribute,
+    ]
 
     Sequential_Statement = [
         Iir_Kind.Simple_Signal_Assignment_Statement,
@@ -700,7 +725,8 @@ class Iir_Kinds:
         Iir_Kind.Case_Statement,
         Iir_Kind.Procedure_Call_Statement,
         Iir_Kind.Break_Statement,
-        Iir_Kind.If_Statement]
+        Iir_Kind.If_Statement,
+    ]
 
     Denoting_And_External_Name = [
         Iir_Kind.Character_Literal,
@@ -710,25 +736,29 @@ class Iir_Kinds:
         Iir_Kind.Reference_Name,
         Iir_Kind.External_Constant_Name,
         Iir_Kind.External_Signal_Name,
-        Iir_Kind.External_Variable_Name]
+        Iir_Kind.External_Variable_Name,
+    ]
 
     Association_Element_Parameters = [
         Iir_Kind.Association_Element_By_Expression,
         Iir_Kind.Association_Element_By_Individual,
-        Iir_Kind.Association_Element_Open]
+        Iir_Kind.Association_Element_Open,
+    ]
 
     Range_Type_Definition = [
         Iir_Kind.Physical_Subtype_Definition,
         Iir_Kind.Floating_Subtype_Definition,
         Iir_Kind.Integer_Subtype_Definition,
         Iir_Kind.Enumeration_Subtype_Definition,
-        Iir_Kind.Enumeration_Type_Definition]
+        Iir_Kind.Enumeration_Type_Definition,
+    ]
 
     Discrete_Type_Definition = [
         Iir_Kind.Integer_Subtype_Definition,
         Iir_Kind.Enumeration_Subtype_Definition,
         Iir_Kind.Enumeration_Type_Definition,
-        Iir_Kind.Integer_Type_Definition]
+        Iir_Kind.Integer_Type_Definition,
+    ]
 
     Concurrent_Statement = [
         Iir_Kind.Sensitized_Process_Statement,
@@ -748,22 +778,23 @@ class Iir_Kinds:
         Iir_Kind.Case_Generate_Statement,
         Iir_Kind.For_Generate_Statement,
         Iir_Kind.Component_Instantiation_Statement,
-        Iir_Kind.Psl_Default_Clock]
+        Iir_Kind.Psl_Default_Clock,
+    ]
 
     Signal_Attribute = [
         Iir_Kind.Delayed_Attribute,
         Iir_Kind.Stable_Attribute,
         Iir_Kind.Quiet_Attribute,
-        Iir_Kind.Transaction_Attribute]
+        Iir_Kind.Transaction_Attribute,
+    ]
 
     Type_Declaration = [
         Iir_Kind.Type_Declaration,
         Iir_Kind.Anonymous_Type_Declaration,
-        Iir_Kind.Subtype_Declaration]
+        Iir_Kind.Subtype_Declaration,
+    ]
 
-    Next_Exit_Statement = [
-        Iir_Kind.Next_Statement,
-        Iir_Kind.Exit_Statement]
+    Next_Exit_Statement = [Iir_Kind.Next_Statement, Iir_Kind.Exit_Statement]
 
     Association_Element = [
         Iir_Kind.Association_Element_By_Expression,
@@ -772,35 +803,41 @@ class Iir_Kinds:
         Iir_Kind.Association_Element_Package,
         Iir_Kind.Association_Element_Type,
         Iir_Kind.Association_Element_Subprogram,
-        Iir_Kind.Association_Element_Terminal]
+        Iir_Kind.Association_Element_Terminal,
+    ]
 
     Interface_Object_Declaration = [
         Iir_Kind.Interface_Constant_Declaration,
         Iir_Kind.Interface_Variable_Declaration,
         Iir_Kind.Interface_Signal_Declaration,
         Iir_Kind.Interface_File_Declaration,
-        Iir_Kind.Interface_Quantity_Declaration]
+        Iir_Kind.Interface_Quantity_Declaration,
+    ]
 
     Composite_Type_Definition = [
         Iir_Kind.Record_Type_Definition,
         Iir_Kind.Array_Type_Definition,
         Iir_Kind.Array_Subtype_Definition,
-        Iir_Kind.Record_Subtype_Definition]
+        Iir_Kind.Record_Subtype_Definition,
+    ]
 
     Interface_Subprogram_Declaration = [
         Iir_Kind.Interface_Function_Declaration,
-        Iir_Kind.Interface_Procedure_Declaration]
+        Iir_Kind.Interface_Procedure_Declaration,
+    ]
 
     Branch_Quantity_Declaration = [
         Iir_Kind.Across_Quantity_Declaration,
-        Iir_Kind.Through_Quantity_Declaration]
+        Iir_Kind.Through_Quantity_Declaration,
+    ]
 
     Type_Attribute = [
         Iir_Kind.Left_Type_Attribute,
         Iir_Kind.Right_Type_Attribute,
         Iir_Kind.High_Type_Attribute,
         Iir_Kind.Low_Type_Attribute,
-        Iir_Kind.Ascending_Type_Attribute]
+        Iir_Kind.Ascending_Type_Attribute,
+    ]
 
     Signal_Value_Attribute = [
         Iir_Kind.Event_Attribute,
@@ -809,14 +846,16 @@ class Iir_Kinds:
         Iir_Kind.Last_Active_Attribute,
         Iir_Kind.Last_Value_Attribute,
         Iir_Kind.Driving_Attribute,
-        Iir_Kind.Driving_Value_Attribute]
+        Iir_Kind.Driving_Value_Attribute,
+    ]
 
     Quantity_Declaration = [
         Iir_Kind.Free_Quantity_Declaration,
         Iir_Kind.Spectrum_Quantity_Declaration,
         Iir_Kind.Noise_Quantity_Declaration,
         Iir_Kind.Across_Quantity_Declaration,
-        Iir_Kind.Through_Quantity_Declaration]
+        Iir_Kind.Through_Quantity_Declaration,
+    ]
 
     Nonoverloadable_Declaration = [
         Iir_Kind.Type_Declaration,
@@ -832,7 +871,8 @@ class Iir_Kinds:
         Iir_Kind.Group_Template_Declaration,
         Iir_Kind.Group_Declaration,
         Iir_Kind.Element_Declaration,
-        Iir_Kind.Nature_Element_Declaration]
+        Iir_Kind.Nature_Element_Declaration,
+    ]
 
     Scalar_Type_And_Subtype_Definition = [
         Iir_Kind.Physical_Subtype_Definition,
@@ -842,7 +882,8 @@ class Iir_Kinds:
         Iir_Kind.Enumeration_Type_Definition,
         Iir_Kind.Integer_Type_Definition,
         Iir_Kind.Floating_Type_Definition,
-        Iir_Kind.Physical_Type_Definition]
+        Iir_Kind.Physical_Type_Definition,
+    ]
 
     Attribute = [
         Iir_Kind.Base_Attribute,
@@ -897,32 +938,35 @@ class Iir_Kinds:
         Iir_Kind.Length_Array_Attribute,
         Iir_Kind.Ascending_Array_Attribute,
         Iir_Kind.Range_Array_Attribute,
-        Iir_Kind.Reverse_Range_Array_Attribute]
+        Iir_Kind.Reverse_Range_Array_Attribute,
+    ]
 
-    Physical_Literal = [
-        Iir_Kind.Physical_Int_Literal,
-        Iir_Kind.Physical_Fp_Literal]
+    Physical_Literal = [Iir_Kind.Physical_Int_Literal, Iir_Kind.Physical_Fp_Literal]
 
     Simultaneous_Statement = [
         Iir_Kind.Simple_Simultaneous_Statement,
         Iir_Kind.Simultaneous_Null_Statement,
         Iir_Kind.Simultaneous_Procedural_Statement,
         Iir_Kind.Simultaneous_Case_Statement,
-        Iir_Kind.Simultaneous_If_Statement]
+        Iir_Kind.Simultaneous_If_Statement,
+    ]
 
     Concurrent_Signal_Assignment = [
         Iir_Kind.Concurrent_Simple_Signal_Assignment,
         Iir_Kind.Concurrent_Conditional_Signal_Assignment,
-        Iir_Kind.Concurrent_Selected_Signal_Assignment]
+        Iir_Kind.Concurrent_Selected_Signal_Assignment,
+    ]
 
     Range_Attribute = [
         Iir_Kind.Range_Array_Attribute,
-        Iir_Kind.Reverse_Range_Array_Attribute]
+        Iir_Kind.Reverse_Range_Array_Attribute,
+    ]
 
     Name_Attribute = [
         Iir_Kind.Simple_Name_Attribute,
         Iir_Kind.Instance_Name_Attribute,
-        Iir_Kind.Path_Name_Attribute]
+        Iir_Kind.Path_Name_Attribute,
+    ]
 
     Scalar_Type_Attribute = [
         Iir_Kind.Pos_Attribute,
@@ -930,7 +974,8 @@ class Iir_Kinds:
         Iir_Kind.Succ_Attribute,
         Iir_Kind.Pred_Attribute,
         Iir_Kind.Leftof_Attribute,
-        Iir_Kind.Rightof_Attribute]
+        Iir_Kind.Rightof_Attribute,
+    ]
 
     Name = [
         Iir_Kind.Character_Literal,
@@ -942,7 +987,8 @@ class Iir_Kinds:
         Iir_Kind.External_Signal_Name,
         Iir_Kind.External_Variable_Name,
         Iir_Kind.Selected_By_All_Name,
-        Iir_Kind.Parenthesis_Name]
+        Iir_Kind.Parenthesis_Name,
+    ]
 
     Subtype_Definition = [
         Iir_Kind.Array_Subtype_Definition,
@@ -951,12 +997,10 @@ class Iir_Kinds:
         Iir_Kind.Physical_Subtype_Definition,
         Iir_Kind.Floating_Subtype_Definition,
         Iir_Kind.Integer_Subtype_Definition,
-        Iir_Kind.Enumeration_Subtype_Definition]
+        Iir_Kind.Enumeration_Subtype_Definition,
+    ]
 
-    Allocator = [
-        Iir_Kind.Allocator_By_Expression,
-        Iir_Kind.Allocator_By_Subtype]
-
+    Allocator = [Iir_Kind.Allocator_By_Expression, Iir_Kind.Allocator_By_Subtype]
 
 
 class Iir_Mode:
@@ -1620,6 +1664,7 @@ class Iir_Predefined:
     Ieee_Std_Logic_Misc_Xnor_Reduce_Slv = 623
     Ieee_Std_Logic_Misc_Xnor_Reduce_Suv = 624
 
+
 Get_Kind = libghdl.vhdl__nodes__get_kind
 Get_Location = libghdl.vhdl__nodes__get_location
 
@@ -1795,9 +1840,13 @@ Get_Attribute_Designator = libghdl.vhdl__nodes__get_attribute_designator
 
 Set_Attribute_Designator = libghdl.vhdl__nodes__set_attribute_designator
 
-Get_Attribute_Specification_Chain = libghdl.vhdl__nodes__get_attribute_specification_chain
+Get_Attribute_Specification_Chain = (
+    libghdl.vhdl__nodes__get_attribute_specification_chain
+)
 
-Set_Attribute_Specification_Chain = libghdl.vhdl__nodes__set_attribute_specification_chain
+Set_Attribute_Specification_Chain = (
+    libghdl.vhdl__nodes__set_attribute_specification_chain
+)
 
 Get_Attribute_Specification = libghdl.vhdl__nodes__get_attribute_specification
 
@@ -1967,9 +2016,13 @@ Get_Bound_Vunit_Chain = libghdl.vhdl__nodes__get_bound_vunit_chain
 
 Set_Bound_Vunit_Chain = libghdl.vhdl__nodes__set_bound_vunit_chain
 
-Get_Verification_Block_Configuration = libghdl.vhdl__nodes__get_verification_block_configuration
+Get_Verification_Block_Configuration = (
+    libghdl.vhdl__nodes__get_verification_block_configuration
+)
 
-Set_Verification_Block_Configuration = libghdl.vhdl__nodes__set_verification_block_configuration
+Set_Verification_Block_Configuration = (
+    libghdl.vhdl__nodes__set_verification_block_configuration
+)
 
 Get_Block_Configuration = libghdl.vhdl__nodes__get_block_configuration
 
@@ -2235,9 +2288,13 @@ Get_Resolution_Indication = libghdl.vhdl__nodes__get_resolution_indication
 
 Set_Resolution_Indication = libghdl.vhdl__nodes__set_resolution_indication
 
-Get_Record_Element_Resolution_Chain = libghdl.vhdl__nodes__get_record_element_resolution_chain
+Get_Record_Element_Resolution_Chain = (
+    libghdl.vhdl__nodes__get_record_element_resolution_chain
+)
 
-Set_Record_Element_Resolution_Chain = libghdl.vhdl__nodes__set_record_element_resolution_chain
+Set_Record_Element_Resolution_Chain = (
+    libghdl.vhdl__nodes__set_record_element_resolution_chain
+)
 
 Get_Tolerance = libghdl.vhdl__nodes__get_tolerance
 
@@ -2307,9 +2364,13 @@ Get_Index_Subtype_List = libghdl.vhdl__nodes__get_index_subtype_list
 
 Set_Index_Subtype_List = libghdl.vhdl__nodes__set_index_subtype_list
 
-Get_Index_Subtype_Definition_List = libghdl.vhdl__nodes__get_index_subtype_definition_list
+Get_Index_Subtype_Definition_List = (
+    libghdl.vhdl__nodes__get_index_subtype_definition_list
+)
 
-Set_Index_Subtype_Definition_List = libghdl.vhdl__nodes__set_index_subtype_definition_list
+Set_Index_Subtype_Definition_List = (
+    libghdl.vhdl__nodes__set_index_subtype_definition_list
+)
 
 Get_Element_Subtype_Indication = libghdl.vhdl__nodes__get_element_subtype_indication
 
@@ -2347,9 +2408,13 @@ Get_Designated_Type = libghdl.vhdl__nodes__get_designated_type
 
 Set_Designated_Type = libghdl.vhdl__nodes__set_designated_type
 
-Get_Designated_Subtype_Indication = libghdl.vhdl__nodes__get_designated_subtype_indication
+Get_Designated_Subtype_Indication = (
+    libghdl.vhdl__nodes__get_designated_subtype_indication
+)
 
-Set_Designated_Subtype_Indication = libghdl.vhdl__nodes__set_designated_subtype_indication
+Set_Designated_Subtype_Indication = (
+    libghdl.vhdl__nodes__set_designated_subtype_indication
+)
 
 Get_Index_List = libghdl.vhdl__nodes__get_index_list
 
@@ -2563,9 +2628,13 @@ Get_Default_Binding_Indication = libghdl.vhdl__nodes__get_default_binding_indica
 
 Set_Default_Binding_Indication = libghdl.vhdl__nodes__set_default_binding_indication
 
-Get_Default_Configuration_Declaration = libghdl.vhdl__nodes__get_default_configuration_declaration
+Get_Default_Configuration_Declaration = (
+    libghdl.vhdl__nodes__get_default_configuration_declaration
+)
 
-Set_Default_Configuration_Declaration = libghdl.vhdl__nodes__set_default_configuration_declaration
+Set_Default_Configuration_Declaration = (
+    libghdl.vhdl__nodes__set_default_configuration_declaration
+)
 
 Get_Expression = libghdl.vhdl__nodes__get_expression
 
@@ -2863,9 +2932,13 @@ Get_Association_Choices_Chain = libghdl.vhdl__nodes__get_association_choices_cha
 
 Set_Association_Choices_Chain = libghdl.vhdl__nodes__set_association_choices_chain
 
-Get_Case_Statement_Alternative_Chain = libghdl.vhdl__nodes__get_case_statement_alternative_chain
+Get_Case_Statement_Alternative_Chain = (
+    libghdl.vhdl__nodes__get_case_statement_alternative_chain
+)
 
-Set_Case_Statement_Alternative_Chain = libghdl.vhdl__nodes__set_case_statement_alternative_chain
+Set_Case_Statement_Alternative_Chain = (
+    libghdl.vhdl__nodes__set_case_statement_alternative_chain
+)
 
 Get_Choice_Staticness = libghdl.vhdl__nodes__get_choice_staticness
 

--- a/python/libghdl/thin/vhdl/nodes_meta.py
+++ b/python/libghdl/thin/vhdl/nodes_meta.py
@@ -1,7 +1,6 @@
 from libghdl import libghdl
 
 
-
 # From nodes_meta
 get_fields_first = libghdl.vhdl__nodes_meta__get_fields_first
 
@@ -498,1100 +497,790 @@ Get_Token_Type = libghdl.vhdl__nodes_meta__get_token_type
 Get_Tri_State_Type = libghdl.vhdl__nodes_meta__get_tri_state_type
 
 
-Has_First_Design_Unit =\
-    libghdl.vhdl__nodes_meta__has_first_design_unit
+Has_First_Design_Unit = libghdl.vhdl__nodes_meta__has_first_design_unit
 
-Has_Last_Design_Unit =\
-    libghdl.vhdl__nodes_meta__has_last_design_unit
+Has_Last_Design_Unit = libghdl.vhdl__nodes_meta__has_last_design_unit
 
-Has_Library_Declaration =\
-    libghdl.vhdl__nodes_meta__has_library_declaration
+Has_Library_Declaration = libghdl.vhdl__nodes_meta__has_library_declaration
 
-Has_File_Checksum =\
-    libghdl.vhdl__nodes_meta__has_file_checksum
+Has_File_Checksum = libghdl.vhdl__nodes_meta__has_file_checksum
 
-Has_Analysis_Time_Stamp =\
-    libghdl.vhdl__nodes_meta__has_analysis_time_stamp
+Has_Analysis_Time_Stamp = libghdl.vhdl__nodes_meta__has_analysis_time_stamp
 
-Has_Design_File_Source =\
-    libghdl.vhdl__nodes_meta__has_design_file_source
+Has_Design_File_Source = libghdl.vhdl__nodes_meta__has_design_file_source
 
-Has_Library =\
-    libghdl.vhdl__nodes_meta__has_library
+Has_Library = libghdl.vhdl__nodes_meta__has_library
 
-Has_File_Dependence_List =\
-    libghdl.vhdl__nodes_meta__has_file_dependence_list
+Has_File_Dependence_List = libghdl.vhdl__nodes_meta__has_file_dependence_list
 
-Has_Design_File_Filename =\
-    libghdl.vhdl__nodes_meta__has_design_file_filename
+Has_Design_File_Filename = libghdl.vhdl__nodes_meta__has_design_file_filename
 
-Has_Design_File_Directory =\
-    libghdl.vhdl__nodes_meta__has_design_file_directory
+Has_Design_File_Directory = libghdl.vhdl__nodes_meta__has_design_file_directory
 
-Has_Design_File =\
-    libghdl.vhdl__nodes_meta__has_design_file
+Has_Design_File = libghdl.vhdl__nodes_meta__has_design_file
 
-Has_Design_File_Chain =\
-    libghdl.vhdl__nodes_meta__has_design_file_chain
+Has_Design_File_Chain = libghdl.vhdl__nodes_meta__has_design_file_chain
 
-Has_Library_Directory =\
-    libghdl.vhdl__nodes_meta__has_library_directory
+Has_Library_Directory = libghdl.vhdl__nodes_meta__has_library_directory
 
-Has_Date =\
-    libghdl.vhdl__nodes_meta__has_date
+Has_Date = libghdl.vhdl__nodes_meta__has_date
 
-Has_Context_Items =\
-    libghdl.vhdl__nodes_meta__has_context_items
+Has_Context_Items = libghdl.vhdl__nodes_meta__has_context_items
 
-Has_Dependence_List =\
-    libghdl.vhdl__nodes_meta__has_dependence_list
+Has_Dependence_List = libghdl.vhdl__nodes_meta__has_dependence_list
 
-Has_Analysis_Checks_List =\
-    libghdl.vhdl__nodes_meta__has_analysis_checks_list
+Has_Analysis_Checks_List = libghdl.vhdl__nodes_meta__has_analysis_checks_list
 
-Has_Date_State =\
-    libghdl.vhdl__nodes_meta__has_date_state
+Has_Date_State = libghdl.vhdl__nodes_meta__has_date_state
 
-Has_Guarded_Target_State =\
-    libghdl.vhdl__nodes_meta__has_guarded_target_state
+Has_Guarded_Target_State = libghdl.vhdl__nodes_meta__has_guarded_target_state
 
-Has_Library_Unit =\
-    libghdl.vhdl__nodes_meta__has_library_unit
+Has_Library_Unit = libghdl.vhdl__nodes_meta__has_library_unit
 
-Has_Hash_Chain =\
-    libghdl.vhdl__nodes_meta__has_hash_chain
+Has_Hash_Chain = libghdl.vhdl__nodes_meta__has_hash_chain
 
-Has_Design_Unit_Source_Pos =\
-    libghdl.vhdl__nodes_meta__has_design_unit_source_pos
+Has_Design_Unit_Source_Pos = libghdl.vhdl__nodes_meta__has_design_unit_source_pos
 
-Has_Design_Unit_Source_Line =\
-    libghdl.vhdl__nodes_meta__has_design_unit_source_line
+Has_Design_Unit_Source_Line = libghdl.vhdl__nodes_meta__has_design_unit_source_line
 
-Has_Design_Unit_Source_Col =\
-    libghdl.vhdl__nodes_meta__has_design_unit_source_col
+Has_Design_Unit_Source_Col = libghdl.vhdl__nodes_meta__has_design_unit_source_col
 
-Has_Value =\
-    libghdl.vhdl__nodes_meta__has_value
+Has_Value = libghdl.vhdl__nodes_meta__has_value
 
-Has_Enum_Pos =\
-    libghdl.vhdl__nodes_meta__has_enum_pos
+Has_Enum_Pos = libghdl.vhdl__nodes_meta__has_enum_pos
 
-Has_Physical_Literal =\
-    libghdl.vhdl__nodes_meta__has_physical_literal
+Has_Physical_Literal = libghdl.vhdl__nodes_meta__has_physical_literal
 
-Has_Fp_Value =\
-    libghdl.vhdl__nodes_meta__has_fp_value
+Has_Fp_Value = libghdl.vhdl__nodes_meta__has_fp_value
 
-Has_Simple_Aggregate_List =\
-    libghdl.vhdl__nodes_meta__has_simple_aggregate_list
+Has_Simple_Aggregate_List = libghdl.vhdl__nodes_meta__has_simple_aggregate_list
 
-Has_String8_Id =\
-    libghdl.vhdl__nodes_meta__has_string8_id
+Has_String8_Id = libghdl.vhdl__nodes_meta__has_string8_id
 
-Has_String_Length =\
-    libghdl.vhdl__nodes_meta__has_string_length
+Has_String_Length = libghdl.vhdl__nodes_meta__has_string_length
 
-Has_Bit_String_Base =\
-    libghdl.vhdl__nodes_meta__has_bit_string_base
+Has_Bit_String_Base = libghdl.vhdl__nodes_meta__has_bit_string_base
 
-Has_Has_Signed =\
-    libghdl.vhdl__nodes_meta__has_has_signed
+Has_Has_Signed = libghdl.vhdl__nodes_meta__has_has_signed
 
-Has_Has_Sign =\
-    libghdl.vhdl__nodes_meta__has_has_sign
+Has_Has_Sign = libghdl.vhdl__nodes_meta__has_has_sign
 
-Has_Has_Length =\
-    libghdl.vhdl__nodes_meta__has_has_length
+Has_Has_Length = libghdl.vhdl__nodes_meta__has_has_length
 
-Has_Literal_Length =\
-    libghdl.vhdl__nodes_meta__has_literal_length
+Has_Literal_Length = libghdl.vhdl__nodes_meta__has_literal_length
 
-Has_Literal_Origin =\
-    libghdl.vhdl__nodes_meta__has_literal_origin
+Has_Literal_Origin = libghdl.vhdl__nodes_meta__has_literal_origin
 
-Has_Range_Origin =\
-    libghdl.vhdl__nodes_meta__has_range_origin
+Has_Range_Origin = libghdl.vhdl__nodes_meta__has_range_origin
 
-Has_Literal_Subtype =\
-    libghdl.vhdl__nodes_meta__has_literal_subtype
+Has_Literal_Subtype = libghdl.vhdl__nodes_meta__has_literal_subtype
 
-Has_Allocator_Subtype =\
-    libghdl.vhdl__nodes_meta__has_allocator_subtype
+Has_Allocator_Subtype = libghdl.vhdl__nodes_meta__has_allocator_subtype
 
-Has_Entity_Class =\
-    libghdl.vhdl__nodes_meta__has_entity_class
+Has_Entity_Class = libghdl.vhdl__nodes_meta__has_entity_class
 
-Has_Entity_Name_List =\
-    libghdl.vhdl__nodes_meta__has_entity_name_list
+Has_Entity_Name_List = libghdl.vhdl__nodes_meta__has_entity_name_list
 
-Has_Attribute_Designator =\
-    libghdl.vhdl__nodes_meta__has_attribute_designator
+Has_Attribute_Designator = libghdl.vhdl__nodes_meta__has_attribute_designator
 
-Has_Attribute_Specification_Chain =\
+Has_Attribute_Specification_Chain = (
     libghdl.vhdl__nodes_meta__has_attribute_specification_chain
+)
 
-Has_Attribute_Specification =\
-    libghdl.vhdl__nodes_meta__has_attribute_specification
+Has_Attribute_Specification = libghdl.vhdl__nodes_meta__has_attribute_specification
 
-Has_Signal_List =\
-    libghdl.vhdl__nodes_meta__has_signal_list
+Has_Signal_List = libghdl.vhdl__nodes_meta__has_signal_list
 
-Has_Quantity_List =\
-    libghdl.vhdl__nodes_meta__has_quantity_list
+Has_Quantity_List = libghdl.vhdl__nodes_meta__has_quantity_list
 
-Has_Designated_Entity =\
-    libghdl.vhdl__nodes_meta__has_designated_entity
+Has_Designated_Entity = libghdl.vhdl__nodes_meta__has_designated_entity
 
-Has_Formal =\
-    libghdl.vhdl__nodes_meta__has_formal
+Has_Formal = libghdl.vhdl__nodes_meta__has_formal
 
-Has_Actual =\
-    libghdl.vhdl__nodes_meta__has_actual
+Has_Actual = libghdl.vhdl__nodes_meta__has_actual
 
-Has_Actual_Conversion =\
-    libghdl.vhdl__nodes_meta__has_actual_conversion
+Has_Actual_Conversion = libghdl.vhdl__nodes_meta__has_actual_conversion
 
-Has_Formal_Conversion =\
-    libghdl.vhdl__nodes_meta__has_formal_conversion
+Has_Formal_Conversion = libghdl.vhdl__nodes_meta__has_formal_conversion
 
-Has_Whole_Association_Flag =\
-    libghdl.vhdl__nodes_meta__has_whole_association_flag
+Has_Whole_Association_Flag = libghdl.vhdl__nodes_meta__has_whole_association_flag
 
-Has_Collapse_Signal_Flag =\
-    libghdl.vhdl__nodes_meta__has_collapse_signal_flag
+Has_Collapse_Signal_Flag = libghdl.vhdl__nodes_meta__has_collapse_signal_flag
 
-Has_Artificial_Flag =\
-    libghdl.vhdl__nodes_meta__has_artificial_flag
+Has_Artificial_Flag = libghdl.vhdl__nodes_meta__has_artificial_flag
 
-Has_Open_Flag =\
-    libghdl.vhdl__nodes_meta__has_open_flag
+Has_Open_Flag = libghdl.vhdl__nodes_meta__has_open_flag
 
-Has_After_Drivers_Flag =\
-    libghdl.vhdl__nodes_meta__has_after_drivers_flag
+Has_After_Drivers_Flag = libghdl.vhdl__nodes_meta__has_after_drivers_flag
 
-Has_We_Value =\
-    libghdl.vhdl__nodes_meta__has_we_value
+Has_We_Value = libghdl.vhdl__nodes_meta__has_we_value
 
-Has_Time =\
-    libghdl.vhdl__nodes_meta__has_time
+Has_Time = libghdl.vhdl__nodes_meta__has_time
 
-Has_Associated_Expr =\
-    libghdl.vhdl__nodes_meta__has_associated_expr
+Has_Associated_Expr = libghdl.vhdl__nodes_meta__has_associated_expr
 
-Has_Associated_Block =\
-    libghdl.vhdl__nodes_meta__has_associated_block
+Has_Associated_Block = libghdl.vhdl__nodes_meta__has_associated_block
 
-Has_Associated_Chain =\
-    libghdl.vhdl__nodes_meta__has_associated_chain
+Has_Associated_Chain = libghdl.vhdl__nodes_meta__has_associated_chain
 
-Has_Choice_Name =\
-    libghdl.vhdl__nodes_meta__has_choice_name
+Has_Choice_Name = libghdl.vhdl__nodes_meta__has_choice_name
 
-Has_Choice_Expression =\
-    libghdl.vhdl__nodes_meta__has_choice_expression
+Has_Choice_Expression = libghdl.vhdl__nodes_meta__has_choice_expression
 
-Has_Choice_Range =\
-    libghdl.vhdl__nodes_meta__has_choice_range
+Has_Choice_Range = libghdl.vhdl__nodes_meta__has_choice_range
 
-Has_Same_Alternative_Flag =\
-    libghdl.vhdl__nodes_meta__has_same_alternative_flag
+Has_Same_Alternative_Flag = libghdl.vhdl__nodes_meta__has_same_alternative_flag
 
-Has_Element_Type_Flag =\
-    libghdl.vhdl__nodes_meta__has_element_type_flag
+Has_Element_Type_Flag = libghdl.vhdl__nodes_meta__has_element_type_flag
 
-Has_Architecture =\
-    libghdl.vhdl__nodes_meta__has_architecture
+Has_Architecture = libghdl.vhdl__nodes_meta__has_architecture
 
-Has_Block_Specification =\
-    libghdl.vhdl__nodes_meta__has_block_specification
+Has_Block_Specification = libghdl.vhdl__nodes_meta__has_block_specification
 
-Has_Prev_Block_Configuration =\
-    libghdl.vhdl__nodes_meta__has_prev_block_configuration
+Has_Prev_Block_Configuration = libghdl.vhdl__nodes_meta__has_prev_block_configuration
 
-Has_Configuration_Item_Chain =\
-    libghdl.vhdl__nodes_meta__has_configuration_item_chain
+Has_Configuration_Item_Chain = libghdl.vhdl__nodes_meta__has_configuration_item_chain
 
-Has_Attribute_Value_Chain =\
-    libghdl.vhdl__nodes_meta__has_attribute_value_chain
+Has_Attribute_Value_Chain = libghdl.vhdl__nodes_meta__has_attribute_value_chain
 
-Has_Spec_Chain =\
-    libghdl.vhdl__nodes_meta__has_spec_chain
+Has_Spec_Chain = libghdl.vhdl__nodes_meta__has_spec_chain
 
-Has_Value_Chain =\
-    libghdl.vhdl__nodes_meta__has_value_chain
+Has_Value_Chain = libghdl.vhdl__nodes_meta__has_value_chain
 
-Has_Attribute_Value_Spec_Chain =\
+Has_Attribute_Value_Spec_Chain = (
     libghdl.vhdl__nodes_meta__has_attribute_value_spec_chain
+)
 
-Has_Entity_Name =\
-    libghdl.vhdl__nodes_meta__has_entity_name
+Has_Entity_Name = libghdl.vhdl__nodes_meta__has_entity_name
 
-Has_Package =\
-    libghdl.vhdl__nodes_meta__has_package
+Has_Package = libghdl.vhdl__nodes_meta__has_package
 
-Has_Package_Body =\
-    libghdl.vhdl__nodes_meta__has_package_body
+Has_Package_Body = libghdl.vhdl__nodes_meta__has_package_body
 
-Has_Instance_Package_Body =\
-    libghdl.vhdl__nodes_meta__has_instance_package_body
+Has_Instance_Package_Body = libghdl.vhdl__nodes_meta__has_instance_package_body
 
-Has_Need_Body =\
-    libghdl.vhdl__nodes_meta__has_need_body
+Has_Need_Body = libghdl.vhdl__nodes_meta__has_need_body
 
-Has_Macro_Expanded_Flag =\
-    libghdl.vhdl__nodes_meta__has_macro_expanded_flag
+Has_Macro_Expanded_Flag = libghdl.vhdl__nodes_meta__has_macro_expanded_flag
 
-Has_Need_Instance_Bodies =\
-    libghdl.vhdl__nodes_meta__has_need_instance_bodies
+Has_Need_Instance_Bodies = libghdl.vhdl__nodes_meta__has_need_instance_bodies
 
-Has_Hierarchical_Name =\
-    libghdl.vhdl__nodes_meta__has_hierarchical_name
+Has_Hierarchical_Name = libghdl.vhdl__nodes_meta__has_hierarchical_name
 
-Has_Inherit_Spec_Chain =\
-    libghdl.vhdl__nodes_meta__has_inherit_spec_chain
+Has_Inherit_Spec_Chain = libghdl.vhdl__nodes_meta__has_inherit_spec_chain
 
-Has_Vunit_Item_Chain =\
-    libghdl.vhdl__nodes_meta__has_vunit_item_chain
+Has_Vunit_Item_Chain = libghdl.vhdl__nodes_meta__has_vunit_item_chain
 
-Has_Bound_Vunit_Chain =\
-    libghdl.vhdl__nodes_meta__has_bound_vunit_chain
+Has_Bound_Vunit_Chain = libghdl.vhdl__nodes_meta__has_bound_vunit_chain
 
-Has_Verification_Block_Configuration =\
+Has_Verification_Block_Configuration = (
     libghdl.vhdl__nodes_meta__has_verification_block_configuration
+)
 
-Has_Block_Configuration =\
-    libghdl.vhdl__nodes_meta__has_block_configuration
+Has_Block_Configuration = libghdl.vhdl__nodes_meta__has_block_configuration
 
-Has_Concurrent_Statement_Chain =\
+Has_Concurrent_Statement_Chain = (
     libghdl.vhdl__nodes_meta__has_concurrent_statement_chain
+)
 
-Has_Chain =\
-    libghdl.vhdl__nodes_meta__has_chain
+Has_Chain = libghdl.vhdl__nodes_meta__has_chain
 
-Has_Port_Chain =\
-    libghdl.vhdl__nodes_meta__has_port_chain
+Has_Port_Chain = libghdl.vhdl__nodes_meta__has_port_chain
 
-Has_Generic_Chain =\
-    libghdl.vhdl__nodes_meta__has_generic_chain
+Has_Generic_Chain = libghdl.vhdl__nodes_meta__has_generic_chain
 
-Has_Type =\
-    libghdl.vhdl__nodes_meta__has_type
+Has_Type = libghdl.vhdl__nodes_meta__has_type
 
-Has_Subtype_Indication =\
-    libghdl.vhdl__nodes_meta__has_subtype_indication
+Has_Subtype_Indication = libghdl.vhdl__nodes_meta__has_subtype_indication
 
-Has_Discrete_Range =\
-    libghdl.vhdl__nodes_meta__has_discrete_range
+Has_Discrete_Range = libghdl.vhdl__nodes_meta__has_discrete_range
 
-Has_Type_Definition =\
-    libghdl.vhdl__nodes_meta__has_type_definition
+Has_Type_Definition = libghdl.vhdl__nodes_meta__has_type_definition
 
-Has_Subtype_Definition =\
-    libghdl.vhdl__nodes_meta__has_subtype_definition
+Has_Subtype_Definition = libghdl.vhdl__nodes_meta__has_subtype_definition
 
-Has_Incomplete_Type_Declaration =\
+Has_Incomplete_Type_Declaration = (
     libghdl.vhdl__nodes_meta__has_incomplete_type_declaration
+)
 
-Has_Interface_Type_Subprograms =\
+Has_Interface_Type_Subprograms = (
     libghdl.vhdl__nodes_meta__has_interface_type_subprograms
+)
 
-Has_Nature_Definition =\
-    libghdl.vhdl__nodes_meta__has_nature_definition
+Has_Nature_Definition = libghdl.vhdl__nodes_meta__has_nature_definition
 
-Has_Nature =\
-    libghdl.vhdl__nodes_meta__has_nature
+Has_Nature = libghdl.vhdl__nodes_meta__has_nature
 
-Has_Subnature_Indication =\
-    libghdl.vhdl__nodes_meta__has_subnature_indication
+Has_Subnature_Indication = libghdl.vhdl__nodes_meta__has_subnature_indication
 
-Has_Mode =\
-    libghdl.vhdl__nodes_meta__has_mode
+Has_Mode = libghdl.vhdl__nodes_meta__has_mode
 
-Has_Guarded_Signal_Flag =\
-    libghdl.vhdl__nodes_meta__has_guarded_signal_flag
+Has_Guarded_Signal_Flag = libghdl.vhdl__nodes_meta__has_guarded_signal_flag
 
-Has_Signal_Kind =\
-    libghdl.vhdl__nodes_meta__has_signal_kind
+Has_Signal_Kind = libghdl.vhdl__nodes_meta__has_signal_kind
 
-Has_Base_Name =\
-    libghdl.vhdl__nodes_meta__has_base_name
+Has_Base_Name = libghdl.vhdl__nodes_meta__has_base_name
 
-Has_Interface_Declaration_Chain =\
+Has_Interface_Declaration_Chain = (
     libghdl.vhdl__nodes_meta__has_interface_declaration_chain
+)
 
-Has_Subprogram_Specification =\
-    libghdl.vhdl__nodes_meta__has_subprogram_specification
+Has_Subprogram_Specification = libghdl.vhdl__nodes_meta__has_subprogram_specification
 
-Has_Sequential_Statement_Chain =\
+Has_Sequential_Statement_Chain = (
     libghdl.vhdl__nodes_meta__has_sequential_statement_chain
+)
 
-Has_Simultaneous_Statement_Chain =\
+Has_Simultaneous_Statement_Chain = (
     libghdl.vhdl__nodes_meta__has_simultaneous_statement_chain
+)
 
-Has_Subprogram_Body =\
-    libghdl.vhdl__nodes_meta__has_subprogram_body
+Has_Subprogram_Body = libghdl.vhdl__nodes_meta__has_subprogram_body
 
-Has_Overload_Number =\
-    libghdl.vhdl__nodes_meta__has_overload_number
+Has_Overload_Number = libghdl.vhdl__nodes_meta__has_overload_number
 
-Has_Subprogram_Depth =\
-    libghdl.vhdl__nodes_meta__has_subprogram_depth
+Has_Subprogram_Depth = libghdl.vhdl__nodes_meta__has_subprogram_depth
 
-Has_Subprogram_Hash =\
-    libghdl.vhdl__nodes_meta__has_subprogram_hash
+Has_Subprogram_Hash = libghdl.vhdl__nodes_meta__has_subprogram_hash
 
-Has_Impure_Depth =\
-    libghdl.vhdl__nodes_meta__has_impure_depth
+Has_Impure_Depth = libghdl.vhdl__nodes_meta__has_impure_depth
 
-Has_Return_Type =\
-    libghdl.vhdl__nodes_meta__has_return_type
+Has_Return_Type = libghdl.vhdl__nodes_meta__has_return_type
 
-Has_Implicit_Definition =\
-    libghdl.vhdl__nodes_meta__has_implicit_definition
+Has_Implicit_Definition = libghdl.vhdl__nodes_meta__has_implicit_definition
 
-Has_Default_Value =\
-    libghdl.vhdl__nodes_meta__has_default_value
+Has_Default_Value = libghdl.vhdl__nodes_meta__has_default_value
 
-Has_Deferred_Declaration =\
-    libghdl.vhdl__nodes_meta__has_deferred_declaration
+Has_Deferred_Declaration = libghdl.vhdl__nodes_meta__has_deferred_declaration
 
-Has_Deferred_Declaration_Flag =\
-    libghdl.vhdl__nodes_meta__has_deferred_declaration_flag
+Has_Deferred_Declaration_Flag = libghdl.vhdl__nodes_meta__has_deferred_declaration_flag
 
-Has_Shared_Flag =\
-    libghdl.vhdl__nodes_meta__has_shared_flag
+Has_Shared_Flag = libghdl.vhdl__nodes_meta__has_shared_flag
 
-Has_Design_Unit =\
-    libghdl.vhdl__nodes_meta__has_design_unit
+Has_Design_Unit = libghdl.vhdl__nodes_meta__has_design_unit
 
-Has_Block_Statement =\
-    libghdl.vhdl__nodes_meta__has_block_statement
+Has_Block_Statement = libghdl.vhdl__nodes_meta__has_block_statement
 
-Has_Signal_Driver =\
-    libghdl.vhdl__nodes_meta__has_signal_driver
+Has_Signal_Driver = libghdl.vhdl__nodes_meta__has_signal_driver
 
-Has_Declaration_Chain =\
-    libghdl.vhdl__nodes_meta__has_declaration_chain
+Has_Declaration_Chain = libghdl.vhdl__nodes_meta__has_declaration_chain
 
-Has_File_Logical_Name =\
-    libghdl.vhdl__nodes_meta__has_file_logical_name
+Has_File_Logical_Name = libghdl.vhdl__nodes_meta__has_file_logical_name
 
-Has_File_Open_Kind =\
-    libghdl.vhdl__nodes_meta__has_file_open_kind
+Has_File_Open_Kind = libghdl.vhdl__nodes_meta__has_file_open_kind
 
-Has_Element_Position =\
-    libghdl.vhdl__nodes_meta__has_element_position
+Has_Element_Position = libghdl.vhdl__nodes_meta__has_element_position
 
-Has_Use_Clause_Chain =\
-    libghdl.vhdl__nodes_meta__has_use_clause_chain
+Has_Use_Clause_Chain = libghdl.vhdl__nodes_meta__has_use_clause_chain
 
-Has_Context_Reference_Chain =\
-    libghdl.vhdl__nodes_meta__has_context_reference_chain
+Has_Context_Reference_Chain = libghdl.vhdl__nodes_meta__has_context_reference_chain
 
-Has_Selected_Name =\
-    libghdl.vhdl__nodes_meta__has_selected_name
+Has_Selected_Name = libghdl.vhdl__nodes_meta__has_selected_name
 
-Has_Type_Declarator =\
-    libghdl.vhdl__nodes_meta__has_type_declarator
+Has_Type_Declarator = libghdl.vhdl__nodes_meta__has_type_declarator
 
-Has_Complete_Type_Definition =\
-    libghdl.vhdl__nodes_meta__has_complete_type_definition
+Has_Complete_Type_Definition = libghdl.vhdl__nodes_meta__has_complete_type_definition
 
-Has_Incomplete_Type_Ref_Chain =\
-    libghdl.vhdl__nodes_meta__has_incomplete_type_ref_chain
+Has_Incomplete_Type_Ref_Chain = libghdl.vhdl__nodes_meta__has_incomplete_type_ref_chain
 
-Has_Associated_Type =\
-    libghdl.vhdl__nodes_meta__has_associated_type
+Has_Associated_Type = libghdl.vhdl__nodes_meta__has_associated_type
 
-Has_Enumeration_Literal_List =\
-    libghdl.vhdl__nodes_meta__has_enumeration_literal_list
+Has_Enumeration_Literal_List = libghdl.vhdl__nodes_meta__has_enumeration_literal_list
 
-Has_Entity_Class_Entry_Chain =\
-    libghdl.vhdl__nodes_meta__has_entity_class_entry_chain
+Has_Entity_Class_Entry_Chain = libghdl.vhdl__nodes_meta__has_entity_class_entry_chain
 
-Has_Group_Constituent_List =\
-    libghdl.vhdl__nodes_meta__has_group_constituent_list
+Has_Group_Constituent_List = libghdl.vhdl__nodes_meta__has_group_constituent_list
 
-Has_Unit_Chain =\
-    libghdl.vhdl__nodes_meta__has_unit_chain
+Has_Unit_Chain = libghdl.vhdl__nodes_meta__has_unit_chain
 
-Has_Primary_Unit =\
-    libghdl.vhdl__nodes_meta__has_primary_unit
+Has_Primary_Unit = libghdl.vhdl__nodes_meta__has_primary_unit
 
-Has_Identifier =\
-    libghdl.vhdl__nodes_meta__has_identifier
+Has_Identifier = libghdl.vhdl__nodes_meta__has_identifier
 
-Has_Label =\
-    libghdl.vhdl__nodes_meta__has_label
+Has_Label = libghdl.vhdl__nodes_meta__has_label
 
-Has_Visible_Flag =\
-    libghdl.vhdl__nodes_meta__has_visible_flag
+Has_Visible_Flag = libghdl.vhdl__nodes_meta__has_visible_flag
 
-Has_Range_Constraint =\
-    libghdl.vhdl__nodes_meta__has_range_constraint
+Has_Range_Constraint = libghdl.vhdl__nodes_meta__has_range_constraint
 
-Has_Direction =\
-    libghdl.vhdl__nodes_meta__has_direction
+Has_Direction = libghdl.vhdl__nodes_meta__has_direction
 
-Has_Left_Limit =\
-    libghdl.vhdl__nodes_meta__has_left_limit
+Has_Left_Limit = libghdl.vhdl__nodes_meta__has_left_limit
 
-Has_Right_Limit =\
-    libghdl.vhdl__nodes_meta__has_right_limit
+Has_Right_Limit = libghdl.vhdl__nodes_meta__has_right_limit
 
-Has_Left_Limit_Expr =\
-    libghdl.vhdl__nodes_meta__has_left_limit_expr
+Has_Left_Limit_Expr = libghdl.vhdl__nodes_meta__has_left_limit_expr
 
-Has_Right_Limit_Expr =\
-    libghdl.vhdl__nodes_meta__has_right_limit_expr
+Has_Right_Limit_Expr = libghdl.vhdl__nodes_meta__has_right_limit_expr
 
-Has_Parent_Type =\
-    libghdl.vhdl__nodes_meta__has_parent_type
+Has_Parent_Type = libghdl.vhdl__nodes_meta__has_parent_type
 
-Has_Simple_Nature =\
-    libghdl.vhdl__nodes_meta__has_simple_nature
+Has_Simple_Nature = libghdl.vhdl__nodes_meta__has_simple_nature
 
-Has_Base_Nature =\
-    libghdl.vhdl__nodes_meta__has_base_nature
+Has_Base_Nature = libghdl.vhdl__nodes_meta__has_base_nature
 
-Has_Resolution_Indication =\
-    libghdl.vhdl__nodes_meta__has_resolution_indication
+Has_Resolution_Indication = libghdl.vhdl__nodes_meta__has_resolution_indication
 
-Has_Record_Element_Resolution_Chain =\
+Has_Record_Element_Resolution_Chain = (
     libghdl.vhdl__nodes_meta__has_record_element_resolution_chain
+)
 
-Has_Tolerance =\
-    libghdl.vhdl__nodes_meta__has_tolerance
+Has_Tolerance = libghdl.vhdl__nodes_meta__has_tolerance
 
-Has_Plus_Terminal_Name =\
-    libghdl.vhdl__nodes_meta__has_plus_terminal_name
+Has_Plus_Terminal_Name = libghdl.vhdl__nodes_meta__has_plus_terminal_name
 
-Has_Minus_Terminal_Name =\
-    libghdl.vhdl__nodes_meta__has_minus_terminal_name
+Has_Minus_Terminal_Name = libghdl.vhdl__nodes_meta__has_minus_terminal_name
 
-Has_Plus_Terminal =\
-    libghdl.vhdl__nodes_meta__has_plus_terminal
+Has_Plus_Terminal = libghdl.vhdl__nodes_meta__has_plus_terminal
 
-Has_Minus_Terminal =\
-    libghdl.vhdl__nodes_meta__has_minus_terminal
+Has_Minus_Terminal = libghdl.vhdl__nodes_meta__has_minus_terminal
 
-Has_Magnitude_Expression =\
-    libghdl.vhdl__nodes_meta__has_magnitude_expression
+Has_Magnitude_Expression = libghdl.vhdl__nodes_meta__has_magnitude_expression
 
-Has_Phase_Expression =\
-    libghdl.vhdl__nodes_meta__has_phase_expression
+Has_Phase_Expression = libghdl.vhdl__nodes_meta__has_phase_expression
 
-Has_Power_Expression =\
-    libghdl.vhdl__nodes_meta__has_power_expression
+Has_Power_Expression = libghdl.vhdl__nodes_meta__has_power_expression
 
-Has_Simultaneous_Left =\
-    libghdl.vhdl__nodes_meta__has_simultaneous_left
+Has_Simultaneous_Left = libghdl.vhdl__nodes_meta__has_simultaneous_left
 
-Has_Simultaneous_Right =\
-    libghdl.vhdl__nodes_meta__has_simultaneous_right
+Has_Simultaneous_Right = libghdl.vhdl__nodes_meta__has_simultaneous_right
 
-Has_Text_File_Flag =\
-    libghdl.vhdl__nodes_meta__has_text_file_flag
+Has_Text_File_Flag = libghdl.vhdl__nodes_meta__has_text_file_flag
 
-Has_Only_Characters_Flag =\
-    libghdl.vhdl__nodes_meta__has_only_characters_flag
+Has_Only_Characters_Flag = libghdl.vhdl__nodes_meta__has_only_characters_flag
 
-Has_Is_Character_Type =\
-    libghdl.vhdl__nodes_meta__has_is_character_type
+Has_Is_Character_Type = libghdl.vhdl__nodes_meta__has_is_character_type
 
-Has_Nature_Staticness =\
-    libghdl.vhdl__nodes_meta__has_nature_staticness
+Has_Nature_Staticness = libghdl.vhdl__nodes_meta__has_nature_staticness
 
-Has_Type_Staticness =\
-    libghdl.vhdl__nodes_meta__has_type_staticness
+Has_Type_Staticness = libghdl.vhdl__nodes_meta__has_type_staticness
 
-Has_Constraint_State =\
-    libghdl.vhdl__nodes_meta__has_constraint_state
+Has_Constraint_State = libghdl.vhdl__nodes_meta__has_constraint_state
 
-Has_Index_Subtype_List =\
-    libghdl.vhdl__nodes_meta__has_index_subtype_list
+Has_Index_Subtype_List = libghdl.vhdl__nodes_meta__has_index_subtype_list
 
-Has_Index_Subtype_Definition_List =\
+Has_Index_Subtype_Definition_List = (
     libghdl.vhdl__nodes_meta__has_index_subtype_definition_list
+)
 
-Has_Element_Subtype_Indication =\
+Has_Element_Subtype_Indication = (
     libghdl.vhdl__nodes_meta__has_element_subtype_indication
+)
 
-Has_Element_Subtype =\
-    libghdl.vhdl__nodes_meta__has_element_subtype
+Has_Element_Subtype = libghdl.vhdl__nodes_meta__has_element_subtype
 
-Has_Element_Subnature_Indication =\
+Has_Element_Subnature_Indication = (
     libghdl.vhdl__nodes_meta__has_element_subnature_indication
+)
 
-Has_Element_Subnature =\
-    libghdl.vhdl__nodes_meta__has_element_subnature
+Has_Element_Subnature = libghdl.vhdl__nodes_meta__has_element_subnature
 
-Has_Index_Constraint_List =\
-    libghdl.vhdl__nodes_meta__has_index_constraint_list
+Has_Index_Constraint_List = libghdl.vhdl__nodes_meta__has_index_constraint_list
 
-Has_Array_Element_Constraint =\
-    libghdl.vhdl__nodes_meta__has_array_element_constraint
+Has_Array_Element_Constraint = libghdl.vhdl__nodes_meta__has_array_element_constraint
 
-Has_Elements_Declaration_List =\
-    libghdl.vhdl__nodes_meta__has_elements_declaration_list
+Has_Elements_Declaration_List = libghdl.vhdl__nodes_meta__has_elements_declaration_list
 
-Has_Owned_Elements_Chain =\
-    libghdl.vhdl__nodes_meta__has_owned_elements_chain
+Has_Owned_Elements_Chain = libghdl.vhdl__nodes_meta__has_owned_elements_chain
 
-Has_Designated_Type =\
-    libghdl.vhdl__nodes_meta__has_designated_type
+Has_Designated_Type = libghdl.vhdl__nodes_meta__has_designated_type
 
-Has_Designated_Subtype_Indication =\
+Has_Designated_Subtype_Indication = (
     libghdl.vhdl__nodes_meta__has_designated_subtype_indication
+)
 
-Has_Index_List =\
-    libghdl.vhdl__nodes_meta__has_index_list
+Has_Index_List = libghdl.vhdl__nodes_meta__has_index_list
 
-Has_Reference =\
-    libghdl.vhdl__nodes_meta__has_reference
+Has_Reference = libghdl.vhdl__nodes_meta__has_reference
 
-Has_Nature_Declarator =\
-    libghdl.vhdl__nodes_meta__has_nature_declarator
+Has_Nature_Declarator = libghdl.vhdl__nodes_meta__has_nature_declarator
 
-Has_Across_Type_Mark =\
-    libghdl.vhdl__nodes_meta__has_across_type_mark
+Has_Across_Type_Mark = libghdl.vhdl__nodes_meta__has_across_type_mark
 
-Has_Through_Type_Mark =\
-    libghdl.vhdl__nodes_meta__has_through_type_mark
+Has_Through_Type_Mark = libghdl.vhdl__nodes_meta__has_through_type_mark
 
-Has_Across_Type_Definition =\
-    libghdl.vhdl__nodes_meta__has_across_type_definition
+Has_Across_Type_Definition = libghdl.vhdl__nodes_meta__has_across_type_definition
 
-Has_Through_Type_Definition =\
-    libghdl.vhdl__nodes_meta__has_through_type_definition
+Has_Through_Type_Definition = libghdl.vhdl__nodes_meta__has_through_type_definition
 
-Has_Across_Type =\
-    libghdl.vhdl__nodes_meta__has_across_type
+Has_Across_Type = libghdl.vhdl__nodes_meta__has_across_type
 
-Has_Through_Type =\
-    libghdl.vhdl__nodes_meta__has_through_type
+Has_Through_Type = libghdl.vhdl__nodes_meta__has_through_type
 
-Has_Target =\
-    libghdl.vhdl__nodes_meta__has_target
+Has_Target = libghdl.vhdl__nodes_meta__has_target
 
-Has_Waveform_Chain =\
-    libghdl.vhdl__nodes_meta__has_waveform_chain
+Has_Waveform_Chain = libghdl.vhdl__nodes_meta__has_waveform_chain
 
-Has_Guard =\
-    libghdl.vhdl__nodes_meta__has_guard
+Has_Guard = libghdl.vhdl__nodes_meta__has_guard
 
-Has_Delay_Mechanism =\
-    libghdl.vhdl__nodes_meta__has_delay_mechanism
+Has_Delay_Mechanism = libghdl.vhdl__nodes_meta__has_delay_mechanism
 
-Has_Reject_Time_Expression =\
-    libghdl.vhdl__nodes_meta__has_reject_time_expression
+Has_Reject_Time_Expression = libghdl.vhdl__nodes_meta__has_reject_time_expression
 
-Has_Force_Mode =\
-    libghdl.vhdl__nodes_meta__has_force_mode
+Has_Force_Mode = libghdl.vhdl__nodes_meta__has_force_mode
 
-Has_Has_Force_Mode =\
-    libghdl.vhdl__nodes_meta__has_has_force_mode
+Has_Has_Force_Mode = libghdl.vhdl__nodes_meta__has_has_force_mode
 
-Has_Sensitivity_List =\
-    libghdl.vhdl__nodes_meta__has_sensitivity_list
+Has_Sensitivity_List = libghdl.vhdl__nodes_meta__has_sensitivity_list
 
-Has_Process_Origin =\
-    libghdl.vhdl__nodes_meta__has_process_origin
+Has_Process_Origin = libghdl.vhdl__nodes_meta__has_process_origin
 
-Has_Package_Origin =\
-    libghdl.vhdl__nodes_meta__has_package_origin
+Has_Package_Origin = libghdl.vhdl__nodes_meta__has_package_origin
 
-Has_Condition_Clause =\
-    libghdl.vhdl__nodes_meta__has_condition_clause
+Has_Condition_Clause = libghdl.vhdl__nodes_meta__has_condition_clause
 
-Has_Break_Element =\
-    libghdl.vhdl__nodes_meta__has_break_element
+Has_Break_Element = libghdl.vhdl__nodes_meta__has_break_element
 
-Has_Selector_Quantity =\
-    libghdl.vhdl__nodes_meta__has_selector_quantity
+Has_Selector_Quantity = libghdl.vhdl__nodes_meta__has_selector_quantity
 
-Has_Break_Quantity =\
-    libghdl.vhdl__nodes_meta__has_break_quantity
+Has_Break_Quantity = libghdl.vhdl__nodes_meta__has_break_quantity
 
-Has_Timeout_Clause =\
-    libghdl.vhdl__nodes_meta__has_timeout_clause
+Has_Timeout_Clause = libghdl.vhdl__nodes_meta__has_timeout_clause
 
-Has_Postponed_Flag =\
-    libghdl.vhdl__nodes_meta__has_postponed_flag
+Has_Postponed_Flag = libghdl.vhdl__nodes_meta__has_postponed_flag
 
-Has_Callees_List =\
-    libghdl.vhdl__nodes_meta__has_callees_list
+Has_Callees_List = libghdl.vhdl__nodes_meta__has_callees_list
 
-Has_Passive_Flag =\
-    libghdl.vhdl__nodes_meta__has_passive_flag
+Has_Passive_Flag = libghdl.vhdl__nodes_meta__has_passive_flag
 
-Has_Resolution_Function_Flag =\
-    libghdl.vhdl__nodes_meta__has_resolution_function_flag
+Has_Resolution_Function_Flag = libghdl.vhdl__nodes_meta__has_resolution_function_flag
 
-Has_Wait_State =\
-    libghdl.vhdl__nodes_meta__has_wait_state
+Has_Wait_State = libghdl.vhdl__nodes_meta__has_wait_state
 
-Has_All_Sensitized_State =\
-    libghdl.vhdl__nodes_meta__has_all_sensitized_state
+Has_All_Sensitized_State = libghdl.vhdl__nodes_meta__has_all_sensitized_state
 
-Has_Seen_Flag =\
-    libghdl.vhdl__nodes_meta__has_seen_flag
+Has_Seen_Flag = libghdl.vhdl__nodes_meta__has_seen_flag
 
-Has_Pure_Flag =\
-    libghdl.vhdl__nodes_meta__has_pure_flag
+Has_Pure_Flag = libghdl.vhdl__nodes_meta__has_pure_flag
 
-Has_Foreign_Flag =\
-    libghdl.vhdl__nodes_meta__has_foreign_flag
+Has_Foreign_Flag = libghdl.vhdl__nodes_meta__has_foreign_flag
 
-Has_Resolved_Flag =\
-    libghdl.vhdl__nodes_meta__has_resolved_flag
+Has_Resolved_Flag = libghdl.vhdl__nodes_meta__has_resolved_flag
 
-Has_Signal_Type_Flag =\
-    libghdl.vhdl__nodes_meta__has_signal_type_flag
+Has_Signal_Type_Flag = libghdl.vhdl__nodes_meta__has_signal_type_flag
 
-Has_Has_Signal_Flag =\
-    libghdl.vhdl__nodes_meta__has_has_signal_flag
+Has_Has_Signal_Flag = libghdl.vhdl__nodes_meta__has_has_signal_flag
 
-Has_Purity_State =\
-    libghdl.vhdl__nodes_meta__has_purity_state
+Has_Purity_State = libghdl.vhdl__nodes_meta__has_purity_state
 
-Has_Elab_Flag =\
-    libghdl.vhdl__nodes_meta__has_elab_flag
+Has_Elab_Flag = libghdl.vhdl__nodes_meta__has_elab_flag
 
-Has_Vendor_Library_Flag =\
-    libghdl.vhdl__nodes_meta__has_vendor_library_flag
+Has_Vendor_Library_Flag = libghdl.vhdl__nodes_meta__has_vendor_library_flag
 
-Has_Configuration_Mark_Flag =\
-    libghdl.vhdl__nodes_meta__has_configuration_mark_flag
+Has_Configuration_Mark_Flag = libghdl.vhdl__nodes_meta__has_configuration_mark_flag
 
-Has_Configuration_Done_Flag =\
-    libghdl.vhdl__nodes_meta__has_configuration_done_flag
+Has_Configuration_Done_Flag = libghdl.vhdl__nodes_meta__has_configuration_done_flag
 
-Has_Index_Constraint_Flag =\
-    libghdl.vhdl__nodes_meta__has_index_constraint_flag
+Has_Index_Constraint_Flag = libghdl.vhdl__nodes_meta__has_index_constraint_flag
 
-Has_Hide_Implicit_Flag =\
-    libghdl.vhdl__nodes_meta__has_hide_implicit_flag
+Has_Hide_Implicit_Flag = libghdl.vhdl__nodes_meta__has_hide_implicit_flag
 
-Has_Assertion_Condition =\
-    libghdl.vhdl__nodes_meta__has_assertion_condition
+Has_Assertion_Condition = libghdl.vhdl__nodes_meta__has_assertion_condition
 
-Has_Report_Expression =\
-    libghdl.vhdl__nodes_meta__has_report_expression
+Has_Report_Expression = libghdl.vhdl__nodes_meta__has_report_expression
 
-Has_Severity_Expression =\
-    libghdl.vhdl__nodes_meta__has_severity_expression
+Has_Severity_Expression = libghdl.vhdl__nodes_meta__has_severity_expression
 
-Has_Instantiated_Unit =\
-    libghdl.vhdl__nodes_meta__has_instantiated_unit
+Has_Instantiated_Unit = libghdl.vhdl__nodes_meta__has_instantiated_unit
 
-Has_Generic_Map_Aspect_Chain =\
-    libghdl.vhdl__nodes_meta__has_generic_map_aspect_chain
+Has_Generic_Map_Aspect_Chain = libghdl.vhdl__nodes_meta__has_generic_map_aspect_chain
 
-Has_Port_Map_Aspect_Chain =\
-    libghdl.vhdl__nodes_meta__has_port_map_aspect_chain
+Has_Port_Map_Aspect_Chain = libghdl.vhdl__nodes_meta__has_port_map_aspect_chain
 
-Has_Configuration_Name =\
-    libghdl.vhdl__nodes_meta__has_configuration_name
+Has_Configuration_Name = libghdl.vhdl__nodes_meta__has_configuration_name
 
-Has_Component_Configuration =\
-    libghdl.vhdl__nodes_meta__has_component_configuration
+Has_Component_Configuration = libghdl.vhdl__nodes_meta__has_component_configuration
 
-Has_Configuration_Specification =\
+Has_Configuration_Specification = (
     libghdl.vhdl__nodes_meta__has_configuration_specification
+)
 
-Has_Default_Binding_Indication =\
+Has_Default_Binding_Indication = (
     libghdl.vhdl__nodes_meta__has_default_binding_indication
+)
 
-Has_Default_Configuration_Declaration =\
+Has_Default_Configuration_Declaration = (
     libghdl.vhdl__nodes_meta__has_default_configuration_declaration
+)
 
-Has_Expression =\
-    libghdl.vhdl__nodes_meta__has_expression
+Has_Expression = libghdl.vhdl__nodes_meta__has_expression
 
-Has_Conditional_Expression_Chain =\
+Has_Conditional_Expression_Chain = (
     libghdl.vhdl__nodes_meta__has_conditional_expression_chain
+)
 
-Has_Allocator_Designated_Type =\
-    libghdl.vhdl__nodes_meta__has_allocator_designated_type
+Has_Allocator_Designated_Type = libghdl.vhdl__nodes_meta__has_allocator_designated_type
 
-Has_Selected_Waveform_Chain =\
-    libghdl.vhdl__nodes_meta__has_selected_waveform_chain
+Has_Selected_Waveform_Chain = libghdl.vhdl__nodes_meta__has_selected_waveform_chain
 
-Has_Conditional_Waveform_Chain =\
+Has_Conditional_Waveform_Chain = (
     libghdl.vhdl__nodes_meta__has_conditional_waveform_chain
+)
 
-Has_Guard_Expression =\
-    libghdl.vhdl__nodes_meta__has_guard_expression
+Has_Guard_Expression = libghdl.vhdl__nodes_meta__has_guard_expression
 
-Has_Guard_Decl =\
-    libghdl.vhdl__nodes_meta__has_guard_decl
+Has_Guard_Decl = libghdl.vhdl__nodes_meta__has_guard_decl
 
-Has_Guard_Sensitivity_List =\
-    libghdl.vhdl__nodes_meta__has_guard_sensitivity_list
+Has_Guard_Sensitivity_List = libghdl.vhdl__nodes_meta__has_guard_sensitivity_list
 
-Has_Signal_Attribute_Chain =\
-    libghdl.vhdl__nodes_meta__has_signal_attribute_chain
+Has_Signal_Attribute_Chain = libghdl.vhdl__nodes_meta__has_signal_attribute_chain
 
-Has_Block_Block_Configuration =\
-    libghdl.vhdl__nodes_meta__has_block_block_configuration
+Has_Block_Block_Configuration = libghdl.vhdl__nodes_meta__has_block_block_configuration
 
-Has_Package_Header =\
-    libghdl.vhdl__nodes_meta__has_package_header
+Has_Package_Header = libghdl.vhdl__nodes_meta__has_package_header
 
-Has_Block_Header =\
-    libghdl.vhdl__nodes_meta__has_block_header
+Has_Block_Header = libghdl.vhdl__nodes_meta__has_block_header
 
-Has_Uninstantiated_Package_Name =\
+Has_Uninstantiated_Package_Name = (
     libghdl.vhdl__nodes_meta__has_uninstantiated_package_name
+)
 
-Has_Uninstantiated_Package_Decl =\
+Has_Uninstantiated_Package_Decl = (
     libghdl.vhdl__nodes_meta__has_uninstantiated_package_decl
+)
 
-Has_Instance_Source_File =\
-    libghdl.vhdl__nodes_meta__has_instance_source_file
+Has_Instance_Source_File = libghdl.vhdl__nodes_meta__has_instance_source_file
 
-Has_Generate_Block_Configuration =\
+Has_Generate_Block_Configuration = (
     libghdl.vhdl__nodes_meta__has_generate_block_configuration
+)
 
-Has_Generate_Statement_Body =\
-    libghdl.vhdl__nodes_meta__has_generate_statement_body
+Has_Generate_Statement_Body = libghdl.vhdl__nodes_meta__has_generate_statement_body
 
-Has_Alternative_Label =\
-    libghdl.vhdl__nodes_meta__has_alternative_label
+Has_Alternative_Label = libghdl.vhdl__nodes_meta__has_alternative_label
 
-Has_Generate_Else_Clause =\
-    libghdl.vhdl__nodes_meta__has_generate_else_clause
+Has_Generate_Else_Clause = libghdl.vhdl__nodes_meta__has_generate_else_clause
 
-Has_Condition =\
-    libghdl.vhdl__nodes_meta__has_condition
+Has_Condition = libghdl.vhdl__nodes_meta__has_condition
 
-Has_Else_Clause =\
-    libghdl.vhdl__nodes_meta__has_else_clause
+Has_Else_Clause = libghdl.vhdl__nodes_meta__has_else_clause
 
-Has_Parameter_Specification =\
-    libghdl.vhdl__nodes_meta__has_parameter_specification
+Has_Parameter_Specification = libghdl.vhdl__nodes_meta__has_parameter_specification
 
-Has_Parent =\
-    libghdl.vhdl__nodes_meta__has_parent
+Has_Parent = libghdl.vhdl__nodes_meta__has_parent
 
-Has_Loop_Label =\
-    libghdl.vhdl__nodes_meta__has_loop_label
+Has_Loop_Label = libghdl.vhdl__nodes_meta__has_loop_label
 
-Has_Exit_Flag =\
-    libghdl.vhdl__nodes_meta__has_exit_flag
+Has_Exit_Flag = libghdl.vhdl__nodes_meta__has_exit_flag
 
-Has_Next_Flag =\
-    libghdl.vhdl__nodes_meta__has_next_flag
+Has_Next_Flag = libghdl.vhdl__nodes_meta__has_next_flag
 
-Has_Component_Name =\
-    libghdl.vhdl__nodes_meta__has_component_name
+Has_Component_Name = libghdl.vhdl__nodes_meta__has_component_name
 
-Has_Instantiation_List =\
-    libghdl.vhdl__nodes_meta__has_instantiation_list
+Has_Instantiation_List = libghdl.vhdl__nodes_meta__has_instantiation_list
 
-Has_Entity_Aspect =\
-    libghdl.vhdl__nodes_meta__has_entity_aspect
+Has_Entity_Aspect = libghdl.vhdl__nodes_meta__has_entity_aspect
 
-Has_Default_Entity_Aspect =\
-    libghdl.vhdl__nodes_meta__has_default_entity_aspect
+Has_Default_Entity_Aspect = libghdl.vhdl__nodes_meta__has_default_entity_aspect
 
-Has_Binding_Indication =\
-    libghdl.vhdl__nodes_meta__has_binding_indication
+Has_Binding_Indication = libghdl.vhdl__nodes_meta__has_binding_indication
 
-Has_Named_Entity =\
-    libghdl.vhdl__nodes_meta__has_named_entity
+Has_Named_Entity = libghdl.vhdl__nodes_meta__has_named_entity
 
-Has_Alias_Declaration =\
-    libghdl.vhdl__nodes_meta__has_alias_declaration
+Has_Alias_Declaration = libghdl.vhdl__nodes_meta__has_alias_declaration
 
-Has_Referenced_Name =\
-    libghdl.vhdl__nodes_meta__has_referenced_name
+Has_Referenced_Name = libghdl.vhdl__nodes_meta__has_referenced_name
 
-Has_Expr_Staticness =\
-    libghdl.vhdl__nodes_meta__has_expr_staticness
+Has_Expr_Staticness = libghdl.vhdl__nodes_meta__has_expr_staticness
 
-Has_Scalar_Size =\
-    libghdl.vhdl__nodes_meta__has_scalar_size
+Has_Scalar_Size = libghdl.vhdl__nodes_meta__has_scalar_size
 
-Has_Error_Origin =\
-    libghdl.vhdl__nodes_meta__has_error_origin
+Has_Error_Origin = libghdl.vhdl__nodes_meta__has_error_origin
 
-Has_Operand =\
-    libghdl.vhdl__nodes_meta__has_operand
+Has_Operand = libghdl.vhdl__nodes_meta__has_operand
 
-Has_Left =\
-    libghdl.vhdl__nodes_meta__has_left
+Has_Left = libghdl.vhdl__nodes_meta__has_left
 
-Has_Right =\
-    libghdl.vhdl__nodes_meta__has_right
+Has_Right = libghdl.vhdl__nodes_meta__has_right
 
-Has_Unit_Name =\
-    libghdl.vhdl__nodes_meta__has_unit_name
+Has_Unit_Name = libghdl.vhdl__nodes_meta__has_unit_name
 
-Has_Name =\
-    libghdl.vhdl__nodes_meta__has_name
+Has_Name = libghdl.vhdl__nodes_meta__has_name
 
-Has_Group_Template_Name =\
-    libghdl.vhdl__nodes_meta__has_group_template_name
+Has_Group_Template_Name = libghdl.vhdl__nodes_meta__has_group_template_name
 
-Has_Name_Staticness =\
-    libghdl.vhdl__nodes_meta__has_name_staticness
+Has_Name_Staticness = libghdl.vhdl__nodes_meta__has_name_staticness
 
-Has_Prefix =\
-    libghdl.vhdl__nodes_meta__has_prefix
+Has_Prefix = libghdl.vhdl__nodes_meta__has_prefix
 
-Has_Signature_Prefix =\
-    libghdl.vhdl__nodes_meta__has_signature_prefix
+Has_Signature_Prefix = libghdl.vhdl__nodes_meta__has_signature_prefix
 
-Has_External_Pathname =\
-    libghdl.vhdl__nodes_meta__has_external_pathname
+Has_External_Pathname = libghdl.vhdl__nodes_meta__has_external_pathname
 
-Has_Pathname_Suffix =\
-    libghdl.vhdl__nodes_meta__has_pathname_suffix
+Has_Pathname_Suffix = libghdl.vhdl__nodes_meta__has_pathname_suffix
 
-Has_Pathname_Expression =\
-    libghdl.vhdl__nodes_meta__has_pathname_expression
+Has_Pathname_Expression = libghdl.vhdl__nodes_meta__has_pathname_expression
 
-Has_In_Formal_Flag =\
-    libghdl.vhdl__nodes_meta__has_in_formal_flag
+Has_In_Formal_Flag = libghdl.vhdl__nodes_meta__has_in_formal_flag
 
-Has_Slice_Subtype =\
-    libghdl.vhdl__nodes_meta__has_slice_subtype
+Has_Slice_Subtype = libghdl.vhdl__nodes_meta__has_slice_subtype
 
-Has_Suffix =\
-    libghdl.vhdl__nodes_meta__has_suffix
+Has_Suffix = libghdl.vhdl__nodes_meta__has_suffix
 
-Has_Index_Subtype =\
-    libghdl.vhdl__nodes_meta__has_index_subtype
+Has_Index_Subtype = libghdl.vhdl__nodes_meta__has_index_subtype
 
-Has_Parameter =\
-    libghdl.vhdl__nodes_meta__has_parameter
+Has_Parameter = libghdl.vhdl__nodes_meta__has_parameter
 
-Has_Parameter_2 =\
-    libghdl.vhdl__nodes_meta__has_parameter_2
+Has_Parameter_2 = libghdl.vhdl__nodes_meta__has_parameter_2
 
-Has_Parameter_3 =\
-    libghdl.vhdl__nodes_meta__has_parameter_3
+Has_Parameter_3 = libghdl.vhdl__nodes_meta__has_parameter_3
 
-Has_Parameter_4 =\
-    libghdl.vhdl__nodes_meta__has_parameter_4
+Has_Parameter_4 = libghdl.vhdl__nodes_meta__has_parameter_4
 
-Has_Attr_Chain =\
-    libghdl.vhdl__nodes_meta__has_attr_chain
+Has_Attr_Chain = libghdl.vhdl__nodes_meta__has_attr_chain
 
-Has_Signal_Attribute_Declaration =\
+Has_Signal_Attribute_Declaration = (
     libghdl.vhdl__nodes_meta__has_signal_attribute_declaration
+)
 
-Has_Actual_Type =\
-    libghdl.vhdl__nodes_meta__has_actual_type
+Has_Actual_Type = libghdl.vhdl__nodes_meta__has_actual_type
 
-Has_Actual_Type_Definition =\
-    libghdl.vhdl__nodes_meta__has_actual_type_definition
+Has_Actual_Type_Definition = libghdl.vhdl__nodes_meta__has_actual_type_definition
 
-Has_Association_Chain =\
-    libghdl.vhdl__nodes_meta__has_association_chain
+Has_Association_Chain = libghdl.vhdl__nodes_meta__has_association_chain
 
-Has_Individual_Association_Chain =\
+Has_Individual_Association_Chain = (
     libghdl.vhdl__nodes_meta__has_individual_association_chain
+)
 
-Has_Subprogram_Association_Chain =\
+Has_Subprogram_Association_Chain = (
     libghdl.vhdl__nodes_meta__has_subprogram_association_chain
+)
 
-Has_Aggregate_Info =\
-    libghdl.vhdl__nodes_meta__has_aggregate_info
+Has_Aggregate_Info = libghdl.vhdl__nodes_meta__has_aggregate_info
 
-Has_Sub_Aggregate_Info =\
-    libghdl.vhdl__nodes_meta__has_sub_aggregate_info
+Has_Sub_Aggregate_Info = libghdl.vhdl__nodes_meta__has_sub_aggregate_info
 
-Has_Aggr_Dynamic_Flag =\
-    libghdl.vhdl__nodes_meta__has_aggr_dynamic_flag
+Has_Aggr_Dynamic_Flag = libghdl.vhdl__nodes_meta__has_aggr_dynamic_flag
 
-Has_Aggr_Min_Length =\
-    libghdl.vhdl__nodes_meta__has_aggr_min_length
+Has_Aggr_Min_Length = libghdl.vhdl__nodes_meta__has_aggr_min_length
 
-Has_Aggr_Low_Limit =\
-    libghdl.vhdl__nodes_meta__has_aggr_low_limit
+Has_Aggr_Low_Limit = libghdl.vhdl__nodes_meta__has_aggr_low_limit
 
-Has_Aggr_High_Limit =\
-    libghdl.vhdl__nodes_meta__has_aggr_high_limit
+Has_Aggr_High_Limit = libghdl.vhdl__nodes_meta__has_aggr_high_limit
 
-Has_Aggr_Others_Flag =\
-    libghdl.vhdl__nodes_meta__has_aggr_others_flag
+Has_Aggr_Others_Flag = libghdl.vhdl__nodes_meta__has_aggr_others_flag
 
-Has_Aggr_Named_Flag =\
-    libghdl.vhdl__nodes_meta__has_aggr_named_flag
+Has_Aggr_Named_Flag = libghdl.vhdl__nodes_meta__has_aggr_named_flag
 
-Has_Aggregate_Expand_Flag =\
-    libghdl.vhdl__nodes_meta__has_aggregate_expand_flag
+Has_Aggregate_Expand_Flag = libghdl.vhdl__nodes_meta__has_aggregate_expand_flag
 
-Has_Association_Choices_Chain =\
-    libghdl.vhdl__nodes_meta__has_association_choices_chain
+Has_Association_Choices_Chain = libghdl.vhdl__nodes_meta__has_association_choices_chain
 
-Has_Case_Statement_Alternative_Chain =\
+Has_Case_Statement_Alternative_Chain = (
     libghdl.vhdl__nodes_meta__has_case_statement_alternative_chain
+)
 
-Has_Choice_Staticness =\
-    libghdl.vhdl__nodes_meta__has_choice_staticness
+Has_Choice_Staticness = libghdl.vhdl__nodes_meta__has_choice_staticness
 
-Has_Procedure_Call =\
-    libghdl.vhdl__nodes_meta__has_procedure_call
+Has_Procedure_Call = libghdl.vhdl__nodes_meta__has_procedure_call
 
-Has_Implementation =\
-    libghdl.vhdl__nodes_meta__has_implementation
+Has_Implementation = libghdl.vhdl__nodes_meta__has_implementation
 
-Has_Parameter_Association_Chain =\
+Has_Parameter_Association_Chain = (
     libghdl.vhdl__nodes_meta__has_parameter_association_chain
+)
 
-Has_Method_Object =\
-    libghdl.vhdl__nodes_meta__has_method_object
+Has_Method_Object = libghdl.vhdl__nodes_meta__has_method_object
 
-Has_Subtype_Type_Mark =\
-    libghdl.vhdl__nodes_meta__has_subtype_type_mark
+Has_Subtype_Type_Mark = libghdl.vhdl__nodes_meta__has_subtype_type_mark
 
-Has_Subnature_Nature_Mark =\
-    libghdl.vhdl__nodes_meta__has_subnature_nature_mark
+Has_Subnature_Nature_Mark = libghdl.vhdl__nodes_meta__has_subnature_nature_mark
 
-Has_Type_Conversion_Subtype =\
-    libghdl.vhdl__nodes_meta__has_type_conversion_subtype
+Has_Type_Conversion_Subtype = libghdl.vhdl__nodes_meta__has_type_conversion_subtype
 
-Has_Type_Mark =\
-    libghdl.vhdl__nodes_meta__has_type_mark
+Has_Type_Mark = libghdl.vhdl__nodes_meta__has_type_mark
 
-Has_File_Type_Mark =\
-    libghdl.vhdl__nodes_meta__has_file_type_mark
+Has_File_Type_Mark = libghdl.vhdl__nodes_meta__has_file_type_mark
 
-Has_Return_Type_Mark =\
-    libghdl.vhdl__nodes_meta__has_return_type_mark
+Has_Return_Type_Mark = libghdl.vhdl__nodes_meta__has_return_type_mark
 
-Has_Has_Disconnect_Flag =\
-    libghdl.vhdl__nodes_meta__has_has_disconnect_flag
+Has_Has_Disconnect_Flag = libghdl.vhdl__nodes_meta__has_has_disconnect_flag
 
-Has_Has_Active_Flag =\
-    libghdl.vhdl__nodes_meta__has_has_active_flag
+Has_Has_Active_Flag = libghdl.vhdl__nodes_meta__has_has_active_flag
 
-Has_Is_Within_Flag =\
-    libghdl.vhdl__nodes_meta__has_is_within_flag
+Has_Is_Within_Flag = libghdl.vhdl__nodes_meta__has_is_within_flag
 
-Has_Type_Marks_List =\
-    libghdl.vhdl__nodes_meta__has_type_marks_list
+Has_Type_Marks_List = libghdl.vhdl__nodes_meta__has_type_marks_list
 
-Has_Implicit_Alias_Flag =\
-    libghdl.vhdl__nodes_meta__has_implicit_alias_flag
+Has_Implicit_Alias_Flag = libghdl.vhdl__nodes_meta__has_implicit_alias_flag
 
-Has_Alias_Signature =\
-    libghdl.vhdl__nodes_meta__has_alias_signature
+Has_Alias_Signature = libghdl.vhdl__nodes_meta__has_alias_signature
 
-Has_Attribute_Signature =\
-    libghdl.vhdl__nodes_meta__has_attribute_signature
+Has_Attribute_Signature = libghdl.vhdl__nodes_meta__has_attribute_signature
 
-Has_Overload_List =\
-    libghdl.vhdl__nodes_meta__has_overload_list
+Has_Overload_List = libghdl.vhdl__nodes_meta__has_overload_list
 
-Has_Simple_Name_Identifier =\
-    libghdl.vhdl__nodes_meta__has_simple_name_identifier
+Has_Simple_Name_Identifier = libghdl.vhdl__nodes_meta__has_simple_name_identifier
 
-Has_Simple_Name_Subtype =\
-    libghdl.vhdl__nodes_meta__has_simple_name_subtype
+Has_Simple_Name_Subtype = libghdl.vhdl__nodes_meta__has_simple_name_subtype
 
-Has_Protected_Type_Body =\
-    libghdl.vhdl__nodes_meta__has_protected_type_body
+Has_Protected_Type_Body = libghdl.vhdl__nodes_meta__has_protected_type_body
 
-Has_Protected_Type_Declaration =\
+Has_Protected_Type_Declaration = (
     libghdl.vhdl__nodes_meta__has_protected_type_declaration
+)
 
-Has_Use_Flag =\
-    libghdl.vhdl__nodes_meta__has_use_flag
+Has_Use_Flag = libghdl.vhdl__nodes_meta__has_use_flag
 
-Has_End_Has_Reserved_Id =\
-    libghdl.vhdl__nodes_meta__has_end_has_reserved_id
+Has_End_Has_Reserved_Id = libghdl.vhdl__nodes_meta__has_end_has_reserved_id
 
-Has_End_Has_Identifier =\
-    libghdl.vhdl__nodes_meta__has_end_has_identifier
+Has_End_Has_Identifier = libghdl.vhdl__nodes_meta__has_end_has_identifier
 
-Has_End_Has_Postponed =\
-    libghdl.vhdl__nodes_meta__has_end_has_postponed
+Has_End_Has_Postponed = libghdl.vhdl__nodes_meta__has_end_has_postponed
 
-Has_Has_Label =\
-    libghdl.vhdl__nodes_meta__has_has_label
+Has_Has_Label = libghdl.vhdl__nodes_meta__has_has_label
 
-Has_Has_Begin =\
-    libghdl.vhdl__nodes_meta__has_has_begin
+Has_Has_Begin = libghdl.vhdl__nodes_meta__has_has_begin
 
-Has_Has_End =\
-    libghdl.vhdl__nodes_meta__has_has_end
+Has_Has_End = libghdl.vhdl__nodes_meta__has_has_end
 
-Has_Has_Is =\
-    libghdl.vhdl__nodes_meta__has_has_is
+Has_Has_Is = libghdl.vhdl__nodes_meta__has_has_is
 
-Has_Has_Pure =\
-    libghdl.vhdl__nodes_meta__has_has_pure
+Has_Has_Pure = libghdl.vhdl__nodes_meta__has_has_pure
 
-Has_Has_Body =\
-    libghdl.vhdl__nodes_meta__has_has_body
+Has_Has_Body = libghdl.vhdl__nodes_meta__has_has_body
 
-Has_Has_Parameter =\
-    libghdl.vhdl__nodes_meta__has_has_parameter
+Has_Has_Parameter = libghdl.vhdl__nodes_meta__has_has_parameter
 
-Has_Has_Component =\
-    libghdl.vhdl__nodes_meta__has_has_component
+Has_Has_Component = libghdl.vhdl__nodes_meta__has_has_component
 
-Has_Has_Identifier_List =\
-    libghdl.vhdl__nodes_meta__has_has_identifier_list
+Has_Has_Identifier_List = libghdl.vhdl__nodes_meta__has_has_identifier_list
 
-Has_Has_Mode =\
-    libghdl.vhdl__nodes_meta__has_has_mode
+Has_Has_Mode = libghdl.vhdl__nodes_meta__has_has_mode
 
-Has_Has_Class =\
-    libghdl.vhdl__nodes_meta__has_has_class
+Has_Has_Class = libghdl.vhdl__nodes_meta__has_has_class
 
-Has_Has_Delay_Mechanism =\
-    libghdl.vhdl__nodes_meta__has_has_delay_mechanism
+Has_Has_Delay_Mechanism = libghdl.vhdl__nodes_meta__has_has_delay_mechanism
 
-Has_Suspend_Flag =\
-    libghdl.vhdl__nodes_meta__has_suspend_flag
+Has_Suspend_Flag = libghdl.vhdl__nodes_meta__has_suspend_flag
 
-Has_Is_Ref =\
-    libghdl.vhdl__nodes_meta__has_is_ref
+Has_Is_Ref = libghdl.vhdl__nodes_meta__has_is_ref
 
-Has_Is_Forward_Ref =\
-    libghdl.vhdl__nodes_meta__has_is_forward_ref
+Has_Is_Forward_Ref = libghdl.vhdl__nodes_meta__has_is_forward_ref
 
-Has_Psl_Property =\
-    libghdl.vhdl__nodes_meta__has_psl_property
+Has_Psl_Property = libghdl.vhdl__nodes_meta__has_psl_property
 
-Has_Psl_Sequence =\
-    libghdl.vhdl__nodes_meta__has_psl_sequence
+Has_Psl_Sequence = libghdl.vhdl__nodes_meta__has_psl_sequence
 
-Has_Psl_Declaration =\
-    libghdl.vhdl__nodes_meta__has_psl_declaration
+Has_Psl_Declaration = libghdl.vhdl__nodes_meta__has_psl_declaration
 
-Has_Psl_Expression =\
-    libghdl.vhdl__nodes_meta__has_psl_expression
+Has_Psl_Expression = libghdl.vhdl__nodes_meta__has_psl_expression
 
-Has_Psl_Boolean =\
-    libghdl.vhdl__nodes_meta__has_psl_boolean
+Has_Psl_Boolean = libghdl.vhdl__nodes_meta__has_psl_boolean
 
-Has_PSL_Clock =\
-    libghdl.vhdl__nodes_meta__has_psl_clock
+Has_PSL_Clock = libghdl.vhdl__nodes_meta__has_psl_clock
 
-Has_PSL_NFA =\
-    libghdl.vhdl__nodes_meta__has_psl_nfa
+Has_PSL_NFA = libghdl.vhdl__nodes_meta__has_psl_nfa
 
-Has_PSL_Nbr_States =\
-    libghdl.vhdl__nodes_meta__has_psl_nbr_states
+Has_PSL_Nbr_States = libghdl.vhdl__nodes_meta__has_psl_nbr_states
 
-Has_PSL_Clock_Sensitivity =\
-    libghdl.vhdl__nodes_meta__has_psl_clock_sensitivity
+Has_PSL_Clock_Sensitivity = libghdl.vhdl__nodes_meta__has_psl_clock_sensitivity
 
-Has_PSL_EOS_Flag =\
-    libghdl.vhdl__nodes_meta__has_psl_eos_flag
+Has_PSL_EOS_Flag = libghdl.vhdl__nodes_meta__has_psl_eos_flag
 
-Has_Count_Expression =\
-    libghdl.vhdl__nodes_meta__has_count_expression
+Has_Count_Expression = libghdl.vhdl__nodes_meta__has_count_expression
 
-Has_Clock_Expression =\
-    libghdl.vhdl__nodes_meta__has_clock_expression
+Has_Clock_Expression = libghdl.vhdl__nodes_meta__has_clock_expression
 
-Has_Default_Clock =\
-    libghdl.vhdl__nodes_meta__has_default_clock
+Has_Default_Clock = libghdl.vhdl__nodes_meta__has_default_clock

--- a/python/libghdl/thin/vhdl/nodes_utils.py
+++ b/python/libghdl/thin/vhdl/nodes_utils.py
@@ -4,11 +4,10 @@ Strip_Denoting_Name = libghdl.vhdl__utils__strip_denoting_name
 
 Get_Entity = libghdl.vhdl__utils__get_entity
 
-Is_Second_Subprogram_Specification = \
+Is_Second_Subprogram_Specification = (
     libghdl.vhdl__utils__is_second_subprogram_specification
+)
 
-Get_Entity_From_Entity_Aspect = \
-    libghdl.vhdl__utils__get_entity_from_entity_aspect
+Get_Entity_From_Entity_Aspect = libghdl.vhdl__utils__get_entity_from_entity_aspect
 
-Get_Interface_Of_Formal = \
-    libghdl.vhdl__utils__get_interface_of_formal
+Get_Interface_Of_Formal = libghdl.vhdl__utils__get_interface_of_formal

--- a/python/libghdl/thin/vhdl/parse.py
+++ b/python/libghdl/thin/vhdl/parse.py
@@ -3,5 +3,4 @@ from ctypes import c_bool
 
 Parse_Design_File = libghdl.vhdl__parse__parse_design_file
 
-Flag_Parse_Parenthesis = c_bool.in_dll(
-    libghdl, "vhdl__parse__flag_parse_parenthesis")
+Flag_Parse_Parenthesis = c_bool.in_dll(libghdl, "vhdl__parse__flag_parse_parenthesis")

--- a/python/libghdl/thin/vhdl/pyutils.py
+++ b/python/libghdl/thin/vhdl/pyutils.py
@@ -1,16 +1,18 @@
-from ctypes import (c_char_p, c_int32, c_int, c_bool, sizeof, c_void_p, byref)
+from ctypes import c_char_p, c_int32, c_int, c_bool, sizeof, c_void_p, byref
 import libghdl.thin.name_table as name_table
 import libghdl.thin.vhdl.nodes as nodes
 import libghdl.thin.vhdl.nodes_meta as nodes_meta
 import libghdl.thin.vhdl.lists as lists
 import libghdl.thin.vhdl.flists as flists
-from libghdl.thin.vhdl.nodes_meta import (Attr, types)
+from libghdl.thin.vhdl.nodes_meta import Attr, types
+
 
 def name_image(nameid):
-    return name_table.Get_Name_Ptr(nameid).decode('utf-8')
+    return name_table.Get_Name_Ptr(nameid).decode("utf-8")
+
 
 def _build_enum_image(cls):
-    d = [e for e in dir(cls) if e[0] != '_']
+    d = [e for e in dir(cls) if e[0] != "_"]
     res = [None] * len(d)
     for e in d:
         res[getattr(cls, e)] = e
@@ -88,12 +90,12 @@ def nodes_iter(n):
     Nodes are returned only once."""
     if n == nodes.Null_Iir:
         return
-#    print 'nodes_iter for {0}'.format(n)
+    #    print 'nodes_iter for {0}'.format(n)
     yield n
     for f in fields_iter(n):
         typ = nodes_meta.get_field_type(f)
-#        print ' {0}: field {1} (type: {2})'.format(
-#            n, fields_image(f), types_image(typ))
+        #        print ' {0}: field {1} (type: {2})'.format(
+        #            n, fields_image(f), types_image(typ))
         if typ == nodes_meta.types.Iir:
             attr = nodes_meta.get_field_attribute(f)
             if attr == Attr.ANone:
@@ -156,15 +158,16 @@ def declarations_iter(n):
     if nodes_meta.Has_Declaration_Chain(k):
         for n1 in chain_iter(nodes.Get_Declaration_Chain(n)):
             k1 = nodes.Get_Kind(n1)
-            if k1 in nodes.Iir_Kinds.Specification \
-               or k1 == nodes.Iir_Kind.Use_Clause:
+            if k1 in nodes.Iir_Kinds.Specification or k1 == nodes.Iir_Kind.Use_Clause:
                 # Not a declaration
                 pass
             elif k1 == nodes.Iir_Kind.Signal_Attribute_Declaration:
                 # Not a declaration
                 pass
-            elif k1 in [nodes.Iir_Kind.Type_Declaration,
-                        nodes.Iir_Kind.Anonymous_Type_Declaration]:
+            elif k1 in [
+                nodes.Iir_Kind.Type_Declaration,
+                nodes.Iir_Kind.Anonymous_Type_Declaration,
+            ]:
                 yield n1
                 # Handle nested declarations: record elements, physical units,
                 # enumeration literals...
@@ -205,53 +208,54 @@ def declarations_iter(n):
             for n2 in declarations_iter(n1):
                 yield n2
     # All these nodes are handled:
-    if k in [nodes.Iir_Kind.Entity_Declaration,
-             nodes.Iir_Kind.Architecture_Body,
-             nodes.Iir_Kind.Package_Declaration,
-             nodes.Iir_Kind.Package_Body,
-             nodes.Iir_Kind.Process_Statement,
-             nodes.Iir_Kind.Sensitized_Process_Statement,
-             nodes.Iir_Kind.Concurrent_Assertion_Statement,
-             nodes.Iir_Kind.Concurrent_Simple_Signal_Assignment,
-             nodes.Iir_Kind.Concurrent_Selected_Signal_Assignment,
-             nodes.Iir_Kind.Concurrent_Conditional_Signal_Assignment,
-             nodes.Iir_Kind.Concurrent_Procedure_Call_Statement,
-             nodes.Iir_Kind.Block_Statement,
-             nodes.Iir_Kind.Block_Header,
-             nodes.Iir_Kind.For_Generate_Statement,
-             nodes.Iir_Kind.If_Generate_Statement,
-             nodes.Iir_Kind.Generate_Statement_Body,
-             nodes.Iir_Kind.Assertion_Statement,
-             nodes.Iir_Kind.Wait_Statement,
-             nodes.Iir_Kind.Simple_Signal_Assignment_Statement,
-             nodes.Iir_Kind.Variable_Assignment_Statement,
-             nodes.Iir_Kind.For_Loop_Statement,
-             nodes.Iir_Kind.While_Loop_Statement,
-             nodes.Iir_Kind.Case_Statement,
-             nodes.Iir_Kind.Null_Statement,
-             nodes.Iir_Kind.Exit_Statement,
-             nodes.Iir_Kind.Next_Statement,
-             nodes.Iir_Kind.Procedure_Call_Statement,
-             nodes.Iir_Kind.Signal_Declaration,
-             nodes.Iir_Kind.Constant_Declaration,
-             nodes.Iir_Kind.Variable_Declaration,
-             nodes.Iir_Kind.File_Declaration,
-             nodes.Iir_Kind.Object_Alias_Declaration,
-             nodes.Iir_Kind.Attribute_Declaration,
-             nodes.Iir_Kind.Component_Declaration,
-             nodes.Iir_Kind.Use_Clause,
-             nodes.Iir_Kind.If_Statement,
-             nodes.Iir_Kind.Elsif,
-             nodes.Iir_Kind.Return_Statement,
-             nodes.Iir_Kind.Type_Declaration,
-             nodes.Iir_Kind.Anonymous_Type_Declaration,
-             nodes.Iir_Kind.Subtype_Declaration,
-             nodes.Iir_Kind.Function_Declaration,
-             nodes.Iir_Kind.Function_Body,
-             nodes.Iir_Kind.Procedure_Declaration,
-             nodes.Iir_Kind.Procedure_Body,
-             nodes.Iir_Kind.Component_Instantiation_Statement,
-             ]:
+    if k in [
+        nodes.Iir_Kind.Entity_Declaration,
+        nodes.Iir_Kind.Architecture_Body,
+        nodes.Iir_Kind.Package_Declaration,
+        nodes.Iir_Kind.Package_Body,
+        nodes.Iir_Kind.Process_Statement,
+        nodes.Iir_Kind.Sensitized_Process_Statement,
+        nodes.Iir_Kind.Concurrent_Assertion_Statement,
+        nodes.Iir_Kind.Concurrent_Simple_Signal_Assignment,
+        nodes.Iir_Kind.Concurrent_Selected_Signal_Assignment,
+        nodes.Iir_Kind.Concurrent_Conditional_Signal_Assignment,
+        nodes.Iir_Kind.Concurrent_Procedure_Call_Statement,
+        nodes.Iir_Kind.Block_Statement,
+        nodes.Iir_Kind.Block_Header,
+        nodes.Iir_Kind.For_Generate_Statement,
+        nodes.Iir_Kind.If_Generate_Statement,
+        nodes.Iir_Kind.Generate_Statement_Body,
+        nodes.Iir_Kind.Assertion_Statement,
+        nodes.Iir_Kind.Wait_Statement,
+        nodes.Iir_Kind.Simple_Signal_Assignment_Statement,
+        nodes.Iir_Kind.Variable_Assignment_Statement,
+        nodes.Iir_Kind.For_Loop_Statement,
+        nodes.Iir_Kind.While_Loop_Statement,
+        nodes.Iir_Kind.Case_Statement,
+        nodes.Iir_Kind.Null_Statement,
+        nodes.Iir_Kind.Exit_Statement,
+        nodes.Iir_Kind.Next_Statement,
+        nodes.Iir_Kind.Procedure_Call_Statement,
+        nodes.Iir_Kind.Signal_Declaration,
+        nodes.Iir_Kind.Constant_Declaration,
+        nodes.Iir_Kind.Variable_Declaration,
+        nodes.Iir_Kind.File_Declaration,
+        nodes.Iir_Kind.Object_Alias_Declaration,
+        nodes.Iir_Kind.Attribute_Declaration,
+        nodes.Iir_Kind.Component_Declaration,
+        nodes.Iir_Kind.Use_Clause,
+        nodes.Iir_Kind.If_Statement,
+        nodes.Iir_Kind.Elsif,
+        nodes.Iir_Kind.Return_Statement,
+        nodes.Iir_Kind.Type_Declaration,
+        nodes.Iir_Kind.Anonymous_Type_Declaration,
+        nodes.Iir_Kind.Subtype_Declaration,
+        nodes.Iir_Kind.Function_Declaration,
+        nodes.Iir_Kind.Function_Body,
+        nodes.Iir_Kind.Procedure_Declaration,
+        nodes.Iir_Kind.Procedure_Body,
+        nodes.Iir_Kind.Component_Instantiation_Statement,
+    ]:
         return
     assert False, "unknown node of kind {}".format(kind_image(k))
 
@@ -266,9 +270,11 @@ def concurrent_stmts_iter(n):
     elif k == nodes.Iir_Kind.Design_Unit:
         for n1 in concurrent_stmts_iter(nodes.Get_Library_Unit(n)):
             yield n1
-    elif k == nodes.Iir_Kind.Entity_Declaration \
-         or k == nodes.Iir_Kind.Architecture_Body \
-         or k == nodes.Iir_Kind.Block_Statement:
+    elif (
+        k == nodes.Iir_Kind.Entity_Declaration
+        or k == nodes.Iir_Kind.Architecture_Body
+        or k == nodes.Iir_Kind.Block_Statement
+    ):
         for n1 in chain_iter(nodes.Get_Concurrent_Statement_Chain(n)):
             yield n1
             for n2 in concurrent_stmts_iter(n1):
@@ -278,8 +284,7 @@ def concurrent_stmts_iter(n):
             yield n1
     elif k == nodes.Iir_Kind.If_Generate_Statement:
         while n != Null_Iir:
-            for n1 in concurrent_stmts_iter(
-                    nodes.Get_Generate_Statement_Body(n)):
+            for n1 in concurrent_stmts_iter(nodes.Get_Generate_Statement_Body(n)):
                 yield n1
             n = nodes.Get_Generate_Else_Clause(n)
     elif k == nodes.Iir_Kind.Case_Generate_Statement:
@@ -287,8 +292,7 @@ def concurrent_stmts_iter(n):
         for n1 in chain_iter(alt):
             blk = nodes.Get_Associated_Block(n1)
             if blk != Null_Iir:
-                for n2 in concurrent_stmts_iter(
-                        nodes.Get_Generate_Statement_Body(n)):
+                for n2 in concurrent_stmts_iter(nodes.Get_Generate_Statement_Body(n)):
                     yield n2
 
 
@@ -307,10 +311,12 @@ def constructs_iter(n):
         yield n1
         for n2 in constructs_iter(n1):
             yield n2
-    elif k in [nodes.Iir_Kind.Entity_Declaration,
-               nodes.Iir_Kind.Architecture_Body,
-               nodes.Iir_Kind.Block_Statement,
-               nodes.Iir_Kind.Generate_Statement_Body]:
+    elif k in [
+        nodes.Iir_Kind.Entity_Declaration,
+        nodes.Iir_Kind.Architecture_Body,
+        nodes.Iir_Kind.Block_Statement,
+        nodes.Iir_Kind.Generate_Statement_Body,
+    ]:
         for n1 in chain_iter(nodes.Get_Declaration_Chain(n)):
             yield n1
             for n2 in constructs_iter(n1):
@@ -319,15 +325,17 @@ def constructs_iter(n):
             yield n1
             for n2 in constructs_iter(n1):
                 yield n2
-    elif k in [nodes.Iir_Kind.Configuration_Declaration,
-               nodes.Iir_Kind.Package_Declaration,
-               nodes.Iir_Kind.Package_Body,
-               nodes.Iir_Kind.Function_Body,
-               nodes.Iir_Kind.Procedure_Body,
-               nodes.Iir_Kind.Protected_Type_Declaration,
-               nodes.Iir_Kind.Protected_Type_Body,
-               nodes.Iir_Kind.Process_Statement,
-               nodes.Iir_Kind.Sensitized_Process_Statement]:
+    elif k in [
+        nodes.Iir_Kind.Configuration_Declaration,
+        nodes.Iir_Kind.Package_Declaration,
+        nodes.Iir_Kind.Package_Body,
+        nodes.Iir_Kind.Function_Body,
+        nodes.Iir_Kind.Procedure_Body,
+        nodes.Iir_Kind.Protected_Type_Declaration,
+        nodes.Iir_Kind.Protected_Type_Body,
+        nodes.Iir_Kind.Process_Statement,
+        nodes.Iir_Kind.Sensitized_Process_Statement,
+    ]:
         for n1 in chain_iter(nodes.Get_Declaration_Chain(n)):
             yield n1
             for n2 in constructs_iter(n1):
@@ -354,16 +362,19 @@ def constructs_iter(n):
                 for n3 in constructs_iter(n2):
                     yield n3
 
+
 def sequential_iter(n):
     """Iterator on sequential statements.  The first node must be either
        a process or a subprogram body."""
     if n == thin.Null_Iir:
         return
     k = nodes.Get_Kind(n)
-    if k in [nodes.Iir_Kind.Process_Statement,
-             nodes.Iir_Kind.Sensitized_Process_Statement,
-             nodes.Iir_Kind.Function_Body,
-             nodes.Iir_Kind.Procedure_Body]:
+    if k in [
+        nodes.Iir_Kind.Process_Statement,
+        nodes.Iir_Kind.Sensitized_Process_Statement,
+        nodes.Iir_Kind.Function_Body,
+        nodes.Iir_Kind.Procedure_Body,
+    ]:
         for n1 in chain_iter(nodes.Get_Sequential_Statement_Chain(n)):
             yield n1
             for n2 in sequential_iter(n1):
@@ -384,21 +395,22 @@ def sequential_iter(n):
                     yield n1
                     for n2 in sequential_iter(n1):
                         yield n2
-    elif k in [nodes.Iir_Kind.For_Loop_Statement,
-               nodes.Iir_Kind.While_Loop_Statement]:
+    elif k in [nodes.Iir_Kind.For_Loop_Statement, nodes.Iir_Kind.While_Loop_Statement]:
         for n1 in chain_iter(nodes.Get_Sequential_Statement_Chain(n)):
             yield n1
             for n2 in sequential_iter(n1):
                 yield n2
-    elif k in [nodes.Iir_Kind.Assertion_Statement,
-               nodes.Iir_Kind.Wait_Statement,
-               nodes.Iir_Kind.Null_Statement,
-               nodes.Iir_Kind.Exit_Statement,
-               nodes.Iir_Kind.Next_Statement,
-               nodes.Iir_Kind.Return_Statement,
-               nodes.Iir_Kind.Variable_Assignment_Statement,
-               nodes.Iir_Kind.Simple_Signal_Assignment_Statement,
-               nodes.Iir_Kind.Procedure_Call_Statement]:
+    elif k in [
+        nodes.Iir_Kind.Assertion_Statement,
+        nodes.Iir_Kind.Wait_Statement,
+        nodes.Iir_Kind.Null_Statement,
+        nodes.Iir_Kind.Exit_Statement,
+        nodes.Iir_Kind.Next_Statement,
+        nodes.Iir_Kind.Return_Statement,
+        nodes.Iir_Kind.Variable_Assignment_Statement,
+        nodes.Iir_Kind.Simple_Signal_Assignment_Statement,
+        nodes.Iir_Kind.Procedure_Call_Statement,
+    ]:
         return
     else:
         assert False, "unknown node of kind {}".format(kind_image(k))

--- a/python/libghdl/thin/vhdl/std_package.py
+++ b/python/libghdl/thin/vhdl/std_package.py
@@ -5,9 +5,9 @@ from ctypes import c_int32
 Std_Location = c_int32.in_dll(libghdl, "vhdl__std_package__std_location")
 
 # Use .value
-Standard_Package = c_int32.in_dll(
-    libghdl, "vhdl__std_package__standard_package")
+Standard_Package = c_int32.in_dll(libghdl, "vhdl__std_package__standard_package")
 
 # Use .value
 Character_Type_Definition = c_int32.in_dll(
-    libghdl, "vhdl__std_package__character_type_definition")
+    libghdl, "vhdl__std_package__character_type_definition"
+)

--- a/python/libghdl/thin/vhdl/tokens.py
+++ b/python/libghdl/thin/vhdl/tokens.py
@@ -1,5 +1,3 @@
-
-
 class Tok:
     Invalid = 0
     Left_Paren = 1

--- a/python/libghdl/version.py
+++ b/python/libghdl/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.0-dev'
+__version__ = "1.0-dev"

--- a/python/setup.py
+++ b/python/setup.py
@@ -4,11 +4,12 @@ import distutils.command.build_py
 from distutils.core import setup
 import re
 
+
 def get_version():
     # Try from version.py.  Reads it to avoid loading the shared library.
-    r = re.compile("^__version__ = '(.*)'\n")
+    r = re.compile('^__version__ = "(.*)"\n')
     try:
-        l = open('libghdl/version.py').read()
+        l = open("libghdl/version.py").read()
         m = r.match(l)
         if m:
             return m.group(1)
@@ -16,40 +17,27 @@ def get_version():
         pass
     raise Exception("Cannot find version")
 
+
 # Extract the version now, as setup() may change the current directory.
-version=get_version()
+version = get_version()
 
 setup(
-    name='pyghdl',
+    name="pyghdl",
     version=version,
-    description='VHDL Language Server and interface to ghdl, a VHDL analyzer',
-    long_description=open('README').read(),
-    author='Tristan Gingold',
-    author_email='tgingold@free.fr',
-    url='http://github.com/ghdl/ghdl',
-    license='GPL-2.0-or-later',
-    package_dir={
-        'libghdl': 'libghdl',
-        'vhdl_langserver': 'vhdl_langserver'
-    },
-    packages=[
-        'libghdl',
-        'libghdl.thin',
-        'libghdl.thin.vhdl',
-        'vhdl_langserver'
-    ],
+    description="VHDL Language Server and interface to ghdl, a VHDL analyzer",
+    long_description=open("README").read(),
+    author="Tristan Gingold",
+    author_email="tgingold@free.fr",
+    url="http://github.com/ghdl/ghdl",
+    license="GPL-2.0-or-later",
+    package_dir={"libghdl": "libghdl", "vhdl_langserver": "vhdl_langserver"},
+    packages=["libghdl", "libghdl.thin", "libghdl.thin.vhdl", "vhdl_langserver"],
     # List run-time dependencies here. For an analysis of "install_requires"
     # vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=[
-        'attrs'
-    ],
+    install_requires=["attrs"],
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # pip to create the appropriate form of executable for the target platform.
-    entry_points={
-        'console_scripts': [
-            'ghdl-ls = vhdl_langserver.main:main',
-        ]
-    },
+    entry_points={"console_scripts": ["ghdl-ls = vhdl_langserver.main:main",]},
 )

--- a/python/vhdl_langserver/lsp.py
+++ b/python/vhdl_langserver/lsp.py
@@ -10,7 +10,7 @@ except ImportError:
     from urllib2 import quote
     from urlparse import unquote
 
-log = logging.getLogger('ghdl-ls')
+log = logging.getLogger("ghdl-ls")
 
 
 class ProtocolError(Exception):
@@ -49,7 +49,7 @@ def path_from_uri(uri):
 def path_to_uri(path):
     # Convert path to file uri (add html like head part)
     if os.name == "nt":
-        return "file:///" + quote(path.replace('\\', '/'))
+        return "file:///" + quote(path.replace("\\", "/"))
     else:
         return "file://" + quote(path)
 
@@ -71,20 +71,20 @@ class LanguageProtocolServer(object):
             # Return on EOF.
             if not line:
                 return None
-            if line[-2:] != '\r\n':
+            if line[-2:] != "\r\n":
                 raise ProtocolError("invalid end of line in header")
             line = line[:-2]
             if not line:
                 # End of headers.
-                log.debug('Headers: %r', headers)
-                length = headers.get('Content-Length', None)
+                log.debug("Headers: %r", headers)
+                length = headers.get("Content-Length", None)
                 if length is not None:
                     body = self.conn.read(int(length))
                     return body
                 else:
                     raise ProtocolError("missing Content-Length in header")
             else:
-                key, value = line.split(': ', 1)
+                key, value = line.split(": ", 1)
                 headers[key] = value
 
     def run(self):
@@ -96,22 +96,22 @@ class LanguageProtocolServer(object):
 
             # Text to JSON
             msg = json.loads(body)
-            log.debug('Read msg: %s', msg)
+            log.debug("Read msg: %s", msg)
 
             reply = self.handle(msg)
             if reply is not None:
                 self.write_output(reply)
 
     def handle(self, msg):
-        if msg.get('jsonrpc', None) != '2.0':
+        if msg.get("jsonrpc", None) != "2.0":
             raise ProtocolError("invalid jsonrpc version")
-        tid = msg.get('id', None)
-        method = msg.get('method', None)
+        tid = msg.get("id", None)
+        method = msg.get("method", None)
         if method is None:
             # This is a reply.
-            log.error('Unexpected reply for %s', tid)
+            log.error("Unexpected reply for %s", tid)
             return
-        params = msg.get('params', None)
+        params = msg.get("params", None)
         fmethod = self.handler.dispatcher.get(method, None)
         if fmethod:
             if params is None:
@@ -120,20 +120,20 @@ class LanguageProtocolServer(object):
                 response = fmethod(**params)
             except Exception as e:
                 log.exception(
-                    "Caught exception while handling %s with params %s:",
-                    method, params
+                    "Caught exception while handling %s with params %s:", method, params
                 )
                 self.show_message(
                     MessageType.Error,
-                    ("Caught exception while handling {}, " +
-                     "see VHDL language server output for details.").format(
-                        method)
+                    (
+                        "Caught exception while handling {}, "
+                        + "see VHDL language server output for details."
+                    ).format(method),
                 )
                 response = None
             if tid is None:
                 # If this was just a notification, discard it
                 return None
-            log.debug('Response: %s', response)
+            log.debug("Response: %s", response)
             rbody = {
                 "jsonrpc": "2.0",
                 "id": tid,
@@ -141,7 +141,7 @@ class LanguageProtocolServer(object):
             }
         else:
             # Unknown method.
-            log.error('Unknown method %s', method)
+            log.error("Unknown method %s", method)
             # If this was just a notification, discard it
             if tid is None:
                 return None
@@ -151,15 +151,15 @@ class LanguageProtocolServer(object):
                 "id": tid,
                 "error": {
                     "code": JSONErrorCodes.MethodNotFound,
-                    "message": "unknown method {}".format(method)
-                }
+                    "message": "unknown method {}".format(method),
+                },
             }
         return rbody
 
     def write_output(self, body):
         output = json.dumps(body, separators=(",", ":"))
-        self.conn.write('Content-Length: {}\r\n'.format(len(output)))
-        self.conn.write('\r\n')
+        self.conn.write("Content-Length: {}\r\n".format(len(output)))
+        self.conn.write("\r\n")
         self.conn.write(output)
 
     def notify(self, method, params):
@@ -187,12 +187,13 @@ class LanguageProtocolServer(object):
         self.running = False
 
     def show_message(self, typ, message):
-        self.notify('window/showMessage', {'type': typ, 'message': message})
+        self.notify("window/showMessage", {"type": typ, "message": message})
 
     def configuration(self, items):
-        return self.send_request("workspace/configuration", {'items': items})
+        return self.send_request("workspace/configuration", {"items": items})
 
-#----------------------------------------------------------------------
+
+# ----------------------------------------------------------------------
 #  Standard defines and object types
 #
 
@@ -243,7 +244,7 @@ class DiagnosticSeverity(object):
 
 
 class TextDocumentSyncKind(object):
-    NONE = 0,
+    NONE = (0,)
     FULL = 1
     INCREMENTAL = 2
 

--- a/python/vhdl_langserver/lsptools.py
+++ b/python/vhdl_langserver/lsptools.py
@@ -29,11 +29,9 @@ def json2lsp():
 def main():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(help="sub-command help")
-    parser_l2j = subparsers.add_parser('lsp2json',
-                                       help='convert lsp dump to JSON')
+    parser_l2j = subparsers.add_parser("lsp2json", help="convert lsp dump to JSON")
     parser_l2j.set_defaults(func=lsp2json)
-    parser_j2l = subparsers.add_parser('json2lsp',
-                                       help='convert JSON to lsp dump')
+    parser_j2l = subparsers.add_parser("json2lsp", help="convert JSON to lsp dump")
     parser_j2l.set_defaults(func=json2lsp)
     args = parser.parse_args()
     args.func()

--- a/python/vhdl_langserver/main.py
+++ b/python/vhdl_langserver/main.py
@@ -13,15 +13,16 @@ from . import version
 from . import lsp
 from . import vhdl_ls
 
-logger = logging.getLogger('ghdl-ls')
+logger = logging.getLogger("ghdl-ls")
 
 
 class LSPConnTrace(object):
     """Wrapper class to save in and out packets"""
+
     def __init__(self, basename, conn):
         self.conn = conn
-        self.trace_in = open(basename + '.in', 'w')
-        self.trace_out = open(basename + '.out', 'w')
+        self.trace_in = open(basename + ".in", "w")
+        self.trace_out = open(basename + ".out", "w")
 
     def readline(self):
         res = self.conn.readline()
@@ -42,32 +43,31 @@ class LSPConnTrace(object):
 
 def rotate_log_files(basename, num):
     for i in range(num, 0, -1):
-        oldfile = '{}.{}'.format(basename, i - 1)
+        oldfile = "{}.{}".format(basename, i - 1)
         if os.path.isfile(oldfile):
-            os.rename(oldfile, '{}.{}'.format(basename, i))
+            os.rename(oldfile, "{}.{}".format(basename, i))
     if os.path.isfile(basename):
-        os.rename(basename, '{}.0'.format(basename))
+        os.rename(basename, "{}.0".format(basename))
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description='VHDL Language Protocol Server')
+    parser = argparse.ArgumentParser(description="VHDL Language Protocol Server")
     parser.add_argument(
-        '--version', '-V', action='version', version='%(prog)s ' + version.__version__)
+        "--version", "-V", action="version", version="%(prog)s " + version.__version__
+    )
     parser.add_argument(
-        '--verbose', '-v', action='count', default=0,
-        help='Show debug output')
+        "--verbose", "-v", action="count", default=0, help="Show debug output"
+    )
     parser.add_argument(
-        '--log-file',
-        help="Redirect logs to the given file instead of stderr")
+        "--log-file", help="Redirect logs to the given file instead of stderr"
+    )
+    parser.add_argument("--trace-file", help="Save rpc data to FILE.in and FILE.out")
+    parser.add_argument("--input", "-i", help="Read request from file")
     parser.add_argument(
-        '--trace-file',
-        help="Save rpc data to FILE.in and FILE.out")
-    parser.add_argument(
-        '--input', '-i',
-        help="Read request from file")
-    parser.add_argument(
-        '--disp-config', action='store_true', help="Disp installation configuration and exit")
+        "--disp-config",
+        action="store_true",
+        help="Disp installation configuration and exit",
+    )
 
     args = parser.parse_args()
 
@@ -86,36 +86,39 @@ def main():
 
     if args.log_file:
         rotate_log_files(args.log_file, 5)
-        logstream = open(args.log_file, 'w')
+        logstream = open(args.log_file, "w")
     else:
         logstream = sys.stderr
-    logging.basicConfig(format='%(asctime)-15s [%(levelname)s] %(message)s',
-                        stream=logstream, level=loglevel)
+    logging.basicConfig(
+        format="%(asctime)-15s [%(levelname)s] %(message)s",
+        stream=logstream,
+        level=loglevel,
+    )
 
     if args.verbose != 0:
-        sys.stderr.write('Args: {}\n'.format(sys.argv))
-        sys.stderr.write('Current directory: {}\n'.format(os.getcwd()))
+        sys.stderr.write("Args: {}\n".format(sys.argv))
+        sys.stderr.write("Current directory: {}\n".format(os.getcwd()))
 
-    logger.info('Args: %s', sys.argv)
-    logger.info('Current directory is %s', os.getcwd())
+    logger.info("Args: %s", sys.argv)
+    logger.info("Current directory is %s", os.getcwd())
 
     # Connection
     instream = sys.stdin.buffer
     if args.input is not None:
-        instream = open(args.input, 'rb')
+        instream = open(args.input, "rb")
 
     conn = lsp.LSPConn(instream, sys.stdout.buffer)
 
     trace_file = args.trace_file
     if trace_file is None:
-        trace_file = os.environ.get('GHDL_LS_TRACE')
+        trace_file = os.environ.get("GHDL_LS_TRACE")
     if trace_file is not None:
         if args.input is None:
-            rotate_log_files(trace_file + '.in', 5)
-            rotate_log_files(trace_file + '.out', 5)
+            rotate_log_files(trace_file + ".in", 5)
+            rotate_log_files(trace_file + ".out", 5)
             conn = LSPConnTrace(trace_file, conn)
         else:
-            logger.info('Traces disabled when -i/--input')
+            logger.info("Traces disabled when -i/--input")
 
     handler = vhdl_ls.VhdlLanguageServer()
 
@@ -123,5 +126,5 @@ def main():
         server = lsp.LanguageProtocolServer(handler, conn)
         server.run()
     except Exception:
-        logger.exception('Uncaught error')
+        logger.exception("Uncaught error")
         sys.exit(1)

--- a/python/vhdl_langserver/references.py
+++ b/python/vhdl_langserver/references.py
@@ -22,12 +22,14 @@ def find_def(n, loc):
     if n == nodes.Null_Iir:
         return None
     k = nodes.Get_Kind(n)
-    if k in [nodes.Iir_Kind.Simple_Name,
-             nodes.Iir_Kind.Character_Literal,
-             nodes.Iir_Kind.Operator_Symbol,
-             nodes.Iir_Kind.Selected_Name,
-             nodes.Iir_Kind.Attribute_Name,
-             nodes.Iir_Kind.Selected_Element]:
+    if k in [
+        nodes.Iir_Kind.Simple_Name,
+        nodes.Iir_Kind.Character_Literal,
+        nodes.Iir_Kind.Operator_Symbol,
+        nodes.Iir_Kind.Selected_Name,
+        nodes.Iir_Kind.Attribute_Name,
+        nodes.Iir_Kind.Selected_Element,
+    ]:
         n_loc = nodes.Get_Location(n)
         if loc >= n_loc:
             ident = nodes.Get_Identifier(n)
@@ -39,7 +41,7 @@ def find_def(n, loc):
     elif k == nodes.Iir_Kind.Design_File:
         return find_def_chain(nodes.Get_First_Design_Unit(n), loc)
     elif k == nodes.Iir_Kind.Design_Unit:
-        #if loc > elocations.Get_End_Location(unit):
+        # if loc > elocations.Get_End_Location(unit):
         #    return None
         res = find_def_chain(nodes.Get_Context_Items(n), loc)
         if res is not None:
@@ -89,6 +91,10 @@ def goto_definition(n, loc):
     log.debug("for loc %u found node %s", loc, ref)
     if ref is None:
         return None
-    log.debug("for loc %u id=%s", loc, name_table.Get_Name_Ptr(nodes.Get_Identifier(ref)).decode('utf-8'))
+    log.debug(
+        "for loc %u id=%s",
+        loc,
+        name_table.Get_Name_Ptr(nodes.Get_Identifier(ref)).decode("utf-8"),
+    )
     ent = nodes.Get_Named_Entity(ref)
     return None if ent == nodes.Null_Iir else ent

--- a/python/vhdl_langserver/symbols.py
+++ b/python/vhdl_langserver/symbols.py
@@ -8,63 +8,69 @@ import libghdl.thin.vhdl.elocations as elocations
 from . import lsp
 
 SYMBOLS_MAP = {
-    nodes.Iir_Kind.Package_Declaration: {'kind': lsp.SymbolKind.Package, 'detail': '(declaration)'},
-    nodes.Iir_Kind.Package_Body: {'kind': lsp.SymbolKind.Package, 'detail': '(body)'},
-    nodes.Iir_Kind.Entity_Declaration: {'kind': lsp.SymbolKind.Module},
-    nodes.Iir_Kind.Architecture_Body:  {'kind': lsp.SymbolKind.Module},
-    nodes.Iir_Kind.Configuration_Declaration:  {'kind': lsp.SymbolKind.Module},
-    nodes.Iir_Kind.Package_Instantiation_Declaration: {'kind': lsp.SymbolKind.Module},
-    nodes.Iir_Kind.Component_Declaration: {'kind': lsp.SymbolKind.Module},
-    nodes.Iir_Kind.Context_Declaration: {'kind': lsp.SymbolKind.Module},
-    nodes.Iir_Kind.Use_Clause: {'kind': None},
-    nodes.Iir_Kind.Library_Clause: {'kind': None},
-    nodes.Iir_Kind.Procedure_Declaration: {'kind': lsp.SymbolKind.Function},
-    nodes.Iir_Kind.Function_Declaration: {'kind': lsp.SymbolKind.Function},
-    nodes.Iir_Kind.Interface_Procedure_Declaration: {'kind': lsp.SymbolKind.Function},
-    nodes.Iir_Kind.Interface_Function_Declaration: {'kind': lsp.SymbolKind.Function},
-    nodes.Iir_Kind.Procedure_Body: {'kind': lsp.SymbolKind.Function, 'detail': '(body)'},
-    nodes.Iir_Kind.Function_Body: {'kind': lsp.SymbolKind.Function, 'detail': '(body)'},
-    nodes.Iir_Kind.Type_Declaration: {'kind': lsp.SymbolKind.Constructor},
-    nodes.Iir_Kind.Subtype_Declaration: {'kind': lsp.SymbolKind.Constructor},
-    nodes.Iir_Kind.Attribute_Declaration: {'kind': lsp.SymbolKind.Property},
-    nodes.Iir_Kind.Attribute_Specification: {'kind': None},
-    nodes.Iir_Kind.Disconnection_Specification: {'kind': None},
-    nodes.Iir_Kind.Anonymous_Type_Declaration: {'kind': None},
-    nodes.Iir_Kind.Variable_Declaration: {'kind': lsp.SymbolKind.Variable},
-    nodes.Iir_Kind.Constant_Declaration: {'kind': lsp.SymbolKind.Constant},
-    nodes.Iir_Kind.Signal_Declaration: {'kind': lsp.SymbolKind.Variable},
-    nodes.Iir_Kind.Signal_Attribute_Declaration: {'kind': None},
-    nodes.Iir_Kind.File_Declaration: {'kind': lsp.SymbolKind.File},
-    nodes.Iir_Kind.Interface_Variable_Declaration: {'kind': lsp.SymbolKind.Variable},
-    nodes.Iir_Kind.Interface_Constant_Declaration: {'kind': lsp.SymbolKind.Constant},
-    nodes.Iir_Kind.Interface_Signal_Declaration: {'kind': lsp.SymbolKind.Variable},
-    nodes.Iir_Kind.Interface_File_Declaration: {'kind': lsp.SymbolKind.Variable},
-    nodes.Iir_Kind.File_Declaration: {'kind': lsp.SymbolKind.File},
-    nodes.Iir_Kind.Object_Alias_Declaration:  {'kind': lsp.SymbolKind.Variable},
-    nodes.Iir_Kind.Non_Object_Alias_Declaration: {'kind': lsp.SymbolKind.Variable},
-    nodes.Iir_Kind.Protected_Type_Body: {'kind': lsp.SymbolKind.Class},
-    nodes.Iir_Kind.Group_Template_Declaration: {'kind': lsp.SymbolKind.Variable},
-    nodes.Iir_Kind.Group_Declaration: {'kind': lsp.SymbolKind.Variable},
-    nodes.Iir_Kind.Concurrent_Simple_Signal_Assignment: {'kind': None},
-    nodes.Iir_Kind.Concurrent_Conditional_Signal_Assignment: {'kind': None},
-    nodes.Iir_Kind.Concurrent_Selected_Signal_Assignment: {'kind': None},
-    nodes.Iir_Kind.Concurrent_Procedure_Call_Statement: {'kind': None},
-    nodes.Iir_Kind.Concurrent_Assertion_Statement: {'kind': None},
-    nodes.Iir_Kind.Component_Instantiation_Statement: {'kind': lsp.SymbolKind.Method},
-    nodes.Iir_Kind.Block_Statement: {'kind': lsp.SymbolKind.Method},
-    nodes.Iir_Kind.If_Generate_Statement: {'kind': lsp.SymbolKind.Method},
-    nodes.Iir_Kind.For_Generate_Statement: {'kind': lsp.SymbolKind.Method},
-    nodes.Iir_Kind.Case_Generate_Statement: {'kind': lsp.SymbolKind.Method},
-    nodes.Iir_Kind.Sensitized_Process_Statement: {'kind': lsp.SymbolKind.Method},
-    nodes.Iir_Kind.Process_Statement: {'kind': lsp.SymbolKind.Method},
-    nodes.Iir_Kind.Psl_Assert_Directive: {'kind': lsp.SymbolKind.Method},
-    nodes.Iir_Kind.Psl_Assume_Directive: {'kind': lsp.SymbolKind.Method},
-    nodes.Iir_Kind.Psl_Cover_Directive: {'kind': lsp.SymbolKind.Method},
-    nodes.Iir_Kind.Psl_Restrict_Directive: {'kind': lsp.SymbolKind.Method},
-    nodes.Iir_Kind.Psl_Endpoint_Declaration: {'kind': lsp.SymbolKind.Variable},
-    nodes.Iir_Kind.Psl_Declaration: {'kind': lsp.SymbolKind.Variable},
-    nodes.Iir_Kind.Psl_Assert_Directive: {'kind': lsp.SymbolKind.Method},
-    nodes.Iir_Kind.Configuration_Specification: {'kind': None},
+    nodes.Iir_Kind.Package_Declaration: {
+        "kind": lsp.SymbolKind.Package,
+        "detail": "(declaration)",
+    },
+    nodes.Iir_Kind.Package_Body: {"kind": lsp.SymbolKind.Package, "detail": "(body)"},
+    nodes.Iir_Kind.Entity_Declaration: {"kind": lsp.SymbolKind.Module},
+    nodes.Iir_Kind.Architecture_Body: {"kind": lsp.SymbolKind.Module},
+    nodes.Iir_Kind.Configuration_Declaration: {"kind": lsp.SymbolKind.Module},
+    nodes.Iir_Kind.Package_Instantiation_Declaration: {"kind": lsp.SymbolKind.Module},
+    nodes.Iir_Kind.Component_Declaration: {"kind": lsp.SymbolKind.Module},
+    nodes.Iir_Kind.Context_Declaration: {"kind": lsp.SymbolKind.Module},
+    nodes.Iir_Kind.Use_Clause: {"kind": None},
+    nodes.Iir_Kind.Library_Clause: {"kind": None},
+    nodes.Iir_Kind.Procedure_Declaration: {"kind": lsp.SymbolKind.Function},
+    nodes.Iir_Kind.Function_Declaration: {"kind": lsp.SymbolKind.Function},
+    nodes.Iir_Kind.Interface_Procedure_Declaration: {"kind": lsp.SymbolKind.Function},
+    nodes.Iir_Kind.Interface_Function_Declaration: {"kind": lsp.SymbolKind.Function},
+    nodes.Iir_Kind.Procedure_Body: {
+        "kind": lsp.SymbolKind.Function,
+        "detail": "(body)",
+    },
+    nodes.Iir_Kind.Function_Body: {"kind": lsp.SymbolKind.Function, "detail": "(body)"},
+    nodes.Iir_Kind.Type_Declaration: {"kind": lsp.SymbolKind.Constructor},
+    nodes.Iir_Kind.Subtype_Declaration: {"kind": lsp.SymbolKind.Constructor},
+    nodes.Iir_Kind.Attribute_Declaration: {"kind": lsp.SymbolKind.Property},
+    nodes.Iir_Kind.Attribute_Specification: {"kind": None},
+    nodes.Iir_Kind.Disconnection_Specification: {"kind": None},
+    nodes.Iir_Kind.Anonymous_Type_Declaration: {"kind": None},
+    nodes.Iir_Kind.Variable_Declaration: {"kind": lsp.SymbolKind.Variable},
+    nodes.Iir_Kind.Constant_Declaration: {"kind": lsp.SymbolKind.Constant},
+    nodes.Iir_Kind.Signal_Declaration: {"kind": lsp.SymbolKind.Variable},
+    nodes.Iir_Kind.Signal_Attribute_Declaration: {"kind": None},
+    nodes.Iir_Kind.File_Declaration: {"kind": lsp.SymbolKind.File},
+    nodes.Iir_Kind.Interface_Variable_Declaration: {"kind": lsp.SymbolKind.Variable},
+    nodes.Iir_Kind.Interface_Constant_Declaration: {"kind": lsp.SymbolKind.Constant},
+    nodes.Iir_Kind.Interface_Signal_Declaration: {"kind": lsp.SymbolKind.Variable},
+    nodes.Iir_Kind.Interface_File_Declaration: {"kind": lsp.SymbolKind.Variable},
+    nodes.Iir_Kind.File_Declaration: {"kind": lsp.SymbolKind.File},
+    nodes.Iir_Kind.Object_Alias_Declaration: {"kind": lsp.SymbolKind.Variable},
+    nodes.Iir_Kind.Non_Object_Alias_Declaration: {"kind": lsp.SymbolKind.Variable},
+    nodes.Iir_Kind.Protected_Type_Body: {"kind": lsp.SymbolKind.Class},
+    nodes.Iir_Kind.Group_Template_Declaration: {"kind": lsp.SymbolKind.Variable},
+    nodes.Iir_Kind.Group_Declaration: {"kind": lsp.SymbolKind.Variable},
+    nodes.Iir_Kind.Concurrent_Simple_Signal_Assignment: {"kind": None},
+    nodes.Iir_Kind.Concurrent_Conditional_Signal_Assignment: {"kind": None},
+    nodes.Iir_Kind.Concurrent_Selected_Signal_Assignment: {"kind": None},
+    nodes.Iir_Kind.Concurrent_Procedure_Call_Statement: {"kind": None},
+    nodes.Iir_Kind.Concurrent_Assertion_Statement: {"kind": None},
+    nodes.Iir_Kind.Component_Instantiation_Statement: {"kind": lsp.SymbolKind.Method},
+    nodes.Iir_Kind.Block_Statement: {"kind": lsp.SymbolKind.Method},
+    nodes.Iir_Kind.If_Generate_Statement: {"kind": lsp.SymbolKind.Method},
+    nodes.Iir_Kind.For_Generate_Statement: {"kind": lsp.SymbolKind.Method},
+    nodes.Iir_Kind.Case_Generate_Statement: {"kind": lsp.SymbolKind.Method},
+    nodes.Iir_Kind.Sensitized_Process_Statement: {"kind": lsp.SymbolKind.Method},
+    nodes.Iir_Kind.Process_Statement: {"kind": lsp.SymbolKind.Method},
+    nodes.Iir_Kind.Psl_Assert_Directive: {"kind": lsp.SymbolKind.Method},
+    nodes.Iir_Kind.Psl_Assume_Directive: {"kind": lsp.SymbolKind.Method},
+    nodes.Iir_Kind.Psl_Cover_Directive: {"kind": lsp.SymbolKind.Method},
+    nodes.Iir_Kind.Psl_Restrict_Directive: {"kind": lsp.SymbolKind.Method},
+    nodes.Iir_Kind.Psl_Endpoint_Declaration: {"kind": lsp.SymbolKind.Variable},
+    nodes.Iir_Kind.Psl_Declaration: {"kind": lsp.SymbolKind.Variable},
+    nodes.Iir_Kind.Psl_Assert_Directive: {"kind": lsp.SymbolKind.Method},
+    nodes.Iir_Kind.Configuration_Specification: {"kind": None},
 }
 
 
@@ -72,7 +78,7 @@ def location_to_position(fe, loc):
     assert loc != files_map.No_Location
     line = files_map.Location_File_To_Line(loc, fe)
     off = files_map.Location_File_Line_To_Offset(loc, fe, line)
-    return {'line': line - 1, 'character': off}
+    return {"line": line - 1, "character": off}
 
 
 def get_symbols_chain(fe, n):
@@ -89,11 +95,10 @@ def get_symbols(fe, n):
     m = SYMBOLS_MAP.get(k, None)
     if m is None:
         raise AssertionError("get_symbol: unhandled {}".format(pyutils.kind_image(k)))
-    kind = m['kind']
+    kind = m["kind"]
     if kind is None:
         return None
-    if k in [nodes.Iir_Kind.Procedure_Declaration,
-             nodes.Iir_Kind.Function_Declaration]:
+    if k in [nodes.Iir_Kind.Procedure_Declaration, nodes.Iir_Kind.Function_Declaration]:
         # Discard implicit declarations.
         if nodes.Get_Implicit_Definition(n) < nodes.Iir_Predefined.PNone:
             return None
@@ -101,13 +106,12 @@ def get_symbols(fe, n):
             # Use the body instead.
             # FIXME: but get interface from the spec!
             return None
-    res = {'kind': kind}
-    detail = m.get('detail')
+    res = {"kind": kind}
+    detail = m.get("detail")
     if detail is not None:
-        res['detail'] = detail
+        res["detail"] = detail
     # Get the name
-    if k in [nodes.Iir_Kind.Function_Body,
-             nodes.Iir_Kind.Procedure_Body]:
+    if k in [nodes.Iir_Kind.Function_Body, nodes.Iir_Kind.Procedure_Body]:
         nid = nodes.Get_Identifier(nodes.Get_Subprogram_Specification(n))
     else:
         nid = nodes.Get_Identifier(n)
@@ -116,15 +120,17 @@ def get_symbols(fe, n):
     else:
         name = pyutils.name_image(nid)
     # Get the range.  Use elocations when possible.
-    if k in (nodes.Iir_Kind.Architecture_Body,
-             nodes.Iir_Kind.Entity_Declaration,
-             nodes.Iir_Kind.Package_Declaration,
-             nodes.Iir_Kind.Package_Body,
-             nodes.Iir_Kind.Component_Declaration,
-             nodes.Iir_Kind.Process_Statement,
-             nodes.Iir_Kind.Sensitized_Process_Statement,
-             nodes.Iir_Kind.If_Generate_Statement,
-             nodes.Iir_Kind.For_Generate_Statement):
+    if k in (
+        nodes.Iir_Kind.Architecture_Body,
+        nodes.Iir_Kind.Entity_Declaration,
+        nodes.Iir_Kind.Package_Declaration,
+        nodes.Iir_Kind.Package_Body,
+        nodes.Iir_Kind.Component_Declaration,
+        nodes.Iir_Kind.Process_Statement,
+        nodes.Iir_Kind.Sensitized_Process_Statement,
+        nodes.Iir_Kind.If_Generate_Statement,
+        nodes.Iir_Kind.For_Generate_Statement,
+    ):
         start_loc = elocations.Get_Start_Location(n)
         end_loc = elocations.Get_End_Location(n)
         if end_loc == files_map.No_Location:
@@ -133,30 +139,39 @@ def get_symbols(fe, n):
     else:
         start_loc = nodes.Get_Location(n)
         end_loc = start_loc + name_table.Get_Name_Length(nid)
-    res['range'] = {'start': location_to_position(fe, start_loc),
-                    'end': location_to_position(fe, end_loc)}
+    res["range"] = {
+        "start": location_to_position(fe, start_loc),
+        "end": location_to_position(fe, end_loc),
+    }
 
     # Gather children.
     # FIXME: should we use a list of fields to inspect ?
     children = []
-    #if nodes_meta.Has_Generic_Chain(k):
+    # if nodes_meta.Has_Generic_Chain(k):
     #    children.extend(get_symbols_chain(fe, nodes.Get_Generic_Chain(n)))
-    #if nodes_meta.Has_Port_Chain(k):
+    # if nodes_meta.Has_Port_Chain(k):
     #    children.extend(get_symbols_chain(fe, nodes.Get_Port_Chain(n)))
-    #if nodes_meta.Has_Interface_Declaration_Chain(k):
+    # if nodes_meta.Has_Interface_Declaration_Chain(k):
     #    children.extend(get_symbols_chain(fe, nodes.Get_Interface_Declaration_Chain(n)))
     if k in (nodes.Iir_Kind.Package_Declaration, nodes.Iir_Kind.Package_Body):
         children.extend(get_symbols_chain(fe, nodes.Get_Declaration_Chain(n)))
     if nodes_meta.Has_Concurrent_Statement_Chain(k):
         children.extend(get_symbols_chain(fe, nodes.Get_Concurrent_Statement_Chain(n)))
     if nodes_meta.Has_Generate_Statement_Body(k):
-        children.extend(get_symbols_chain(fe, nodes.Get_Concurrent_Statement_Chain(nodes.Get_Generate_Statement_Body(n))))
+        children.extend(
+            get_symbols_chain(
+                fe,
+                nodes.Get_Concurrent_Statement_Chain(
+                    nodes.Get_Generate_Statement_Body(n)
+                ),
+            )
+        )
 
     if children:
-        res['children'] = children
+        res["children"] = children
     else:
         # Discard anonymous symbols without children.
         if name is None:
             return None
-    res['name'] = name if name is not None else '<anon>'
+    res["name"] = name if name is not None else "<anon>"
     return res

--- a/python/vhdl_langserver/version.py
+++ b/python/vhdl_langserver/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.1dev'
+__version__ = "0.1dev"

--- a/python/vhdl_langserver/vhdl_ls.py
+++ b/python/vhdl_langserver/vhdl_ls.py
@@ -12,23 +12,23 @@ class VhdlLanguageServer(object):
         self.lsp = None
         self._shutdown = False
         self.dispatcher = {
-            'initialize': self.initialize,
-            'initialized': self.initialized,
-            'shutdown': self.shutdown,
-            '$/setTraceNotification': self.setTraceNotification,
-            'textDocument/didOpen': self.textDocument_didOpen,
-            'textDocument/didChange': self.textDocument_didChange,
-            'textDocument/didClose': self.textDocument_didClose,
-            'textDocument/didSave': self.textDocument_didSave,
+            "initialize": self.initialize,
+            "initialized": self.initialized,
+            "shutdown": self.shutdown,
+            "$/setTraceNotification": self.setTraceNotification,
+            "textDocument/didOpen": self.textDocument_didOpen,
+            "textDocument/didChange": self.textDocument_didChange,
+            "textDocument/didClose": self.textDocument_didClose,
+            "textDocument/didSave": self.textDocument_didSave,
             # 'textDocument/hover': self.hover,
-            'textDocument/definition': self.textDocument_definition,
-            'textDocument/documentSymbol': self.textDocument_documentSymbol,
+            "textDocument/definition": self.textDocument_definition,
+            "textDocument/documentSymbol": self.textDocument_documentSymbol,
             # 'textDocument/completion': self.completion,
-            'textDocument/rangeFormatting': self.textDocument_rangeFormatting,
-            'workspace/xShowAllFiles': self.workspace_xShowAllFiles,
-            'workspace/xGetAllEntities': self.workspace_xGetAllEntities,
-            'workspace/xGetEntityInterface': self.workspace_xGetEntityInterface,
-            }
+            "textDocument/rangeFormatting": self.textDocument_rangeFormatting,
+            "workspace/xShowAllFiles": self.workspace_xShowAllFiles,
+            "workspace/xGetAllEntities": self.workspace_xGetAllEntities,
+            "workspace/xGetEntityInterface": self.workspace_xGetEntityInterface,
+        }
 
     def set_lsp(self, server):
         self.lsp = server
@@ -41,80 +41,91 @@ class VhdlLanguageServer(object):
 
     def capabilities(self):
         server_capabilities = {
-            'textDocumentSync': {
-                'openClose': True,
-                'change': lsp.TextDocumentSyncKind.INCREMENTAL,
-                'save': {
-                    'includeText': True}
-                },
-            'hoverProvider': False,
+            "textDocumentSync": {
+                "openClose": True,
+                "change": lsp.TextDocumentSyncKind.INCREMENTAL,
+                "save": {"includeText": True},
+            },
+            "hoverProvider": False,
             #            'completionProvider': False,
             #            'signatureHelpProvider': {
             #                'triggerCharacters': ['(', ',']
             #            },
-            'definitionProvider': True,
-            'referencesProvider': False,
-            'documentHighlightProvider': False,
-            'documentSymbolProvider': True,
-            'codeActionProvider': False,
-            'documentFormattingProvider': False,
-            'documentRangeFormattingProvider': True,
-            'renameProvider': False,
+            "definitionProvider": True,
+            "referencesProvider": False,
+            "documentHighlightProvider": False,
+            "documentSymbolProvider": True,
+            "codeActionProvider": False,
+            "documentFormattingProvider": False,
+            "documentRangeFormattingProvider": True,
+            "renameProvider": False,
         }
         return server_capabilities
 
-    def initialize(self, processId, rootPath, capabilities, rootUri=None,
-                   initializationOptions=None, **_):
-        log.debug('Language server initialized with %s %s %s %s',
-                  processId, rootUri, rootPath, initializationOptions)
+    def initialize(
+        self,
+        processId,
+        rootPath,
+        capabilities,
+        rootUri=None,
+        initializationOptions=None,
+        **_
+    ):
+        log.debug(
+            "Language server initialized with %s %s %s %s",
+            processId,
+            rootUri,
+            rootPath,
+            initializationOptions,
+        )
         if rootUri is None:
-            rootUri = lsp.path_to_uri(rootPath) if rootPath is not None else ''
+            rootUri = lsp.path_to_uri(rootPath) if rootPath is not None else ""
         self.workspace = Workspace(rootUri, self.lsp)
 
         # Get our capabilities
-        return {'capabilities': self.capabilities()}
+        return {"capabilities": self.capabilities()}
 
     def initialized(self):
         # Event when the client is fully initialized.
         return None
 
     def textDocument_didOpen(self, textDocument=None):
-        doc_uri = textDocument['uri']
-        self.workspace.put_document(doc_uri, textDocument['text'],
-                                    version=textDocument.get('version'))
+        doc_uri = textDocument["uri"]
+        self.workspace.put_document(
+            doc_uri, textDocument["text"], version=textDocument.get("version")
+        )
         self.lint(doc_uri)
 
-    def textDocument_didChange(self, textDocument=None, contentChanges=None,
-                               **_kwargs):
-        doc_uri = textDocument['uri']
-        new_version = textDocument.get('version')
+    def textDocument_didChange(self, textDocument=None, contentChanges=None, **_kwargs):
+        doc_uri = textDocument["uri"]
+        new_version = textDocument.get("version")
         self.workspace.apply_changes(doc_uri, contentChanges, new_version)
 
     def lint(self, doc_uri):
         self.workspace.lint(doc_uri)
 
     def textDocument_didClose(self, textDocument=None, **_kwargs):
-        self.workspace.rm_document(textDocument['uri'])
+        self.workspace.rm_document(textDocument["uri"])
 
     def textDocument_didSave(self, textDocument=None, text=None, **_kwargs):
         if text is not None:
             # Sanity check: check we have the same content for the document.
-            self.workspace.check_document(textDocument['uri'], text)
+            self.workspace.check_document(textDocument["uri"], text)
         else:
             log.debug("did save - no text")
-        self.lint(textDocument['uri'])
+        self.lint(textDocument["uri"])
 
     def textDocument_definition(self, textDocument=None, position=None):
-        return self.workspace.goto_definition(textDocument['uri'], position)
+        return self.workspace.goto_definition(textDocument["uri"], position)
 
     def textDocument_documentSymbol(self, textDocument=None):
-        doc = self.workspace.get_or_create_document(textDocument['uri'])
+        doc = self.workspace.get_or_create_document(textDocument["uri"])
         return doc.document_symbols()
 
     def textDocument_rangeFormatting(self, textDocument=None, range=None, options=None):
-        doc_uri = textDocument['uri']
+        doc_uri = textDocument["uri"]
         doc = self.workspace.get_document(doc_uri)
-        assert doc is not None, 'Try to format a non-loaded document'
+        assert doc is not None, "Try to format a non-loaded document"
         res = doc.format_range(range)
         if res is not None:
             self.lint(doc_uri)

--- a/python/vhdl_langserver/workspace.py
+++ b/python/vhdl_langserver/workspace.py
@@ -24,6 +24,7 @@ log = logging.getLogger(__name__)
 
 class ProjectError(Exception):
     "Exception raised in case of unrecoverable error in the project file."
+
     def __init__(self, msg):
         super().__init__()
         self.msg = msg
@@ -34,13 +35,13 @@ class Workspace(object):
         self._root_uri = root_uri
         self._server = server
         self._root_path = lsp.path_from_uri(self._root_uri)
-        self._docs = {}     # uri -> doc
-        self._fe_map = {}   # fe -> doc
+        self._docs = {}  # uri -> doc
+        self._fe_map = {}  # fe -> doc
         self._prj = {}
         self._last_linted_doc = None
         errorout_memory.Install_Handler()
         libghdl.thin.flags.Flag_Elocations.value = True
-        #thin.Flags.Verbose.value = True
+        # thin.Flags.Verbose.value = True
         # We do analysis even in case of errors.
         libghdl.thin.vhdl.parse.Flag_Parse_Parenthesis.value = True
         # Force analysis to get more feedback + navigation even in case
@@ -52,7 +53,7 @@ class Workspace(object):
         self.read_project()
         self.set_options_from_project()
         libghdl.analyze_init()
-        self._diags_set = set() # Documents with at least one diagnostic.
+        self._diags_set = set()  # Documents with at least one diagnostic.
         self.read_files_from_project()
         self.gather_diagnostics(None)
 
@@ -89,7 +90,9 @@ class Workspace(object):
         path = lsp.path_from_uri(doc_uri)
         if source is None:
             source = open(path).read()
-        sfe = document.Document.load(source, os.path.dirname(path), os.path.basename(path))
+        sfe = document.Document.load(
+            source, os.path.dirname(path), os.path.basename(path)
+        )
         return self._create_document(doc_uri, sfe)
 
     def get_or_create_document(self, doc_uri):
@@ -143,14 +146,14 @@ class Workspace(object):
             fd.close()
         except OSError as err:
             self._server.show_message(
-                lsp.MessageType.Error,
-                "cannot load {}: {}".format(name, err.strerror))
+                lsp.MessageType.Error, "cannot load {}: {}".format(name, err.strerror)
+            )
             return
         doc = self.create_document_from_sfe(sfe, absname)
         doc.parse_document()
 
     def read_project(self):
-        prj_file = os.path.join(self.root_path, 'hdl-prj.json')
+        prj_file = os.path.join(self.root_path, "hdl-prj.json")
         if not os.path.exists(prj_file):
             log.info("project file %s does not exist", prj_file)
             return
@@ -159,7 +162,8 @@ class Workspace(object):
         except OSError as err:
             self._server.show_message(
                 lsp.MessageType.Error,
-                "cannot open project file {}: {}".format(prj_file, err.strerror))
+                "cannot open project file {}: {}".format(prj_file, err.strerror),
+            )
             return
         log.info("reading project file %s", prj_file)
         try:
@@ -169,7 +173,9 @@ class Workspace(object):
             self._server.show_message(
                 lsp.MessageType.Error,
                 "json error in project file {}:{}:{}".format(
-                    prj_file, e.lineno, e.colno))
+                    prj_file, e.lineno, e.colno
+                ),
+            )
         f.close()
 
     def set_options_from_project(self):
@@ -178,43 +184,48 @@ class Workspace(object):
                 return
             if not isinstance(self._prj, dict):
                 raise ProjectError("project file is not a dictionnary")
-            opts = self._prj.get('options', None)
+            opts = self._prj.get("options", None)
             if opts is None:
                 return
             if not isinstance(opts, dict):
                 raise ProjectError("'options' is not a dictionnary")
-            ghdl_opts = opts.get('ghdl_analysis', None)
+            ghdl_opts = opts.get("ghdl_analysis", None)
             if ghdl_opts is None:
                 return
             log.info("Using options: %s", ghdl_opts)
             for opt in ghdl_opts:
-                if not libghdl.set_option(opt.encode('utf-8')):
-                    self._server.show_message(lsp.MessageType.Error,
-                        "error with option: {}".format(opt))
+                if not libghdl.set_option(opt.encode("utf-8")):
+                    self._server.show_message(
+                        lsp.MessageType.Error, "error with option: {}".format(opt)
+                    )
         except ProjectError as e:
-            self._server.show_message(lsp.MessageType.Error,
-                "error in project file: {}".format(e.msg))
+            self._server.show_message(
+                lsp.MessageType.Error, "error in project file: {}".format(e.msg)
+            )
 
     def read_files_from_project(self):
         try:
-            files = self._prj.get('files', [])
+            files = self._prj.get("files", [])
             if not isinstance(files, list):
                 raise ProjectError("'files' is not a list")
             for f in files:
                 if not isinstance(f, dict):
                     raise ProjectError("an element of 'files' is not a dict")
-                name = f.get('file')
+                name = f.get("file")
                 if not isinstance(name, str):
                     raise ProjectError("a 'file' is not a string")
-                lang = f.get('language', 'vhdl')
-                if lang == 'vhdl':
+                lang = f.get("language", "vhdl")
+                if lang == "vhdl":
                     self.add_vhdl_file(name)
         except ProjectError as e:
-            self._server.show_message(lsp.MessageType.Error,
-                "error in project file: {}".format(e.msg))
+            self._server.show_message(
+                lsp.MessageType.Error, "error in project file: {}".format(e.msg)
+            )
 
     def get_configuration(self):
-        self._server.configuration([{'scopeUri': '', 'section': 'vhdl.maxNumberOfProblems'}])
+        self._server.configuration(
+            [{"scopeUri": "", "section": "vhdl.maxNumberOfProblems"}]
+        )
 
     def gather_diagnostics(self, doc):
         # Gather messages (per file)
@@ -222,15 +233,14 @@ class Workspace(object):
         diags = {}
         diag = {}
         for i in range(nbr_msgs):
-            hdr = errorout_memory.Get_Error_Record(i+1)
-            msg = errorout_memory.Get_Error_Message(i+1).decode('utf-8')
+            hdr = errorout_memory.Get_Error_Record(i + 1)
+            msg = errorout_memory.Get_Error_Message(i + 1).decode("utf-8")
             if hdr.file == 0:
                 # Possible for error limit reached.
                 continue
             err_range = {
-                'start': {'line': hdr.line - 1, 'character': hdr.offset},
-                'end': {'line': hdr.line - 1,
-                        'character': hdr.offset + hdr.length},
+                "start": {"line": hdr.line - 1, "character": hdr.offset},
+                "end": {"line": hdr.line - 1, "character": hdr.offset + hdr.length},
             }
             if hdr.group <= errorout_memory.Msg_Main:
                 if hdr.id <= errorout.Msgid.Msgid_Note:
@@ -239,12 +249,14 @@ class Workspace(object):
                     severity = lsp.DiagnosticSeverity.Warning
                 else:
                     severity = lsp.DiagnosticSeverity.Error
-                diag = {'source': 'ghdl',
-                        'range': err_range,
-                        'message': msg,
-                        'severity': severity}
+                diag = {
+                    "source": "ghdl",
+                    "range": err_range,
+                    "message": msg,
+                    "severity": severity,
+                }
                 if hdr.group == errorout_memory.Msg_Main:
-                    diag['relatedInformation'] = []
+                    diag["relatedInformation"] = []
                 fdiag = diags.get(hdr.file, None)
                 if fdiag is None:
                     diags[hdr.file] = [diag]
@@ -254,9 +266,12 @@ class Workspace(object):
                 assert diag
                 if True:
                     doc = self.sfe_to_document(hdr.file)
-                    diag['relatedInformation'].append(
-                        {'location': {'uri': doc.uri, 'range': err_range},
-                         'message': msg})
+                    diag["relatedInformation"].append(
+                        {
+                            "location": {"uri": doc.uri, "range": err_range},
+                            "message": msg,
+                        }
+                    )
         errorout_memory.Clear_Errors()
         # Publish diagnostics
         for sfe, diag in diags.items():
@@ -275,7 +290,9 @@ class Workspace(object):
         # Avoid infinite recursion
         antideps[unit] = None
         for un in udeps:
-            log.debug("obsolete %d %s", un, pyutils.name_image(nodes.Get_Identifier(un)))
+            log.debug(
+                "obsolete %d %s", un, pyutils.name_image(nodes.Get_Identifier(un))
+            )
             # Recurse
             self.obsolete_dependent_units(un, antideps)
             if nodes.Set_Date_State(un) == nodes.Date_State.Disk:
@@ -319,7 +336,7 @@ class Workspace(object):
 
     def apply_changes(self, doc_uri, contentChanges, new_version):
         doc = self.get_document(doc_uri)
-        assert doc is not None, 'try to modify a non-loaded document'
+        assert doc is not None, "try to modify a non-loaded document"
         self.obsolete_doc(doc)
         prev_sfe = doc._fe
         for change in contentChanges:
@@ -338,15 +355,18 @@ class Workspace(object):
         pass
 
     def apply_edit(self, edit):
-        return self._server.request('workspace/applyEdit', {'edit': edit})
+        return self._server.request("workspace/applyEdit", {"edit": edit})
 
     def publish_diagnostics(self, doc_uri, diagnostics):
-        self._server.notify('textDocument/publishDiagnostics',
-                            params={'uri': doc_uri, 'diagnostics': diagnostics})
+        self._server.notify(
+            "textDocument/publishDiagnostics",
+            params={"uri": doc_uri, "diagnostics": diagnostics},
+        )
 
     def show_message(self, message, msg_type=lsp.MessageType.Info):
-        self._server.notify('window/showMessage',
-                            params={'type': msg_type, 'message': message})
+        self._server.notify(
+            "window/showMessage", params={"type": msg_type, "message": message}
+        )
 
     def declaration_to_location(self, decl):
         "Convert declaration :param decl: to an LSP Location"
@@ -359,10 +379,14 @@ class Workspace(object):
             return None
         fe = files_map.Location_To_File(decl_loc)
         doc = self.sfe_to_document(fe)
-        res = {'uri': doc.uri}
+        res = {"uri": doc.uri}
         nid = nodes.Get_Identifier(decl)
-        res['range'] = {'start': symbols.location_to_position(fe, decl_loc),
-                        'end': symbols.location_to_position(fe, decl_loc + name_table.Get_Name_Length(nid))}
+        res["range"] = {
+            "start": symbols.location_to_position(fe, decl_loc),
+            "end": symbols.location_to_position(
+                fe, decl_loc + name_table.Get_Name_Length(nid)
+            ),
+        }
         return res
 
     def goto_definition(self, doc_uri, position):
@@ -383,10 +407,14 @@ class Workspace(object):
         res = []
         for fe in range(1, files_map.Get_Last_Source_File_Entry() + 1):
             doc = self._fe_map.get(fe, None)
-            res.append({'fe': fe,
-                        'uri': doc.uri if doc is not None else None,
-                        'name': pyutils.name_image(files_map.Get_File_Name(fe)),
-                        'dir': pyutils.name_image(files_map.Get_Directory_Name(fe))})
+            res.append(
+                {
+                    "fe": fe,
+                    "uri": doc.uri if doc is not None else None,
+                    "name": pyutils.name_image(files_map.Get_File_Name(fe)),
+                    "dir": pyutils.name_image(files_map.Get_Directory_Name(fe)),
+                }
+            )
         return res
 
     def x_get_all_entities(self):
@@ -405,7 +433,7 @@ class Workspace(object):
                 files = nodes.Get_Chain(files)
             ents = [pyutils.name_image(nodes.Get_Identifier(e)) for e in ents]
             lib_name = pyutils.name_image(nodes.Get_Identifier(lib))
-            res.extend([{'name': n, 'library': lib_name} for n in ents])
+            res.extend([{"name": n, "library": lib_name} for n in ents])
             lib = nodes.Get_Chain(lib)
         return res
 
@@ -413,24 +441,33 @@ class Workspace(object):
         def create_interfaces(inters):
             res = []
             while inters != nodes.Null_Iir:
-                res.append({'name': name_table.Get_Name_Ptr(nodes.Get_Identifier(inters)).decode('latin-1')})
+                res.append(
+                    {
+                        "name": name_table.Get_Name_Ptr(
+                            nodes.Get_Identifier(inters)
+                        ).decode("latin-1")
+                    }
+                )
                 inters = nodes.Get_Chain(inters)
             return res
+
         # Find library
-        lib_id = name_table.Get_Identifier(library.encode('utf-8'))
+        lib_id = name_table.Get_Identifier(library.encode("utf-8"))
         lib = libraries.Get_Library_No_Create(lib_id)
         if lib == name_table.Null_Identifier:
             return None
         # Find entity
-        ent_id = name_table.Get_Identifier(name.encode('utf-8'))
+        ent_id = name_table.Get_Identifier(name.encode("utf-8"))
         unit = libraries.Find_Primary_Unit(lib, ent_id)
         if unit == nodes.Null_Iir:
             return None
         ent = nodes.Get_Library_Unit(unit)
-        return {'library': library,
-                'entity': name,
-                'generics': create_interfaces(nodes.Get_Generic_Chain(ent)),
-                'ports': create_interfaces(nodes.Get_Port_Chain(ent))}
+        return {
+            "library": library,
+            "entity": name,
+            "generics": create_interfaces(nodes.Get_Generic_Chain(ent)),
+            "ports": create_interfaces(nodes.Get_Port_Chain(ent)),
+        }
 
     def compute_anti_dependences(self):
         """Return a dictionnary of anti dependencies for design unit"""

--- a/python/xtools/pnodes.py
+++ b/python/xtools/pnodes.py
@@ -13,12 +13,11 @@ prefix_name = "Iir_Kind_"
 prefix_range_name = "Iir_Kinds_"
 type_name = "Iir_Kind"
 node_type = "Iir"
-conversions = ['uc', 'pos', 'grp']
+conversions = ["uc", "pos", "grp"]
 
 
 class FuncDesc:
-    def __init__(self, name, fields, conv, acc,
-                 pname, ptype, rname, rtype):
+    def __init__(self, name, fields, conv, acc, pname, ptype, rname, rtype):
         self.name = name
         self.fields = fields  # List of physical fields used
         self.conv = conv
@@ -35,8 +34,8 @@ class NodeDesc:
         self.name = name
         self.format = format
         self.fields = fields  # {field: FuncDesc} dict, defined for all fields
-        self.attrs = attrs    # A {attr: FuncDesc} dict
-        self.order = []       # List of fields name, in order of appearance.
+        self.attrs = attrs  # A {attr: FuncDesc} dict
+        self.order = []  # List of fields name, in order of appearance.
 
 
 class line:
@@ -58,7 +57,7 @@ class linereader:
         self.filename = filename
         self.f = open(filename)
         self.lineno = 0
-        self.l = ''
+        self.l = ""
 
     def get(self):
         self.l = self.f.readline()
@@ -74,9 +73,10 @@ class ParseError(Exception):
         self.msg = msg
 
     def __str__(self):
-        return 'Error: ' + self.msg
-        return 'Parse error at ' + self.lr.filname + ':' + self.lr.lineno + \
-               ': ' + self.msg
+        return "Error: " + self.msg
+        return (
+            "Parse error at " + self.lr.filname + ":" + self.lr.lineno + ": " + self.msg
+        )
 
 
 # Return fields description.
@@ -89,21 +89,21 @@ def read_fields(file):
     lr = linereader(file)
 
     #  Search for 'type Format_Type is'
-    while lr.get() != '   type Format_Type is\n':
+    while lr.get() != "   type Format_Type is\n":
         pass
 
     # Skip '('
-    if lr.get() != '     (\n':
-        raise 'no open parenthesis after Format_Type'
+    if lr.get() != "     (\n":
+        raise "no open parenthesis after Format_Type"
 
     # Read formats
     l = lr.get()
-    pat_field_name = re.compile('      Format_(\w+),?\n')
-    while l != '     );\n':
+    pat_field_name = re.compile("      Format_(\w+),?\n")
+    while l != "     );\n":
         m = pat_field_name.match(l)
         if m is None:
             print l
-            raise 'bad literal within Format_Type'
+            raise "bad literal within Format_Type"
         name = m.group(1)
         formats.append(name)
         fields[name] = {}
@@ -111,15 +111,15 @@ def read_fields(file):
 
     # Read fields
     l = lr.get()
-    pat_fields = re.compile('   -- Fields of Format_(\w+):\n')
-    pat_field_desc = re.compile('   --   (\w+) : (\w+).*\n')
-    format_name = ''
+    pat_fields = re.compile("   -- Fields of Format_(\w+):\n")
+    pat_field_desc = re.compile("   --   (\w+) : (\w+).*\n")
+    format_name = ""
     common_desc = {}
 
     # Read until common fields.
-    while l != '   -- Common fields are:\n':
+    while l != "   -- Common fields are:\n":
         l = lr.get()
-    format_name = 'Common'
+    format_name = "Common"
     nbr_formats = 0
 
     while True:
@@ -135,13 +135,13 @@ def read_fields(file):
             # print 'For: ' + format_name + ': ' + m.group(1)
 
         # 2) Disp
-        if format_name == 'Common':
+        if format_name == "Common":
             common_desc = desc
         else:
             fields[format_name] = desc
 
         # 3) Read next format
-        if l == '\n':
+        if l == "\n":
             if nbr_formats == len(fields):
                 break
             else:
@@ -152,11 +152,10 @@ def read_fields(file):
         if m is not None:
             format_name = m.group(1)
             if format_name not in fields:
-                raise ParseError(
-                    lr, 'Format ' + format_name + ' is unknown')
+                raise ParseError(lr, "Format " + format_name + " is unknown")
             nbr_formats = nbr_formats + 1
         else:
-            raise ParseError(lr, 'unhandled format line')
+            raise ParseError(lr, "unhandled format line")
 
     return (formats, fields)
 
@@ -166,19 +165,18 @@ def read_kinds(filename):
     lr = linereader(filename)
     kinds = []
     #  Search for 'type Iir_Kind is'
-    while lr.get() != '   type ' + type_name + ' is\n':
+    while lr.get() != "   type " + type_name + " is\n":
         pass
     # Skip '('
-    if lr.get() != '     (\n':
-        raise ParseError(
-            lr, 'no open parenthesis after "type ' + type_name + '"')
+    if lr.get() != "     (\n":
+        raise ParseError(lr, 'no open parenthesis after "type ' + type_name + '"')
 
     # Read literals
-    pat_node = re.compile('      ' + prefix_name + '(\w+),?( +-- .*)?\n')
-    pat_comment = re.compile('( +-- .*)?\n')
+    pat_node = re.compile("      " + prefix_name + "(\w+),?( +-- .*)?\n")
+    pat_comment = re.compile("( +-- .*)?\n")
     while True:
         l = lr.get()
-        if l == '     );\n':
+        if l == "     );\n":
             break
         m = pat_node.match(l)
         if m:
@@ -186,19 +184,18 @@ def read_kinds(filename):
             continue
         m = pat_comment.match(l)
         if not m:
-            raise ParseError(lr, 'Unknown line within kind declaration')
+            raise ParseError(lr, "Unknown line within kind declaration")
 
     # Check subtypes
-    pat_subtype = re.compile('   subtype ' + r'(\w+) is '
-                              + type_name + ' range\n')
-    pat_first = re.compile('     ' + prefix_name + r'(\w+) ..\n')
-    pat_last = re.compile('     ' + prefix_name + r'(\w+);\n')
-    pat_middle = re.compile('   --' + prefix_name + r'(\w+)\n')
+    pat_subtype = re.compile("   subtype " + r"(\w+) is " + type_name + " range\n")
+    pat_first = re.compile("     " + prefix_name + r"(\w+) ..\n")
+    pat_last = re.compile("     " + prefix_name + r"(\w+);\n")
+    pat_middle = re.compile("   --" + prefix_name + r"(\w+)\n")
     kinds_ranges = {}
     while True:
         l = lr.get()
         # Start of methods is also end of subtypes.
-        if l == '   -- General methods.\n':
+        if l == "   -- General methods.\n":
             break
         # Found a subtype.
         m = pat_subtype.match(l)
@@ -206,12 +203,12 @@ def read_kinds(filename):
             # Check first bound
             name = m.group(1)
             if not name.startswith(prefix_range_name):
-                raise ParseError(lr, 'incorrect prefix for subtype')
-            name = name[len(prefix_range_name):]
+                raise ParseError(lr, "incorrect prefix for subtype")
+            name = name[len(prefix_range_name) :]
             l = lr.get()
             mf = pat_first.match(l)
             if not mf:
-                raise ParseError(lr, 'badly formated first bound of subtype')
+                raise ParseError(lr, "badly formated first bound of subtype")
             first = kinds.index(mf.group(1))
             idx = first
             has_middle = None
@@ -223,11 +220,11 @@ def read_kinds(filename):
                     # Check element in the middle
                     n = ml.group(1)
                     if n not in kinds:
-                        raise ParseError(
-                            lr, "unknown kind " + n + " in subtype")
+                        raise ParseError(lr, "unknown kind " + n + " in subtype")
                     if kinds.index(n) != idx + 1:
                         raise ParseError(
-                            lr, "missing " + kinds[idx + 1] + " in subtype")
+                            lr, "missing " + kinds[idx + 1] + " in subtype"
+                        )
                     has_middle = True
                     idx = idx + 1
                 else:
@@ -237,27 +234,27 @@ def read_kinds(filename):
                         last = kinds.index(ml.group(1))
                         if last != idx + 1 and has_middle:
                             raise ParseError(
-                                lr, "missing " + kinds[idx] + " in subtype")
+                                lr, "missing " + kinds[idx] + " in subtype"
+                            )
                         break
                     raise ParseError(lr, "unhandled line in subtype")
-            kinds_ranges[name] = kinds[first:last+1]
+            kinds_ranges[name] = kinds[first : last + 1]
     return (kinds, kinds_ranges)
+
 
 # Read functions
 def read_methods(filename):
     lr = linereader(filename)
     funcs = []
-    pat_field = re.compile(r'   --  Field: ([\w,]+)( \w+)?( \(\w+\))?\n')
-    pat_conv = re.compile(r'^ \((\w+)\)$')
-    pat_func = re.compile(
-        r'   function Get_(\w+) \((\w+) : (\w+)\) return (\w+);\n')
-    pat_proc = re.compile(
-        r'   procedure Set_(\w+) \((\w+) : (\w+); (\w+) : (\w+)\);\n')
-    pat_end = re.compile('end [A-Za-z.]+;\n')
+    pat_field = re.compile(r"   --  Field: ([\w,]+)( \w+)?( \(\w+\))?\n")
+    pat_conv = re.compile(r"^ \((\w+)\)$")
+    pat_func = re.compile(r"   function Get_(\w+) \((\w+) : (\w+)\) return (\w+);\n")
+    pat_proc = re.compile(r"   procedure Set_(\w+) \((\w+) : (\w+); (\w+) : (\w+)\);\n")
+    pat_end = re.compile("end [A-Za-z.]+;\n")
     while True:
         l = lr.get()
         # Start of methods
-        if l == '   -- General methods.\n':
+        if l == "   -- General methods.\n":
             break
     while True:
         l = lr.get()
@@ -265,7 +262,7 @@ def read_methods(filename):
             break
         m = pat_field.match(l)
         if m:
-            fields = m.group(1).split(',')
+            fields = m.group(1).split(",")
             # Extract access modifier
             acc = m.group(2)
             if acc:
@@ -275,38 +272,45 @@ def read_methods(filename):
             if conv:
                 mc = pat_conv.match(conv)
                 if not mc:
-                    raise ParseError(lr, 'conversion ill formed')
+                    raise ParseError(lr, "conversion ill formed")
                 conv = mc.group(1)
                 if conv not in conversions:
-                    raise ParseError(lr, 'unknown conversion ' + conv)
+                    raise ParseError(lr, "unknown conversion " + conv)
             else:
                 conv = None
-            if len(fields) > 1 and conv != 'grp':
-                raise ParseError(lr, 'bad conversion for multiple fields')
+            if len(fields) > 1 and conv != "grp":
+                raise ParseError(lr, "bad conversion for multiple fields")
             # Read function
             l = lr.get()
             mf = pat_func.match(l)
             if not mf:
-                raise ParseError(
-                    lr, 'function declaration expected after Field')
+                raise ParseError(lr, "function declaration expected after Field")
             # Read procedure
             l = lr.get()
             mp = pat_proc.match(l)
             if not mp:
-                raise ParseError(
-                    lr, 'procedure declaration expected after function')
+                raise ParseError(lr, "procedure declaration expected after function")
             # Consistency check between function and procedure
             if mf.group(1) != mp.group(1):
-                raise ParseError(lr, 'function and procedure name mismatch')
+                raise ParseError(lr, "function and procedure name mismatch")
             if mf.group(2) != mp.group(2):
-                raise ParseError(lr, 'parameter name mismatch with function')
+                raise ParseError(lr, "parameter name mismatch with function")
             if mf.group(3) != mp.group(3):
-                raise ParseError(lr, 'parameter type mismatch with function')
+                raise ParseError(lr, "parameter type mismatch with function")
             if mf.group(4) != mp.group(5):
-                raise ParseError(lr, 'result type mismatch with function')
-            funcs.append(FuncDesc(mf.group(1), fields, conv, acc,
-                                  mp.group(2), mp.group(3),
-                                  mp.group(4), mp.group(5)))
+                raise ParseError(lr, "result type mismatch with function")
+            funcs.append(
+                FuncDesc(
+                    mf.group(1),
+                    fields,
+                    conv,
+                    acc,
+                    mp.group(2),
+                    mp.group(3),
+                    mp.group(4),
+                    mp.group(5),
+                )
+            )
 
     return funcs
 
@@ -316,10 +320,10 @@ def read_methods(filename):
 #  (one description may describe several nodes).
 # A comment start at column 2 or 4 or later.
 def read_nodes_fields(lr, names, fields, nodes, funcs_dict):
-    pat_only = re.compile('   -- Only for ' + prefix_name + '(\w+):\n')
-    pat_only_bad = re.compile ('   -- *Only for.*\n')
-    pat_field = re.compile('   --   Get/Set_(\w+) \((Alias )?([\w,]+)\)\n')
-    pat_comment = re.compile('   --(|  [^ ].*|    .*)\n')
+    pat_only = re.compile("   -- Only for " + prefix_name + "(\w+):\n")
+    pat_only_bad = re.compile("   -- *Only for.*\n")
+    pat_field = re.compile("   --   Get/Set_(\w+) \((Alias )?([\w,]+)\)\n")
+    pat_comment = re.compile("   --(|  [^ ].*|    .*)\n")
 
     # Create nodes
     cur_nodes = []
@@ -336,7 +340,7 @@ def read_nodes_fields(lr, names, fields, nodes, funcs_dict):
         l = lr.get()
 
     # Look for fields
-    while l != '\n':
+    while l != "\n":
         # Skip comments
         while pat_comment.match(l):
             l = lr.get()
@@ -349,9 +353,9 @@ def read_nodes_fields(lr, names, fields, nodes, funcs_dict):
                 name = m.group(1)
                 n = nodes.get(name, None)
                 if n is None:
-                    raise ParseError(lr, 'node is unknown')
+                    raise ParseError(lr, "node is unknown")
                 if n not in cur_nodes:
-                    raise ParseError(lr, 'node not currently described')
+                    raise ParseError(lr, "node not currently described")
                 only_nodes.append(n)
                 l = lr.get()
                 m = pat_only.match(l)
@@ -371,29 +375,27 @@ def read_nodes_fields(lr, names, fields, nodes, funcs_dict):
             if pat_only_bad.match(l):
                 raise ParseError(lr, "misleading 'Only for' comment")
             else:
-                raise ParseError(lr, 'bad line in node description')
+                raise ParseError(lr, "bad line in node description")
 
         func = m.group(1)
         alias = m.group(2)
-        fields = m.group(3).split(',')
+        fields = m.group(3).split(",")
 
         # Check the function exists and if the field is correct.
         if func not in funcs_dict:
-            raise ParseError(lr, 'unknown function')
+            raise ParseError(lr, "unknown function")
         func = funcs_dict[func]
         if func.fields != fields:
-            raise ParseError(lr, 'fields mismatch')
+            raise ParseError(lr, "fields mismatch")
 
         for c in only_nodes:
             for f in fields:
                 if f not in c.fields:
-                    raise ParseError(
-                        lr, 'field ' + f + ' does not exist in node')
+                    raise ParseError(lr, "field " + f + " does not exist in node")
             if not alias:
                 for f in fields:
                     if c.fields[f]:
-                        raise ParseError(
-                            lr, 'field ' + f + ' already used')
+                        raise ParseError(lr, "field " + f + " already used")
                     c.fields[f] = func
                     c.order.append(f)
             c.attrs[func.name] = func
@@ -408,18 +410,18 @@ def read_nodes(filename, kinds, kinds_ranges, fields, funcs):
     nodes = {}
 
     # Skip until start
-    while lr.get() != '   -- Start of ' + type_name + '.\n':
+    while lr.get() != "   -- Start of " + type_name + ".\n":
         pass
 
-    pat_decl = re.compile('   -- ' + prefix_name + '(\w+) \((\w+)\)\n')
-    pat_decls = re.compile('   -- ' + prefix_range_name + '(\w+) \((\w+)\)\n')
-    pat_comment_line = re.compile('   --+\n')
-    pat_comment_box = re.compile('   --(  .*)?\n')
+    pat_decl = re.compile("   -- " + prefix_name + "(\w+) \((\w+)\)\n")
+    pat_decls = re.compile("   -- " + prefix_range_name + "(\w+) \((\w+)\)\n")
+    pat_comment_line = re.compile("   --+\n")
+    pat_comment_box = re.compile("   --(  .*)?\n")
     while True:
         l = lr.get()
-        if l == '   -- End of ' + type_name + '.\n':
+        if l == "   -- End of " + type_name + ".\n":
             break
-        if l == '\n':
+        if l == "\n":
             continue
         m = pat_decl.match(l)
         if m:
@@ -430,12 +432,11 @@ def read_nodes(filename, kinds, kinds_ranges, fields, funcs):
             while True:
                 name = m.group(1)
                 if name not in kinds:
-                    raise ParseError(lr, 'unknown node')
+                    raise ParseError(lr, "unknown node")
                 fmt = m.group(2)
                 names.append((name, fmt))
                 if name in nodes:
-                    raise ParseError(
-                        lr, 'node {} already described'.format(name));
+                    raise ParseError(lr, "node {} already described".format(name))
                 # There might be several nodes described at once.
                 l = lr.get()
                 m = pat_decl.match(l)
@@ -454,7 +455,7 @@ def read_nodes(filename, kinds, kinds_ranges, fields, funcs):
             continue
         if pat_comment_line.match(l) or pat_comment_box.match(l):
             continue
-        raise ParseError(lr, 'bad line in node description')
+        raise ParseError(lr, "bad line in node description")
 
     for k in kinds:
         if k not in nodes:
@@ -467,51 +468,50 @@ def gen_choices(choices):
     is_first = True
     for c in choices:
         if is_first:
-            print '        ',
-            print 'when',
+            print "        ",
+            print "when",
         else:
             print
-            print '        ',
-            print '  |',
+            print "        ",
+            print "  |",
         print prefix_name + c,
         is_first = False
-    print '=>'
+    print "=>"
 
 
 def gen_get_format(formats, nodes, kinds):
     """Generate the Get_Format function."""
-    print '   function Get_Format (Kind : ' + type_name + ') ' + \
-          'return Format_Type is'
-    print '   begin'
-    print '      case Kind is'
+    print "   function Get_Format (Kind : " + type_name + ") " + "return Format_Type is"
+    print "   begin"
+    print "      case Kind is"
     for f in formats:
         choices = [k for k in kinds if nodes[k].format == f]
         gen_choices(choices)
-        print '            return Format_' + f + ';'
-    print '      end case;'
-    print '   end Get_Format;'
+        print "            return Format_" + f + ";"
+    print "      end case;"
+    print "   end Get_Format;"
 
 
 def gen_subprg_header(decl):
     if len(decl) < 76:
-        print decl + ' is'
+        print decl + " is"
     else:
         print decl
-        print '   is'
-    print '   begin'
+        print "   is"
+    print "   begin"
 
 
 def gen_assert(func):
-    print '      pragma Assert (' + func.pname + ' /= Null_' + node_type + ');'
-    cond = '(Has_' + func.name + ' (Get_Kind (' + func.pname + ')),'
+    print "      pragma Assert (" + func.pname + " /= Null_" + node_type + ");"
+    cond = "(Has_" + func.name + " (Get_Kind (" + func.pname + ")),"
     msg = '"no field ' + func.name + '");'
     if len(cond) < 60:
-        print '      pragma Assert ' + cond
-        print '                     ' + msg
+        print "      pragma Assert " + cond
+        print "                     " + msg
     else:
-        print '      pragma Assert'
-        print '         ' + cond
-        print '          ' + msg
+        print "      pragma Assert"
+        print "         " + cond
+        print "          " + msg
 
 
 def get_field_type(fields, f):
@@ -525,70 +525,86 @@ def gen_get_set(func, nodes, fields):
     """Generate Get_XXX/Set_XXX subprograms for FUNC."""
     rtype = func.rtype
     # If the function needs several fields, it must be user defined
-    if func.conv == 'grp':
-        print '   type %s_Conv is record' % rtype
+    if func.conv == "grp":
+        print "   type %s_Conv is record" % rtype
         for f in func.fields:
-            print '      %s: %s;' % (f, get_field_type(fields, f))
-        print '   end record;'
-        print '   pragma Pack (%s_Conv);' % rtype
+            print "      %s: %s;" % (f, get_field_type(fields, f))
+        print "   end record;"
+        print "   pragma Pack (%s_Conv);" % rtype
         print "   pragma Assert (%s_Conv'Size = %s'Size);" % (rtype, rtype)
         print
     else:
         f = func.fields[0]
-        g = 'Get_' + f + ' (' + func.pname + ')'
+        g = "Get_" + f + " (" + func.pname + ")"
 
     s = func.rname
     if func.conv:
-        if func.conv == 'uc':
+        if func.conv == "uc":
             field_type = get_field_type(fields, f)
-            g = field_type + '_To_' + rtype + ' (' + g + ')'
-            s = rtype + '_To_' + field_type + ' (' + s + ')'
-        elif func.conv == 'pos':
-            g = rtype + "'Val (" + g + ')'
-            s = rtype + "'Pos (" + s + ')'
+            g = field_type + "_To_" + rtype + " (" + g + ")"
+            s = rtype + "_To_" + field_type + " (" + s + ")"
+        elif func.conv == "pos":
+            g = rtype + "'Val (" + g + ")"
+            s = rtype + "'Pos (" + s + ")"
 
-    subprg = '   function Get_' + func.name + ' (' + func.pname \
-             + ' : ' + func.ptype + ') return ' + rtype
-    if func.conv == 'grp':
+    subprg = (
+        "   function Get_"
+        + func.name
+        + " ("
+        + func.pname
+        + " : "
+        + func.ptype
+        + ") return "
+        + rtype
+    )
+    if func.conv == "grp":
         print subprg
-        print '   is'
-        print '      function To_%s is new Ada.Unchecked_Conversion' % \
-            func.rtype
-        print '         (%s_Conv, %s);' % (rtype, rtype)
-        print '      Conv : %s_Conv;' % rtype
-        print '   begin'
+        print "   is"
+        print "      function To_%s is new Ada.Unchecked_Conversion" % func.rtype
+        print "         (%s_Conv, %s);" % (rtype, rtype)
+        print "      Conv : %s_Conv;" % rtype
+        print "   begin"
     else:
         gen_subprg_header(subprg)
     gen_assert(func)
-    if func.conv == 'grp':
+    if func.conv == "grp":
         for f in func.fields:
-            print '      Conv.%s := Get_%s (%s);' % (f, f, func.pname)
-        g = 'To_%s (Conv)' % rtype
-    print '      return ' + g + ';'
-    print '   end Get_' + func.name + ';'
+            print "      Conv.%s := Get_%s (%s);" % (f, f, func.pname)
+        g = "To_%s (Conv)" % rtype
+    print "      return " + g + ";"
+    print "   end Get_" + func.name + ";"
     print
 
-    subprg = '   procedure Set_' + func.name + ' (' \
-             + func.pname + ' : ' + func.ptype + '; ' \
-             + func.rname + ' : ' + func.rtype + ')'
-    if func.conv == 'grp':
+    subprg = (
+        "   procedure Set_"
+        + func.name
+        + " ("
+        + func.pname
+        + " : "
+        + func.ptype
+        + "; "
+        + func.rname
+        + " : "
+        + func.rtype
+        + ")"
+    )
+    if func.conv == "grp":
         print subprg
-        print '   is'
-        print '      function To_%s_Conv is new Ada.Unchecked_Conversion' % \
-            func.rtype
-        print '         (%s, %s_Conv);' % (rtype, rtype)
-        print '      Conv : %s_Conv;' % rtype
-        print '   begin'
+        print "   is"
+        print "      function To_%s_Conv is new Ada.Unchecked_Conversion" % func.rtype
+        print "         (%s, %s_Conv);" % (rtype, rtype)
+        print "      Conv : %s_Conv;" % rtype
+        print "   begin"
     else:
         gen_subprg_header(subprg)
     gen_assert(func)
-    if func.conv == 'grp':
-        print '      Conv := To_%s_Conv (%s);' % (rtype, func.rname)
+    if func.conv == "grp":
+        print "      Conv := To_%s_Conv (%s);" % (rtype, func.rname)
         for f in func.fields:
-            print '      Set_%s (%s, Conv.%s);' % (f, func.pname, f)
+            print "      Set_%s (%s, Conv.%s);" % (f, func.pname, f)
     else:
-        print '      Set_' + f + ' (' + func.pname + ', ' + s + ');'
-    print '   end Set_' + func.name + ';'
+        print "      Set_" + f + " (" + func.pname + ", " + s + ");"
+    print "   end Set_" + func.name + ";"
     print
 
 
@@ -597,38 +613,38 @@ def funcs_of_node(n):
 
 
 def gen_has_func_spec(name, suff):
-    spec = '   function Has_' + name + ' (K : ' + type_name + ')'
-    ret = ' return Boolean' + suff
+    spec = "   function Has_" + name + " (K : " + type_name + ")"
+    ret = " return Boolean" + suff
     if len(spec) < 60:
         print spec + ret
     else:
         print spec
-        print '     ' + ret
+        print "     " + ret
 
 
 def do_disp_formats():
     for fmt in fields:
-        print "Fields of Format_"+fmt
+        print "Fields of Format_" + fmt
         fld = fields[fmt]
         for k in fld:
-            print '  ' + k + ' (' + fld[k] + ')'
+            print "  " + k + " (" + fld[k] + ")"
 
 
 def do_disp_kinds():
     print "Kinds are:"
     for k in kinds:
-        print '  ' + prefix_name + k
+        print "  " + prefix_name + k
 
 
 def do_disp_funcs():
     print "Functions are:"
     for f in funcs:
-        s = '{0} ({1}: {2}'.format(f.name, f.field, f.rtype)
+        s = "{0} ({1}: {2}".format(f.name, f.field, f.rtype)
         if f.acc:
-            s += ' acc:' + f.acc
+            s += " acc:" + f.acc
         if f.conv:
-            s += ' conv:' + f.conv
-        s += ')'
+            s += " conv:" + f.conv
+        s += ")"
         print s
 
 
@@ -638,16 +654,16 @@ def do_disp_types():
     for f in funcs:
         s |= set([f.rtype])
     for t in sorted(s):
-        print '  ' + t
+        print "  " + t
 
 
 def do_disp_nodes():
     for k in kinds:
         v = nodes[k]
-        print prefix_name + k + ' (' + v.format + ')'
+        print prefix_name + k + " (" + v.format + ")"
         flds = [fk for fk, fv in v.fields.items() if fv]
         for fk in sorted(flds):
-            print '  ' + fk + ': ' + v.fields[fk].name
+            print "  " + fk + ": " + v.fields[fk].name
 
 
 def do_get_format():
@@ -659,12 +675,12 @@ def do_body():
     while True:
         l = lr.get().rstrip()
         print l
-        if l == '   --  Subprograms':
+        if l == "   --  Subprograms":
             gen_get_format(formats, nodes, kinds)
             print
             for f in funcs:
                 gen_get_set(f, nodes, fields)
-        if l[0:3] == 'end':
+        if l[0:3] == "end":
             break
 
 
@@ -681,7 +697,7 @@ def get_attributes():
         if f.acc:
             s |= set([f.acc])
     res = [t for t in sorted(s)]
-    res.insert(0, 'None')
+    res.insert(0, "None")
     return res
 
 
@@ -689,34 +705,32 @@ def gen_enum(prefix, vals):
     last = None
     for v in vals:
         if last:
-            print last + ','
+            print last + ","
         last = prefix + v
     print last
 
 
 def do_meta_specs():
-    lr = linereader(meta_base_file + '.ads.in')
+    lr = linereader(meta_base_file + ".ads.in")
     types = get_types()
     while True:
         l = lr.get().rstrip()
-        if l == '      --  TYPES':
-            gen_enum('      Type_', types)
-        elif l == '      --  FIELDS':
-            gen_enum('      Field_', [f.name for f in funcs])
-        elif l == '      --  ATTRS':
-            gen_enum('      Attr_', get_attributes())
-        elif l == '   --  FUNCS':
+        if l == "      --  TYPES":
+            gen_enum("      Type_", types)
+        elif l == "      --  FIELDS":
+            gen_enum("      Field_", [f.name for f in funcs])
+        elif l == "      --  ATTRS":
+            gen_enum("      Attr_", get_attributes())
+        elif l == "   --  FUNCS":
             for t in types:
-                print '   function Get_' + t
-                print '      (N : ' + node_type + '; F : Fields_Enum) return '\
-                      + t + ';'
-                print '   procedure Set_' + t
-                print '      (N : ' + node_type + '; F : Fields_Enum; V: ' \
-                      + t + ');'
+                print "   function Get_" + t
+                print "      (N : " + node_type + "; F : Fields_Enum) return " + t + ";"
+                print "   procedure Set_" + t
+                print "      (N : " + node_type + "; F : Fields_Enum; V: " + t + ");"
                 print
             for f in funcs:
-                gen_has_func_spec(f.name, ';')
-        elif l[0:3] == 'end':
+                gen_has_func_spec(f.name, ";")
+        elif l[0:3] == "end":
             print l
             break
         else:
@@ -724,68 +738,71 @@ def do_meta_specs():
 
 
 def do_meta_body():
-    lr = linereader(meta_base_file + '.adb.in')
+    lr = linereader(meta_base_file + ".adb.in")
     while True:
         l = lr.get().rstrip()
-        if l == '      --  FIELDS_TYPE':
+        if l == "      --  FIELDS_TYPE":
             last = None
             for f in funcs:
                 if last:
-                    print last + ','
-                last = '      Field_' + f.name + ' => Type_' + f.rtype
+                    print last + ","
+                last = "      Field_" + f.name + " => Type_" + f.rtype
             print last
-        elif l == '         --  FIELD_IMAGE':
+        elif l == "         --  FIELD_IMAGE":
             for f in funcs:
-                print '         when Field_' + f.name + ' =>'
+                print "         when Field_" + f.name + " =>"
                 print '            return "' + f.name.lower() + '";'
-        elif l == '         --  IIR_IMAGE':
+        elif l == "         --  IIR_IMAGE":
             for k in kinds:
-                print '         when ' + prefix_name + k + ' =>'
+                print "         when " + prefix_name + k + " =>"
                 print '            return "' + k.lower() + '";'
-        elif l == '         --  FIELD_ATTRIBUTE':
+        elif l == "         --  FIELD_ATTRIBUTE":
             for f in funcs:
-                print '         when Field_' + f.name + ' =>'
+                print "         when Field_" + f.name + " =>"
                 if f.acc:
                     attr = f.acc
                 else:
-                    attr = 'None'
-                print '            return Attr_' + attr + ';'
-        elif l == '      --  FIELDS_ARRAY':
+                    attr = "None"
+                print "            return Attr_" + attr + ";"
+        elif l == "      --  FIELDS_ARRAY":
             last = None
-            nodes_types = [node_type,
-                           node_type + '_List', node_type + '_Flist']
+            nodes_types = [node_type, node_type + "_List", node_type + "_Flist"]
             for k in kinds:
                 v = nodes[k]
                 if last:
-                    print last + ','
+                    print last + ","
                 last = None
-                print '      --  ' + prefix_name + k
+                print "      --  " + prefix_name + k
                 # Get list of physical fields for V, in some order.
                 if flag_keep_order:
                     flds = v.order
                 else:
                     # First non Iir and no Iir_List.
-                    flds = sorted([fk for fk, fv in v.fields.items()
-                                   if fv and fv.rtype not in nodes_types])
+                    flds = sorted(
+                        [
+                            fk
+                            for fk, fv in v.fields.items()
+                            if fv and fv.rtype not in nodes_types
+                        ]
+                    )
                     # Then Iir and Iir_List in order of appearance
-                    flds += (fv for fv in v.order
-                             if v.fields[fv].rtype in nodes_types)
+                    flds += (fv for fv in v.order if v.fields[fv].rtype in nodes_types)
                 # Print the corresponding node field, but remove duplicate due
                 # to 'grp'.
                 fldsn = []
                 for fk in flds:
                     if last:
-                        print last + ','
+                        print last + ","
                     # Remove duplicate
                     fn = v.fields[fk].name
                     if fn not in fldsn:
-                        last = '      Field_' + fn
+                        last = "      Field_" + fn
                         fldsn.append(fn)
                     else:
                         last = None
             if last:
                 print last
-        elif l == '      --  FIELDS_ARRAY_POS':
+        elif l == "      --  FIELDS_ARRAY_POS":
             pos = -1
             last = None
             for k in kinds:
@@ -794,117 +811,140 @@ def do_meta_body():
                 flds = set([fv.name for fk, fv in v.fields.items() if fv])
                 pos += len(flds)
                 if last:
-                    print last + ','
-                last = '      ' + prefix_name + k + ' => {}'.format(pos)
+                    print last + ","
+                last = "      " + prefix_name + k + " => {}".format(pos)
             print last
-        elif l == '   --  FUNCS_BODY':
+        elif l == "   --  FUNCS_BODY":
             # Build list of types
             s = set([])
             for f in funcs:
                 s |= set([f.rtype])
             types = [t for t in sorted(s)]
             for t in types:
-                print '   function Get_' + t
-                print '      (N : ' + node_type + '; F : Fields_Enum) return '\
-                      + t + ' is'
-                print '   begin'
-                print '      pragma Assert (Fields_Type (F) = Type_' + t + ');'
-                print '      case F is'
+                print "   function Get_" + t
+                print "      (N : " + node_type + "; F : Fields_Enum) return " + t + " is"
+                print "   begin"
+                print "      pragma Assert (Fields_Type (F) = Type_" + t + ");"
+                print "      case F is"
                 for f in funcs:
                     if f.rtype == t:
-                        print '         when Field_' + f.name + ' =>'
-                        print '            return Get_' + f.name + ' (N);'
-                print '         when others =>'
-                print '            raise Internal_Error;'
-                print '      end case;'
-                print '   end Get_' + t + ';'
+                        print "         when Field_" + f.name + " =>"
+                        print "            return Get_" + f.name + " (N);"
+                print "         when others =>"
+                print "            raise Internal_Error;"
+                print "      end case;"
+                print "   end Get_" + t + ";"
                 print
-                print '   procedure Set_' + t
-                print '      (N : ' + node_type + '; F : Fields_Enum; V: ' \
-                      + t + ') is'
-                print '   begin'
-                print '      pragma Assert (Fields_Type (F) = Type_' + t + ');'
-                print '      case F is'
+                print "   procedure Set_" + t
+                print "      (N : " + node_type + "; F : Fields_Enum; V: " + t + ") is"
+                print "   begin"
+                print "      pragma Assert (Fields_Type (F) = Type_" + t + ");"
+                print "      case F is"
                 for f in funcs:
                     if f.rtype == t:
-                        print '         when Field_' + f.name + ' =>'
-                        print '            Set_' + f.name + ' (N, V);'
-                print '         when others =>'
-                print '            raise Internal_Error;'
-                print '      end case;'
-                print '   end Set_' + t + ';'
+                        print "         when Field_" + f.name + " =>"
+                        print "            Set_" + f.name + " (N, V);"
+                print "         when others =>"
+                print "            raise Internal_Error;"
+                print "      end case;"
+                print "   end Set_" + t + ";"
                 print
             for f in funcs:
-                gen_has_func_spec(f.name, ' is')
+                gen_has_func_spec(f.name, " is")
                 choices = [k for k in kinds if f.name in nodes[k].attrs]
                 if len(choices) == 0:
-                    print '      pragma Unreferenced (K);'
-                print '   begin'
+                    print "      pragma Unreferenced (K);"
+                print "   begin"
                 if len(choices) == 0:
-                    print '      return False;'
+                    print "      return False;"
                 elif len(choices) == 1:
-                    print '      return K = ' + prefix_name + choices[0] + ';'
+                    print "      return K = " + prefix_name + choices[0] + ";"
                 else:
-                    print '      case K is'
+                    print "      case K is"
                     gen_choices(choices)
-                    print '            return True;'
-                    print '         when others =>'
-                    print '            return False;'
-                    print '      end case;'
-                print '   end Has_' + f.name + ';'
+                    print "            return True;"
+                    print "         when others =>"
+                    print "            return False;"
+                    print "      end case;"
+                print "   end Has_" + f.name + ";"
                 print
-        elif l[0:3] == 'end':
+        elif l[0:3] == "end":
             print l
             break
         else:
             print l
 
 
-actions = {'disp-nodes': do_disp_nodes,
-           'disp-kinds': do_disp_kinds,
-           'disp-formats': do_disp_formats,
-           'disp-funcs': do_disp_funcs,
-           'disp-types': do_disp_types,
-           'get_format': do_get_format,
-           'body': do_body,
-           'meta_specs': do_meta_specs,
-           'meta_body': do_meta_body}
+actions = {
+    "disp-nodes": do_disp_nodes,
+    "disp-kinds": do_disp_kinds,
+    "disp-formats": do_disp_formats,
+    "disp-funcs": do_disp_funcs,
+    "disp-types": do_disp_types,
+    "get_format": do_get_format,
+    "body": do_body,
+    "meta_specs": do_meta_specs,
+    "meta_body": do_meta_body,
+}
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Meta-grammar processor')
-    parser.add_argument('action', choices=actions.keys(),
-                        default='disp-nodes')
-    parser.add_argument('--field-file', dest='field_file',
-                        default='nodes.ads',
-                        help='specify file which defines fields')
-    parser.add_argument('--kind-file', dest='kind_file',
-                        default='iirs.ads',
-                        help='specify file which defines nodes kind')
-    parser.add_argument('--node-file', dest='node_file',
-                        default='iirs.ads',
-                        help='specify file which defines nodes and methods')
-    parser.add_argument('--template-file', dest='template_file',
-                        default='iirs.adb.in',
-                        help='specify template body file')
-    parser.add_argument('--meta-basename', dest='meta_basename',
-                        default='nodes_meta',
-                        help='specify base name of meta files')
-    parser.add_argument('--kind-type', dest='kind_type',
-                        default='Iir_Kind',
-                        help='name of kind type')
-    parser.add_argument('--kind-prefix', dest='kind_prefix',
-                        default='Iir_Kind_',
-                        help='prefix for kind literals')
-    parser.add_argument('--kind-range-prefix', dest='kind_range_prefix',
-                        default='Iir_Kinds_',
-                        help='prefix for kind subtype (range)')
-    parser.add_argument('--node-type', dest='node_type',
-                        default='Iir',
-                        help='name of the node type')
-    parser.add_argument('--keep-order', dest='flag_keep_order',
-                        action='store_true',
-                        help='keep field order of nodes')
+    parser = argparse.ArgumentParser(description="Meta-grammar processor")
+    parser.add_argument("action", choices=actions.keys(), default="disp-nodes")
+    parser.add_argument(
+        "--field-file",
+        dest="field_file",
+        default="nodes.ads",
+        help="specify file which defines fields",
+    )
+    parser.add_argument(
+        "--kind-file",
+        dest="kind_file",
+        default="iirs.ads",
+        help="specify file which defines nodes kind",
+    )
+    parser.add_argument(
+        "--node-file",
+        dest="node_file",
+        default="iirs.ads",
+        help="specify file which defines nodes and methods",
+    )
+    parser.add_argument(
+        "--template-file",
+        dest="template_file",
+        default="iirs.adb.in",
+        help="specify template body file",
+    )
+    parser.add_argument(
+        "--meta-basename",
+        dest="meta_basename",
+        default="nodes_meta",
+        help="specify base name of meta files",
+    )
+    parser.add_argument(
+        "--kind-type", dest="kind_type", default="Iir_Kind", help="name of kind type"
+    )
+    parser.add_argument(
+        "--kind-prefix",
+        dest="kind_prefix",
+        default="Iir_Kind_",
+        help="prefix for kind literals",
+    )
+    parser.add_argument(
+        "--kind-range-prefix",
+        dest="kind_range_prefix",
+        default="Iir_Kinds_",
+        help="prefix for kind subtype (range)",
+    )
+    parser.add_argument(
+        "--node-type", dest="node_type", default="Iir", help="name of the node type"
+    )
+    parser.add_argument(
+        "--keep-order",
+        dest="flag_keep_order",
+        action="store_true",
+        help="keep field order of nodes",
+    )
     parser.set_defaults(flag_keep_order=False)
     args = parser.parse_args()
 
@@ -934,8 +974,7 @@ def main():
 
     except ParseError as e:
         print >> sys.stderr, e
-        print >> sys.stderr, \
-            "in {0}:{1}:{2}".format(e.lr.filename, e.lr.lineno, e.lr.l)
+        print >> sys.stderr, "in {0}:{1}:{2}".format(e.lr.filename, e.lr.lineno, e.lr.l)
         sys.exit(1)
 
     f = actions.get(args.action, None)
@@ -945,5 +984,5 @@ def main():
     f()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/python/xtools/pnodespy.py
+++ b/python/xtools/pnodespy.py
@@ -6,123 +6,137 @@ from __future__ import print_function
 import pnodes
 import re
 
-libname = 'libghdl'
+libname = "libghdl"
 
 
 def print_enum(name, vals):
     print()
     print()
-    print('class {0}:'.format(name))
+    print("class {0}:".format(name))
     for n, k in enumerate(vals):
-        if k == 'None':
-            k = 'PNone'
-        print('    {0} = {1}'.format(k, n))
+        if k == "None":
+            k = "PNone"
+        print("    {0} = {1}".format(k, n))
 
 
 def do_class_kinds():
-    print_enum(pnodes.prefix_name.rstrip('_'), pnodes.kinds)
+    print_enum(pnodes.prefix_name.rstrip("_"), pnodes.kinds)
 
     print()
     print()
-    print('class Iir_Kinds:')
+    print("class Iir_Kinds:")
     for k, v in pnodes.kinds_ranges.items():
-        print('    {0} = ['.format(k))
+        print("    {0} = [".format(k))
         first = True
         for e in v:
             if first:
                 first = False
             else:
-                print(',')
-            print('        Iir_Kind.{}'.format(e), end='')
-        print(']')
+                print(",")
+            print("        Iir_Kind.{}".format(e), end="")
+        print("]")
         print()
 
+
 def do_iirs_subprg():
-    classname = 'vhdl__nodes'
+    classname = "vhdl__nodes"
     print()
-    print('Get_Kind = {0}.{1}__get_kind'.format(libname, classname))
-    print('Get_Location = {0}.{1}__get_location'.format(libname, classname))
+    print("Get_Kind = {0}.{1}__get_kind".format(libname, classname))
+    print("Get_Location = {0}.{1}__get_location".format(libname, classname))
     for k in pnodes.funcs:
         print()
-        print('Get_{0} = {1}.{2}__get_{3}'.format(
-            k.name, libname, classname, k.name.lower()))
+        print(
+            "Get_{0} = {1}.{2}__get_{3}".format(
+                k.name, libname, classname, k.name.lower()
+            )
+        )
         print()
-        print('Set_{0} = {1}.{2}__set_{3}'.format(
-            k.name, libname, classname, k.name.lower(), k.pname, k.rname))
+        print(
+            "Set_{0} = {1}.{2}__set_{3}".format(
+                k.name, libname, classname, k.name.lower(), k.pname, k.rname
+            )
+        )
 
 
 def do_libghdl_elocations():
-    classname = 'vhdl__elocations'
-    print('from libghdl import libghdl')
+    classname = "vhdl__elocations"
+    print("from libghdl import libghdl")
     print()
     for k in pnodes.funcs:
         print()
-        print('Get_{0} = {1}.{2}__get_{3}'.format(
-            k.name, libname, classname, k.name.lower()))
+        print(
+            "Get_{0} = {1}.{2}__get_{3}".format(
+                k.name, libname, classname, k.name.lower()
+            )
+        )
         print()
-        print('Set_{0} = {1}.{2}__set_{3}'.format(
-            k.name, libname, classname, k.name.lower(), k.pname, k.rname))
+        print(
+            "Set_{0} = {1}.{2}__set_{3}".format(
+                k.name, libname, classname, k.name.lower(), k.pname, k.rname
+            )
+        )
 
 
 def do_class_types():
-    print_enum('types', pnodes.get_types())
+    print_enum("types", pnodes.get_types())
 
 
 def do_types_subprg():
     print()
     for k in pnodes.get_types():
         print()
-        print('Get_{0} = {1}.vhdl__nodes_meta__get_{2}'.format(
-            k, libname, k.lower()))
+        print("Get_{0} = {1}.vhdl__nodes_meta__get_{2}".format(k, libname, k.lower()))
 
 
 def do_has_subprg():
     print()
     for f in pnodes.funcs:
         print()
-        print('Has_{0} =\\'.format(f.name))
-        print('    {0}.vhdl__nodes_meta__has_{1}'.format(libname, f.name.lower()))
+        print("Has_{0} =\\".format(f.name))
+        print("    {0}.vhdl__nodes_meta__has_{1}".format(libname, f.name.lower()))
 
 
 def do_class_field_attributes():
-    print_enum('Attr', ['ANone' if a == 'None' else a
-                        for a in pnodes.get_attributes()])
+    print_enum("Attr", ["ANone" if a == "None" else a for a in pnodes.get_attributes()])
 
 
 def do_class_fields():
-    print_enum('fields', [f.name for f in pnodes.funcs])
+    print_enum("fields", [f.name for f in pnodes.funcs])
 
 
-def read_enum(filename, type_name, prefix, class_name, g=lambda m:m.group(1)):
+def read_enum(filename, type_name, prefix, class_name, g=lambda m: m.group(1)):
     """Read an enumeration declaration from :param filename:"""
-    pat_decl = re.compile(r'   type {0} is$'.format(type_name))
-    pat_enum = re.compile(r'      {0}(\w+),?( *-- .*)?$'.format(prefix))
-    pat_comment = re.compile(r' *-- .*$')
+    pat_decl = re.compile(r"   type {0} is$".format(type_name))
+    pat_enum = re.compile(r"      {0}(\w+),?( *-- .*)?$".format(prefix))
+    pat_comment = re.compile(r" *-- .*$")
     lr = pnodes.linereader(filename)
     while not pat_decl.match(lr.get()):
         pass
     line = lr.get()
-    if line != '     (\n':
+    if line != "     (\n":
         raise pnodes.ParseError(
-            lr, "{}:{}: missing open parenthesis".format(
-                filename, lr.lineno))
+            lr, "{}:{}: missing open parenthesis".format(filename, lr.lineno)
+        )
     toks = []
     while True:
         line = lr.get()
-        if line == '     );\n':
+        if line == "     );\n":
             break
         m = pat_enum.match(line)
         if m:
             toks.append(g(m))
         elif pat_comment.match(line):
             pass
-        elif line == '\n':
+        elif line == "\n":
             pass
         else:
             print(line, file=sys.stderr)
             raise pnodes.ParseError(
-                lr, "{}:{}: incorrect line in enum {}".format(
-                    filename, lr.lineno, type_name))
+                lr,
+                "{}:{}: incorrect line in enum {}".format(
+                    filename, lr.lineno, type_name
+                ),
+            )
     print_enum(class_name, toks)
 
 
@@ -132,8 +146,9 @@ def read_spec_enum(type_name, prefix, class_name):
 
 
 def do_libghdl_nodes():
-    print('from libghdl import libghdl')
-    print("""
+    print("from libghdl import libghdl")
+    print(
+        """
 Null_Iir = 0
 
 Null_Iir_List = 0
@@ -142,21 +157,22 @@ Iir_List_All = 1
 Null_Iir_Flist = 0
 Iir_Flist_Others = 1
 Iir_Flist_All = 2
-""")
+"""
+    )
     do_class_kinds()
-    read_spec_enum('Iir_Mode', 'Iir_', 'Iir_Mode')
-    read_spec_enum('Iir_Staticness', '', 'Iir_Staticness')
-    read_spec_enum('Iir_Constraint', '', 'Iir_Constraint')
-    read_spec_enum('Iir_Delay_Mechanism', 'Iir_', 'Iir_Delay_Mechanism')
-    read_spec_enum('Date_State_Type', 'Date_', 'Date_State')
-    read_spec_enum('Iir_Predefined_Functions',
-                   'Iir_Predefined_', 'Iir_Predefined')
+    read_spec_enum("Iir_Mode", "Iir_", "Iir_Mode")
+    read_spec_enum("Iir_Staticness", "", "Iir_Staticness")
+    read_spec_enum("Iir_Constraint", "", "Iir_Constraint")
+    read_spec_enum("Iir_Delay_Mechanism", "Iir_", "Iir_Delay_Mechanism")
+    read_spec_enum("Date_State_Type", "Date_", "Date_State")
+    read_spec_enum("Iir_Predefined_Functions", "Iir_Predefined_", "Iir_Predefined")
     do_iirs_subprg()
 
 
 def do_libghdl_meta():
-    print('from libghdl import libghdl')
-    print("""
+    print("from libghdl import libghdl")
+    print(
+        """
 
 
 # From nodes_meta
@@ -168,7 +184,8 @@ get_field_by_index = libghdl.vhdl__nodes_meta__get_field_by_index
 
 get_field_type = libghdl.vhdl__nodes_meta__get_field_type
 
-get_field_attribute = libghdl.vhdl__nodes_meta__get_field_attribute""")
+get_field_attribute = libghdl.vhdl__nodes_meta__get_field_attribute"""
+    )
     do_class_types()
     do_class_field_attributes()
     do_class_fields()
@@ -177,12 +194,12 @@ get_field_attribute = libghdl.vhdl__nodes_meta__get_field_attribute""")
 
 
 def do_libghdl_names():
-    pat_name_first = re.compile(
-        r'   Name_(\w+)\s+: constant Name_Id := (\d+);')
+    pat_name_first = re.compile(r"   Name_(\w+)\s+: constant Name_Id := (\d+);")
     pat_name_def = re.compile(
-        r'   Name_(\w+)\s+:\s+constant Name_Id :=\s+Name_(\w+)( \+ (\d+))?;')
+        r"   Name_(\w+)\s+:\s+constant Name_Id :=\s+Name_(\w+)( \+ (\d+))?;"
+    )
     dict = {}
-    lr = pnodes.linereader('../std_names.ads')
+    lr = pnodes.linereader("../std_names.ads")
     while True:
         line = lr.get()
         m = pat_name_first.match(line)
@@ -195,9 +212,9 @@ def do_libghdl_names():
     val_max = 1
     while True:
         line = lr.get()
-        if line == 'end Std_Names;\n':
+        if line == "end Std_Names;\n":
             break
-        if line.endswith(':=\n'):
+        if line.endswith(":=\n"):
             line = line.rstrip() + lr.get()
         m = pat_name_def.match(line)
         if m:
@@ -208,18 +225,17 @@ def do_libghdl_names():
                 val = 0
             val_ref = dict.get(name_ref, None)
             if not val_ref:
-                raise pnodes.ParseError(
-                    lr, "name {0} not found".format(name_ref))
+                raise pnodes.ParseError(lr, "name {0} not found".format(name_ref))
             val = val_ref + int(val)
             val_max = max(val_max, val)
             dict[name_def] = val
             res.append((name_def, val))
-    print('class Name:')
+    print("class Name:")
     for n, v in res:
         # Avoid clash with Python names
-        if n in ['False', 'True', 'None']:
-            n = 'N' + n
-        print('    {0} = {1}'.format(n, v))
+        if n in ["False", "True", "None"]:
+            n = "N" + n
+        print("    {0} = {1}".format(n, v))
 
 
 def do_libghdl_tokens():
@@ -227,21 +243,32 @@ def do_libghdl_tokens():
 
 
 def do_libghdl_errorout():
-    print('from libghdl import libghdl')
-    print("""
+    print("from libghdl import libghdl")
+    print(
+        """
 Enable_Warning = libghdl.errorout__enable_warning
-""")
-    read_enum("../errorout.ads", "Msgid_Type", "(Msgid|Warnid)_", "Msgid",
-              g=lambda m: m.group(1) + '_' + m.group(2))
+"""
+    )
+    read_enum(
+        "../errorout.ads",
+        "Msgid_Type",
+        "(Msgid|Warnid)_",
+        "Msgid",
+        g=lambda m: m.group(1) + "_" + m.group(2),
+    )
 
 
-pnodes.actions.update({'class-kinds': do_class_kinds,
-                       'libghdl-nodes': do_libghdl_nodes,
-                       'libghdl-meta': do_libghdl_meta,
-                       'libghdl-names': do_libghdl_names,
-                       'libghdl-tokens': do_libghdl_tokens,
-                       'libghdl-elocs': do_libghdl_elocations,
-                       'libghdl-errorout': do_libghdl_errorout})
+pnodes.actions.update(
+    {
+        "class-kinds": do_class_kinds,
+        "libghdl-nodes": do_libghdl_nodes,
+        "libghdl-meta": do_libghdl_meta,
+        "libghdl-names": do_libghdl_names,
+        "libghdl-tokens": do_libghdl_tokens,
+        "libghdl-elocs": do_libghdl_elocations,
+        "libghdl-errorout": do_libghdl_errorout,
+    }
+)
 
 
 pnodes.main()


### PR DESCRIPTION
As discussed in #1434, in this PR `black python` was executed, to have the code in subdir `python` automatically formatted by [black](https://github.com/psf/black). Moreover, a test is added to CI, which executes `black --check python`. As a result, users modifying the code should execute `black python` (they can optionally set a hook), before pushing changes to a PR. Otherwise, CI might fail. Apart from that, we can forget about formatting/style issues (in Python)!

/cc @m-kru