### PR TITLE
Support building GHDL with LLVM backend using clang on MSYS2/mingw64

### DIFF
--- a/configure
+++ b/configure
@@ -294,7 +294,7 @@ fi
 # Define default file extensions for Windows or Linux-like systems and
 # use -fPIC or not.
 case "$build" in
-  *mingw* | *cygwin*) SOEXT=".dll";   EXEEXT=".exe"; PIC_FLAGS="";;
+  *mingw* | *cygwin* | *windows-gnu*) SOEXT=".dll";   EXEEXT=".exe"; PIC_FLAGS="";;
   *darwin*)           SOEXT=".dylib"; EXEEXT="";     PIC_FLAGS="";;
   *)                  SOEXT=".so";    EXEEXT="";     PIC_FLAGS="-fPIC";;
 esac

--- a/dist/msys2-mingw/llvm/PKGBUILD
+++ b/dist/msys2-mingw/llvm/PKGBUILD
@@ -11,6 +11,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-ada")
 build() {
   mkdir "${srcdir}/builddir"
   cd "${srcdir}/builddir"
+  export CC=clang
+  export CXX=clang++
   ../../../../../configure --prefix=${MINGW_PREFIX} --with-llvm-config="llvm-config --link-static" LDFLAGS="-static" --enable-libghdl --enable-synth
   make GNATMAKE="gnatmake -j$(nproc)"
 }

--- a/src/grt/Makefile.inc
+++ b/src/grt/Makefile.inc
@@ -57,7 +57,7 @@ GRT_ELF_EXEC_OPTS:=-Wl,--version-script=@/grt.ver -Wl,--export-dynamic
 #     functions) so that a vpi object file can refer them.
 #  GRT_SHARED_OPTS: platform specific options to be added during link of
 #     -shared simulation binaries.  Used instead of GET_EXEC_OPTS
-ifeq ($(filter-out mingw32 mingw64,$(osys)),)
+ifeq ($(filter-out mingw32 mingw64 windows,$(osys)),)
   # For windows.
   GRT_TARGET_OBJS=win32.o clock.o
   GRT_EXTRA_LIB=-ldbghelp


### PR DESCRIPTION
Currently, building GHDL with LLVM backend using clang on MSYS2/mingw64 fails because the output of `clang -dumpmachine` is not supported.

On GNU/Linux:

```
# gcc -dumpmachine
x86_64-linux-gnu

# clang -dumpmachine
x86_64-pc-linux-gnu
```

On MINGW64:

```
# gcc -dumpmachine
x86_64-w64-mingw32

# clang -dumpmachine
x86_64-w64-windows-gnu
```

This PR fixes `configure` and `src/grt/Makefile.inc` for detecting `x86_64-w64-windows-gnu` properly. At the same time, the PKGBUILD recipe is modified to use `CC=clang` and `CXX=clang++`.

The build is successful and several tests do pass. However, one of the tests in gna fails:

```
  gna issue635: failed
  analyze tb.vhdl ram.vhdl fsm.vhdl
  ram.vhdl:29:15:warning: declaration of "ram" hides entity "ram" [-Whide]
  elaborate and simulate (failure expected) testbench
  ../../src/ieee2008/numeric_std-body.vhdl:3036:7:@100ns:(assertion warning): NUMERIC_STD.TO_INTEGER: metavalue detected, returning 0
  ../../src/ieee2008/numeric_std-body.vhdl:3036:7:@100ns:(assertion warning): NUMERIC_STD.TO_INTEGER: metavalue detected, returning 0
  ../../src/ieee2008/numeric_std-body.vhdl:3036:7:@100ns:(assertion warning): NUMERIC_STD.TO_INTEGER: metavalue detected, returning 0
  ../../src/ieee2008/numeric_std-body.vhdl:3036:7:@100ns:(assertion warning): NUMERIC_STD.TO_INTEGER: metavalue detected, returning 0
  ../../src/ieee2008/numeric_std-body.vhdl:3036:7:@200ns:(assertion warning): NUMERIC_STD.TO_INTEGER: metavalue detected, returning 0
  ../../src/ieee2008/numeric_std-body.vhdl:3036:7:@200ns:(assertion warning): NUMERIC_STD.TO_INTEGER: metavalue detected, returning 0
  ../../src/ieee2008/numeric_std-body.vhdl:3036:7:@200ns:(assertion warning): NUMERIC_STD.TO_INTEGER: metavalue detected, returning 0
  ../../src/ieee2008/numeric_std-body.vhdl:3036:7:@200ns:(assertion warning): NUMERIC_STD.TO_INTEGER: metavalue detected, returning 0
  tb.vhdl:71:24:@28200ns:(assertion failure): Unexpected result: intput1 = 10; output = 81; outputExpected = 59
  .\testbench:error: assertion failed
  in process .testbench(test).simulation
```

Ref https://github.com/msys2/MINGW-packages/pull/5757#issuecomment-650382155 https://github.com/open-tool-forge/fpga-toolchain/issues/62#issuecomment-714855356
