### PR TITLE
Fix 'ghdl build produces an executable with RWX sections'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,26 +16,31 @@ testsuite/get_entities
 /dist/msys2-mingw/**/logpipe.*
 /dist/msys2-mingw/**/*.log
 
-# Generated directories on Linux
-lib/
-
 # Generated files on Linux
-/Makefile
-libghdlvpi.so
-version.ads
-version.tmp
 config.status
 default_paths.ads
+doc/_build/
 elf_arch.ads
-ghdl.gpr
 ghdl1-*
+ghdl.gpr
 ghdl_llvm
+ghdl_mcode
+ghdlsynth_maybe.ads
 grt-backtraces-impl.ads
 grt-files
 grt-files.in
 grt.lst
+lib/
+libghdl-*.so
+libghdl.a
+libghdl.bind
+libghdl.link
+libghdlvpi.so
 libgrt.a
+/Makefile
+ortho_code-x86-flags.ads
 run-bind.adb
 run-bind.ads
 src/version.ads
-doc/_build/
+version.ads
+version.tmp

--- a/src/grt/config/chkstk.S
+++ b/src/grt/config/chkstk.S
@@ -50,3 +50,7 @@ __chkstk:
 #endif
 
 	.ident	"Written by T.Gingold"
+
+#if defined(__linux__) && defined(__ELF__)
+	.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
This PR adds an `.note.GNU-stack` section to `chkstk.o`, which fixes #1524.
Additionally, it updates `.gitignore` to ignore a few additional generated files on linux. I sorted the "generated files list" to be easier comparable.
