### PR TITLE
doc: add gnatdoc HTML output

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -15,7 +15,21 @@ jobs:
         docker build -t ghdl/doc - <<-EOF
         FROM ghdl/vunit:llvm
         ENV PYTHONPATH=/src/python
+        RUN apt update -qq && apt install -y gnat-gps
         EOF
+
+    - name: Run gnatdoc
+      run: |
+        cat > run.sh <<-EOF
+        #!/usr/bin/env sh
+        ./configure
+        make
+        gnatdoc -P./ghdl
+        mkdir public
+        mv gnatdoc public
+        EOF
+        chmod +x run.sh
+        docker run --rm -v $(pwd):/src -w /src ghdl/doc ./run.sh
 
     - uses: buildthedocs/btd@v0
       with:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -113,10 +113,8 @@ if ctx.is_file():
 html_theme_path = ["."]
 html_theme = "_theme"
 
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+html_extra_path = [str(Path(__file__).resolve().parent.parent / 'public')]
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'GHDLdoc'


### PR DESCRIPTION
Ref #484 #1437

In this PR browsable documentation of the codebase is generated with `gnatdoc` and published to the site. See https://umarcor.github.io/ghdl/gnatdoc/
