### PR TITLE
scripts: add 'update_py_bindings.sh'

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,25 +11,36 @@ env:
 jobs:
 
 #
-# Format
+# pyGHDL
 #
 
-#  fmt:
-#    runs-on: ubuntu-latest
-#    name: '🐍 Format (black)'
-#    steps:
-#
-#    - name: '🧰 Checkout'
-#      uses: actions/checkout@v2
-#
-#    - name: '🐍 Setup Python'
-#      uses: actions/setup-python@v2
-#      with:
-#        python-version: 3.8
-#
+  fmt:
+    runs-on: ubuntu-latest
+    name: '🐍 pyGHDL'
+    steps:
+
+    - name: '🧰 Checkout'
+      uses: actions/checkout@v2
+
+    - name: '🐍 Setup Python'
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install dependencies
+      run: |
+        sudo apt update -qq
+        sudo apt install -y gnat
+
+    - name: Update Python bindings
+      run: ./scripts/update_py_bindings.sh
+
+    - name: Check if Python bindings changed
+      run: git diff --quiet || git status
+
 #    - run: python -m pip install black
 #
-#    - run: python -m black --check python
+#    - run: python -m black --check pyGHDL
 
 #
 # GPL

--- a/scripts/update_py_bindings.sh
+++ b/scripts/update_py_bindings.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+set -e
+
+cd $(dirname "$0")/../src
+
+for item in edif psl vhdl; do
+  cd "$item"
+  make clean
+  make
+  cd ..
+done


### PR DESCRIPTION
This PR adds an script for regenerating all python bindings in pyGHDL. At the same time, a test is aded to CI. It will produce a failure if a commit is pushed without updating pyGHDL sources (if required).