### PR TITLE
update python interface test/example

### DIFF
--- a/python/libghdl/thin/__init__.py
+++ b/python/libghdl/thin/__init__.py
@@ -1,0 +1,3 @@
+from libghdl.thin.vhdl import nodes
+from libghdl.thin.vhdl import sem_lib
+from libghdl.thin.vhdl import pyutils

--- a/testsuite/python/units01/show_ports.py
+++ b/testsuite/python/units01/show_ports.py
@@ -3,11 +3,7 @@ from sys import argv
 from pathlib import Path
 
 import libghdl
-from libghdl.thin import name_table
-from libghdl.thin import files_map
-from libghdl.thin.vhdl import nodes
-from libghdl.thin.vhdl import sem_lib
-from libghdl.thin.vhdl import pyutils
+from libghdl.thin import name_table, files_map, nodes, sem_lib, pyutils
 
 
 def get_identifier_ptr(n):


### PR DESCRIPTION
This is an attempt to update testsuite/python/units01 and do something more than just printing the name of the design units. I could successfully get and print the entity name that the architecture belongs to (`Get_Entity_Name`). Then, for the entity, I'd like to get the name, direction and type of the ports. I could use `nodes.Get_Port_Chain(lib_unit)` to get access to the first port (and print the name). But I don't know how to iterate and get the second port.

Note: in the first commit, `show_units.py` was formatted with `black`. Relevant changes are in the second commit.

Ref #1437 #1441 #1373 #1492
