### PR TITLE
Paebbels/py ghdl exports

### DIFF
--- a/pyGHDL/dom/Common.py
+++ b/pyGHDL/dom/Common.py
@@ -32,6 +32,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
+"""
+.. todo::
+   Add a module documentation.
+"""
 from pydecor import export
 
 from pyVHDLModel.VHDLModel import Modes

--- a/pyGHDL/dom/Common.py
+++ b/pyGHDL/dom/Common.py
@@ -40,7 +40,6 @@ from pyGHDL.libghdl        import name_table
 from pyGHDL.libghdl.vhdl   import nodes
 
 __all__ = []
-__api__ = __all__
 
 
 @export

--- a/pyGHDL/dom/Common.py
+++ b/pyGHDL/dom/Common.py
@@ -38,7 +38,7 @@
 """
 from pydecor import export
 
-from pyVHDLModel.VHDLModel import Modes
+from pyVHDLModel.VHDLModel import Mode
 
 from pyGHDL.libghdl        import name_table
 from pyGHDL.libghdl.vhdl   import nodes
@@ -64,11 +64,11 @@ class GHDLException(GHDLBaseException):
 @export
 class GHDLMixin:
 	_MODE_TRANSLATION = {
-		nodes.Iir_Mode.In_Mode:      Modes.In,
-		nodes.Iir_Mode.Out_Mode:     Modes.Out,
-		nodes.Iir_Mode.Inout_Mode:   Modes.InOut,
-		nodes.Iir_Mode.Buffer_Mode:  Modes.Buffer,
-		nodes.Iir_Mode.Linkage_Mode: Modes.Linkage
+		nodes.Iir_Mode.In_Mode:      Mode.In,
+		nodes.Iir_Mode.Out_Mode:     Mode.Out,
+		nodes.Iir_Mode.Inout_Mode:   Mode.InOut,
+		nodes.Iir_Mode.Buffer_Mode:  Mode.Buffer,
+		nodes.Iir_Mode.Linkage_Mode: Mode.Linkage
 	}
 
 	@classmethod

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -44,12 +44,11 @@ from pyVHDLModel.VHDLModel import Configuration as VHDLModel_Configuration
 from pyGHDL.libghdl.vhdl   import nodes
 import pyGHDL.libghdl.utils as pyutils
 
-from pyGHDL.dom.Common     import GHDLMixin
+from pyGHDL.dom.Common        import GHDLMixin
+from pyGHDL.dom.InterfaceItem import GenericConstantInterfaceItem, PortSignalInterfaceItem
 
 __all__ = []
-__api__ = __all__
 
-from pyGHDL.dom.InterfaceItem import GenericConstantInterfaceItem, PortSignalInterfaceItem
 
 
 @export

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -32,6 +32,14 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
+"""
+This module contains all DOM classes for VHDL's design units (:cls:`entity <Entity>`,
+:cls:`architecture <Architecture>`, :cls:`package <Package>`,
+:cls:`package body <PackageBody>`, :cls:`context <Context>` and
+:cls:`configuration <Configuration>`.
+
+
+"""
 from pydecor import export
 
 from pyVHDLModel.VHDLModel import Entity        as VHDLModel_Entity

--- a/pyGHDL/dom/InterfaceItem.py
+++ b/pyGHDL/dom/InterfaceItem.py
@@ -40,7 +40,6 @@ from pyVHDLModel.VHDLModel  import GenericConstantInterfaceItem as VHDLModel_Gen
 from pyGHDL.dom.Common      import GHDLMixin
 
 __all__ = []
-__api__ = __all__
 
 
 @export

--- a/pyGHDL/dom/Misc.py
+++ b/pyGHDL/dom/Misc.py
@@ -32,6 +32,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
+"""
+.. todo::
+   Add a module documentation.
+"""
 from pathlib import Path
 from typing  import Any
 

--- a/pyGHDL/dom/Misc.py
+++ b/pyGHDL/dom/Misc.py
@@ -49,7 +49,6 @@ from pyGHDL.dom.Common      import LibGHDLException, GHDLException
 from pyGHDL.dom.DesignUnit  import Entity, Architecture, Package, PackageBody, Context, Configuration
 
 __all__ = []
-__api__ = __all__
 
 
 @export

--- a/pyGHDL/dom/__init__.py
+++ b/pyGHDL/dom/__init__.py
@@ -35,4 +35,3 @@
 from pydecor            import export
 
 __all__ = []
-__api__ = __all__

--- a/pyGHDL/libghdl/__init__.py
+++ b/pyGHDL/libghdl/__init__.py
@@ -146,21 +146,25 @@ libghdl.libghdl__set_exec_prefix(
     *_to_char_p(str(_libghdl_path.parent.parent).encode("utf-8"))
 )
 
+@export
 def finalize() -> None:
     """Free all the memory, be ready for a new initialization."""
     libghdl.options__finalize()
 
 
+@export
 def initialize() -> None:
     """Initialize or re-initialize the shared library."""
     libghdl.options__initialize()
 
 
+@export
 def set_option(opt: bytes) -> bool:
     """Set option :param:`opt`. Return true, if the option is known and handled."""
     return libghdl.libghdl__set_option(*_to_char_p(opt)) == 0
 
 
+@export
 def analyze_init() -> None:
     """
     Initialize the analyzer.
@@ -170,15 +174,18 @@ def analyze_init() -> None:
     """
     libghdl.libghdl__analyze_init()
 
+@export
 def analyze_init_status() -> int:
     """Initialize the analyzer. Returns 0 in case of success."""
     return libghdl.libghdl__analyze_init_status()
 
+@export
 def analyze_file(fname: bytes):
     """"Analyze a given filename :param:`fname`."""
     return libghdl.libghdl__analyze_file(*_to_char_p(fname))
 
 
+@export
 def disp_config():
     """"Display the configured prefixes for libghdl."""
     return libghdl.ghdllocal__disp_config_prefixes()

--- a/pyGHDL/libghdl/errorout_memory.py
+++ b/pyGHDL/libghdl/errorout_memory.py
@@ -39,6 +39,7 @@ from pydecor import export
 from pyGHDL.libghdl import libghdl
 
 
+@export
 class Error_Message(Structure):
     _fields_ = [
         ("id", c_int8),

--- a/pyGHDL/libghdl/name_table.py
+++ b/pyGHDL/libghdl/name_table.py
@@ -47,6 +47,7 @@ Get_Name_Ptr.restype = c_char_p
 _Get_Identifier_With_Len = libghdl.name_table__get_identifier_with_len
 
 
+@export
 def Get_Identifier(s):
     return _Get_Identifier_With_Len(c_char_p(s), len(s))
 

--- a/pyGHDL/libghdl/utils/__init__.py
+++ b/pyGHDL/libghdl/utils/__init__.py
@@ -45,6 +45,7 @@ import pyGHDL.libghdl.vhdl.lists as lists
 import pyGHDL.libghdl.vhdl.flists as flists
 
 
+@export
 def name_image(nameid) -> str:
     """Lookup a :param:`nameid` and return its string."""
     return name_table.Get_Name_Ptr(nameid).decode("utf-8")
@@ -62,6 +63,7 @@ def _build_enum_image(cls) -> List[str]:
 _fields_image = _build_enum_image(nodes_meta.fields)
 
 
+@export
 def fields_image(idx) -> str:
     """String representation of field :param:`idx`."""
     return _fields_image[idx]
@@ -70,6 +72,7 @@ def fields_image(idx) -> str:
 _kind_image = _build_enum_image(nodes.Iir_Kind)
 
 
+@export
 def kind_image(k) -> str:
     """String representation of Iir_Kind :param:`k`."""
     return _kind_image[k]
@@ -78,6 +81,7 @@ def kind_image(k) -> str:
 _types_image = _build_enum_image(nodes_meta.types)
 
 
+@export
 def types_image(t) -> str:
     """String representation of Nodes_Meta.Types :param:`t`."""
     return _types_image[t]
@@ -86,11 +90,13 @@ def types_image(t) -> str:
 _attr_image = _build_enum_image(nodes_meta.Attr)
 
 
+@export
 def attr_image(a) -> str:
     """String representation of Nodes_Meta.Attr :param:`a`."""
     return _attr_image[a]
 
 
+@export
 def leftest_location(n):
     while True:
         if n == nodes.Null_Iir:
@@ -102,6 +108,7 @@ def leftest_location(n):
             return nodes.Get_Location(n)
 
 
+@export
 def fields_iter(n) -> Generator[Any, None, None]:
     """Iterate on fields of node :param:`n`."""
     if n == nodes.Null_Iir:
@@ -113,6 +120,7 @@ def fields_iter(n) -> Generator[Any, None, None]:
         yield nodes_meta.get_field_by_index(i)
 
 
+@export
 def chain_iter(n) -> Generator[Any, None, None]:
     """Iterate of a chain headed by node :param:`n`."""
     while n != nodes.Null_Iir:
@@ -120,11 +128,13 @@ def chain_iter(n) -> Generator[Any, None, None]:
         n = nodes.Get_Chain(n)
 
 
+@export
 def chain_to_list(n) -> List[Any]:
     """Convert a chain headed by node :param:`n` to a Python list."""
     return [e for e in chain_iter(n)]
 
 
+@export
 def nodes_iter(n) -> Generator[Any, None, None]:
     """
     Iterate all nodes of :param:`n`, including :param:`n`.
@@ -167,6 +177,7 @@ def nodes_iter(n) -> Generator[Any, None, None]:
                         yield n2
 
 
+@export
 def list_iter(lst) -> Generator[Any, None, None]:
     """Iterate all element of Iir_List :param:`lst`."""
     if lst <= nodes.Iir_List_All:
@@ -177,6 +188,7 @@ def list_iter(lst) -> Generator[Any, None, None]:
         lists.Next(byref(iter))
 
 
+@export
 def flist_iter(lst) -> Generator[Any, None, None]:
     """Iterate all element of Iir_List :param:`lst`."""
     if lst <= nodes.Iir_Flist_All:
@@ -185,6 +197,7 @@ def flist_iter(lst) -> Generator[Any, None, None]:
         yield flists.Get_Nth_Element(lst, i)
 
 
+@export
 def declarations_iter(n) -> Generator[Any, None, None]:
     """Iterate all declarations in node :param:`n`."""
     k = nodes.Get_Kind(n)
@@ -302,6 +315,7 @@ def declarations_iter(n) -> Generator[Any, None, None]:
     raise Exception("Unknown node of kind {}".format(kind_image(k)))
 
 
+@export
 def concurrent_stmts_iter(n) -> Generator[Any, None, None]:
     """Iterate concurrent statements in node :param:`n`."""
     k = nodes.Get_Kind(n)
@@ -338,6 +352,7 @@ def concurrent_stmts_iter(n) -> Generator[Any, None, None]:
                     yield n2
 
 
+@export
 def constructs_iter(n) -> Generator[Any, None, None]:
     """
     Iterate library units, concurrent statements and declarations
@@ -407,6 +422,7 @@ def constructs_iter(n) -> Generator[Any, None, None]:
                     yield n3
 
 
+@export
 def sequential_iter(n) -> Generator[Any, None, None]:
     """
     Iterate sequential statements. The first node must be either

--- a/pyGHDL/libghdl/vhdl/lists.py
+++ b/pyGHDL/libghdl/vhdl/lists.py
@@ -42,6 +42,7 @@ from pyGHDL.libghdl import libghdl
 List_Type = c_int32
 
 
+@export
 class Iterator(Structure):
     _fields_ = [("chunk", c_int32), ("chunk_idx", c_int32), ("remain", c_int32)]
 


### PR DESCRIPTION
Required PR before this:
* #1575 (when merged, CI of this branch should be successful)

-------------
This PR adds `export` decorators from `pydecor` to all publicly visible classes. The decorator adds each class in `__all__`.

In a next step, this information per module is used by Sphinx and it's documentation plugins (e.g. `AutoAPI.Spinx`) to auto document modules, classes, etc.