### PR TITLE
Add missing file headers and reorder import statements

### DIFF
--- a/pyGHDL/libghdl/__init__.py
+++ b/pyGHDL/libghdl/__init__.py
@@ -39,6 +39,8 @@ from pathlib import Path
 from shutil import which
 from typing import Tuple
 
+from pydecor import export
+
 from pyGHDL.libghdl.version import __version__
 
 

--- a/pyGHDL/libghdl/errorout_memory.py
+++ b/pyGHDL/libghdl/errorout_memory.py
@@ -32,8 +32,11 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
-from pyGHDL.libghdl import libghdl
 from ctypes import c_int8, c_int32, c_char_p, Structure
+
+from pydecor import export
+
+from pyGHDL.libghdl import libghdl
 
 
 class Error_Message(Structure):

--- a/pyGHDL/libghdl/errorout_memory.py
+++ b/pyGHDL/libghdl/errorout_memory.py
@@ -1,3 +1,37 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:          Tristan Gingold
+#
+# Package package:  Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+# Copyright (C) 2019-2020 Tristan Gingold
+#
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+#
 from pyGHDL.libghdl import libghdl
 from ctypes import c_int8, c_int32, c_char_p, Structure
 

--- a/pyGHDL/libghdl/files_map.py
+++ b/pyGHDL/libghdl/files_map.py
@@ -1,3 +1,37 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:          Tristan Gingold
+#
+# Package package:  Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+# Copyright (C) 2019-2020 Tristan Gingold
+#
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+#
 from pyGHDL.libghdl import libghdl
 from ctypes import c_void_p
 

--- a/pyGHDL/libghdl/files_map.py
+++ b/pyGHDL/libghdl/files_map.py
@@ -32,8 +32,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
-from pyGHDL.libghdl import libghdl
 from ctypes import c_void_p
+
+from pyGHDL.libghdl import libghdl
+
 
 EOT = b"\x04"
 

--- a/pyGHDL/libghdl/files_map_editor.py
+++ b/pyGHDL/libghdl/files_map_editor.py
@@ -32,8 +32,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
-from pyGHDL.libghdl import libghdl
 from ctypes import c_int32, c_char_p, c_bool
+
+from pyGHDL.libghdl import libghdl
+
 
 Replace_Text = libghdl.files_map__editor__replace_text_ptr
 Replace_Text.argstype = [c_int32, c_int32, c_int32, c_int32, c_char_p, c_int32]

--- a/pyGHDL/libghdl/files_map_editor.py
+++ b/pyGHDL/libghdl/files_map_editor.py
@@ -1,3 +1,37 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:          Tristan Gingold
+#
+# Package package:  Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+# Copyright (C) 2019-2020 Tristan Gingold
+#
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+#
 from pyGHDL.libghdl import libghdl
 from ctypes import c_int32, c_char_p, c_bool
 

--- a/pyGHDL/libghdl/flags.py
+++ b/pyGHDL/libghdl/flags.py
@@ -1,3 +1,37 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:          Tristan Gingold
+#
+# Package package:  Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+# Copyright (C) 2019-2020 Tristan Gingold
+#
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+#
 from pyGHDL.libghdl import libghdl
 from ctypes import c_bool, sizeof
 

--- a/pyGHDL/libghdl/flags.py
+++ b/pyGHDL/libghdl/flags.py
@@ -32,8 +32,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
-from pyGHDL.libghdl import libghdl
 from ctypes import c_bool, sizeof
+
+from pyGHDL.libghdl import libghdl
+
 
 assert sizeof(c_bool) == 1
 

--- a/pyGHDL/libghdl/libraries.py
+++ b/pyGHDL/libghdl/libraries.py
@@ -32,8 +32,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
-from pyGHDL.libghdl import libghdl
 from ctypes import c_int32
+
+from pyGHDL.libghdl import libghdl
+
 
 Get_Libraries_Chain = libghdl.libraries__get_libraries_chain
 

--- a/pyGHDL/libghdl/libraries.py
+++ b/pyGHDL/libghdl/libraries.py
@@ -1,3 +1,37 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:          Tristan Gingold
+#
+# Package package:  Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+# Copyright (C) 2019-2020 Tristan Gingold
+#
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+#
 from pyGHDL.libghdl import libghdl
 from ctypes import c_int32
 

--- a/pyGHDL/libghdl/name_table.py
+++ b/pyGHDL/libghdl/name_table.py
@@ -32,8 +32,12 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
-from pyGHDL.libghdl import libghdl
 from ctypes import c_char_p
+
+from pydecor import export
+
+from pyGHDL.libghdl import libghdl
+
 
 Get_Name_Length = libghdl.name_table__get_name_length
 

--- a/pyGHDL/libghdl/name_table.py
+++ b/pyGHDL/libghdl/name_table.py
@@ -1,3 +1,37 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:          Tristan Gingold
+#
+# Package package:  Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+# Copyright (C) 2019-2020 Tristan Gingold
+#
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+#
 from pyGHDL.libghdl import libghdl
 from ctypes import c_char_p
 

--- a/pyGHDL/libghdl/utils/__init__.py
+++ b/pyGHDL/libghdl/utils/__init__.py
@@ -35,6 +35,8 @@
 from ctypes import byref
 from typing import List, Any, Generator
 
+from pydecor import export
+
 import pyGHDL.libghdl.name_table as name_table
 import pyGHDL.libghdl.files_map as files_map
 import pyGHDL.libghdl.vhdl.nodes as nodes

--- a/pyGHDL/libghdl/vhdl/__init__.py
+++ b/pyGHDL/libghdl/vhdl/__init__.py
@@ -1,0 +1,34 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:          Tristan Gingold
+#
+# Package package:  Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+# Copyright (C) 2019-2020 Tristan Gingold
+#
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+#

--- a/pyGHDL/libghdl/vhdl/canon.py
+++ b/pyGHDL/libghdl/vhdl/canon.py
@@ -32,8 +32,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
-from pyGHDL.libghdl import libghdl
 from ctypes import c_bool
+
+from pyGHDL.libghdl import libghdl
 
 
 Flag_Concurrent_Stmts = c_bool.in_dll(

--- a/pyGHDL/libghdl/vhdl/canon.py
+++ b/pyGHDL/libghdl/vhdl/canon.py
@@ -1,3 +1,37 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:          Tristan Gingold
+#
+# Package package:  Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+# Copyright (C) 2019-2020 Tristan Gingold
+#
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+#
 from pyGHDL.libghdl import libghdl
 from ctypes import c_bool
 

--- a/pyGHDL/libghdl/vhdl/flists.py
+++ b/pyGHDL/libghdl/vhdl/flists.py
@@ -32,8 +32,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
-from pyGHDL.libghdl import libghdl
 from ctypes import c_int32
+
+from pyGHDL.libghdl import libghdl
 
 
 Flist_Type = c_int32

--- a/pyGHDL/libghdl/vhdl/flists.py
+++ b/pyGHDL/libghdl/vhdl/flists.py
@@ -1,3 +1,37 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:          Tristan Gingold
+#
+# Package package:  Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+# Copyright (C) 2019-2020 Tristan Gingold
+#
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+#
 from pyGHDL.libghdl import libghdl
 from ctypes import c_int32
 

--- a/pyGHDL/libghdl/vhdl/formatters.py
+++ b/pyGHDL/libghdl/vhdl/formatters.py
@@ -1,3 +1,37 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:          Tristan Gingold
+#
+# Package package:  Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+# Copyright (C) 2019-2020 Tristan Gingold
+#
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+#
 from pyGHDL.libghdl import libghdl
 from ctypes import c_int32, c_char_p
 

--- a/pyGHDL/libghdl/vhdl/formatters.py
+++ b/pyGHDL/libghdl/vhdl/formatters.py
@@ -32,8 +32,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
-from pyGHDL.libghdl import libghdl
 from ctypes import c_int32, c_char_p
+
+from pyGHDL.libghdl import libghdl
 
 
 Indent_String = libghdl.vhdl__formatters__indent_string

--- a/pyGHDL/libghdl/vhdl/ieee.py
+++ b/pyGHDL/libghdl/vhdl/ieee.py
@@ -32,8 +32,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
-from pyGHDL.libghdl import libghdl
 from ctypes import c_int
+
+from pyGHDL.libghdl import libghdl
 
 
 Std_Logic_1164_Pkg = c_int.in_dll(

--- a/pyGHDL/libghdl/vhdl/ieee.py
+++ b/pyGHDL/libghdl/vhdl/ieee.py
@@ -1,3 +1,37 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:          Tristan Gingold
+#
+# Package package:  Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+# Copyright (C) 2019-2020 Tristan Gingold
+#
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+#
 from pyGHDL.libghdl import libghdl
 from ctypes import c_int
 

--- a/pyGHDL/libghdl/vhdl/lists.py
+++ b/pyGHDL/libghdl/vhdl/lists.py
@@ -1,3 +1,37 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:          Tristan Gingold
+#
+# Package package:  Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+# Copyright (C) 2019-2020 Tristan Gingold
+#
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+#
 from pyGHDL.libghdl import libghdl
 from ctypes import c_int32, c_bool, POINTER, Structure
 

--- a/pyGHDL/libghdl/vhdl/lists.py
+++ b/pyGHDL/libghdl/vhdl/lists.py
@@ -32,8 +32,11 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
-from pyGHDL.libghdl import libghdl
 from ctypes import c_int32, c_bool, POINTER, Structure
+
+from pydecor import export
+
+from pyGHDL.libghdl import libghdl
 
 
 List_Type = c_int32

--- a/pyGHDL/libghdl/vhdl/nodes_utils.py
+++ b/pyGHDL/libghdl/vhdl/nodes_utils.py
@@ -1,3 +1,37 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:          Tristan Gingold
+#
+# Package package:  Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+# Copyright (C) 2019-2020 Tristan Gingold
+#
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+#
 from pyGHDL.libghdl import libghdl
 
 

--- a/pyGHDL/libghdl/vhdl/parse.py
+++ b/pyGHDL/libghdl/vhdl/parse.py
@@ -32,8 +32,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
-from pyGHDL.libghdl import libghdl
 from ctypes import c_bool
+
+from pyGHDL.libghdl import libghdl
 
 
 Parse_Design_File = libghdl.vhdl__parse__parse_design_file

--- a/pyGHDL/libghdl/vhdl/parse.py
+++ b/pyGHDL/libghdl/vhdl/parse.py
@@ -1,3 +1,37 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:          Tristan Gingold
+#
+# Package package:  Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+# Copyright (C) 2019-2020 Tristan Gingold
+#
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+#
 from pyGHDL.libghdl import libghdl
 from ctypes import c_bool
 

--- a/pyGHDL/libghdl/vhdl/scanner.py
+++ b/pyGHDL/libghdl/vhdl/scanner.py
@@ -1,3 +1,37 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:          Tristan Gingold
+#
+# Package package:  Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+# Copyright (C) 2019-2020 Tristan Gingold
+#
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+#
 from pyGHDL.libghdl import libghdl
 from ctypes import c_int, c_bool
 

--- a/pyGHDL/libghdl/vhdl/scanner.py
+++ b/pyGHDL/libghdl/vhdl/scanner.py
@@ -32,8 +32,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
-from pyGHDL.libghdl import libghdl
 from ctypes import c_int, c_bool
+
+from pyGHDL.libghdl import libghdl
 
 
 Set_File = libghdl.vhdl__scanner__set_file

--- a/pyGHDL/libghdl/vhdl/sem.py
+++ b/pyGHDL/libghdl/vhdl/sem.py
@@ -1,3 +1,37 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:          Tristan Gingold
+#
+# Package package:  Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+# Copyright (C) 2019-2020 Tristan Gingold
+#
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+#
 from pyGHDL.libghdl import libghdl
 
 

--- a/pyGHDL/libghdl/vhdl/sem_lib.py
+++ b/pyGHDL/libghdl/vhdl/sem_lib.py
@@ -1,3 +1,37 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:          Tristan Gingold
+#
+# Package package:  Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+# Copyright (C) 2019-2020 Tristan Gingold
+#
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+#
 from pyGHDL.libghdl import libghdl
 
 

--- a/pyGHDL/libghdl/vhdl/std_package.py
+++ b/pyGHDL/libghdl/vhdl/std_package.py
@@ -32,8 +32,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
-from pyGHDL.libghdl import libghdl
 from ctypes import c_int32
+
+from pyGHDL.libghdl import libghdl
 
 
 # Use .value

--- a/pyGHDL/libghdl/vhdl/std_package.py
+++ b/pyGHDL/libghdl/vhdl/std_package.py
@@ -1,3 +1,37 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:          Tristan Gingold
+#
+# Package package:  Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+# Copyright (C) 2019-2020 Tristan Gingold
+#
+#	GHDL is free software; you can redistribute it and/or modify it under
+#	the terms of the GNU General Public License as published by the Free
+#	Software Foundation; either version 2, or (at your option) any later
+#	version.
+#
+#	GHDL is distributed in the hope that it will be useful, but WITHOUT ANY
+#	WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#	FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#	for more details.
+#
+#	You should have received a copy of the GNU General Public License
+#	along with GHDL; see the file COPYING.  If not, write to the Free
+#	Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+#	02111-1307, USA.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+#
 from pyGHDL.libghdl import libghdl
 from ctypes import c_int32
 


### PR DESCRIPTION
As we now know what files are auto generated, here are the remaining file headers incl. license info for Python files.

**Changes:**
* Add more missing file headers (incl. license info) to non-autogenerated Python files.
* Reordered import statements to:
  1. Python standard library
  2. Globally installed
  3. Current project.

Hint: To avoid merge conflicts, some files already contain imports of `pydecor`. pydecor offers an `export` decorator to automatically list public classes and functions in the interface description `__all__`. This is later used by Sphinx to auto generate documentation.