### PR TITLE
Replace distutils with setuptools for pyghdl and remove unused import

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import distutils.command.build_py
 from distutils.core import setup
 import re
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 import re
 
 


### PR DESCRIPTION
Currently, using directly setup.py (without pip) fails to include `ghdl-ls`, as `entry_point` is not available in distutils.