### PR TITLE
termux: update gnat, install llvm and make explicitly

### DIFF
--- a/dist/termux.sh
+++ b/dist/termux.sh
@@ -3,8 +3,8 @@
 cd $(dirname "$0")/..
 
 curl -fsSL https://its-pointless.github.io/setup-pointless-repo.sh | bash -
-pkg install gnat-9
-setupgcc-9
+pkg install gnat-10 llvm make
+setupgcc-10
 
 mkdir -p build-termux
 cd build-termux

--- a/dist/termux.sh
+++ b/dist/termux.sh
@@ -6,6 +6,9 @@ curl -fsSL https://its-pointless.github.io/setup-pointless-repo.sh | bash -
 pkg install gnat-10 llvm make
 setupgcc-10
 
+# Temporal fix. See https://github.com/its-pointless/gcc_termux/issues/100
+ln -s $PREFIX/bin/gnatmake-10 $PREFIX/bin/gnatmake
+
 mkdir -p build-termux
 cd build-termux
 ../configure --default-pic --enable-synth --with-llvm-config=llvm-config --prefix="$PREFIX"


### PR DESCRIPTION
Fix #1458

I cannot test it in a "clean" environment, but it works in my existing termux installation.

/cc @BenjaminRenz