### PR TITLE
Create a version header to export version strings to C

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -172,6 +172,17 @@ version.ads: version.tmp
 #	useless rebuild.
 	if [ ! -r $@ ] || ! cmp $< $@ > /dev/null; then $(CP) $< $@; fi
 
+# Same tasks, but generate a C header instead
+version.tmp_h: $(srcdir)/src/version.in_h force
+#	Create version.tmp_h from version.in, using git date/hash, or envvar GHDL_DESC. Defaults to 'tarball'.
+	if test -d $(srcdir)/.git && desc=`cd $(srcdir); git describe --dirty`; then GHDL_DESC="$$desc"; fi; \
+	$(SED) -e "s/[(].*[)]/($$GHDL_DESC)/" -e "s/@VER@/$(ghdl_version)/" < $< > $@; \
+
+ghdl_version.h: version.tmp_h
+#	Change ghdl_version.h only if version.tmp_h has been modified to avoid
+#	useless rebuild.
+	if [ ! -r $@ ] || ! cmp $< $@ > /dev/null; then $(CP) $< $@; fi
+
 #################### For mcode backend ##############################
 
 all.mcode: ghdl_mcode$(EXEEXT) libs.vhdl.mcode all.vpi
@@ -439,6 +450,7 @@ all.libghdl.false:
 all.libghdl: all.libghdl.$(enable_libghdl)
 
 install.libghdl.include: install.dirs $(srcdir)/src/synth/ghdlsynth_gates.h
+	$(INSTALL_DATA) -p ghdl_version.h $(DESTDIR)$(incdir)/
 	$(INSTALL_DATA) -p $(srcdir)/src/synth/ghdlsynth.h $(DESTDIR)$(incdir)/
 	$(INSTALL_DATA) -p $(srcdir)/src/synth/ghdlsynth_gates.h $(DESTDIR)$(incdir)/
 
@@ -571,7 +583,7 @@ uninstall.vhdllib:
 ####################### clean ############################################
 
 clean: force
-	$(RM) -f *.o *.ali b~*.ad? *~ *.d b__*.ad? *.a *.so *.deps *.bexch version.* *.dll *.dylib
+	$(RM) -f *.o *.ali b~*.ad? *~ *.d b__*.ad? *.a *.so *.deps *.bexch version.* ghdl_version.* *.dll *.dylib
 	$(RM) -f ghdl_gcc$(EXEEXT) ghdl_mcode$(EXEEXT) ghdl$(EXEEXT) ghdl_llvm$(EXEEXT) ghdl_llvm_jit$(EXEEXT) ghdl_simul$(EXEEXT)
 	$(RM) -f ghdl1-gcc$(EXEEXT) ghdl1-llvm$(EXEEXT) ghdl1-debug$(EXEEXT)
 	$(RM) -f grt/run-bind.ad? grt.lst grt/grt-files grt/grt-files.in

--- a/Makefile.in
+++ b/Makefile.in
@@ -174,7 +174,7 @@ version.ads: version.tmp
 
 # Same tasks, but generate a C header instead
 version.tmp_h: $(srcdir)/src/version.in_h force
-#	Create version.tmp_h from version.in, using git date/hash, or envvar GHDL_DESC. Defaults to 'tarball'.
+#	Create version.tmp_h from version.in_h, using git date/hash, or envvar GHDL_DESC. Defaults to 'tarball'.
 	if test -d $(srcdir)/.git && desc=`cd $(srcdir); git describe --dirty`; then GHDL_DESC="$$desc"; fi; \
 	$(SED) -e "s/[(].*[)]/($$GHDL_DESC)/" -e "s/@VER@/$(ghdl_version)/" < $< > $@; \
 
@@ -449,7 +449,7 @@ all.libghdl.true: $(libghdl_name) libghdl.a
 all.libghdl.false:
 all.libghdl: all.libghdl.$(enable_libghdl)
 
-install.libghdl.include: install.dirs $(srcdir)/src/synth/ghdlsynth_gates.h
+install.libghdl.include: install.dirs ghdl_version.h $(srcdir)/src/synth/ghdlsynth_gates.h
 	$(INSTALL_DATA) -p ghdl_version.h $(DESTDIR)$(incdir)/
 	$(INSTALL_DATA) -p $(srcdir)/src/synth/ghdlsynth.h $(DESTDIR)$(incdir)/
 	$(INSTALL_DATA) -p $(srcdir)/src/synth/ghdlsynth_gates.h $(DESTDIR)$(incdir)/

--- a/src/version.in_h
+++ b/src/version.in_h
@@ -1,7 +1,7 @@
 #ifndef _GHDL_VERSION
 #define _GHDL_VERSION
 
-const char* ghdl_ver const = "@VER@";
+const char* ghdl_ver = "@VER@";
 const char* ghdl_release = "(tarball) [Dunoon edition]";
 
 #endif

--- a/src/version.in_h
+++ b/src/version.in_h
@@ -1,0 +1,7 @@
+#ifndef _GHDL_VERSION
+#define _GHDL_VERSION
+
+const char* ghdl_ver const = "@VER@";
+const char* ghdl_release = "(tarball) [Dunoon edition]";
+
+#endif


### PR DESCRIPTION
**Description**

Export the version strings as a C header to allow access to these strings from C extensions using GHDL. This is intended specifically for the VHDL backend at ghdl/ghdl-yosys-plugin#122, but may also be useful for other people.