### PR TITLE
manpage: updated Link to modern documentation

### DIFF
--- a/doc/ghdl.1
+++ b/doc/ghdl.1
@@ -99,7 +99,7 @@ Back annotate SDF onto design using TYPE (min|typ|max), instance PATH, and SDF f
 .PP
 .br 
 The texinfo manual fully documents GHDL. You may also browse it at
-\fB<http://ghdl.free.fr/ghdl/index.html>\fP.
+\fB<https://ghdl.github.io/ghdl/>\fP.
 .SH "AUTHOR"
 This manual page was written by Wesley J. Landaker
 <wjl@icecavern.net>, for the Debian project (but may be used by


### PR DESCRIPTION
**Description**

The manual page still contained a link to the free.fr-hosted, pretty dated GHDL documentation.

Replaced that with a link to the readthedocs page.


- [x] DO indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

**When contributing to the GHDL codebase...**

Not happening here.

**When contributing to the docs...**

- [x] DO make sure that the build is successful.

**Further comments**

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!