### PR TITLE
ci/msys2: split build and test

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -106,7 +106,7 @@ jobs:
         GITHUB_OS: ${{ runner.os }}
 
 #
-# Windows
+# Windows Build
 #
 
   win:
@@ -121,7 +121,7 @@ jobs:
           #{installs: "MINGW64", arch: x86_64, pkg: "mcode"}, ! mcode is not yet supported on win64
           {installs: "MINGW64", arch: x86_64, pkg: "llvm"},
         ]
-    name: '🟪 MSYS2 · ${{ matrix.installs }} · ${{ matrix.pkg }}'
+    name: '🟪 Build · ${{ matrix.installs }} · ${{ matrix.pkg }}'
     env:
       MINGW_INSTALLS: ${{ matrix.installs }}
     defaults:
@@ -138,7 +138,6 @@ jobs:
           base-devel
           git
           mingw-w64-${{ matrix.arch }}-toolchain
-          mingw-w64-${{ matrix.arch }}-python-pip
 
     - run: git config --global core.autocrlf input
       shell: bash
@@ -154,9 +153,6 @@ jobs:
         cd dist/msys2-${{ matrix.pkg }}
         makepkg-mingw --noconfirm --noprogressbar -sCLf
 
-    - name: Install package
-      run: pacman --noconfirm -U dist/msys2-${{ matrix.pkg }}/mingw-w64-*-any.pkg.tar.zst
-
     - name: '📤 Upload artifact: builddir'
       uses: actions/upload-artifact@v2
       with:
@@ -170,12 +166,61 @@ jobs:
       with:
         path: ./dist/msys2-${{ matrix.pkg }}/mingw-*ghdl*.pkg.tar.zst
 
-    - name: Test package
+#
+# Windows Test
+#
+
+  win-test:
+    needs: win
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        sys: [
+          {installs: "MINGW32", arch: i686, pkg: "mcode"},
+          #{installs: "MINGW32", arch: i686, pkg: "llvm"},  ! Not yet functional
+          #{installs: "MINGW64", arch: x86_64, pkg: "mcode"}, ! mcode is not yet supported on win64
+          {installs: "MINGW64", arch: x86_64, pkg: "llvm"},
+        ]
+        suite: [
+          'sanity pyunit vpi',
+          'gna',
+          'vests',
+          'synth',
+        ]
+    name: '🟪 Test · ${{ matrix.sys.installs }} · ${{ matrix.sys.pkg }} · ${{ matrix.suite }}'
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+
+    - name: '🟪 Setup MSYS2'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.sys.installs }}
+        update: true
+        install: >
+          mingw-w64-${{ matrix.sys.arch }}-diffutils
+          mingw-w64-${{ matrix.sys.arch }}-gcc
+          mingw-w64-${{ matrix.sys.arch }}-python-pip
+
+    - run: git config --global core.autocrlf input
+      shell: bash
+
+    - name: '🧰 Checkout'
+      uses: actions/checkout@v2
+
+    - name: '📥 Download artifact: package'
+      uses: actions/download-artifact@v2
+
+    - name: Install package and Python dependencies
       run: |
+        pacman --noconfirm -U artifact/mingw-w64-${{ matrix.sys.arch }}-ghdl-${{ matrix.sys.pkg }}-*.zst
         pip3 install -r testsuite/requirements.txt
-        GHDL=ghdl ./testsuite/testsuite.sh
-      env:
-        MSYSTEM: ${{ matrix.installs }}
+
+    - name: Test package
+      run: GHDL=ghdl ./testsuite/testsuite.sh ${{ matrix.suite }}
 
 #
 # NIGHTLY
@@ -183,7 +228,7 @@ jobs:
 
   nightly:
     if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
-    needs: [ lin, win ]
+    needs: [ lin, win-test ]
     runs-on: ubuntu-latest
     name: '📦 Nightly'
     steps:

--- a/dist/msys2-llvm/PKGBUILD
+++ b/dist/msys2-llvm/PKGBUILD
@@ -5,15 +5,21 @@ pkgver=ci
 pkgrel=1
 pkgdesc="GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL (LLVM backend) (mingw-w64)"
 arch=('any')
-depends=('zlib-devel' "${MINGW_PACKAGE_PREFIX}-clang")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-ada")
+depends=('zlib-devel'
+         "${MINGW_PACKAGE_PREFIX}-clang"
+         "${MINGW_PACKAGE_PREFIX}-gcc-ada")
 
 build() {
   mkdir "${srcdir}/builddir"
   cd "${srcdir}/builddir"
   export CC=clang
   export CXX=clang++
-  ../../../../configure --prefix=${MINGW_PREFIX} --with-llvm-config="llvm-config --link-static" LDFLAGS="-static" --enable-libghdl --enable-synth
+  ../../../../configure \
+    --prefix=${MINGW_PREFIX} \
+    --with-llvm-config="llvm-config --link-static" \
+    LDFLAGS="-static" \
+    --enable-libghdl \
+    --enable-synth
   make GNATMAKE="gnatmake -j$(nproc)"
 }
 

--- a/dist/msys2-mcode/PKGBUILD
+++ b/dist/msys2-mcode/PKGBUILD
@@ -5,13 +5,18 @@ pkgver=ci
 pkgrel=1
 pkgdesc="GHDL: the open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL (mcode backend) (mingw-w64)"
 arch=('any')
-depends=('zlib-devel')
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-gcc-ada")
+depends=('zlib-devel'
+         "${MINGW_PACKAGE_PREFIX}-gcc-ada")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 
 build() {
   mkdir "${srcdir}/builddir"
   cd "${srcdir}/builddir"
-  ../../../../configure --prefix=${MINGW_PREFIX} LDFLAGS=-static --enable-libghdl --enable-synth
+  ../../../../configure \
+    --prefix=${MINGW_PREFIX} \
+    LDFLAGS=-static \
+    --enable-libghdl \
+    --enable-synth
   make GNATMAKE="gnatmake -j$(nproc)"
 }
 


### PR DESCRIPTION
This PR updates the CI workflow in order to test MSYS2 packages in separated jobs, instead of doing it in the same job where the packages are built. The main motivation for doing so was reducing execution time. `vests` and `synth` test suites on Windows need ~15min each when LLVM backend is used. Executing suites in parallel should reduce overall time 5-10min.

While testing it, I found that pyunit tests require `gcc-ada` on MSYS2 shells. Otherwise, loading libghdl fails. Hence, I added the dependency to the PKGBUILD recipes.

