### PR TITLE
PSL doc: only clocked directives are supported

### DIFF
--- a/doc/using/ImplementationOfVHDL.rst
+++ b/doc/using/ImplementationOfVHDL.rst
@@ -121,8 +121,8 @@ PSL implementation
 A PSL statement is considered as a process, so it's not allowed within
 a process.
 
-All PSL assertions must be clocked (GHDL doesn't support unclocked assertions).
-Furthermore only one clock per assertion is allowed.
+All PSL directives (`assert`, `assume`, `restrict`, `cover`) must be clocked (GHDL doesn't support unclocked directives).
+Furthermore only one clock per directive is allowed.
 
 You can either use a default clock like this:
 


### PR DESCRIPTION
Small update to PSL documentation adding a hint that all directives has to be clocked. Not only `assert` as  before.