### PR TITLE
Revisit CLI syntax

### DIFF
--- a/src/ghdldrv/ghdlcomp.adb
+++ b/src/ghdldrv/ghdlcomp.adb
@@ -116,14 +116,20 @@ package body Ghdlcomp is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "-r" or Name = "--elab-run";
+      return
+        Name = "elab-run" or else
+        Name = "--elab-run" or else
+        Name = "-r" or else
+        Name = "run";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Run) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "-r,--elab-run [OPTS] UNIT [ARCH] [RUNOPTS]  Run UNIT";
+      return "elab-run [OPTS] UNIT [ARCH] [RUNOPTS]"
+        & ASCII.LF & "  Elaborate and run design UNIT"
+        & ASCII.LF & "  aliases: --elab-run, -r, run";
    end Get_Short_Help;
 
 
@@ -171,15 +177,18 @@ package body Ghdlcomp is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "-c";
+      return
+        Name = "compile" or else
+        Name = "-c";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Compile) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "-c [OPTS] FILEs -r UNIT [ARCH] [RUNOPTS]  "
-        & "Compile, elaborate and run UNIT";
+      return "compile [OPTS] FILEs -e|-r UNIT [ARCH] [RUNOPTS]"
+        & ASCII.LF & "  Compile, elaborate (and run) design UNIT"
+        & ASCII.LF & "  alias: -c";
    end Get_Short_Help;
 
    procedure Decode_Option (Cmd : in out Command_Compile;
@@ -427,14 +436,19 @@ package body Ghdlcomp is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "-a";
+      return
+        Name = "analyze" or else
+        Name = "-a" or else
+        Name = "analyse";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Analyze) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "-a [OPTS] FILEs    Analyze FILEs";
+      return "analyze [OPTS] FILEs"
+        & ASCII.LF & "  Analyze one or multiple VHDL files"
+        & ASCII.LF & "  aliases: -a, analyse";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Analyze;
@@ -564,14 +578,18 @@ package body Ghdlcomp is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "-e";
+      return
+        Name = "elaborate" or else
+        Name = "-e";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Elab) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "-e [OPTS] UNIT [ARCH]  Elaborate UNIT";
+      return "elaborate [OPTS] UNIT [ARCH]"
+        & ASCII.LF & "  Elaborate design UNIT"
+        & ASCII.LF & "  alias: -e";
    end Get_Short_Help;
 
    procedure Decode_Option (Cmd : in out Command_Elab;
@@ -639,14 +657,20 @@ package body Ghdlcomp is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--dispconfig" or else Name = "--disp-config";
+      return
+        Name = "disp-config" or else
+        Name = "--disp-config" or else
+        Name = "dispconfig" or else
+        Name = "--dispconfig";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Dispconfig) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--disp-config      Disp tools path";
+      return "disp-config"
+        & ASCII.LF & "  Display tools path"
+        & ASCII.LF & "  aliases: --disp-config, dispconfig, --dispconfig";
    end Get_Short_Help;
 
    procedure Disp_Config
@@ -691,14 +715,18 @@ package body Ghdlcomp is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "-m";
+      return
+        Name = "make" or else
+        Name = "-m";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Make) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "-m [OPTS] UNIT [ARCH]  Make UNIT";
+      return "make [OPTS] UNIT [ARCH]"
+        & ASCII.LF & "  Make design UNIT"
+        & ASCII.LF & "  alias: -m";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Make; Args : Argument_List)
@@ -818,14 +846,18 @@ package body Ghdlcomp is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--gen-makefile";
+      return
+        Name = "gen-makefile" or else
+        Name = "--gen-makefile";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Gen_Makefile) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--gen-makefile [OPTS] UNIT [ARCH]  Generate a Makefile for UNIT";
+      return "gen-makefile [OPTS] UNIT [ARCH]"
+        & ASCII.LF & "  Generate a Makefile for UNIT"
+        & ASCII.LF & "  alias: --gen-makefile";
    end Get_Short_Help;
 
    function Is_Makeable_File (File : Iir_Design_File) return Boolean is

--- a/src/ghdldrv/ghdldrv.adb
+++ b/src/ghdldrv/ghdldrv.adb
@@ -749,19 +749,30 @@ package body Ghdldrv is
    procedure Disp_Long_Help (Cmd : Command_Comp) is
    begin
       Disp_Long_Help (Command_Lib (Cmd));
-      Put_Line (" -v             Be verbose");
-      Put_Line (" --GHDL1=PATH   Set the path of the ghdl1 compiler");
-      Put_Line (" --AS=as        Use as for the assembler");
-      Put_Line (" --LINK=gcc     Use gcc for the linker driver");
-      Put_Line (" -S             Do not assemble");
-      Put_Line (" -o FILE        Set the name of the output file");
+      Put_Line (" -v");
+      Put_Line ("   Be verbose");
+      Put_Line (" --GHDL1=PATH");
+      Put_Line ("   Set the path of the ghdl1 compiler");
+      Put_Line (" --AS=as");
+      Put_Line ("   Use as for the assembler");
+      Put_Line (" --LINK=gcc");
+      Put_Line ("   Use gcc for the linker driver");
+      Put_Line (" -S");
+      Put_Line ("   Do not assemble");
+      Put_Line (" -o FILE");
+      Put_Line ("   Set the name of the output file");
    -- Put_Line (" -m32           Generate 32bit code on 64bit machines");
-      Put_Line (" -WX,OPTION     Pass OPTION to X, where X is one of");
-      Put_Line ("                 c: compiler, a: assembler, l: linker");
-      Put_Line (" -g[XX]         Pass debugging option to the compiler");
-      Put_Line (" -O[XX]/-f[XX]  Pass optimization option to the compiler");
-      Put_Line (" -Q             Do not add -quiet option to compiler");
-      Put_Line (" --expect-failure  Expect analysis/elaboration failure");
+      Put_Line (" -WX,OPTION");
+      Put_Line ("   Pass OPTION to X, where X is one of");
+      Put_Line ("  c: compiler, a: assembler, l: linker");
+      Put_Line (" -g[XX]");
+      Put_Line ("   Pass debugging option to the compiler");
+      Put_Line (" -O[XX]/-f[XX]");
+      Put_Line ("   Pass optimization option to the compiler");
+      Put_Line (" -Q");
+      Put_Line ("   Do not add -quiet option to compiler");
+      Put_Line (" --expect-failure");
+      Put_Line ("   Expect analysis/elaboration failure");
    end Disp_Long_Help;
 
    --  Command dispconfig.
@@ -777,14 +788,20 @@ package body Ghdldrv is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--dispconfig" or else Name = "--disp-config";
+      return
+        Name = "disp-config" or else
+        Name = "--disp-config" or else
+        Name = "dispconfig" or else
+        Name = "--dispconfig";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Dispconfig) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--disp-config      Disp tools path";
+      return "disp-config"
+        & ASCII.LF & "  Display tools path"
+        & ASCII.LF & "  aliases: --disp-config, dispconfig, --dispconfig";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Dispconfig;
@@ -861,14 +878,18 @@ package body Ghdldrv is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--bootstrap-standard";
+      return
+        Name = "bootstrap-std" or else
+        Name = "--bootstrap-standard";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Bootstrap) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--bootstrap-standard  (Internal) compile std.standard";
+      return "bootstrap-std"
+        & ASCII.LF & "  (internal) Compile std.standard"
+        & ASCII.LF & "  alias: --bootstrap-standard";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Bootstrap;
@@ -900,14 +921,19 @@ package body Ghdldrv is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "-a";
+      return
+        Name = "analyze" or else
+        Name = "-a" or else
+        Name = "analyse";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Analyze) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "-a [OPTS] FILEs    Analyze FILEs";
+      return "analyze [OPTS] FILEs"
+        & ASCII.LF & "  Analyze one or multiple VHDL files"
+        & ASCII.LF & "  aliases: -a, analyse";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Analyze;
@@ -1137,14 +1163,18 @@ package body Ghdldrv is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "-e";
+      return
+        Name = "elaborate" or else
+        Name = "-e";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Elab) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "-e [OPTS] UNIT [ARCH]      Elaborate UNIT";
+      return "elaborate [OPTS] UNIT [ARCH]"
+        & ASCII.LF & "  Elaborate design UNIT"
+        & ASCII.LF & "  alias: -e";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Elab; Args : Argument_List)
@@ -1175,14 +1205,18 @@ package body Ghdldrv is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "-r";
+      return
+        Name = "run" or else
+        Name = "-r";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Run) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "-r UNIT [ARCH] [OPTS]      Run UNIT";
+      return "run UNIT [ARCH] [RUNOPTS]"
+        & ASCII.LF & "  Run design UNIT"
+        & ASCII.LF & "  alias: -r";
    end Get_Short_Help;
 
    procedure Run_Design
@@ -1235,14 +1269,18 @@ package body Ghdldrv is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--elab-run";
+      return
+        Name = "elab-run" or else
+        Name = "--elab-run";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Elab_Run) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--elab-run [OPTS] UNIT [ARCH] [OPTS]  Elaborate and run UNIT";
+      return "elab-run [OPTS] UNIT [ARCH] [RUNOPTS]"
+        & ASCII.LF & "  Elaborate and run design UNIT"
+        & ASCII.LF & "  alias: --elab-run";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Elab_Run;
@@ -1277,20 +1315,24 @@ package body Ghdldrv is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--bind";
+      return
+        Name = "bind" or else
+        Name = "--bind";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Bind) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--bind [OPTS] UNIT [ARCH]  Bind UNIT";
+      return "bind [OPTS] UNIT [ARCH]"
+        & ASCII.LF & "  Bind design UNIT"
+        & ASCII.LF & "  alias: --bind";
    end Get_Short_Help;
 
    procedure Perform_Action
      (Cmd : in out Command_Bind; Args : Argument_List) is
    begin
-      Set_Elab_Units (Cmd, "--bind", Args);
+      Set_Elab_Units (Cmd, "bind", Args);
       Setup_Compiler (Cmd, False);
 
       Bind (Cmd);
@@ -1308,14 +1350,18 @@ package body Ghdldrv is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--link";
+      return
+        Name = "link" or else
+        Name = "--link";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Link) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--link [OPTS] UNIT [ARCH]  Link UNIT";
+      return "link [OPTS] UNIT [ARCH]"
+        & ASCII.LF & "  Link design UNIT"
+        & ASCII.LF & "  alias: --link";
    end Get_Short_Help;
 
    procedure Perform_Action
@@ -1342,14 +1388,18 @@ package body Ghdldrv is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--list-link";
+      return
+        Name = "list-link" or else
+        Name = "--list-link";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_List_Link) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--list-link [OPTS] UNIT [ARCH]  List objects file to link UNIT";
+      return "list-link [OPTS] UNIT [ARCH]"
+        & ASCII.LF & "  List objects file to link UNIT"
+        & ASCII.LF & "  alias: --list-link";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_List_Link;
@@ -1381,15 +1431,19 @@ package body Ghdldrv is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "-c";
+      return
+        Name = "compile" or else
+        Name = "-c";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Anaelab) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "-c [OPTS] FILEs -e UNIT [ARCH]  "
-        & "Generate whole code to elab UNIT from FILEs";
+      return "compile [OPTS] FILEs -e UNIT [ARCH]"
+        & ASCII.LF & "  Generate whole sequence to elaborate "
+        & "design UNIT from FILEs"
+        & ASCII.LF & "  alias: -c";
    end Get_Short_Help;
 
    procedure Decode_Option (Cmd : in out Command_Anaelab;
@@ -1464,23 +1518,27 @@ package body Ghdldrv is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "-m";
+      return
+        Name = "make" or else
+        Name = "-m";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Make) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "-m [OPTS] UNIT [ARCH]  Make UNIT";
+      return "make [OPTS] UNIT [ARCH]"
+        & ASCII.LF & "  Make design UNIT"
+        & ASCII.LF & "  alias: -m";
    end Get_Short_Help;
 
    procedure Disp_Long_Help (Cmd : Command_Make)
    is
    begin
       Disp_Long_Help (Command_Comp (Cmd));
-      Put_Line (" -b             Bind only; don't link");
-      Put_Line (" -f             Force recompilation of work units");
-      Put_Line (" -Mu            Disp unit dependences (human format)");
+      Put_Line (" -b" & ASCII.LF & "  Bind only; don't link");
+      Put_Line (" -f" & ASCII.LF & "  Force recompilation of work units");
+      Put_Line (" -Mu" & ASCII.LF & "  Disp unit dependences (human format)");
    end Disp_Long_Help;
 
    procedure Init (Cmd : in out Command_Make) is
@@ -1752,14 +1810,18 @@ package body Ghdldrv is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--gen-makefile";
+      return
+        Name = "gen-makefile" or else
+        Name = "--gen-makefile";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Gen_Makefile) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--gen-makefile [OPTS] UNIT [ARCH]  Generate a Makefile for UNIT";
+      return "gen-makefile [OPTS] UNIT [ARCH]"
+        & ASCII.LF & "  Generate a Makefile for design UNIT"
+        & ASCII.LF & "  alias: --gen-makefile";
    end Get_Short_Help;
 
    function Is_Makeable_File (File : Iir_Design_File) return Boolean is
@@ -1789,15 +1851,18 @@ package body Ghdldrv is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--gen-depends";
+      return
+        Name = "gen-depends" or else
+        Name = "--gen-depends";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Gen_Depends) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--gen-depends [OPTS] UNIT [ARCH]"
-        & "  Generate dependencies of UNIT";
+      return "gen-depends [OPTS] UNIT [ARCH]"
+        & ASCII.LF & "  Generate dependencies of design UNIT"
+        & ASCII.LF & "  alias: --gen-depends";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Gen_Depends;

--- a/src/ghdldrv/ghdllocal.adb
+++ b/src/ghdldrv/ghdllocal.adb
@@ -173,13 +173,20 @@ package body Ghdllocal is
       procedure P (Str : String) renames Put_Line;
    begin
       P ("Main options (try --options-help for details):");
-      P (" --std=XX       Use XX as VHDL standard (87,93c,93,00,02 or 08)");
-      P (" --work=NAME    Set the name of the WORK library");
-      P (" -PDIR          Add DIR in the library search path");
-      P (" --workdir=DIR  Specify the directory of the WORK library");
-      P (" -fsynopsys     Allow to use synopsys packages in ieee library");
-      P (" -frelaxed      Relax semantic rules");
-      P (" -fexplicit     Gives priority to explicit operator redefinitions");
+      P (" --std=XX");
+      P ("   Use XX as VHDL standard (87,93c,93,00,02 or 08)");
+      P (" --work=NAME");
+      P ("   Set the name of the WORK library");
+      P (" -PDIR");
+      P ("   Add DIR in the library search path");
+      P (" --workdir=DIR");
+      P ("   Specify the directory of the WORK library");
+      P (" -fsynopsys");
+      P ("   Allow to use synopsys packages in ieee library");
+      P (" -frelaxed");
+      P ("   Relax semantic rules");
+      P (" -fexplicit");
+      P ("   Gives priority to explicit operator redefinitions");
    end Disp_Long_Help;
 
    function Is_Directory_Separator (C : Character) return Boolean is
@@ -612,15 +619,20 @@ package body Ghdllocal is
    is
       pragma Unreferenced (Cmd);
    begin
-      --  '-d' is for compatibility.
-      return Name = "-d" or else Name = "--dir";
+      return
+        Name = "dir" or else
+        Name = "--dir" or else
+        --  '-d' is for compatibility.
+        Name = "-d";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Dir) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--dir [LIBs]       Disp contents of the libraries";
+      return "dir [LIBs]"
+        & ASCII.LF & "  Display contents of the libraries"
+        & ASCII.LF & "  alias: --dir";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Dir; Args : Argument_List)
@@ -648,14 +660,19 @@ package body Ghdllocal is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "-f";
+      return
+        Name = "files" or else
+        Name = "-f";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Find) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "-f FILEs           Disp units in FILES";
+      return "files FILEs"
+        & ASCII.LF & "  Display units in FILES"
+        & ASCII.LF & "  alias: -f";
+
    end Get_Short_Help;
 
    --  Return TRUE is UNIT can be at the apex of a design hierarchy.
@@ -727,14 +744,18 @@ package body Ghdllocal is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "-i";
+      return
+        Name = "import" or else
+        Name = "-i";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Import) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "-i [OPTS] FILEs    Import units of FILEs";
+      return "import [OPTS] FILEs"
+        & ASCII.LF & "  Import units of FILEs"
+        & ASCII.LF & "  alias: -i";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Import; Args : Argument_List)
@@ -823,14 +844,18 @@ package body Ghdllocal is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "-s";
+      return
+        Name = "syntax" or else
+        Name = "-s";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Check_Syntax) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "-s [OPTS] FILEs    Check syntax of FILEs";
+      return "syntax [OPTS] FILEs"
+        & ASCII.LF & "  Check syntax of FILEs"
+        & ASCII.LF & "  alias: -s";
    end Get_Short_Help;
 
    procedure Decode_Option (Cmd : in out Command_Check_Syntax;
@@ -931,14 +956,18 @@ package body Ghdllocal is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--clean";
+      return
+        Name = "clean" or else
+        Name = "--clean";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Clean) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--clean            Remove generated files";
+      return "clean"
+        & ASCII.LF & "  Remove generated files"
+        & ASCII.LF & "  alias: --clean";
    end Get_Short_Help;
 
    procedure Delete (Str : String)
@@ -1036,14 +1065,18 @@ package body Ghdllocal is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--remove";
+      return
+        Name = "remove" or else
+        Name = "--remove";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Remove) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--remove           Remove generated files and library file";
+      return "remove"
+        & ASCII.LF & "  Remove generated files and library file"
+        & ASCII.LF & "  alias: --remove";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Remove; Args : Argument_List)
@@ -1070,14 +1103,18 @@ package body Ghdllocal is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--copy";
+      return
+        Name = "copy" or else
+        Name = "--copy";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Copy) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--copy             Copy work library to current directory";
+      return "copy"
+        & ASCII.LF & "  Copy work library to current directory"
+        & ASCII.LF & "  alias: --copy";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Copy; Args : Argument_List)
@@ -1148,14 +1185,18 @@ package body Ghdllocal is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--disp-standard";
+      return
+        Name = "disp-std" or else
+        Name = "--disp-standard";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Disp_Standard) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--disp-standard    Disp std.standard in pseudo-vhdl";
+      return "disp-std"
+        & ASCII.LF & "  Disp std.standard in pseudo-vhdl"
+        & ASCII.LF & "  alias: --disp-standard";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Disp_Standard;
@@ -1185,14 +1226,18 @@ package body Ghdllocal is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--find-top";
+      return
+        Name = "find-top" or else
+        Name = "--find-top";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Find_Top) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--find-top         Disp possible top entity in work library";
+      return "find-top"
+        & ASCII.LF & "  Display possible top entity in work library"
+        & ASCII.LF & "  alias: --find-top";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Find_Top;
@@ -1242,14 +1287,18 @@ package body Ghdllocal is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--bug-box";
+      return
+        Name = "bug-box" or else
+        Name = "--bug-box";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Bug_Box) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "!--bug-box          Crash and emit a bug-box";
+      return "!bug-box"
+        & ASCII.LF & "  Crash and emit a bug-box"
+        & ASCII.LF & "  alias: --bug-box";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Bug_Box;
@@ -1735,14 +1784,18 @@ package body Ghdllocal is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--elab-order";
+      return
+        Name = "elab-order" or else
+        Name = "--elab-order";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Elab_Order) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--elab-order [OPTS] UNIT [ARCH]  Display ordered source files";
+      return "elab-order [OPTS] UNIT [ARCH]"
+        & ASCII.LF & "  Display ordered source files"
+        & ASCII.LF & "  alias: --elab-order";
    end Get_Short_Help;
 
    function Is_Makeable_File (File : Iir_Design_File) return Boolean is

--- a/src/ghdldrv/ghdlmain.adb
+++ b/src/ghdldrv/ghdlmain.adb
@@ -117,7 +117,10 @@ package body Ghdlmain is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "-h" or else Name = "--help";
+      return
+        Name = "help" or else
+        Name = "--help" or else
+        Name = "-h";
    end Decode_Command;
 
    procedure Decode_Option (Cmd : in out Command_Help;
@@ -136,7 +139,9 @@ package body Ghdlmain is
    is
       pragma Unreferenced (Cmd);
    begin
-      return "-h or --help [CMD] Disp this help or [help on CMD]";
+      return "help [CMD]"
+        & ASCII.LF & "  Display this help or [help on CMD]"
+        & ASCII.LF & "  aliases: -h, --help";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Help; Args : Argument_List)
@@ -163,8 +168,8 @@ package body Ghdlmain is
          end loop;
          New_Line;
          Put_Line ("To display the options of a GHDL program,");
-         Put_Line ("  run your program with the --help option.");
-         Put_Line ("Also see --options-help for analyzer options.");
+         Put_Line ("  run your program with the 'help' option.");
+         Put_Line ("Also see 'opts-help' for analyzer options.");
          New_Line;
          Put_Line ("Please, refer to the GHDL manual for more information.");
          Put_Line ("Report issues on https://github.com/ghdl/ghdl");
@@ -177,7 +182,7 @@ package body Ghdlmain is
          Put_Line (Get_Short_Help (C.all));
          Disp_Long_Help (C.all);
       else
-         Error ("Command '--help' accepts at most one argument.");
+         Error ("Command 'help' accepts at most one argument.");
          raise Option_Error;
       end if;
    end Perform_Action;
@@ -195,14 +200,18 @@ package body Ghdlmain is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--options-help";
+      return
+        Name = "opts-help" or else
+        Name = "--options-help";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Option_Help) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--options-help     Disp help for analyzer options";
+      return "opts-help"
+        & ASCII.LF & "  Display help for analyzer options"
+        & ASCII.LF & "  alias: --options-help";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Option_Help;
@@ -212,7 +221,7 @@ package body Ghdlmain is
    begin
       if Args'Length /= 0 then
          Error
-           ("warning: command '--option-help' does not accept any argument");
+           ("warning: command 'opts-help' does not accept any argument");
       end if;
       Options.Disp_Options_Help;
    end Perform_Action;
@@ -230,14 +239,19 @@ package body Ghdlmain is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "-v" or Name = "--version";
+      return
+        Name = "version" or else
+        Name = "--version" or else
+        Name = "-v";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Version) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "-v or --version    Disp ghdl version";
+      return "version"
+        & ASCII.LF & "  Display ghdl version"
+        & ASCII.LF & "  aliases: -v, --version";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Version;
@@ -300,7 +314,7 @@ package body Ghdlmain is
       --  Decode command.
       Cmd := Find_Command (Cmd_Name);
       if Cmd = null then
-         Error ("unknown command '" & Cmd_Name & "', try --help");
+         Error ("unknown command '" & Cmd_Name & "', try 'help'");
          raise Option_Error;
       end if;
 
@@ -414,7 +428,7 @@ package body Ghdlmain is
 
       --  Handle case of no argument
       if Argument_Count = 0 then
-         Error ("missing command, try " & Command_Name & " --help");
+         Error ("missing command, try " & Command_Name & " 'help'");
          raise Option_Error;
       end if;
 

--- a/src/ghdldrv/ghdlprint.adb
+++ b/src/ghdldrv/ghdlprint.adb
@@ -560,14 +560,18 @@ package body Ghdlprint is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--chop";
+      return
+        Name = "chop" or else
+        Name = "--chop";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Chop) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--chop [OPTS] FILEs  Chop FILEs";
+      return "chop [OPTS] FILEs"
+        & ASCII.LF & "  Chop FILEs"
+        & ASCII.LF & "  alias: --chop";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Chop; Args : Argument_List)
@@ -858,14 +862,18 @@ package body Ghdlprint is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--lines";
+      return
+        Name = "lines" or else
+        Name = "--lines";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Lines) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--lines FILEs      Precede line with its number";
+      return "lines FILEs"
+        & ASCII.LF & "  Precede line with its number"
+        & ASCII.LF & "  alias: --lines";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Lines; Args : Argument_List)
@@ -988,14 +996,18 @@ package body Ghdlprint is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--reprint";
+      return
+        Name = "reprint" or else
+        Name = "--reprint";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Reprint) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--reprint [OPTS] FILEs    Redisplay FILEs";
+      return "reprint [OPTS] FILEs"
+        & ASCII.LF & "  Redisplay FILEs"
+        & ASCII.LF & "  alias: --reprint";
    end Get_Short_Help;
 
    procedure Decode_Option (Cmd : in out Command_Reprint;
@@ -1134,14 +1146,18 @@ package body Ghdlprint is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--compare-tokens";
+      return
+        Name = "cmp-tokens" or else
+        Name = "--compare-tokens";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Compare_Tokens) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--compare-tokens [OPTS] REF FILEs    Compare FILEs with REF";
+      return "cmp-tokens [OPTS] REF FILEs"
+        & ASCII.LF & "  Compare FILEs with REF"
+        & ASCII.LF & "  alias: --compare-tokens";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Compare_Tokens;
@@ -1261,14 +1277,18 @@ package body Ghdlprint is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--pp-html";
+      return
+        Name = "pp-html" or else
+        Name = "--pp-html";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_PP_Html) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--pp-html FILEs    Pretty-print FILEs in HTML";
+      return "pp-html FILEs"
+        & ASCII.LF & "  Pretty-print FILEs in HTML"
+        & ASCII.LF & "  alias: --pp-html";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_PP_Html;
@@ -1332,14 +1352,18 @@ package body Ghdlprint is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--xref-html";
+      return
+        Name = "xref-html" or else
+        Name = "--xref-html";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Xref_Html) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--xref-html FILEs  Display FILEs in HTML with xrefs";
+      return "xref-html FILEs"
+        & ASCII.LF & "  Display FILEs in HTML with xrefs"
+        & ASCII.LF & "  alias: --xref-html";
    end Get_Short_Help;
 
    procedure Decode_Option (Cmd : in out Command_Xref_Html;
@@ -1640,14 +1664,18 @@ package body Ghdlprint is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--xref";
+      return
+        Name = "xref" or else
+        Name = "--xref";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Xref) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--xref FILEs  Generate xrefs";
+      return "xref FILEs"
+        & ASCII.LF & "  Generate xrefs"
+        & ASCII.LF & "  alias: --xref";
    end Get_Short_Help;
 
    procedure Perform_Action

--- a/src/ghdldrv/ghdlrun.adb
+++ b/src/ghdldrv/ghdlrun.adb
@@ -793,14 +793,18 @@ package body Ghdlrun is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--run-help";
+      return
+        Name = "run-help" or else
+        Name = "--run-help";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Run_Help) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--run-help         Disp help for RUNOPTS options";
+      return "run-help"
+        & ASCII.LF & "  Display help for RUNOPTS options"
+        & ASCII.LF & "  alias: --run-help";
    end Get_Short_Help;
 
    procedure Perform_Action (Cmd : in out Command_Run_Help;

--- a/src/ghdldrv/ghdlsynth.adb
+++ b/src/ghdldrv/ghdlsynth.adb
@@ -95,14 +95,18 @@ package body Ghdlsynth is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--synth";
+      return
+        Name = "synth" or else
+        Name = "--synth";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_Synth) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--synth [FILES... -e] UNIT [ARCH]   Synthesis from UNIT";
+      return "synth [FILES... -e] UNIT [ARCH]"
+        & ASCII.LF & "  Synthesis from UNIT"
+        & ASCII.LF & "  alias: --synth";
    end Get_Short_Help;
 
    procedure Disp_Long_Help (Cmd : Command_Synth)
@@ -117,10 +121,14 @@ package body Ghdlsynth is
       P ("Or use already analysed files:");
       P ("   --synth [OPTIONS] -e UNIT");
       P ("In addition to analyze options, you can use:");
-      P ("  -gNAME=VALUE          Override the generic NAME of the top unit");
-      P ("  --vendor-library=NAME Any unit from library NAME is a black boxe");
-      P ("  --no-formal           Neither synthesize assert nor PSL");
-      P ("  --no-assert-cover     Cover PSL assertion activation");
+      P ("  -gNAME=VALUE");
+      P ("    Override the generic NAME of the top unit");
+      P ("  --vendor-library=NAME");
+      P ("    Any unit from library NAME is a black boxe");
+      P ("  --no-formal");
+      P ("    Neither synthesize assert nor PSL");
+      P ("  --no-assert-cover");
+      P ("    Cover PSL assertion activation");
    end Disp_Long_Help;
 
    procedure Decode_Option (Cmd : in out Command_Synth;
@@ -536,7 +544,8 @@ package body Ghdlsynth is
             Cmd_Str => new String'
               ("--libghdl-name"),
             Help_Str => new String'
-              ("--libghdl-name  Display libghdl name"),
+              ("--libghdl-name"
+              & ASCII.LF & "  Display libghdl name"),
             Disp => Get_Libghdl_Name'Access));
       Register_Command
         (new Command_Str_Disp'
@@ -544,7 +553,8 @@ package body Ghdlsynth is
             Cmd_Str => new String'
               ("--libghdl-library-path"),
             Help_Str => new String'
-              ("--libghdl-library-path  Display libghdl library path"),
+              ("--libghdl-library-path"
+              & ASCII.LF & "  Display libghdl library path"),
             Disp => Get_Libghdl_Path'Access));
       Register_Command
         (new Command_Str_Disp'
@@ -552,7 +562,8 @@ package body Ghdlsynth is
             Cmd_Str => new String'
               ("--libghdl-include-dir"),
             Help_Str => new String'
-              ("--libghdl-include-dir  Display libghdl include directory"),
+              ("--libghdl-include-dir"
+              & ASCII.LF & "  Display libghdl include directory"),
             Disp => Get_Libghdl_Include_Dir'Access));
    end Register_Commands;
 

--- a/src/ghdldrv/ghdlvpi.adb
+++ b/src/ghdldrv/ghdlvpi.adb
@@ -222,7 +222,8 @@ package body Ghdlvpi is
             Cmd_Str => new String'
               ("--vpi-compile"),
             Help_Str => new String'
-              ("--vpi-compile CMD ARGS    Compile with VPI include path"),
+              ("--vpi-compile CMD ARGS"
+              & ASCII.LF & "  Compile with VPI include path"),
             Extra_Args => Get_Vpi_Cflags'Access));
       Register_Command
         (new Command_Spawn_Type'
@@ -231,7 +232,8 @@ package body Ghdlvpi is
             Cmd_Str => new String'
               ("--vpi-link"),
             Help_Str => new String'
-              ("--vpi-link CMD ARGS       Link with VPI library"),
+              ("--vpi-link CMD ARGS"
+              & ASCII.LF & "  Link with VPI library"),
             Extra_Args => Get_Vpi_Ldflags'Access));
 
       Register_Command
@@ -240,7 +242,8 @@ package body Ghdlvpi is
             Cmd_Str => new String'
               ("--vpi-cflags"),
             Help_Str => new String'
-              ("--vpi-cflags       Display VPI compile flags"),
+              ("--vpi-cflags"
+              & ASCII.LF & "  Display VPI compile flags"),
             Flags => Get_Vpi_Cflags'Access));
       Register_Command
         (new Command_Vpi_Flags'
@@ -248,7 +251,8 @@ package body Ghdlvpi is
             Cmd_Str => new String'
               ("--vpi-ldflags"),
             Help_Str => new String'
-              ("--vpi-ldflags      Display VPI link flags"),
+              ("--vpi-ldflags"
+              & ASCII.LF & "  Display VPI link flags"),
             Flags => Get_Vpi_Ldflags'Access));
 
       Register_Command
@@ -257,7 +261,8 @@ package body Ghdlvpi is
             Cmd_Str => new String'
               ("--vpi-include-dir"),
             Help_Str => new String'
-              ("--vpi-include-dir  Display VPI include directory"),
+              ("--vpi-include-dir"
+              & ASCII.LF & "  Display VPI include directory"),
             Disp => Get_Vpi_Include_Dir'Access));
       Register_Command
         (new Command_Str_Disp'
@@ -265,7 +270,8 @@ package body Ghdlvpi is
             Cmd_Str => new String'
               ("--vpi-library-dir"),
             Help_Str => new String'
-              ("--vpi-library-dir  Display VPI library directory"),
+              ("--vpi-library-dir"
+              & ASCII.LF & "  Display VPI library directory"),
             Disp => Get_Vpi_Lib_Dir'Access));
       Register_Command
         (new Command_Str_Disp'
@@ -273,8 +279,8 @@ package body Ghdlvpi is
             Cmd_Str => new String'
               ("--vpi-library-dir-unix"),
             Help_Str => new String'
-              ("--vpi-library-dir-unix  "
-                 & "Display VPI library directory (unix form)"),
+              ("--vpi-library-dir-unix"
+              & ASCII.LF & "  Display VPI library directory (unix form)"),
             Disp => Get_Vpi_Lib_Dir_Unix'Access));
 
    end Register_Commands;

--- a/src/ghdldrv/ghdlxml.adb
+++ b/src/ghdldrv/ghdlxml.adb
@@ -523,14 +523,18 @@ package body Ghdlxml is
    is
       pragma Unreferenced (Cmd);
    begin
-      return Name = "--file-to-xml";
+      return
+        Name = "file-to-xml" or else
+        Name = "--file-to-xml";
    end Decode_Command;
 
    function Get_Short_Help (Cmd : Command_File_To_Xml) return String
    is
       pragma Unreferenced (Cmd);
    begin
-      return "--file-to-xml FILEs  Dump AST in XML";
+      return "file-to-xml FILEs"
+        & ASCII.LF & "  Dump AST in XML"
+        & ASCII.LF & "  alias: --file-to-xml";
    end Get_Short_Help;
 
    procedure Perform_Action

--- a/testsuite/testsuite.sh
+++ b/testsuite/testsuite.sh
@@ -249,5 +249,10 @@ for t in $tests; do do_test $t; done
 printf "${ANSI_GREEN}[GHDL - test] SUCCESSFUL${ANSI_NOCOLOR}\n"
 touch test_ok
 
-printf "GHDL is: %s\n\n" "$GHDL"
-$GHDL --version
+gstart "GHDL is: $GHDL"
+$GHDL version
+gend
+
+gstart "GHDL help"
+$GHDL help
+gend


### PR DESCRIPTION
This PR implements the initial proposal in #1204. Commands without `--` or `-` are supported, and others are defined as aliases. The help is modified accordingly.

I modified the testsuite for printing the help at the end. As a result, the proposed new layout can be seen in the tests below.

There are two sets of commands which are defined differently, and I didn't know how define aliases for them, so I left them untouched (the layout changed only). Those are `--libghdl-*` and `--vpi-*` commands, defined/registered in `ghdlvpi.adb` and `ghdlsynth.adb`, respectively.

Apart from that, there are some commands which have the same prefix. For example `disp-config` and `disp-std`, or `gen-makefile` and `gen-depends`. The last two are close, but `disp-*` are far from each other. I tried to understand how to change the order, but it seems not straightforward because commands are shown in the same order as registered. @tgingold what do you think about displaying commands alphabetically? Alternatively, I thought about making subcommands (`ghdl disp config`, `ghdl disp std`, etc.), but I think it is not worth (not yet, at least).


