### PR TITLE
Skip some tests if gcc is not installed

### DIFF
--- a/testsuite/gna/bug097/testsuite.sh
+++ b/testsuite/gna/bug097/testsuite.sh
@@ -2,17 +2,19 @@
 
 . ../../testenv.sh
 
-if [ -z $CC ]; then
-  CC="gcc"
+if c_compiler_is_available; then
+  if [ -z $CC ]; then
+    CC="gcc"
+  fi
+
+  $CC -c -fPIC getrand.c
+  $CC -o getrand.so --shared getrand.o
+
+  analyze tb.vhdl
+  elab_simulate tb
+
+  rm -f getrand.o getrand.so
 fi
-
-$CC -c -fPIC getrand.c
-$CC -o getrand.so --shared getrand.o
-
-analyze tb.vhdl
-elab_simulate tb
-
 clean
-rm -f getrand.o getrand.so
 
 echo "Test successful"

--- a/testsuite/gna/issue1226/testsuite.sh
+++ b/testsuite/gna/issue1226/testsuite.sh
@@ -5,7 +5,7 @@
 analyze adder.vhdl
 elab adder
 
-if ghdl_has_feature adder vpi; then
+if c_compiler_is_available && ghdl_has_feature adder vpi; then
   add_vpi_path
 
   $GHDL --vpi-compile -v gcc -c vpi_plugin.c

--- a/testsuite/gna/issue1228/testsuite.sh
+++ b/testsuite/gna/issue1228/testsuite.sh
@@ -5,7 +5,7 @@
 analyze test_load.vhdl
 elab test_load
 
-if ghdl_has_feature test_load vpi; then
+if c_compiler_is_available && ghdl_has_feature test_load vpi; then
   add_vpi_path
 
   $GHDL --vpi-compile -v gcc $CFLAGS -c vpi1.c

--- a/testsuite/gna/issue1233/testsuite.sh
+++ b/testsuite/gna/issue1233/testsuite.sh
@@ -5,7 +5,7 @@
 analyze adder.vhdl
 elab adder
 
-if ghdl_has_feature adder vpi; then
+if c_compiler_is_available && ghdl_has_feature adder vpi; then
   add_vpi_path
 
   $GHDL --vpi-compile -v gcc -c vpi_plugin.c

--- a/testsuite/gna/issue1256/testsuite.sh
+++ b/testsuite/gna/issue1256/testsuite.sh
@@ -5,7 +5,7 @@
 analyze enum_test.vhdl
 elab enum_test
 
-if ghdl_has_feature enum_test vpi; then
+if c_compiler_is_available && ghdl_has_feature enum_test vpi; then
   add_vpi_path
 
   $GHDL --vpi-compile -v gcc -c vpi_plugin.c

--- a/testsuite/gna/issue1326/testsuite.sh
+++ b/testsuite/gna/issue1326/testsuite.sh
@@ -7,10 +7,13 @@ elab mytestbench
 
 simulate mytestbench --wave=dump.ghw | tee mytestbench.out
 
-gcc ../../../src/grt/ghwdump.c ../../../src/grt/ghwlib.c -I../../../src/grt/ -o ghwdump
+if c_compiler_is_available; then
 
-# We're just checking that ghwdump doesn't crash on a zero length signal.
-./ghwdump -ths dump.ghw > dump.txt
+  gcc ../../../src/grt/ghwdump.c ../../../src/grt/ghwlib.c -I../../../src/grt/ -o ghwdump
+
+  # We're just checking that ghwdump doesn't crash on a zero length signal.
+  ./ghwdump -ths dump.ghw > dump.txt
+fi
 
 rm -f mytestbench.out ghwdump dump.txt dump.ghw
 clean

--- a/testsuite/gna/issue450/testsuite.sh
+++ b/testsuite/gna/issue450/testsuite.sh
@@ -5,7 +5,7 @@
 analyze disptree.vhdl
 elab disptree
 
-if ghdl_has_feature disptree vpi; then
+if c_compiler_is_available && ghdl_has_feature disptree vpi; then
   add_vpi_path
 
   $GHDL --vpi-compile -v gcc -c vpi2.c

--- a/testsuite/gna/issue531/testsuite.sh
+++ b/testsuite/gna/issue531/testsuite.sh
@@ -5,7 +5,7 @@
 analyze repro1.vhdl
 elab sliced_ex
 
-if ghdl_has_feature sliced_ex vpi; then
+if c_compiler_is_available && ghdl_has_feature sliced_ex vpi; then
   $GHDL --vpi-compile -v gcc -c vpi1.c
   $GHDL --vpi-link -v gcc -o vpi1.vpi vpi1.o
 

--- a/testsuite/gna/issue98/testsuite.sh
+++ b/testsuite/gna/issue98/testsuite.sh
@@ -5,7 +5,7 @@
 analyze test_load.vhdl
 elab test_load
 
-if ghdl_has_feature test_load vpi; then
+if c_compiler_is_available && ghdl_has_feature test_load vpi; then
   add_vpi_path
 
   $GHDL --vpi-compile -v gcc -c vpi1.c

--- a/testsuite/testenv.sh
+++ b/testsuite/testenv.sh
@@ -148,6 +148,15 @@ synth_tb()
   clean
 }
 
+# Check if a C compiler is installed on this system
+c_compiler_is_available ()
+{
+  if [ -z $CC ]; then
+    CC="gcc"
+  fi
+  which $CC
+}
+
 # Check if a feature is present
 ghdl_has_feature ()
 {

--- a/testsuite/vpi/vpi001/testsuite.sh
+++ b/testsuite/vpi/vpi001/testsuite.sh
@@ -5,7 +5,7 @@
 analyze mydesign.vhdl
 elab myentity
 
-if ghdl_has_feature myentity vpi; then
+if c_compiler_is_available && ghdl_has_feature myentity vpi; then
   $GHDL --vpi-compile -v gcc -c vpi1.c
   $GHDL --vpi-link -v gcc -o vpi1.vpi vpi1.o
 

--- a/testsuite/vpi/vpi002/testsuite.sh
+++ b/testsuite/vpi/vpi002/testsuite.sh
@@ -5,7 +5,7 @@
 analyze mydesign.vhdl
 elab myentity
 
-if ghdl_has_feature myentity vpi; then
+if c_compiler_is_available && ghdl_has_feature myentity vpi; then
   $GHDL --vpi-compile -v gcc -c vpi1.c
   $GHDL --vpi-link -v gcc -o vpi1.vpi vpi1.o
 

--- a/testsuite/vpi/vpi003/testsuite.sh
+++ b/testsuite/vpi/vpi003/testsuite.sh
@@ -5,7 +5,7 @@
 analyze mydesign.vhdl
 elab myentity
 
-if ghdl_has_feature myentity vpi; then
+if c_compiler_is_available && ghdl_has_feature myentity vpi; then
   $GHDL --vpi-compile -v gcc -c vpi1.c
   $GHDL --vpi-link -v gcc -o vpi1.vpi vpi1.o
 


### PR DESCRIPTION
**Background**
Related to ghdl/docker#34.

We want to have a docker image with ghdl that is minimal in size. That implies not including a gcc installation in the image. We do however want to run the testsuite to make sure the docker image "works".

**Description**
This PR makes it possible to run the testsuite on a system that does not have gcc installed. Tests that require gcc will be skipped (reported as "ok").