### PR TITLE
vhdl-sem_stmts: fix typo

### DIFF
--- a/src/vhdl/vhdl-sem_stmts.adb
+++ b/src/vhdl/vhdl-sem_stmts.adb
@@ -587,7 +587,7 @@ package body Vhdl.Sem_Stmts is
                      elsif Time <= Last_Time then
                         Error_Msg_Sem
                           (+Expr,
-                           "time must be greather than previous transaction");
+                           "time must be greater than previous transaction");
                      else
                         Last_Time := Time;
                      end if;


### PR DESCRIPTION
**Description** Please explain the changes you made here.

"time must be **greather** than previous transaction" -> "time must be **greater** than previous transaction"

(h was in the word 'greater')

:rotating_light: Before submitting your PR, please read [contribute](http://ghdl.github.io/ghdl/contribute.html#fork-modify-and-pull-request) in the [Docs](http://ghdl.github.io/ghdl), and review the following checklist:

- [X] DO indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

No issues fixed, just a typo.

**When contributing to the GHDL codebase...**

- [X] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [X] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
- [X] CONSIDER adding a unit test if your PR resolves an issue.
- [X] CONSIDER modifying the docs, if your contribution is relevant to any of the content.
- [X] AVOID breaking the continuous integration build.
- [X] AVOID breaking the testsuite.

**When contributing to the docs...**

- [X] DO make sure that the build is successful.

**Further comments**

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
