### PR TITLE
win32: add fprintf to grt_save_backtrace

### DIFF
--- a/src/grt/config/win32.c
+++ b/src/grt/config/win32.c
@@ -198,6 +198,14 @@ __ghdl_run_through_longjump (int (*func)(void))
 void
 grt_save_backtrace (struct backtrace_addrs *bt, int skip)
 {
+  /* FIXME
+  testsuite/gna/issue635 fails on GitHub Actions when executed with
+  LLVM backend on MINGW64 (MSYS2). GHDL returns '3', instead of '0'.
+  This dummy printf fixes it, surprisingly.
+  See https://github.com/ghdl/ghdl/pull/1516
+  */
+  printf("");
+
   CONTEXT ctxt;
 
   RtlCaptureContext (&ctxt);


### PR DESCRIPTION
Honestly, I don't know how to explain this. Since MSYS2 recipes were modifidied for using clang when building with LLVM backend (#1497), one test has been failing in CI: issue635. It is difficult to debug, because I cannot reproduce locally.

The issue is that the exit code is `3`, when it should be `0`. I run the test on GDB in CI, and I could confirm that: https://github.com/eine/ghdl/runs/1422980823?check_suite_focus=true#step:8:64. Then, Tristan told me that the issue might be in `src/grt/config/win32.c`. Hence, I added some `printf` statements, to see which functions are used. Surprisingly, that fixed the issue. I removed the print statements one by one, until I came to this minimal "fix".

So, adding an empty printf statement to `grt_save_backtrace` fixes the issue, but I cannot explain why.

