### PR TITLE
Bind Python to libghdl via decorator

### DIFF
--- a/pyGHDL/dom/Common.py
+++ b/pyGHDL/dom/Common.py
@@ -37,8 +37,8 @@
 """
 from pydecor import export
 
-from pyGHDL                import GHDLBaseException
-from pyGHDL.libghdl        import LibGHDLException, errorout_memory
+from pyGHDL import GHDLBaseException
+from pyGHDL.libghdl import LibGHDLException, errorout_memory
 
 __all__ = []
 
@@ -61,5 +61,6 @@ class GHDLMixin:
             for i in range(errorCount):
                 print(errorout_memory.Get_Error_Message(i + 1))
 
-            raise DOMException("Error in libghdl.") \
-                from LibGHDLException("libghdl: Internal error 2.")
+            raise DOMException("Error in libghdl.") from LibGHDLException(
+                "libghdl: Internal error 2."
+            )

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -41,19 +41,24 @@ This module contains all DOM classes for VHDL's design units (:class:`context <E
 """
 from pydecor import export
 
-from pyVHDLModel.VHDLModel import Entity        as VHDLModel_Entity
-from pyVHDLModel.VHDLModel import Architecture  as VHDLModel_Architecture
-from pyVHDLModel.VHDLModel import Package       as VHDLModel_Package
-from pyVHDLModel.VHDLModel import PackageBody   as VHDLModel_PackageBody
-from pyVHDLModel.VHDLModel import Context       as VHDLModel_Context
+from pyVHDLModel.VHDLModel import Entity as VHDLModel_Entity
+from pyVHDLModel.VHDLModel import Architecture as VHDLModel_Architecture
+from pyVHDLModel.VHDLModel import Package as VHDLModel_Package
+from pyVHDLModel.VHDLModel import PackageBody as VHDLModel_PackageBody
+from pyVHDLModel.VHDLModel import Context as VHDLModel_Context
 from pyVHDLModel.VHDLModel import Configuration as VHDLModel_Configuration
 
 from pyGHDL.libghdl import utils
 from pyGHDL.libghdl.vhdl import nodes
 
 from pyGHDL.dom._Utils import NodeToName, GetIirKindOfNode
-from pyGHDL.dom._Translate import GetExpressionFromNode, GetSubtypeIndicationFromNode, GetGenericsFromChainedNodes, GetPortsFromChainedNodes, \
-    GetDeclaredItemsFromChainedNodes
+from pyGHDL.dom._Translate import (
+    GetExpressionFromNode,
+    GetSubtypeIndicationFromNode,
+    GetGenericsFromChainedNodes,
+    GetPortsFromChainedNodes,
+    GetDeclaredItemsFromChainedNodes,
+)
 from pyGHDL.dom.Common import GHDLMixin, DOMException
 from pyGHDL.dom.Object import Constant, Signal
 
@@ -62,19 +67,22 @@ __all__ = []
 
 @export
 class Entity(VHDLModel_Entity, GHDLMixin):
-
     @classmethod
     def parse(cls, libraryUnit):
         name = NodeToName(libraryUnit)
         entity = cls(name)
 
-        for generic in GetGenericsFromChainedNodes(nodes.Get_Generic_Chain(libraryUnit)):
+        for generic in GetGenericsFromChainedNodes(
+            nodes.Get_Generic_Chain(libraryUnit)
+        ):
             entity.GenericItems.append(generic)
 
         for port in GetPortsFromChainedNodes(nodes.Get_Port_Chain(libraryUnit)):
             entity.PortItems.append(port)
 
-        for item in GetDeclaredItemsFromChainedNodes(nodes.Get_Declaration_Chain(libraryUnit), "entity", name):
+        for item in GetDeclaredItemsFromChainedNodes(
+            nodes.Get_Declaration_Chain(libraryUnit), "entity", name
+        ):
             entity.DeclaredItems.append(item)
 
         return entity
@@ -94,7 +102,9 @@ class Architecture(VHDLModel_Architecture, GHDLMixin):
 
         architecture = cls(name, entityName)
 
-        for item in GetDeclaredItemsFromChainedNodes(nodes.Get_Declaration_Chain(libraryUnit), "architecture", name):
+        for item in GetDeclaredItemsFromChainedNodes(
+            nodes.Get_Declaration_Chain(libraryUnit), "architecture", name
+        ):
             architecture.DeclaredItems.append(item)
 
         return architecture
@@ -105,14 +115,15 @@ class Architecture(VHDLModel_Architecture, GHDLMixin):
 
 @export
 class Package(VHDLModel_Package, GHDLMixin):
-
     @classmethod
     def parse(cls, libraryUnit):
         name = NodeToName(libraryUnit)
 
         package = cls(name)
 
-        for item in GetDeclaredItemsFromChainedNodes(nodes.Get_Declaration_Chain(libraryUnit), "package", name):
+        for item in GetDeclaredItemsFromChainedNodes(
+            nodes.Get_Declaration_Chain(libraryUnit), "package", name
+        ):
             package.DeclaredItems.append(item)
 
         return package
@@ -120,14 +131,15 @@ class Package(VHDLModel_Package, GHDLMixin):
 
 @export
 class PackageBody(VHDLModel_PackageBody, GHDLMixin):
-
     @classmethod
     def parse(cls, libraryUnit):
         name = NodeToName(libraryUnit)
 
         packageBody = cls(name)
 
-        for item in GetDeclaredItemsFromChainedNodes(nodes.Get_Declaration_Chain(libraryUnit), "package body", name):
+        for item in GetDeclaredItemsFromChainedNodes(
+            nodes.Get_Declaration_Chain(libraryUnit), "package body", name
+        ):
             packageBody.DeclaredItems.append(item)
 
         return packageBody
@@ -135,7 +147,6 @@ class PackageBody(VHDLModel_PackageBody, GHDLMixin):
 
 @export
 class Context(VHDLModel_Context, GHDLMixin):
-
     @classmethod
     def parse(cls, libraryUnit):
         name = NodeToName(libraryUnit)
@@ -144,7 +155,6 @@ class Context(VHDLModel_Context, GHDLMixin):
 
 @export
 class Configuration(VHDLModel_Configuration, GHDLMixin):
-
     @classmethod
     def parse(cls, libraryUnit):
         name = NodeToName(libraryUnit)

--- a/pyGHDL/dom/Expression.py
+++ b/pyGHDL/dom/Expression.py
@@ -32,42 +32,44 @@
 # ============================================================================
 from pydecor import export
 
-from pyVHDLModel.VHDLModel import \
-    InverseExpression as VHDLModel_InverseExpression, \
-    IdentityExpression as VHDLModel_IdentityExpression, \
-    NegationExpression as VHDLModel_NegationExpression, \
-    AbsoluteExpression as VHDLModel_AbsoluteExpression, \
-    TypeConversion as VHDLModel_TypeConversion, \
-    FunctionCall as VHDLModel_FunctionCall, \
-    QualifiedExpression as VHDLModel_QualifiedExpression, \
-    AdditionExpression as VHDLModel_AdditionExpression, \
-    SubtractionExpression as VHDLModel_SubtractionExpression, \
-    ConcatenationExpression as VHDLModel_ConcatenationExpression, \
-    MultiplyExpression as VHDLModel_MultiplyExpression, \
-    DivisionExpression as VHDLModel_DivisionExpression, \
-    RemainderExpression as VHDLModel_RemainderExpression, \
-    ModuloExpression as VHDLModel_ModuloExpression, \
-    ExponentiationExpression as VHDLModel_ExponentiationExpression, \
-    AndExpression as VHDLModel_AndExpression, \
-    NandExpression as VHDLModel_NandExpression, \
-    OrExpression as VHDLModel_OrExpression, \
-    NorExpression as VHDLModel_NorExpression, \
-    XorExpression as VHDLModel_XorExpression, \
-    XnorExpression as VHDLModel_XnorExpression, \
-    EqualExpression as VHDLModel_EqualExpression, \
-    UnequalExpression as VHDLModel_UnequalExpression, \
-    GreaterThanExpression as VHDLModel_GreaterThanExpression, \
-    GreaterEqualExpression as VHDLModel_GreaterEqualExpression, \
-    LessThanExpression as VHDLModel_LessThanExpression, \
-    ShiftRightLogicExpression as VHDLModel_ShiftRightLogicExpression, \
-    ShiftLeftLogicExpression as VHDLModel_ShiftLeftLogicExpression, \
-    ShiftRightArithmeticExpression as VHDLModel_ShiftRightArithmeticExpression, \
-    ShiftLeftArithmeticExpression as VHDLModel_ShiftLeftArithmeticExpression, \
-    RotateRightExpression as VHDLModel_RotateRightExpression, \
-    RotateLeftExpression as VHDLModel_RotateLeftExpression, \
-    Expression
+from pyVHDLModel.VHDLModel import (
+    InverseExpression as VHDLModel_InverseExpression,
+    IdentityExpression as VHDLModel_IdentityExpression,
+    NegationExpression as VHDLModel_NegationExpression,
+    AbsoluteExpression as VHDLModel_AbsoluteExpression,
+    TypeConversion as VHDLModel_TypeConversion,
+    FunctionCall as VHDLModel_FunctionCall,
+    QualifiedExpression as VHDLModel_QualifiedExpression,
+    AdditionExpression as VHDLModel_AdditionExpression,
+    SubtractionExpression as VHDLModel_SubtractionExpression,
+    ConcatenationExpression as VHDLModel_ConcatenationExpression,
+    MultiplyExpression as VHDLModel_MultiplyExpression,
+    DivisionExpression as VHDLModel_DivisionExpression,
+    RemainderExpression as VHDLModel_RemainderExpression,
+    ModuloExpression as VHDLModel_ModuloExpression,
+    ExponentiationExpression as VHDLModel_ExponentiationExpression,
+    AndExpression as VHDLModel_AndExpression,
+    NandExpression as VHDLModel_NandExpression,
+    OrExpression as VHDLModel_OrExpression,
+    NorExpression as VHDLModel_NorExpression,
+    XorExpression as VHDLModel_XorExpression,
+    XnorExpression as VHDLModel_XnorExpression,
+    EqualExpression as VHDLModel_EqualExpression,
+    UnequalExpression as VHDLModel_UnequalExpression,
+    GreaterThanExpression as VHDLModel_GreaterThanExpression,
+    GreaterEqualExpression as VHDLModel_GreaterEqualExpression,
+    LessThanExpression as VHDLModel_LessThanExpression,
+    ShiftRightLogicExpression as VHDLModel_ShiftRightLogicExpression,
+    ShiftLeftLogicExpression as VHDLModel_ShiftLeftLogicExpression,
+    ShiftRightArithmeticExpression as VHDLModel_ShiftRightArithmeticExpression,
+    ShiftLeftArithmeticExpression as VHDLModel_ShiftLeftArithmeticExpression,
+    RotateRightExpression as VHDLModel_RotateRightExpression,
+    RotateLeftExpression as VHDLModel_RotateLeftExpression,
+    Expression,
+)
 
 __all__ = []
+
 
 @export
 class InverseExpression(VHDLModel_InverseExpression):
@@ -75,11 +77,13 @@ class InverseExpression(VHDLModel_InverseExpression):
         super().__init__()
         self._operand = operand
 
+
 @export
 class IdentityExpression(VHDLModel_IdentityExpression):
     def __init__(self, operand: Expression):
         super().__init__()
         self._operand = operand
+
 
 @export
 class NegationExpression(VHDLModel_NegationExpression):
@@ -87,11 +91,13 @@ class NegationExpression(VHDLModel_NegationExpression):
         super().__init__()
         self._operand = operand
 
+
 @export
 class AbsoluteExpression(VHDLModel_AbsoluteExpression):
     def __init__(self, operand: Expression):
         super().__init__()
         self._operand = operand
+
 
 @export
 class TypeConversion(VHDLModel_TypeConversion):
@@ -99,17 +105,20 @@ class TypeConversion(VHDLModel_TypeConversion):
         super().__init__()
         self._operand = operand
 
+
 @export
 class FunctionCall(VHDLModel_FunctionCall):
     def __init__(self, operand: Expression):
         super().__init__()
         self._operand = operand
 
+
 @export
 class QualifiedExpression(VHDLModel_QualifiedExpression):
     def __init__(self, operand: Expression):
         super().__init__()
         self._operand = operand
+
 
 @export
 class AdditionExpression(VHDLModel_AdditionExpression):
@@ -118,12 +127,14 @@ class AdditionExpression(VHDLModel_AdditionExpression):
         self._leftOperand = left
         self._rightOperand = right
 
+
 @export
 class SubtractionExpression(VHDLModel_SubtractionExpression):
     def __init__(self, left: Expression, right: Expression):
         super().__init__()
         self._leftOperand = left
         self._rightOperand = right
+
 
 @export
 class ConcatenationExpression(VHDLModel_ConcatenationExpression):
@@ -132,12 +143,14 @@ class ConcatenationExpression(VHDLModel_ConcatenationExpression):
         self._leftOperand = left
         self._rightOperand = right
 
+
 @export
 class MultiplyExpression(VHDLModel_MultiplyExpression):
     def __init__(self, left: Expression, right: Expression):
         super().__init__()
         self._leftOperand = left
         self._rightOperand = right
+
 
 @export
 class DivisionExpression(VHDLModel_DivisionExpression):
@@ -146,12 +159,14 @@ class DivisionExpression(VHDLModel_DivisionExpression):
         self._leftOperand = left
         self._rightOperand = right
 
+
 @export
 class RemainderExpression(VHDLModel_RemainderExpression):
     def __init__(self, left: Expression, right: Expression):
         super().__init__()
         self._leftOperand = left
         self._rightOperand = right
+
 
 @export
 class ModuloExpression(VHDLModel_ModuloExpression):
@@ -160,12 +175,14 @@ class ModuloExpression(VHDLModel_ModuloExpression):
         self._leftOperand = left
         self._rightOperand = right
 
+
 @export
 class ExponentiationExpression(VHDLModel_ExponentiationExpression):
     def __init__(self, left: Expression, right: Expression):
         super().__init__()
         self._leftOperand = left
         self._rightOperand = right
+
 
 @export
 class AndExpression(VHDLModel_AndExpression):
@@ -174,12 +191,14 @@ class AndExpression(VHDLModel_AndExpression):
         self._leftOperand = left
         self._rightOperand = right
 
+
 @export
 class NandExpression(VHDLModel_NandExpression):
     def __init__(self, left: Expression, right: Expression):
         super().__init__()
         self._leftOperand = left
         self._rightOperand = right
+
 
 @export
 class OrExpression(VHDLModel_OrExpression):
@@ -188,12 +207,14 @@ class OrExpression(VHDLModel_OrExpression):
         self._leftOperand = left
         self._rightOperand = right
 
+
 @export
 class NorExpression(VHDLModel_NorExpression):
     def __init__(self, left: Expression, right: Expression):
         super().__init__()
         self._leftOperand = left
         self._rightOperand = right
+
 
 @export
 class XorExpression(VHDLModel_XorExpression):
@@ -202,12 +223,14 @@ class XorExpression(VHDLModel_XorExpression):
         self._leftOperand = left
         self._rightOperand = right
 
+
 @export
 class XnorExpression(VHDLModel_XnorExpression):
     def __init__(self, left: Expression, right: Expression):
         super().__init__()
         self._leftOperand = left
         self._rightOperand = right
+
 
 @export
 class EqualExpression(VHDLModel_EqualExpression):
@@ -216,12 +239,14 @@ class EqualExpression(VHDLModel_EqualExpression):
         self._leftOperand = left
         self._rightOperand = right
 
+
 @export
 class UnequalExpression(VHDLModel_UnequalExpression):
     def __init__(self, left: Expression, right: Expression):
         super().__init__()
         self._leftOperand = left
         self._rightOperand = right
+
 
 @export
 class GreaterThanExpression(VHDLModel_GreaterThanExpression):
@@ -230,12 +255,14 @@ class GreaterThanExpression(VHDLModel_GreaterThanExpression):
         self._leftOperand = left
         self._rightOperand = right
 
+
 @export
 class GreaterEqualExpression(VHDLModel_GreaterEqualExpression):
     def __init__(self, left: Expression, right: Expression):
         super().__init__()
         self._leftOperand = left
         self._rightOperand = right
+
 
 @export
 class LessThanExpression(VHDLModel_LessThanExpression):
@@ -244,12 +271,14 @@ class LessThanExpression(VHDLModel_LessThanExpression):
         self._leftOperand = left
         self._rightOperand = right
 
+
 @export
 class ShiftRightLogicExpression(VHDLModel_ShiftRightLogicExpression):
     def __init__(self, left: Expression, right: Expression):
         super().__init__()
         self._leftOperand = left
         self._rightOperand = right
+
 
 @export
 class ShiftLeftLogicExpression(VHDLModel_ShiftLeftLogicExpression):
@@ -258,12 +287,14 @@ class ShiftLeftLogicExpression(VHDLModel_ShiftLeftLogicExpression):
         self._leftOperand = left
         self._rightOperand = right
 
+
 @export
 class ShiftRightArithmeticExpression(VHDLModel_ShiftRightArithmeticExpression):
     def __init__(self, left: Expression, right: Expression):
         super().__init__()
         self._leftOperand = left
         self._rightOperand = right
+
 
 @export
 class ShiftLeftArithmeticExpression(VHDLModel_ShiftLeftArithmeticExpression):
@@ -272,12 +303,14 @@ class ShiftLeftArithmeticExpression(VHDLModel_ShiftLeftArithmeticExpression):
         self._leftOperand = left
         self._rightOperand = right
 
+
 @export
 class RotateRightExpression(VHDLModel_RotateRightExpression):
     def __init__(self, left: Expression, right: Expression):
         super().__init__()
         self._leftOperand = left
         self._rightOperand = right
+
 
 @export
 class RotateLeftExpression(VHDLModel_RotateLeftExpression):

--- a/pyGHDL/dom/InterfaceItem.py
+++ b/pyGHDL/dom/InterfaceItem.py
@@ -32,14 +32,17 @@
 # ============================================================================
 from pydecor import export
 
-from pyVHDLModel.VHDLModel import \
-    GenericConstantInterfaceItem as VHDLModel_GenericConstantInterfaceItem, \
-    PortSignalInterfaceItem as VHDLModel_PortSignalInterfaceItem, \
-    Mode, SubTypeOrSymbol, Expression
+from pyVHDLModel.VHDLModel import (
+    GenericConstantInterfaceItem as VHDLModel_GenericConstantInterfaceItem,
+    PortSignalInterfaceItem as VHDLModel_PortSignalInterfaceItem,
+    Mode,
+    SubTypeOrSymbol,
+    Expression,
+)
 
-from pyGHDL.dom._Utils     import NodeToName, GetModeOfNode
+from pyGHDL.dom._Utils import NodeToName, GetModeOfNode
 from pyGHDL.dom._Translate import GetSubtypeIndicationFromNode
-from pyGHDL.dom.Common     import GHDLMixin
+from pyGHDL.dom.Common import GHDLMixin
 
 __all__ = []
 
@@ -56,9 +59,10 @@ class GenericConstantInterfaceItem(VHDLModel_GenericConstantInterfaceItem, GHDLM
 
         return generic
 
-    def __init__(self, name:str, mode: Mode, subType: SubTypeOrSymbol):
+    def __init__(self, name: str, mode: Mode, subType: SubTypeOrSymbol):
         super().__init__(name=name, mode=mode)
         self._subType = subType
+
 
 @export
 class PortSignalInterfaceItem(VHDLModel_PortSignalInterfaceItem, GHDLMixin):
@@ -72,8 +76,13 @@ class PortSignalInterfaceItem(VHDLModel_PortSignalInterfaceItem, GHDLMixin):
 
         return port
 
-    def __init__(self, name:str, mode: Mode, subType: SubTypeOrSymbol, defaultExpression: Expression = None):
+    def __init__(
+        self,
+        name: str,
+        mode: Mode,
+        subType: SubTypeOrSymbol,
+        defaultExpression: Expression = None,
+    ):
         super().__init__(name=name, mode=mode)
         self._subType = subType
         self._defaultExpression = defaultExpression
-

--- a/pyGHDL/dom/Literal.py
+++ b/pyGHDL/dom/Literal.py
@@ -32,10 +32,11 @@
 # ============================================================================
 from pydecor import export
 
-from pyVHDLModel.VHDLModel import \
-    IntegerLiteral as VHDLModel_IntegerLiteral, \
-    FloatingPointLiteral as VHDLModel_FloatingPointLiteral, \
-    CharacterLiteral as VHDLModel_CharacterLiteral
+from pyVHDLModel.VHDLModel import (
+    IntegerLiteral as VHDLModel_IntegerLiteral,
+    FloatingPointLiteral as VHDLModel_FloatingPointLiteral,
+    CharacterLiteral as VHDLModel_CharacterLiteral,
+)
 
 __all__ = []
 

--- a/pyGHDL/dom/Misc.py
+++ b/pyGHDL/dom/Misc.py
@@ -36,22 +36,35 @@
    Add a module documentation.
 """
 from pathlib import Path
-from typing  import Any
+from typing import Any
 
 import pyGHDL.libghdl.utils
 from pydecor import export
 
 from pyGHDL.dom._Utils import GetIirKindOfNode
-from pyVHDLModel.VHDLModel import Design        as VHDLModel_Design
-from pyVHDLModel.VHDLModel import Library       as VHDLModel_Library
-from pyVHDLModel.VHDLModel import Document      as VHDLModel_Document
+from pyVHDLModel.VHDLModel import Design as VHDLModel_Design
+from pyVHDLModel.VHDLModel import Library as VHDLModel_Library
+from pyVHDLModel.VHDLModel import Document as VHDLModel_Document
 
-import pyGHDL.libghdl       as libghdl
-from pyGHDL.libghdl import name_table, files_map, errorout_memory, LibGHDLException, utils
-from pyGHDL.libghdl.vhdl    import nodes, sem_lib
+import pyGHDL.libghdl as libghdl
+from pyGHDL.libghdl import (
+    name_table,
+    files_map,
+    errorout_memory,
+    LibGHDLException,
+    utils,
+)
+from pyGHDL.libghdl.vhdl import nodes, sem_lib
 
-from pyGHDL.dom.Common      import DOMException, GHDLMixin
-from pyGHDL.dom.DesignUnit  import Entity, Architecture, Package, PackageBody, Context, Configuration
+from pyGHDL.dom.Common import DOMException, GHDLMixin
+from pyGHDL.dom.DesignUnit import (
+    Entity,
+    Architecture,
+    Package,
+    PackageBody,
+    Context,
+    Configuration,
+)
 
 __all__ = []
 
@@ -95,13 +108,15 @@ class Document(VHDLModel_Document, GHDLMixin):
         GHDLMixin.__init__(self)
 
         self.__ghdl_init()
-        if (dontParse == False):
+        if dontParse == False:
             self.parse()
 
     def __ghdl_init(self):
         # Read input file
         self.__ghdlFileID = name_table.Get_Identifier(str(self.Path))
-        self.__ghdlSourceFileEntry = files_map.Read_Source_File(name_table.Null_Identifier, self.__ghdlFileID)
+        self.__ghdlSourceFileEntry = files_map.Read_Source_File(
+            name_table.Null_Identifier, self.__ghdlFileID
+        )
         if self.__ghdlSourceFileEntry == files_map.No_Source_File_Entry:
             raise LibGHDLException("Cannot load file '{!s}'".format(self.Path))
 
@@ -119,32 +134,33 @@ class Document(VHDLModel_Document, GHDLMixin):
             libraryUnit = nodes.Get_Library_Unit(unit)
             nodeKind = GetIirKindOfNode(libraryUnit)
 
-            if (nodeKind == nodes.Iir_Kind.Entity_Declaration):
+            if nodeKind == nodes.Iir_Kind.Entity_Declaration:
                 entity = Entity.parse(libraryUnit)
                 self.Entities.append(entity)
 
-            elif (nodeKind == nodes.Iir_Kind.Architecture_Body):
+            elif nodeKind == nodes.Iir_Kind.Architecture_Body:
                 architecture = Architecture.parse(libraryUnit)
                 self.Architectures.append(architecture)
 
-            elif (nodeKind == nodes.Iir_Kind.Package_Declaration):
+            elif nodeKind == nodes.Iir_Kind.Package_Declaration:
                 package = Package.parse(libraryUnit)
                 self.Packages.append(package)
 
-            elif (nodeKind == nodes.Iir_Kind.Package_Body):
+            elif nodeKind == nodes.Iir_Kind.Package_Body:
                 packageBody = PackageBody.parse(libraryUnit)
                 self.PackageBodies.append(packageBody)
 
-            elif (nodeKind == nodes.Iir_Kind.Context_Declaration):
+            elif nodeKind == nodes.Iir_Kind.Context_Declaration:
                 context = Context.parse(libraryUnit)
                 self.Contexts.append(context)
 
-            elif (nodeKind == nodes.Iir_Kind.Configuration_Declaration):
+            elif nodeKind == nodes.Iir_Kind.Configuration_Declaration:
                 configuration = Configuration.parse(libraryUnit)
                 self.Configurations.append(configuration)
 
             else:
                 raise DOMException(
                     "Unknown design unit kind '{kindName}'({kind}).".format(
-                        kindName=nodeKind.name, kind=nodeKind)
+                        kindName=nodeKind.name, kind=nodeKind
+                    )
                 )

--- a/pyGHDL/dom/Object.py
+++ b/pyGHDL/dom/Object.py
@@ -32,18 +32,22 @@
 # ============================================================================
 from pydecor import export
 
-from pyVHDLModel.VHDLModel import \
-    Constant as VHDLModel_Constant, \
-    Variable as VHDLModel_Variable, \
-    Signal as VHDLModel_Signal, \
-    Expression, SubTypeOrSymbol
+from pyVHDLModel.VHDLModel import (
+    Constant as VHDLModel_Constant,
+    Variable as VHDLModel_Variable,
+    Signal as VHDLModel_Signal,
+    Expression,
+    SubTypeOrSymbol,
+)
 
 __all__ = []
 
 
 @export
 class Constant(VHDLModel_Constant):
-    def __init__(self, name: str, subType: SubTypeOrSymbol, defaultExpression: Expression):
+    def __init__(
+        self, name: str, subType: SubTypeOrSymbol, defaultExpression: Expression
+    ):
         super().__init__(name)
 
         self._name = name
@@ -53,7 +57,9 @@ class Constant(VHDLModel_Constant):
 
 @export
 class Variable(VHDLModel_Variable):
-    def __init__(self, name: str, subType: SubTypeOrSymbol, defaultExpression: Expression):
+    def __init__(
+        self, name: str, subType: SubTypeOrSymbol, defaultExpression: Expression
+    ):
         super().__init__(name)
 
         self._name = name
@@ -63,10 +69,11 @@ class Variable(VHDLModel_Variable):
 
 @export
 class Signal(VHDLModel_Signal):
-    def __init__(self, name: str, subType: SubTypeOrSymbol, defaultExpression: Expression):
+    def __init__(
+        self, name: str, subType: SubTypeOrSymbol, defaultExpression: Expression
+    ):
         super().__init__(name)
 
         self._name = name
         self._subType = subType
         self._defaultExpression = defaultExpression
-

--- a/pyGHDL/dom/Range.py
+++ b/pyGHDL/dom/Range.py
@@ -32,10 +32,12 @@
 # ============================================================================
 from pydecor import export
 
-from pyVHDLModel.VHDLModel import \
-    Range as VHDLModel_Range, \
-    RangeExpression as VHDLModel_RangeExpression, \
-    Direction, Expression
+from pyVHDLModel.VHDLModel import (
+    Range as VHDLModel_Range,
+    RangeExpression as VHDLModel_RangeExpression,
+    Direction,
+    Expression,
+)
 
 __all__ = []
 

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -34,11 +34,12 @@ from pydecor import export
 
 from typing import List
 
-from pyVHDLModel.VHDLModel import \
-    SimpleSubTypeSymbol as VHDLModel_SimpleSubTypeSymbol, \
-    ConstrainedSubTypeSymbol as VHDLModel_ConstrainedSubTypeSymbol, \
-    SimpleObjectSymbol as VHDLModel_SimpleObjectSymbol, \
-    Constraint
+from pyVHDLModel.VHDLModel import (
+    SimpleSubTypeSymbol as VHDLModel_SimpleSubTypeSymbol,
+    ConstrainedSubTypeSymbol as VHDLModel_ConstrainedSubTypeSymbol,
+    SimpleObjectSymbol as VHDLModel_SimpleObjectSymbol,
+    Constraint,
+)
 
 __all__ = []
 
@@ -53,6 +54,7 @@ class SimpleSubTypeSymbol(VHDLModel_SimpleSubTypeSymbol):
 class ConstrainedSubTypeSymbol(VHDLModel_ConstrainedSubTypeSymbol):
     def __init__(self, subTypeName: str, constraints: List[Constraint] = None):
         super().__init__(subTypeName=subTypeName, constraints=constraints)
+
 
 @export
 class SimpleObjectSymbol(VHDLModel_SimpleObjectSymbol):

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -5,14 +5,25 @@ from pydecor import export
 from pyVHDLModel.VHDLModel import Constraint, Direction, Expression, SubTypeOrSymbol
 
 from pyGHDL.libghdl import utils, name_table
-from pyGHDL.libghdl.utils  import flist_iter
-from pyGHDL.libghdl.vhdl   import nodes
-from pyGHDL.dom._Utils     import NodeToName, GetIirKindOfNode
-from pyGHDL.dom.Common     import DOMException
-from pyGHDL.dom.Range      import Range, RangeExpression
-from pyGHDL.dom.Symbol     import SimpleObjectSymbol, SimpleSubTypeSymbol, ConstrainedSubTypeSymbol
+from pyGHDL.libghdl.utils import flist_iter
+from pyGHDL.libghdl.vhdl import nodes
+from pyGHDL.dom._Utils import NodeToName, GetIirKindOfNode
+from pyGHDL.dom.Common import DOMException
+from pyGHDL.dom.Range import Range, RangeExpression
+from pyGHDL.dom.Symbol import (
+    SimpleObjectSymbol,
+    SimpleSubTypeSymbol,
+    ConstrainedSubTypeSymbol,
+)
 from pyGHDL.dom.Literal import IntegerLiteral, CharacterLiteral, FloatingPointLiteral
-from pyGHDL.dom.Expression import SubtractionExpression, AdditionExpression, MultiplyExpression, DivisionExpression, InverseExpression, ExponentiationExpression
+from pyGHDL.dom.Expression import (
+    SubtractionExpression,
+    AdditionExpression,
+    MultiplyExpression,
+    DivisionExpression,
+    InverseExpression,
+    ExponentiationExpression,
+)
 
 __all__ = []
 
@@ -22,28 +33,31 @@ def GetSubtypeIndicationFromNode(node, entity: str, name: str) -> SubTypeOrSymbo
     subTypeIndication = nodes.Get_Subtype_Indication(node)
     subTypeKind = GetIirKindOfNode(subTypeIndication)
 
-    if (subTypeKind == nodes.Iir_Kind.Simple_Name):
+    if subTypeKind == nodes.Iir_Kind.Simple_Name:
         subTypeName = NodeToName(subTypeIndication)
 
         subType = SimpleSubTypeSymbol(subTypeName)
-    elif (subTypeKind == nodes.Iir_Kind.Array_Subtype_Definition):
+    elif subTypeKind == nodes.Iir_Kind.Array_Subtype_Definition:
         typeMark = nodes.Get_Subtype_Type_Mark(subTypeIndication)
         typeMarkName = NodeToName(typeMark)
 
         constraints = GetArrayConstraintsFromSubtypeIndication(subTypeIndication)
         subType = ConstrainedSubTypeSymbol(typeMarkName, constraints)
-    elif (subTypeKind == nodes.Iir_Kind.Subtype_Definition):
+    elif subTypeKind == nodes.Iir_Kind.Subtype_Definition:
         raise DOMException(
             "Unknown handling of subtype kind '{kind}' of subtype indication '{indication}' while parsing {entity} '{name}'.".format(
-                kind=subTypeKind, indication=subTypeIndication, entity=entity, name=name)
+                kind=subTypeKind, indication=subTypeIndication, entity=entity, name=name
+            )
         )
     else:
         raise DOMException(
             "Unknown subtype kind '{kind}' of subtype indication '{indication}' while parsing {entity} '{name}'.".format(
-                kind=subTypeKind, indication=subTypeIndication, entity=entity, name=name)
+                kind=subTypeKind, indication=subTypeIndication, entity=entity, name=name
+            )
         )
 
     return subType
+
 
 @export
 def GetArrayConstraintsFromSubtypeIndication(subTypeIndication) -> List[Constraint]:
@@ -58,7 +72,7 @@ def GetArrayConstraintsFromSubtypeIndication(subTypeIndication) -> List[Constrai
             r = Range(
                 GetExpressionFromNode(leftBound),
                 GetExpressionFromNode(rightBound),
-                Direction.DownTo if direction else Direction.To
+                Direction.DownTo if direction else Direction.To,
             )
             constraints.append(RangeExpression(r))
         elif constraintKind == nodes.Iir_Kind.Attribute_Name:
@@ -68,7 +82,10 @@ def GetArrayConstraintsFromSubtypeIndication(subTypeIndication) -> List[Constrai
         else:
             raise DOMException(
                 "Unknown constraint kind '{kind}' for constraint '{constraint}' in subtype indication '{indication}'.".format(
-                    kind=constraintKind, constraint=constraint, indication=subTypeIndication)
+                    kind=constraintKind,
+                    constraint=constraint,
+                    indication=subTypeIndication,
+                )
             )
 
     return constraints
@@ -117,8 +134,10 @@ def GetExpressionFromNode(node) -> Expression:
     else:
         raise DOMException(
             "Unknown expression kind '{kindName}'({kind}) in expression '{expr}'.".format(
-                kind=kind, kindName=kind.name, expr=node)
+                kind=kind, kindName=kind.name, expr=node
+            )
         )
+
 
 # FIXME: rewrite to generator
 @export
@@ -135,10 +154,12 @@ def GetGenericsFromChainedNodes(nodeChain):
         else:
             raise DOMException(
                 "Unknown generic kind '{kindName}'({kind}) in generic '{generic}'.".format(
-                    kind=kind, kindName=kind.name, generic=generic)
+                    kind=kind, kindName=kind.name, generic=generic
+                )
             )
 
     return result
+
 
 # FIXME: rewrite to generator
 @export
@@ -155,10 +176,12 @@ def GetPortsFromChainedNodes(nodeChain):
         else:
             raise DOMException(
                 "Unknown port kind '{kindName}'({kind}) in port '{port}'.".format(
-                    kind=kind, kindName=kind.name, port=port)
+                    kind=kind, kindName=kind.name, port=port
+                )
             )
 
     return result
+
 
 def GetDeclaredItemsFromChainedNodes(nodeChain, entity: str, name: str):
     result = []
@@ -168,7 +191,9 @@ def GetDeclaredItemsFromChainedNodes(nodeChain, entity: str, name: str):
             from pyGHDL.dom.Object import Constant
 
             constantName = NodeToName(item)
-            subTypeIndication = GetSubtypeIndicationFromNode(item, "constant", constantName)
+            subTypeIndication = GetSubtypeIndicationFromNode(
+                item, "constant", constantName
+            )
             defaultExpression = GetExpressionFromNode(nodes.Get_Default_Value(item))
 
             constant = Constant(constantName, subTypeIndication, defaultExpression)
@@ -202,7 +227,8 @@ def GetDeclaredItemsFromChainedNodes(nodeChain, entity: str, name: str):
         else:
             raise DOMException(
                 "Unknown declared item kind '{kindName}'({kind}) in {entity} '{name}'.".format(
-                    kind=kind, kindName=kind.name, entity=entity, name=name)
+                    kind=kind, kindName=kind.name, entity=entity, name=name
+                )
             )
 
     return result

--- a/pyGHDL/dom/_Utils.py
+++ b/pyGHDL/dom/_Utils.py
@@ -1,20 +1,21 @@
 from pydecor import export
 
-from pyVHDLModel.VHDLModel import  Mode
+from pyVHDLModel.VHDLModel import Mode
 
-from pyGHDL.libghdl      import LibGHDLException, name_table
+from pyGHDL.libghdl import LibGHDLException, name_table
 from pyGHDL.libghdl.vhdl import nodes
 
 
 __all__ = []
 
 __MODE_TRANSLATION = {
-    nodes.Iir_Mode.In_Mode:      Mode.In,
-    nodes.Iir_Mode.Out_Mode:     Mode.Out,
-    nodes.Iir_Mode.Inout_Mode:   Mode.InOut,
-    nodes.Iir_Mode.Buffer_Mode:  Mode.Buffer,
-    nodes.Iir_Mode.Linkage_Mode: Mode.Linkage
+    nodes.Iir_Mode.In_Mode: Mode.In,
+    nodes.Iir_Mode.Out_Mode: Mode.Out,
+    nodes.Iir_Mode.Inout_Mode: Mode.InOut,
+    nodes.Iir_Mode.Buffer_Mode: Mode.Buffer,
+    nodes.Iir_Mode.Linkage_Mode: Mode.Linkage,
 }
+
 
 @export
 def GetIirKindOfNode(node) -> nodes.Iir_Kind:

--- a/pyGHDL/dom/formatting/prettyprint.py
+++ b/pyGHDL/dom/formatting/prettyprint.py
@@ -3,52 +3,82 @@ from typing import List, Union
 from pydecor import export
 
 from pyGHDL.dom.Object import Constant, Signal
-from pyVHDLModel.VHDLModel import GenericInterfaceItem, Expression, Direction, Mode, NamedEntity, PortInterfaceItem, BinaryExpression, IdentityExpression, \
-    UnaryExpression
+from pyVHDLModel.VHDLModel import (
+    GenericInterfaceItem,
+    Expression,
+    Direction,
+    Mode,
+    NamedEntity,
+    PortInterfaceItem,
+    BinaryExpression,
+    IdentityExpression,
+    UnaryExpression,
+)
 
 from pyGHDL import GHDLBaseException
 from pyGHDL.dom.Misc import Document
-from pyGHDL.dom.DesignUnit import Entity, Architecture, Package, PackageBody, Configuration, Context
-from pyGHDL.dom.InterfaceItem import GenericConstantInterfaceItem, PortSignalInterfaceItem
-from pyGHDL.dom.Symbol import SimpleSubTypeSymbol, ConstrainedSubTypeSymbol, SimpleObjectSymbol
+from pyGHDL.dom.DesignUnit import (
+    Entity,
+    Architecture,
+    Package,
+    PackageBody,
+    Configuration,
+    Context,
+)
+from pyGHDL.dom.InterfaceItem import (
+    GenericConstantInterfaceItem,
+    PortSignalInterfaceItem,
+)
+from pyGHDL.dom.Symbol import (
+    SimpleSubTypeSymbol,
+    ConstrainedSubTypeSymbol,
+    SimpleObjectSymbol,
+)
 from pyGHDL.dom.Literal import IntegerLiteral, CharacterLiteral, FloatingPointLiteral
 
-from pyGHDL.dom.Expression import SubtractionExpression, AdditionExpression, MultiplyExpression, DivisionExpression, InverseExpression, AbsoluteExpression, \
-    NegationExpression, ExponentiationExpression
+from pyGHDL.dom.Expression import (
+    SubtractionExpression,
+    AdditionExpression,
+    MultiplyExpression,
+    DivisionExpression,
+    InverseExpression,
+    AbsoluteExpression,
+    NegationExpression,
+    ExponentiationExpression,
+)
 
 StringBuffer = List[str]
 
-DirectionTranslation = {
-    Direction.To:     "to",
-    Direction.DownTo: "downto"
-}
+DirectionTranslation = {Direction.To: "to", Direction.DownTo: "downto"}
 
 ModeTranslation = {
-    Mode.In:      "in",
-    Mode.Out:     "out",
-    Mode.InOut:   "inout",
-    Mode.Buffer:  "buffer",
-    Mode.Linkage: "linkage"
+    Mode.In: "in",
+    Mode.Out: "out",
+    Mode.InOut: "inout",
+    Mode.Buffer: "buffer",
+    Mode.Linkage: "linkage",
 }
 
 UnaryExpressionTranslation = {
-    IdentityExpression:    " +",
-    NegationExpression:    " -",
-    InverseExpression:     "not ",
-    AbsoluteExpression:    "abs ",
+    IdentityExpression: " +",
+    NegationExpression: " -",
+    InverseExpression: "not ",
+    AbsoluteExpression: "abs ",
 }
 
 BinaryExpressionTranslation = {
-    AdditionExpression:       " + ",
-    SubtractionExpression:    " - ",
-    MultiplyExpression:       " * ",
-    DivisionExpression:       " / ",
-    ExponentiationExpression: "**"
+    AdditionExpression: " + ",
+    SubtractionExpression: " - ",
+    MultiplyExpression: " * ",
+    DivisionExpression: " / ",
+    ExponentiationExpression: "**",
 }
+
 
 @export
 class PrettyPrintException(GHDLBaseException):
     pass
+
 
 @export
 class PrettyPrint:
@@ -60,30 +90,32 @@ class PrettyPrint:
     def formatDocument(self, document: Document, level: int = 0) -> StringBuffer:
         buffer = []
         prefix = "  " * level
-        buffer.append("{prefix}Document '{doc!s}':".format(doc=document.Path, prefix=prefix))
+        buffer.append(
+            "{prefix}Document '{doc!s}':".format(doc=document.Path, prefix=prefix)
+        )
         buffer.append("{prefix}  Entities:".format(prefix=prefix))
         for entity in document.Entities:
-            for line in self.formatEntity(entity, level+1):
+            for line in self.formatEntity(entity, level + 1):
                 buffer.append(line)
         buffer.append("{prefix}  Architectures:".format(prefix=prefix))
         for architecture in document.Architectures:
-            for line in self.formatArchitecture(architecture, level+1):
+            for line in self.formatArchitecture(architecture, level + 1):
                 buffer.append(line)
         buffer.append("{prefix}  Packages:".format(prefix=prefix))
         for package in document.Packages:
-            for line in self.formatPackage(package, level+1):
+            for line in self.formatPackage(package, level + 1):
                 buffer.append(line)
         buffer.append("{prefix}  PackageBodies:".format(prefix=prefix))
         for packageBodies in document.PackageBodies:
-            for line in self.formatPackageBody(packageBodies, level+1):
+            for line in self.formatPackageBody(packageBodies, level + 1):
                 buffer.append(line)
         buffer.append("{prefix}  Configurations:".format(prefix=prefix))
         for configuration in document.Configurations:
-            for line in self.formatConfiguration(configuration, level+1):
+            for line in self.formatConfiguration(configuration, level + 1):
                 buffer.append(line)
         buffer.append("{prefix}  Contexts:".format(prefix=prefix))
         for context in document.Contexts:
-            for line in self.formatContext(context, level+1):
+            for line in self.formatContext(context, level + 1):
                 buffer.append(line)
 
         return buffer
@@ -107,7 +139,9 @@ class PrettyPrint:
 
         return buffer
 
-    def formatArchitecture(self, architecture: Architecture, level: int = 0) -> StringBuffer:
+    def formatArchitecture(
+        self, architecture: Architecture, level: int = 0
+    ) -> StringBuffer:
         buffer = []
         prefix = "  " * level
         buffer.append("{prefix}- {name}".format(name=architecture.Name, prefix=prefix))
@@ -129,7 +163,9 @@ class PrettyPrint:
 
         return buffer
 
-    def formatPackageBody(self, packageBody: PackageBody, level: int = 0) -> StringBuffer:
+    def formatPackageBody(
+        self, packageBody: PackageBody, level: int = 0
+    ) -> StringBuffer:
         buffer = []
         prefix = "  " * level
         buffer.append("{prefix}- {name}".format(name=packageBody.Name, prefix=prefix))
@@ -140,7 +176,9 @@ class PrettyPrint:
 
         return buffer
 
-    def formatConfiguration(self, configuration: Configuration, level: int = 0) -> StringBuffer:
+    def formatConfiguration(
+        self, configuration: Configuration, level: int = 0
+    ) -> StringBuffer:
         buffer = []
         prefix = "  " * level
         buffer.append("{prefix}- {name}".format(name=configuration.Name, prefix=prefix))
@@ -154,19 +192,29 @@ class PrettyPrint:
 
         return buffer
 
-    def formatGeneric(self, generic: Union[NamedEntity, GenericInterfaceItem], level: int = 0) -> StringBuffer:
+    def formatGeneric(
+        self, generic: Union[NamedEntity, GenericInterfaceItem], level: int = 0
+    ) -> StringBuffer:
         if isinstance(generic, GenericConstantInterfaceItem):
             return self.formatGenericConstant(generic, level)
         else:
-            raise PrettyPrintException("Unhandled generic kind for generic '{name}'.".format(name=generic.Name))
+            raise PrettyPrintException(
+                "Unhandled generic kind for generic '{name}'.".format(name=generic.Name)
+            )
 
-    def formatPort(self, port: Union[NamedEntity, PortInterfaceItem], level: int = 0) -> StringBuffer:
+    def formatPort(
+        self, port: Union[NamedEntity, PortInterfaceItem], level: int = 0
+    ) -> StringBuffer:
         if isinstance(port, PortSignalInterfaceItem):
             return self.formatPortSignal(port, level)
         else:
-            raise PrettyPrintException("Unhandled port kind for port '{name}'.".format(name=port.Name))
+            raise PrettyPrintException(
+                "Unhandled port kind for port '{name}'.".format(name=port.Name)
+            )
 
-    def formatGenericConstant(self, generic: GenericConstantInterfaceItem, level: int = 0) -> StringBuffer:
+    def formatGenericConstant(
+        self, generic: GenericConstantInterfaceItem, level: int = 0
+    ) -> StringBuffer:
         buffer = []
         prefix = "  " * level
         subType = generic.SubType
@@ -176,7 +224,7 @@ class PrettyPrint:
                     prefix=prefix,
                     name=generic.Name,
                     mode=ModeTranslation[generic.Mode],
-                    type=subType.SymbolName
+                    type=subType.SymbolName,
                 )
             )
         elif isinstance(subType, ConstrainedSubTypeSymbol):
@@ -187,19 +235,31 @@ class PrettyPrint:
                     mode=ModeTranslation[generic.Mode],
                     type=subType.SymbolName,
                     constraints=", ".join(
-                        ["{left} {dir} {right}".format(
-                            left=self.formatExpression(constraint.Range.LeftBound),
-                            right=self.formatExpression(constraint.Range.RightBound),
-                            dir=DirectionTranslation[constraint.Range.Direction])
-                                for constraint in subType.Constraints])
+                        [
+                            "{left} {dir} {right}".format(
+                                left=self.formatExpression(constraint.Range.LeftBound),
+                                right=self.formatExpression(
+                                    constraint.Range.RightBound
+                                ),
+                                dir=DirectionTranslation[constraint.Range.Direction],
+                            )
+                            for constraint in subType.Constraints
+                        ]
+                    ),
                 )
             )
         else:
-            raise PrettyPrintException("Unhandled constraint kind for generic '{name}'.".format(name=generic.Name))
+            raise PrettyPrintException(
+                "Unhandled constraint kind for generic '{name}'.".format(
+                    name=generic.Name
+                )
+            )
 
         return buffer
 
-    def formatPortSignal(self, port: PortSignalInterfaceItem, level: int = 0) -> StringBuffer:
+    def formatPortSignal(
+        self, port: PortSignalInterfaceItem, level: int = 0
+    ) -> StringBuffer:
         buffer = []
         prefix = "  " * level
 
@@ -208,7 +268,9 @@ class PrettyPrint:
                 prefix=prefix,
                 name=port.Name,
                 mode=ModeTranslation[port.Mode],
-                subtypeindication=self.formatSubtypeIndication(port.SubType, "port", port.Name)
+                subtypeindication=self.formatSubtypeIndication(
+                    port.SubType, "port", port.Name
+                ),
             )
         )
 
@@ -223,8 +285,10 @@ class PrettyPrint:
                 "{prefix}- constant {name} : {subtype} := {expr}".format(
                     prefix=prefix,
                     name=item.Name,
-                    subtype=self.formatSubtypeIndication(item.SubType, "constant", item.Name),
-                    expr=self.formatExpression(item.DefaultExpression)
+                    subtype=self.formatSubtypeIndication(
+                        item.SubType, "constant", item.Name
+                    ),
+                    expr=self.formatExpression(item.DefaultExpression),
                 )
             )
         elif isinstance(item, Signal):
@@ -232,10 +296,14 @@ class PrettyPrint:
                 "{prefix}- signal {name} : {subtype}{initValue}".format(
                     prefix=prefix,
                     name=item.Name,
-                    subtype=self.formatSubtypeIndication(item.SubType, "signal", item.Name),
+                    subtype=self.formatSubtypeIndication(
+                        item.SubType, "signal", item.Name
+                    ),
                     initValue=" := {expr}".format(
                         expr=self.formatExpression(item.DefaultExpression)
-                    ) if item.DefaultExpression is not None else ""
+                    )
+                    if item.DefaultExpression is not None
+                    else "",
                 )
             )
         else:
@@ -248,19 +316,25 @@ class PrettyPrint:
             return "{type}".format(type=subTypeIndication.SymbolName)
         elif isinstance(subTypeIndication, ConstrainedSubTypeSymbol):
             constraints = ", ".join(
-                ["{left} {dir} {right}".format(
-                    left=self.formatExpression(constraint.Range.LeftBound),
-                    right=self.formatExpression(constraint.Range.RightBound),
-                    dir=DirectionTranslation[constraint.Range.Direction]
-                ) for constraint in subTypeIndication.Constraints]
+                [
+                    "{left} {dir} {right}".format(
+                        left=self.formatExpression(constraint.Range.LeftBound),
+                        right=self.formatExpression(constraint.Range.RightBound),
+                        dir=DirectionTranslation[constraint.Range.Direction],
+                    )
+                    for constraint in subTypeIndication.Constraints
+                ]
             )
 
             return "{type}({constraints})".format(
-                type=subTypeIndication.SymbolName,
-                constraints=constraints
+                type=subTypeIndication.SymbolName, constraints=constraints
             )
         else:
-            raise PrettyPrintException("Unhandled constraint kind for {entity} '{name}'.".format(entity=entity, name=name))
+            raise PrettyPrintException(
+                "Unhandled constraint kind for {entity} '{name}'.".format(
+                    entity=entity, name=name
+                )
+            )
 
     def formatExpression(self, expression: Expression) -> str:
         if isinstance(expression, SimpleObjectSymbol):
@@ -278,8 +352,7 @@ class PrettyPrint:
                 raise PrettyPrintException("Unhandled operator for unary expression.")
 
             return "{operator}{operand}".format(
-                operand=self.formatExpression(expression.Operand),
-                operator=operator
+                operand=self.formatExpression(expression.Operand), operator=operator
             )
         elif isinstance(expression, BinaryExpression):
             try:
@@ -290,7 +363,7 @@ class PrettyPrint:
             return "{left}{operator}{right}".format(
                 left=self.formatExpression(expression.LeftOperand),
                 right=self.formatExpression(expression.RightOperand),
-                operator=operator
+                operator=operator,
             )
         else:
             raise PrettyPrintException("Unhandled expression kind.")

--- a/pyGHDL/libghdl/__init__.py
+++ b/pyGHDL/libghdl/__init__.py
@@ -6,9 +6,9 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
-#    Patrick Lehmann
+# Authors:
+#   Tristan Gingold
+#   Patrick Lehmann
 #
 # Package package:  Python binding and low-level API for shared library 'libghdl'.
 #
@@ -40,7 +40,9 @@ from shutil import which
 
 from pydecor import export
 
+from pyGHDL import GHDLBaseException
 from pyGHDL.libghdl._types import Iir
+#from pyGHDL.libghdl._decorator import BindToLibGHDL
 from pyGHDL.libghdl.version import __version__
 
 
@@ -150,18 +152,21 @@ libghdl = _initialize()
 
 
 @export
+# @BindToLibGHDL("options__finalize")
 def finalize() -> None:
     """Free all the memory, be ready for a new initialization."""
     libghdl.options__finalize()
 
 
 @export
+#@BindToLibGHDL("options__initialize")
 def initialize() -> None:
     """Initialize or re-initialize the shared library."""
     libghdl.options__initialize()
 
 
 @export
+# @BindToLibGHDL("libghdl__set_option")
 def set_option(Opt: str) -> bool:
     """
     Set option :obj:`opt`.
@@ -174,6 +179,7 @@ def set_option(Opt: str) -> bool:
 
 
 @export
+#@BindToLibGHDL("libghdl__analyze_init")
 def analyze_init() -> None:
     """
     Initialize the analyzer.
@@ -185,6 +191,7 @@ def analyze_init() -> None:
 
 
 @export
+#@BindToLibGHDL("libghdl__analyze_init_status")
 def analyze_init_status() -> int:
     """
     Initialize the analyzer.
@@ -195,6 +202,7 @@ def analyze_init_status() -> int:
 
 
 @export
+# @BindToLibGHDL("libghdl__analyze_file")
 def analyze_file(fname: str) -> Iir:
     """
     Analyze a given filename :obj:`fname`.
@@ -207,6 +215,12 @@ def analyze_file(fname: str) -> Iir:
 
 
 @export
+#@BindToLibGHDL("ghdllocal__disp_config_prefixes")
 def disp_config() -> None:
     """Display the configured prefixes for libghdl."""
     libghdl.ghdllocal__disp_config_prefixes()
+
+
+@export
+class LibGHDLException(GHDLBaseException):
+    pass

--- a/pyGHDL/libghdl/__init__.py
+++ b/pyGHDL/libghdl/__init__.py
@@ -42,8 +42,13 @@ from pydecor import export
 
 from pyGHDL import GHDLBaseException
 from pyGHDL.libghdl._types import Iir
-#from pyGHDL.libghdl._decorator import BindToLibGHDL
+
+# from pyGHDL.libghdl._decorator import BindToLibGHDL
 from pyGHDL.libghdl.version import __version__
+
+
+class LibGHDLException(GHDLBaseException):
+    pass
 
 
 def _get_libghdl_name() -> Path:
@@ -159,7 +164,7 @@ def finalize() -> None:
 
 
 @export
-#@BindToLibGHDL("options__initialize")
+# @BindToLibGHDL("options__initialize")
 def initialize() -> None:
     """Initialize or re-initialize the shared library."""
     libghdl.options__initialize()
@@ -179,7 +184,7 @@ def set_option(Opt: str) -> bool:
 
 
 @export
-#@BindToLibGHDL("libghdl__analyze_init")
+# @BindToLibGHDL("libghdl__analyze_init")
 def analyze_init() -> None:
     """
     Initialize the analyzer.
@@ -191,7 +196,7 @@ def analyze_init() -> None:
 
 
 @export
-#@BindToLibGHDL("libghdl__analyze_init_status")
+# @BindToLibGHDL("libghdl__analyze_init_status")
 def analyze_init_status() -> int:
     """
     Initialize the analyzer.
@@ -215,12 +220,7 @@ def analyze_file(fname: str) -> Iir:
 
 
 @export
-#@BindToLibGHDL("ghdllocal__disp_config_prefixes")
+# @BindToLibGHDL("ghdllocal__disp_config_prefixes")
 def disp_config() -> None:
     """Display the configured prefixes for libghdl."""
     libghdl.ghdllocal__disp_config_prefixes()
-
-
-@export
-class LibGHDLException(GHDLBaseException):
-    pass

--- a/pyGHDL/libghdl/_decorator.py
+++ b/pyGHDL/libghdl/_decorator.py
@@ -82,24 +82,30 @@ def BindToLibGHDL(subprogramName):
         typeHintCount = len(typeHints)
 
         if typeHintCount == 0:
-            raise ValueError("Function {0} is not annotated with types.".format(func.__name__))
-
-        try:
-            returnType = typeHints['return']
-        except KeyError:
-            raise ValueError("Function {0} is not annotated with a return type.".format(func.__name__))
-
-        if (typeHintCount - 1) != func.__code__.co_argcount:
-            raise ValueError("Number of type annotations ({0}) for function '{1}' does not match number of parameters ({2}).".format(
-                typeHintCount - 1,
-                func.__name__,
-                func.__code__.co_argcount)
+            raise ValueError(
+                "Function {0} is not annotated with types.".format(func.__name__)
             )
 
-        #		print(typeHints)
+        try:
+            returnType = typeHints["return"]
+        except KeyError:
+            raise ValueError(
+                "Function {0} is not annotated with a return type.".format(
+                    func.__name__
+                )
+            )
+
+        if (typeHintCount - 1) != func.__code__.co_argcount:
+            raise ValueError(
+                "Number of type annotations ({0}) for function '{1}' does not match number of parameters ({2}).".format(
+                    typeHintCount - 1, func.__name__, func.__code__.co_argcount
+                )
+            )
+
+        # 		print(typeHints)
 
         parameters = typeHints.copy()
-        del parameters['return']
+        del parameters["return"]
 
         parameterTypes = []
         for parameter in parameters.values():
@@ -117,9 +123,17 @@ def BindToLibGHDL(subprogramName):
                 if (parameter.__bound__ is int) or (parameter.__bound__ is c_int32):
                     parameterTypes.append(c_int32)
                 else:
-                    raise TypeError("Unsupported parameter type '{0!s}' in function '{1}'.".format(parameter, func.__name__))
+                    raise TypeError(
+                        "Unsupported parameter type '{0!s}' in function '{1}'.".format(
+                            parameter, func.__name__
+                        )
+                    )
             else:
-                raise TypeError("Unsupported parameter type '{0!s}' in function '{1}'.".format(parameter, func.__name__))
+                raise TypeError(
+                    "Unsupported parameter type '{0!s}' in function '{1}'.".format(
+                        parameter, func.__name__
+                    )
+                )
 
         if returnType is None:
             resultType = None
@@ -129,19 +143,27 @@ def BindToLibGHDL(subprogramName):
             resultType = c_char
         elif returnType is c_char_p:
             resultType = c_char_p
-        elif (returnType is int):
+        elif returnType is int:
             resultType = c_int32
-        elif (returnType is bool):
+        elif returnType is bool:
             resultType = c_bool
         elif isinstance(returnType, TypeVar):
             if (returnType.__bound__ is int) or (returnType.__bound__ is c_int32):
                 resultType = c_int32
             else:
-                raise Exception("Unsupported return type '{0!s}' in function '{1}'.".format(returnType, func.__name__))
+                raise Exception(
+                    "Unsupported return type '{0!s}' in function '{1}'.".format(
+                        returnType, func.__name__
+                    )
+                )
         elif issubclass(returnType, Structure):
             resultType = returnType
         else:
-            raise Exception("Unsupported return type '{0!s}' in function '{1}'.".format(returnType, func.__name__))
+            raise Exception(
+                "Unsupported return type '{0!s}' in function '{1}'.".format(
+                    returnType, func.__name__
+                )
+            )
 
         functionPointer = getattr(libghdl, subprogramName)
         functionPointer.parameterTypes = parameterTypes

--- a/pyGHDL/libghdl/_decorator.py
+++ b/pyGHDL/libghdl/_decorator.py
@@ -6,8 +6,8 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Patrick Lehmann
+# Authors:
+#   Patrick Lehmann
 #
 # Package module:   Python binding and low-level API for shared library 'libghdl'.
 #
@@ -30,10 +30,14 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
-
-from typing import Callable, List
+#
+from ctypes import c_int32, c_char_p, c_bool, Structure, c_char
+from functools import wraps
+from typing import Callable, List, Dict, Any, TypeVar
 
 from pydecor import export
+
+from pyGHDL.libghdl import libghdl
 
 
 @export
@@ -41,8 +45,6 @@ def EnumLookupTable(cls) -> Callable:
     """
     Decorator to precalculate a enum lookup table (LUT) for enum position to
     enum literal name.
-
-    .. todo:: Make compatible to chained decorators
 
     :param cls: Enumerator class for which a LUT shall be pre-calculated.
     """
@@ -57,6 +59,7 @@ def EnumLookupTable(cls) -> Callable:
 
         __lut = gen()
 
+        @wraps(func)
         def wrapper(id: int) -> str:
             # function that replaces the placeholder function
             return __lut[id]
@@ -64,3 +67,90 @@ def EnumLookupTable(cls) -> Callable:
         return wrapper
 
     return decorator
+
+
+def BindToLibGHDL(subprogramName):
+    """
+    This decorator creates a Python function to interface with subprograms in
+    libghdl via :mod:`ctypes`.
+
+    :param subprogramName: Name of the subprogram in *libghdl*.
+    """
+
+    def wrapper(func: Callable):
+        typeHints: Dict[str, Any] = func.__annotations__
+        typeHintCount = len(typeHints)
+
+        if typeHintCount == 0:
+            raise ValueError("Function {0} is not annotated with types.".format(func.__name__))
+
+        try:
+            returnType = typeHints['return']
+        except KeyError:
+            raise ValueError("Function {0} is not annotated with a return type.".format(func.__name__))
+
+        if (typeHintCount - 1) != func.__code__.co_argcount:
+            raise ValueError("Number of type annotations ({0}) for function '{1}' does not match number of parameters ({2}).".format(
+                typeHintCount - 1,
+                func.__name__,
+                func.__code__.co_argcount)
+            )
+
+        #		print(typeHints)
+
+        parameters = typeHints.copy()
+        del parameters['return']
+
+        parameterTypes = []
+        for parameter in parameters.values():
+            if parameter is int:
+                parameterTypes.append(c_int32)
+            elif parameter is bool:
+                parameterTypes.append(c_bool)
+            elif parameter is bytes:
+                parameterTypes.append(c_char_p)
+            elif parameter is c_char:
+                parameterTypes.append(c_char)
+            elif parameter is c_char_p:
+                parameterTypes.append(c_char_p)
+            elif isinstance(parameter, TypeVar):
+                if (parameter.__bound__ is int) or (parameter.__bound__ is c_int32):
+                    parameterTypes.append(c_int32)
+                else:
+                    raise TypeError("Unsupported parameter type '{0!s}' in function '{1}'.".format(parameter, func.__name__))
+            else:
+                raise TypeError("Unsupported parameter type '{0!s}' in function '{1}'.".format(parameter, func.__name__))
+
+        if returnType is None:
+            resultType = None
+        elif returnType is bytes:
+            resultType = c_char_p
+        elif returnType is c_char:
+            resultType = c_char
+        elif returnType is c_char_p:
+            resultType = c_char_p
+        elif (returnType is int):
+            resultType = c_int32
+        elif (returnType is bool):
+            resultType = c_bool
+        elif isinstance(returnType, TypeVar):
+            if (returnType.__bound__ is int) or (returnType.__bound__ is c_int32):
+                resultType = c_int32
+            else:
+                raise Exception("Unsupported return type '{0!s}' in function '{1}'.".format(returnType, func.__name__))
+        elif issubclass(returnType, Structure):
+            resultType = returnType
+        else:
+            raise Exception("Unsupported return type '{0!s}' in function '{1}'.".format(returnType, func.__name__))
+
+        functionPointer = getattr(libghdl, subprogramName)
+        functionPointer.parameterTypes = parameterTypes
+        functionPointer.restype = resultType
+
+        @wraps(func)
+        def inner(*args):
+            return functionPointer(*args)
+
+        return inner
+
+    return wrapper

--- a/pyGHDL/libghdl/_types.py
+++ b/pyGHDL/libghdl/_types.py
@@ -39,7 +39,7 @@ __all__ = [
     "NameId",
     "SourceFileEntry",
     "Iir",
-    "IirKind"
+    "IirKind",
 ]
 
 ErrorIndex = TypeVar("ErrorIndex", bound=int)
@@ -56,4 +56,6 @@ Iir_Design_File = TypeVar("Iir_Design_File", bound=int)
 Iir_Design_Unit = TypeVar("Iir_Design_Unit", bound=int)
 Iir_Library_Declaration = TypeVar("Iir_Library_Declaration", bound=c_int32)
 Iir_Package_Declaration = TypeVar("Iir_Package_Declaration", bound=c_int32)
-Iir_Enumeration_Type_Definition = TypeVar("Iir_Enumeration_Type_Definition", bound=c_int32)
+Iir_Enumeration_Type_Definition = TypeVar(
+    "Iir_Enumeration_Type_Definition", bound=c_int32
+)

--- a/pyGHDL/libghdl/_types.py
+++ b/pyGHDL/libghdl/_types.py
@@ -30,7 +30,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
-
+from ctypes import c_int32
 from typing import TypeVar
 
 __all__ = [
@@ -39,13 +39,21 @@ __all__ = [
     "NameId",
     "SourceFileEntry",
     "Iir",
-    "IirKind",
+    "IirKind"
 ]
 
 ErrorIndex = TypeVar("ErrorIndex", bound=int)
 MessageIdWarnings = TypeVar("MessageIdWarnings", bound=int)
 NameId = TypeVar("NameId", bound=int)
+
 SourceFileEntry = TypeVar("SourceFileEntry", bound=int)
+Location_Type = TypeVar("Location_Type", bound=c_int32)
 
 Iir = TypeVar("Iir", bound=int)
 IirKind = TypeVar("IirKind", bound=int)
+
+Iir_Design_File = TypeVar("Iir_Design_File", bound=int)
+Iir_Design_Unit = TypeVar("Iir_Design_Unit", bound=int)
+Iir_Library_Declaration = TypeVar("Iir_Library_Declaration", bound=c_int32)
+Iir_Package_Declaration = TypeVar("Iir_Package_Declaration", bound=c_int32)
+Iir_Enumeration_Type_Definition = TypeVar("Iir_Enumeration_Type_Definition", bound=c_int32)

--- a/pyGHDL/libghdl/errorout.py
+++ b/pyGHDL/libghdl/errorout.py
@@ -1,7 +1,10 @@
 # Auto generated Python source file from Ada sources
 # Call 'make' in 'src/vhdl' to regenerate:
 #
+from enum import IntEnum, unique
 from pydecor import export
+from enum import IntEnum, unique
+
 from pyGHDL.libghdl import libghdl
 
 
@@ -11,7 +14,8 @@ def Enable_Warning(Id: int, Enable: bool) -> None:
 
 
 @export
-class Msgid:
+@unique
+class Msgid(IntEnum):
     Msgid_Note = 0
     Warnid_Library = 1
     Warnid_Deprecated_Option = 2

--- a/pyGHDL/libghdl/errorout_console.py
+++ b/pyGHDL/libghdl/errorout_console.py
@@ -6,9 +6,9 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
-#    Patrick Lehmann
+# Authors:
+#   Tristan Gingold
+#   Patrick Lehmann
 #
 # Package module:   Python binding and low-level API for shared library 'libghdl'.
 #
@@ -34,10 +34,10 @@
 
 from pydecor import export
 
-from pyGHDL.libghdl import libghdl
+from pyGHDL.libghdl._decorator import BindToLibGHDL
 
 
 @export
+@BindToLibGHDL("errorout__console__install_handler")
 def Install_Handler() -> None:
     """Install the handlers for reporting errors."""
-    libghdl.errorout__console__install_handler()

--- a/pyGHDL/libghdl/errorout_memory.py
+++ b/pyGHDL/libghdl/errorout_memory.py
@@ -107,10 +107,11 @@ def Get_Error_Record(Idx: ErrorIndex) -> Error_Message:
     """
 
 
-#@export
+# @export
 @BindToLibGHDL("errorout__memory__get_error_message_addr")
 def _Get_Error_Message(Idx: ErrorIndex) -> c_char_p:
     pass
+
 
 @export
 def Get_Error_Message(Idx: ErrorIndex) -> str:

--- a/pyGHDL/libghdl/errorout_memory.py
+++ b/pyGHDL/libghdl/errorout_memory.py
@@ -6,9 +6,9 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
-#    Patrick Lehmann
+# Authors:
+#   Tristan Gingold
+#   Patrick Lehmann
 #
 # Package package:  Python binding and low-level API for shared library 'libghdl'.
 #
@@ -36,8 +36,8 @@ from ctypes import c_int8, c_int32, c_char_p, Structure
 
 from pydecor import export
 
-from pyGHDL.libghdl import libghdl
 from pyGHDL.libghdl._types import ErrorIndex
+from pyGHDL.libghdl._decorator import BindToLibGHDL
 
 
 @export
@@ -81,22 +81,23 @@ Msg_Last = 3
 
 
 @export
+@BindToLibGHDL("errorout__memory__install_handler")
 def Install_Handler() -> None:
     """Install the handlers for reporting errors."""
-    libghdl.errorout__memory__install_handler()
 
 
 @export
+@BindToLibGHDL("errorout__memory__get_nbr_messages")
 def Get_Nbr_Messages() -> ErrorIndex:
     """
     Get number of error messages available.
 
     :return: Number of messages available.
     """
-    return libghdl.errorout__memory__get_nbr_messages()
 
 
 @export
+@BindToLibGHDL("errorout__memory__get_error_record")
 def Get_Error_Record(Idx: ErrorIndex) -> Error_Message:
     """
     Get error messages by index :obj:`Idy` as structure :class:`Error_Message`.
@@ -104,29 +105,25 @@ def Get_Error_Record(Idx: ErrorIndex) -> Error_Message:
     :param Idx: Index from 1 to ``Nbr_Messages`` See :func:`Get_Nbr_Messages`.
     :return:    Type: ``Error_Message``
     """
-    func = libghdl.errorout__memory__get_error_record
-    func.argstypes = [c_int32]
-    func.restype = Error_Message
 
-    return func(Idx)
 
+#@export
+@BindToLibGHDL("errorout__memory__get_error_message_addr")
+def _Get_Error_Message(Idx: ErrorIndex) -> c_char_p:
+    pass
 
 @export
 def Get_Error_Message(Idx: ErrorIndex) -> str:
     """
-    Get error messages by index :obj:`Idy` as string.
+    Get error messages by index :obj:`Idx` as string.
 
     :param Idx: Index from 1 to ``Nbr_Messages`` See :func:`Get_Nbr_Messages`.
-    :return:    Type: ``Error_Message``
+    :return:    Error message.
     """
-    func = libghdl.errorout__memory__get_error_message_addr
-    func.argstype = [c_int32]
-    func.restype = c_char_p
-
-    return func(Idx).decode("utf-8")
+    return _Get_Error_Message(Idx).decode("utf-8")
 
 
 @export
+@BindToLibGHDL("errorout__memory__clear_errors")
 def Clear_Errors() -> None:
     """Remove all error messages."""
-    libghdl.errorout__memory__clear_errors()

--- a/pyGHDL/libghdl/files_map.py
+++ b/pyGHDL/libghdl/files_map.py
@@ -87,7 +87,9 @@ def Location_File_To_Line(Location: Location_Type, File: SourceFileEntry) -> int
 
 @export
 @BindToLibGHDL("files_map__location_file_line_to_offset")
-def Location_File_Line_To_Offset(Location: Location_Type, File: SourceFileEntry, Line: int) -> int:
+def Location_File_Line_To_Offset(
+    Location: Location_Type, File: SourceFileEntry, Line: int
+) -> int:
     """
     Get the offset in :obj:`Line` of :obj:`Location`.
 
@@ -100,7 +102,9 @@ def Location_File_Line_To_Offset(Location: Location_Type, File: SourceFileEntry,
 
 @export
 @BindToLibGHDL("files_map__location_file_line_to_col")
-def Location_File_Line_To_Col(Location: Location_Type, File: SourceFileEntry, Line: int) -> int:
+def Location_File_Line_To_Col(
+    Location: Location_Type, File: SourceFileEntry, Line: int
+) -> int:
     """
     Get logical column (with HT expanded) from :obj:`Location`, :obj:`File` and
     :obj:`Line`.
@@ -219,7 +223,9 @@ def Read_Source_File(Directory: NameId, Name: NameId) -> SourceFileEntry:
 
 @export
 @BindToLibGHDL("files_map__reserve_source_file")
-def Reserve_Source_File(Directory: NameId, Name: NameId, Length: int) -> SourceFileEntry:
+def Reserve_Source_File(
+    Directory: NameId, Name: NameId, Length: int
+) -> SourceFileEntry:
     """
     Reserve an entry, but do not read any file.
 

--- a/pyGHDL/libghdl/files_map.py
+++ b/pyGHDL/libghdl/files_map.py
@@ -6,9 +6,9 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
-#    Patrick Lehmann
+# Authors:
+#   Tristan Gingold
+#   Patrick Lehmann
 #
 # Package package:  Python binding and low-level API for shared library 'libghdl'.
 #
@@ -32,12 +32,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 
-from ctypes import c_void_p
-
 from pydecor import export
 
-from pyGHDL.libghdl import libghdl
-from pyGHDL.libghdl._types import NameId, SourceFileEntry
+from pyGHDL.libghdl._decorator import BindToLibGHDL
+from pyGHDL.libghdl._types import NameId, SourceFileEntry, Location_Type
 
 __all__ = [
     "EOT",
@@ -53,18 +51,19 @@ No_Location = 0
 
 
 @export
-def Location_To_File(Location) -> SourceFileEntry:
+@BindToLibGHDL("files_map__location_to_file")
+def Location_To_File(Location: Location_Type) -> SourceFileEntry:
     """
     Convert :obj:`Location` to a source file.
 
     :param Location: Location
     :return:         Source file. Return ``No_Source_File_Entry`` if location is incorrect.
     """
-    return libghdl.files_map__location_to_file(Location)
 
 
 @export
-def Location_File_To_Pos(Location, File: SourceFileEntry) -> int:
+@BindToLibGHDL("files_map__location_file_to_pos")
+def Location_File_To_Pos(Location: Location_Type, File: SourceFileEntry) -> int:
     """
     Convert :obj:`Location` and :obj:`File` to a position (offset) into the source file.
 
@@ -72,11 +71,11 @@ def Location_File_To_Pos(Location, File: SourceFileEntry) -> int:
     :param File:     Source file
     :return:         Offset
     """
-    return libghdl.files_map__location_file_to_pos(Location, File)
 
 
 @export
-def Location_File_To_Line(Location, File: SourceFileEntry) -> int:
+@BindToLibGHDL("files_map__location_file_to_line")
+def Location_File_To_Line(Location: Location_Type, File: SourceFileEntry) -> int:
     """
     Convert :obj:`Location` and :obj:`File` to a line number.
 
@@ -84,11 +83,11 @@ def Location_File_To_Line(Location, File: SourceFileEntry) -> int:
     :param File:     Source file
     :return:         Line number
     """
-    return libghdl.files_map__location_file_to_line(Location, File)
 
 
 @export
-def Location_File_Line_To_Offset(Location, File: SourceFileEntry, Line: int) -> int:
+@BindToLibGHDL("files_map__location_file_line_to_offset")
+def Location_File_Line_To_Offset(Location: Location_Type, File: SourceFileEntry, Line: int) -> int:
     """
     Get the offset in :obj:`Line` of :obj:`Location`.
 
@@ -97,11 +96,11 @@ def Location_File_Line_To_Offset(Location, File: SourceFileEntry, Line: int) -> 
     :param Line:     Line number
     :return:         Offset
     """
-    return libghdl.files_map__location_file_line_to_offset(Location, File, Line)
 
 
 @export
-def Location_File_Line_To_Col(Location, File: SourceFileEntry, Line: int) -> int:
+@BindToLibGHDL("files_map__location_file_line_to_col")
+def Location_File_Line_To_Col(Location: Location_Type, File: SourceFileEntry, Line: int) -> int:
     """
     Get logical column (with HT expanded) from :obj:`Location`, :obj:`File` and
     :obj:`Line`.
@@ -111,32 +110,32 @@ def Location_File_Line_To_Col(Location, File: SourceFileEntry, Line: int) -> int
     :param Line:     Line number
     :return:         logical column (horizontal tabs are expanded)
     """
-    return libghdl.files_map__location_file_line_to_col(Location, File, Line)
 
 
 @export
-def File_To_Location(File: SourceFileEntry):
+@BindToLibGHDL("files_map__file_to_location")
+def File_To_Location(File: SourceFileEntry) -> Location_Type:
     """Convert a :obj:`File` into a location.
 
     :param File: Source file
-    :return:     Location. Type: ``Location_Type``
+    :return:     Location.
     """
-    return libghdl.files_map__file_to_location(File)
 
 
 @export
-def File_Pos_To_Location(File: SourceFileEntry, Pos: int):
+@BindToLibGHDL("files_map__file_pos_to_location")
+def File_Pos_To_Location(File: SourceFileEntry, Pos: int) -> Location_Type:
     """
     Convert a :obj:`File` and an offset :obj:`Pos` in the file into a location.
 
     :param File: Source file
     :param Pos:  Offset in the file
-    :return:     Location. Type: ``Location_Type``
+    :return:     Location.
     """
-    return libghdl.files_map__file_pos_to_location(File, Pos)
 
 
 @export
+@BindToLibGHDL("files_map__file_line_to_position")
 def File_Line_To_Position(File: SourceFileEntry, Line: int) -> int:
     """
     Convert a :obj:`File` and :obj:`Line` into a position.
@@ -145,10 +144,10 @@ def File_Line_To_Position(File: SourceFileEntry, Line: int) -> int:
     :param Line: Line number
     :return:     Return ``Source_Ptr_Bad`` in case of error (:obj:`Line` out of bounds).
     """
-    return libghdl.files_map__file_line_to_position(File, Line)
 
 
 @export
+@BindToLibGHDL("files_map__get_file_name")
 def Get_File_Name(File: SourceFileEntry) -> NameId:
     """
     Return the name of the file.
@@ -156,10 +155,10 @@ def Get_File_Name(File: SourceFileEntry) -> NameId:
     :param File: Source file to get the filename from.
     :return:     NameId for the filename.
     """
-    return libghdl.files_map__get_file_name(File)
 
 
 @export
+@BindToLibGHDL("files_map__get_directory_name")
 def Get_Directory_Name(File: SourceFileEntry) -> NameId:
     """
     Return the directory of the file.
@@ -167,10 +166,10 @@ def Get_Directory_Name(File: SourceFileEntry) -> NameId:
     :param File: Source file to get the directory name from.
     :return:     NameId for the directory.
     """
-    return libghdl.files_map__get_directory_name(File)
 
 
 @export
+@BindToLibGHDL("files_map__get_file_buffer")
 def Get_File_Buffer(File: SourceFileEntry) -> bytes:
     """
     Return a buffer (access to the contents of the file) for a file entry.
@@ -178,13 +177,10 @@ def Get_File_Buffer(File: SourceFileEntry) -> bytes:
     :param File: Source file to get the buffer from.
     :return:     Type: ``File_Buffer_Ptr``
     """
-    func = libghdl.files_map__get_file_buffer
-    func.restype = c_void_p
-
-    return func(File)
 
 
 @export
+@BindToLibGHDL("files_map__get_file_length")
 def Get_File_Length(File: SourceFileEntry) -> int:
     """
     Get the position of the first EOT character.
@@ -192,10 +188,10 @@ def Get_File_Length(File: SourceFileEntry) -> int:
     :param File: Source file
     :return:     Type: ``Source_Ptr``
     """
-    return libghdl.files_map__get_file_length(File)
 
 
 @export
+@BindToLibGHDL("files_map__set_file_length")
 def Set_File_Length(File: SourceFileEntry, Length: int) -> None:
     """
     Set the length of the file (which is less than the size of the file buffer).
@@ -205,10 +201,10 @@ def Set_File_Length(File: SourceFileEntry, Length: int) -> None:
     :param File:   Source file
     :param Length: Length for the file. Type: ``Source_Ptr``
     """
-    libghdl.files_map__set_file_length(File, Length)
 
 
-@export
+# @export
+@BindToLibGHDL("files_map__read_source_file")
 def Read_Source_File(Directory: NameId, Name: NameId) -> SourceFileEntry:
     """
     Return an entry for a filename.
@@ -219,11 +215,11 @@ def Read_Source_File(Directory: NameId, Name: NameId) -> SourceFileEntry:
     :param Name:      File name
     :return:          Return ``No_Source_File_Entry``, if the file does not exist.
     """
-    return libghdl.files_map__read_source_file(Directory, Name)
 
 
 @export
-def Reserve_Source_File(Directory: NameId, Name: NameId, Length) -> SourceFileEntry:
+@BindToLibGHDL("files_map__reserve_source_file")
+def Reserve_Source_File(Directory: NameId, Name: NameId, Length: int) -> SourceFileEntry:
     """
     Reserve an entry, but do not read any file.
 
@@ -234,10 +230,10 @@ def Reserve_Source_File(Directory: NameId, Name: NameId, Length) -> SourceFileEn
     :param Length:    Length to reserve. Type: ``Source_Ptr``
     :return:          SourceFile
     """
-    return libghdl.files_map__reserve_source_file(Directory, Name, Length)
 
 
 @export
+@BindToLibGHDL("files_map__discard_source_file")
 def Discard_Source_File(File: SourceFileEntry) -> None:
     """
     Mark :obj:`File` as unavailable: clear the name and directory.
@@ -246,10 +242,10 @@ def Discard_Source_File(File: SourceFileEntry) -> None:
 
     :param File: Source file to discard.
     """
-    libghdl.files_map__discard_source_file(File)
 
 
 @export
+@BindToLibGHDL("files_map__free_source_file")
 def Free_Source_File(File: SourceFileEntry) -> None:
     """
     Free resources used by :obj:`File`, but keep the entry.
@@ -258,10 +254,10 @@ def Free_Source_File(File: SourceFileEntry) -> None:
 
     :param File: Source file to free.
     """
-    libghdl.files_map__free_source_file(File)
 
 
 @export
+@BindToLibGHDL("files_map__get_last_source_file_entry")
 def Get_Last_Source_File_Entry() -> SourceFileEntry:
     """
     Returns the entry of the last known file.
@@ -270,4 +266,3 @@ def Get_Last_Source_File_Entry() -> SourceFileEntry:
 
     :return: Last SourceFileEntry. Type: ``SourceFileEntry``
     """
-    return libghdl.files_map__get_last_source_file_entry()

--- a/pyGHDL/libghdl/files_map_editor.py
+++ b/pyGHDL/libghdl/files_map_editor.py
@@ -6,9 +6,9 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
-#    Patrick Lehmann
+# Authors:
+#   Tristan Gingold
+#   Patrick Lehmann
 #
 # Package module:   Python binding and low-level API for shared library 'libghdl'.
 #
@@ -37,22 +37,14 @@ from ctypes import c_int32, c_char_p, c_bool
 from pydecor import export
 
 from pyGHDL.libghdl import libghdl
+from pyGHDL.libghdl._decorator import BindToLibGHDL
 from pyGHDL.libghdl._types import SourceFileEntry
 
 
-@export
-def Replace_Text(
-    File: SourceFileEntry,
-    Start_Line: int,
-    Start_Offset: int,
-    End_Line: int,
-    End_Offset: int,
-    Text_Pointer,
-    Text_Length: int,
-) -> bool:
+#@export
+@BindToLibGHDL("files_map__editor__replace_text_ptr")
+def _Replace_Text(File: SourceFileEntry, Start_Line: int, Start_Offset: int, End_Line: int, End_Offset: int, Text_Pointer: c_char_p, Text_Length: int) -> bool:
     """Replace [START; END) by TEXT.
-
-    .. todo:: Replace ``Text_Pointer`` and ``Text_Length`` with Python string
 
     :param File:         File where to replace a text section.
     :param Start_Line:
@@ -63,16 +55,26 @@ def Replace_Text(
     :param Text_Length:  Type: ``Source_Ptr``
     :return:             Return True in case of success, False in case of failure (the gap is too small).
     """
-    func = libghdl.files_map__editor__replace_text_ptr
-    func.argstype = [c_int32, c_int32, c_int32, c_int32, c_char_p, c_int32]
-    func.restype = c_bool
-
-    return func(
-        File, Start_Line, Start_Offset, End_Line, End_Offset, Text_Pointer, Text_Length
-    )
 
 
 @export
+def Replace_Text(File: SourceFileEntry, Start_Line: int, Start_Offset: int, End_Line: int, End_Offset: int, Text: str) -> bool:
+    """ Replace [START; END) by TEXT.
+
+    :param File:         File where to replace a text section.
+    :param Start_Line:   undocumented
+    :param Start_Offset: undocumented
+    :param End_Line:     undocumented
+    :param End_Offset:   undocumented
+    :param Text:         undocumented
+    :return:             Return True in case of success, False in case of failure (the gap is too small).
+    """
+    buffer = Text.encode("utf-8")
+    return _Replace_Text(File, Start_Line, Start_Offset, End_Line, End_Offset, c_char_p(buffer), len(buffer))
+
+
+@export
+#@BindToLibGHDL("files_map__editor__fill_text_ptr")
 def Fill_Text(File: SourceFileEntry, Text_Pointer, Text_Length: int) -> None:
     """Replace the content of :obj:`File` with TEXT.
 
@@ -86,9 +88,8 @@ def Fill_Text(File: SourceFileEntry, Text_Pointer, Text_Length: int) -> None:
 
 
 @export
-def Check_Buffer_Content(
-    File: SourceFileEntry, String_Pointer, String_Length: int
-) -> None:
+#@BindToLibGHDL("files_map__editor__check_buffer_content")
+def Check_Buffer_Content(File: SourceFileEntry, String_Pointer, String_Length: int) -> None:
     """
     Check that content of :obj:`File` is STR[1 .. STR_LEN].
 
@@ -102,6 +103,7 @@ def Check_Buffer_Content(
 
 
 @export
+@BindToLibGHDL("files_map__editor__copy_source_file")
 def Copy_Source_File(Dest: SourceFileEntry, Src: SourceFileEntry) -> None:
     """
     Copy content of :obj:`Src` to :obj:`Dest`.
@@ -110,4 +112,3 @@ def Copy_Source_File(Dest: SourceFileEntry, Src: SourceFileEntry) -> None:
 
     Clear lines table of :obj:`Dest`.
     """
-    return libghdl.files_map__editor__copy_source_file(Dest, Src)

--- a/pyGHDL/libghdl/files_map_editor.py
+++ b/pyGHDL/libghdl/files_map_editor.py
@@ -41,9 +41,17 @@ from pyGHDL.libghdl._decorator import BindToLibGHDL
 from pyGHDL.libghdl._types import SourceFileEntry
 
 
-#@export
+# @export
 @BindToLibGHDL("files_map__editor__replace_text_ptr")
-def _Replace_Text(File: SourceFileEntry, Start_Line: int, Start_Offset: int, End_Line: int, End_Offset: int, Text_Pointer: c_char_p, Text_Length: int) -> bool:
+def _Replace_Text(
+    File: SourceFileEntry,
+    Start_Line: int,
+    Start_Offset: int,
+    End_Line: int,
+    End_Offset: int,
+    Text_Pointer: c_char_p,
+    Text_Length: int,
+) -> bool:
     """Replace [START; END) by TEXT.
 
     :param File:         File where to replace a text section.
@@ -58,8 +66,15 @@ def _Replace_Text(File: SourceFileEntry, Start_Line: int, Start_Offset: int, End
 
 
 @export
-def Replace_Text(File: SourceFileEntry, Start_Line: int, Start_Offset: int, End_Line: int, End_Offset: int, Text: str) -> bool:
-    """ Replace [START; END) by TEXT.
+def Replace_Text(
+    File: SourceFileEntry,
+    Start_Line: int,
+    Start_Offset: int,
+    End_Line: int,
+    End_Offset: int,
+    Text: str,
+) -> bool:
+    """Replace [START; END) by TEXT.
 
     :param File:         File where to replace a text section.
     :param Start_Line:   undocumented
@@ -70,11 +85,19 @@ def Replace_Text(File: SourceFileEntry, Start_Line: int, Start_Offset: int, End_
     :return:             Return True in case of success, False in case of failure (the gap is too small).
     """
     buffer = Text.encode("utf-8")
-    return _Replace_Text(File, Start_Line, Start_Offset, End_Line, End_Offset, c_char_p(buffer), len(buffer))
+    return _Replace_Text(
+        File,
+        Start_Line,
+        Start_Offset,
+        End_Line,
+        End_Offset,
+        c_char_p(buffer),
+        len(buffer),
+    )
 
 
 @export
-#@BindToLibGHDL("files_map__editor__fill_text_ptr")
+# @BindToLibGHDL("files_map__editor__fill_text_ptr")
 def Fill_Text(File: SourceFileEntry, Text_Pointer, Text_Length: int) -> None:
     """Replace the content of :obj:`File` with TEXT.
 
@@ -88,8 +111,10 @@ def Fill_Text(File: SourceFileEntry, Text_Pointer, Text_Length: int) -> None:
 
 
 @export
-#@BindToLibGHDL("files_map__editor__check_buffer_content")
-def Check_Buffer_Content(File: SourceFileEntry, String_Pointer, String_Length: int) -> None:
+# @BindToLibGHDL("files_map__editor__check_buffer_content")
+def Check_Buffer_Content(
+    File: SourceFileEntry, String_Pointer, String_Length: int
+) -> None:
     """
     Check that content of :obj:`File` is STR[1 .. STR_LEN].
 

--- a/pyGHDL/libghdl/flags.py
+++ b/pyGHDL/libghdl/flags.py
@@ -6,9 +6,9 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
-#    Patrick Lehmann
+# Authors:
+#   Tristan Gingold
+#   Patrick Lehmann
 #
 # Package module:   Python binding and low-level API for shared library 'libghdl'.
 #
@@ -40,7 +40,7 @@ __all__ = [
     "Flag_Elocations",
     "Verbose",
     "Flag_Elaborate_With_Outdated",
-    "Flag_Force_Analysis",
+    "Flag_Force_Analysis"
 ]
 
 assert sizeof(c_bool) == 1
@@ -49,8 +49,6 @@ Flag_Elocations = c_bool.in_dll(libghdl, "flags__flag_elocations")
 
 Verbose = c_bool.in_dll(libghdl, "flags__verbose")
 
-Flag_Elaborate_With_Outdated = c_bool.in_dll(
-    libghdl, "flags__flag_elaborate_with_outdated"
-)
+Flag_Elaborate_With_Outdated = c_bool.in_dll(libghdl, "flags__flag_elaborate_with_outdated")
 
 Flag_Force_Analysis = c_bool.in_dll(libghdl, "flags__flag_force_analysis")

--- a/pyGHDL/libghdl/flags.py
+++ b/pyGHDL/libghdl/flags.py
@@ -40,7 +40,7 @@ __all__ = [
     "Flag_Elocations",
     "Verbose",
     "Flag_Elaborate_With_Outdated",
-    "Flag_Force_Analysis"
+    "Flag_Force_Analysis",
 ]
 
 assert sizeof(c_bool) == 1
@@ -49,6 +49,8 @@ Flag_Elocations = c_bool.in_dll(libghdl, "flags__flag_elocations")
 
 Verbose = c_bool.in_dll(libghdl, "flags__verbose")
 
-Flag_Elaborate_With_Outdated = c_bool.in_dll(libghdl, "flags__flag_elaborate_with_outdated")
+Flag_Elaborate_With_Outdated = c_bool.in_dll(
+    libghdl, "flags__flag_elaborate_with_outdated"
+)
 
 Flag_Force_Analysis = c_bool.in_dll(libghdl, "flags__flag_force_analysis")

--- a/pyGHDL/libghdl/libraries.py
+++ b/pyGHDL/libghdl/libraries.py
@@ -37,32 +37,41 @@ from ctypes import c_int32
 from pydecor import export
 
 from pyGHDL.libghdl import libghdl
+from pyGHDL.libghdl._types import NameId, Iir_Library_Declaration, Iir_Design_Unit, Iir_Design_File, Location_Type
+from pyGHDL.libghdl._decorator import BindToLibGHDL
 
-__all__ = ["Library_Location", "Work_Library"]
+__all__ = [
+    "Library_Location",
+    "Work_Library"
+]
 
-from pyGHDL.libghdl._types import NameId
+Library_Location: Location_Type = c_int32.in_dll(libghdl, "libraries__library_location")
+"""
+A location for library declarations (such as library WORK). Use ``.value`` to
+access this variable inside libghdl.
+"""
 
-
-Library_Location = c_int32.in_dll(
-    libghdl, "libraries__library_location"
-)  #: A location for library declarations (such as library WORK). Type ``Location_Type``. Use ``.value`` to access this variable inside libghdl
-Work_Library = c_int32.in_dll(
-    libghdl, "libraries__work_library"
-)  #: Library declaration for the work library. Note: the identifier of the work_library is ``work_library_name``, which may be different from 'WORK'. Type: ``Iir_Library_Declaration``. Use ``.value`` to access this variable inside libghdl
-
-
-@export
-def Get_Libraries_Chain():
-    """
-    Get the chain of libraries.  Can be used only to read (it mustn't be modified).
-
-    :return: Type ``Iir_Library_Declaration``
-    """
-    return libghdl.libraries__get_libraries_chain()
+Work_Library:Iir_Library_Declaration = c_int32.in_dll(libghdl, "libraries__work_library")
+"""
+Library declaration for the work library. Note: the identifier of the work_library
+is ``work_library_name``, which may be different from 'WORK'. Use ``.value`` to
+access this variable inside libghdl.
+"""
 
 
 @export
-def Add_Design_Unit_Into_Library(Unit, Keep_Obsolete: bool = False) -> None:
+@BindToLibGHDL("libraries__get_libraries_chain")
+def Get_Libraries_Chain() -> Iir_Library_Declaration:
+    """
+    Get the chain of libraries. Can be used only to read (it mustn't be modified).
+
+    :return: undocumented
+    """
+
+
+@export
+@BindToLibGHDL("libraries__add_design_unit_into_library")
+def Add_Design_Unit_Into_Library(Unit: Iir_Design_Unit, Keep_Obsolete: bool) -> None:
     """
     Add or replace an design unit in the work library. DECL must not have a chain
     (because it may be modified).
@@ -71,7 +80,7 @@ def Add_Design_Unit_Into_Library(Unit, Keep_Obsolete: bool = False) -> None:
 
     Units are always appended to the design_file. Therefore, the order is kept.
 
-    :param Unit:          Type: ``Iir_Design_Unit``
+    :param Unit:          undocumented
     :param Keep_Obsolete: If :obj:`Keep_Obsolete` is True, obsoleted units are
                           kept in the library.
 
@@ -79,50 +88,49 @@ def Add_Design_Unit_Into_Library(Unit, Keep_Obsolete: bool = False) -> None:
                           in the library and then processed (without that feature,
                           redefined units would disappear).
     """
-    libghdl.libraries__add_design_unit_into_library(Unit, Keep_Obsolete)
 
 
 @export
-def Purge_Design_File(Design_File) -> None:
+@BindToLibGHDL("libraries__purge_design_file")
+def Purge_Design_File(Design_File: Iir_Design_File) -> None:
     """
-    Remove the same file as DESIGN_FILE from work library and all of its units.
+    Remove the same file as :obj:`Design_File` from work library and all of its units.
 
-    :param Design_File: Type: ``Iir_Design_File``
+    :param Design_File: undocumented
     """
-    libghdl.libraries__purge_design_file(Design_File)
 
 
 @export
-def Find_Entity_For_Component(Name: NameId):
+@BindToLibGHDL("libraries__find_entity_for_component")
+def Find_Entity_For_Component(Name: NameId) -> Iir_Design_Unit:
     """
     Find an entity whose name is :obj:`Name` in any library. |br|
     If there is no such entity, return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`. |br|
     If there are several entities, return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`;
 
     :param Name: Entity name to search for.
-    :return:     Type: ``Iir_Design_Unit``
+    :return:     undocumented
     """
-    return libghdl.libraries__find_entity_for_component(Name)
 
 
 @export
-def Get_Library_No_Create(Ident: NameId):
+@BindToLibGHDL("libraries__get_library_no_create")
+def Get_Library_No_Create(Ident: NameId) -> Iir_Library_Declaration:
     """
     Get the library named :obj:`Ident`.
 
-    :param Ident: Libryr to look for.
-    :return:      Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` if it doesn't exist. Type ``Iir_Library_Declaration``
+    :param Ident: Library to look for.
+    :return:      Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` if it doesn't exist.
     """
-    return libghdl.libraries__get_library_no_create(Ident)
 
 
 @export
-def Find_Primary_Unit(Library, Name: NameId):
+@BindToLibGHDL("libraries__find_primary_unit")
+def Find_Primary_Unit(Library: Iir_Library_Declaration, Name: NameId) -> Iir_Design_Unit:
     """
     Just return the design_unit for :obj:`Name`, or ``NULL`` if not found.
 
-    :param Library: Library to look in. Type: ``Iir_Library_Declaration``
+    :param Library: Library to look in.
     :param Name:    Primary unit to search for.
-    :return:        Type: ``Iir_Design_Unit``
+    :return:        undocumented
     """
-    return libghdl.libraries__find_primary_unit(Library, Name)

--- a/pyGHDL/libghdl/libraries.py
+++ b/pyGHDL/libghdl/libraries.py
@@ -37,13 +37,16 @@ from ctypes import c_int32
 from pydecor import export
 
 from pyGHDL.libghdl import libghdl
-from pyGHDL.libghdl._types import NameId, Iir_Library_Declaration, Iir_Design_Unit, Iir_Design_File, Location_Type
+from pyGHDL.libghdl._types import (
+    NameId,
+    Iir_Library_Declaration,
+    Iir_Design_Unit,
+    Iir_Design_File,
+    Location_Type,
+)
 from pyGHDL.libghdl._decorator import BindToLibGHDL
 
-__all__ = [
-    "Library_Location",
-    "Work_Library"
-]
+__all__ = ["Library_Location", "Work_Library"]
 
 Library_Location: Location_Type = c_int32.in_dll(libghdl, "libraries__library_location")
 """
@@ -51,7 +54,9 @@ A location for library declarations (such as library WORK). Use ``.value`` to
 access this variable inside libghdl.
 """
 
-Work_Library:Iir_Library_Declaration = c_int32.in_dll(libghdl, "libraries__work_library")
+Work_Library: Iir_Library_Declaration = c_int32.in_dll(
+    libghdl, "libraries__work_library"
+)
 """
 Library declaration for the work library. Note: the identifier of the work_library
 is ``work_library_name``, which may be different from 'WORK'. Use ``.value`` to
@@ -126,7 +131,9 @@ def Get_Library_No_Create(Ident: NameId) -> Iir_Library_Declaration:
 
 @export
 @BindToLibGHDL("libraries__find_primary_unit")
-def Find_Primary_Unit(Library: Iir_Library_Declaration, Name: NameId) -> Iir_Design_Unit:
+def Find_Primary_Unit(
+    Library: Iir_Library_Declaration, Name: NameId
+) -> Iir_Design_Unit:
     """
     Just return the design_unit for :obj:`Name`, or ``NULL`` if not found.
 

--- a/pyGHDL/libghdl/name_table.py
+++ b/pyGHDL/libghdl/name_table.py
@@ -39,9 +39,7 @@ from pydecor import export
 from pyGHDL.libghdl._types import NameId
 from pyGHDL.libghdl._decorator import BindToLibGHDL
 
-__all__ = [
-    "Null_Identifier"
-]
+__all__ = ["Null_Identifier"]
 
 Null_Identifier = 0
 
@@ -57,7 +55,7 @@ def Get_Name_Length(Id: NameId) -> int:
     """
 
 
-#@export
+# @export
 @BindToLibGHDL("name_table__get_name_ptr")
 def _Get_Name_Ptr(Id: NameId) -> c_char_p:
     """"""
@@ -76,7 +74,7 @@ def Get_Name_Ptr(Id: NameId) -> str:
     return _Get_Name_Ptr(Id).decode("utf-8")
 
 
-#@export
+# @export
 @BindToLibGHDL("name_table__get_character")
 def _Get_Character(Id: NameId) -> c_char:
     """"""
@@ -97,7 +95,7 @@ def Get_Character(Id: NameId) -> str:
     return _Get_Character(Id).decode("utf-8")
 
 
-#@export
+# @export
 @BindToLibGHDL("name_table__get_identifier_with_len")
 def _Get_Identifier(string: c_char_p, length: int) -> NameId:
     """"""

--- a/pyGHDL/libghdl/name_table.py
+++ b/pyGHDL/libghdl/name_table.py
@@ -6,9 +6,9 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
-#    Patrick Lehmann
+# Authors:
+#   Tristan Gingold
+#   Patrick Lehmann
 #
 # Package package:  Python binding and low-level API for shared library 'libghdl'.
 #
@@ -31,20 +31,23 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
-
-from ctypes import c_char_p, c_char
+#
+from ctypes import c_char, c_char_p
 
 from pydecor import export
 
-from pyGHDL.libghdl import libghdl
 from pyGHDL.libghdl._types import NameId
+from pyGHDL.libghdl._decorator import BindToLibGHDL
 
-__all__ = ["Null_Identifier"]
+__all__ = [
+    "Null_Identifier"
+]
 
 Null_Identifier = 0
 
 
 @export
+@BindToLibGHDL("name_table__get_name_length")
 def Get_Name_Length(Id: NameId) -> int:
     """
     Get the length of an identifier denoted by a ``NameId``.
@@ -52,23 +55,31 @@ def Get_Name_Length(Id: NameId) -> int:
     :param Id: NameId for the identifier to query.
     :return:   Length of the identifier.
     """
-    return libghdl.name_table__get_name_length(Id)
+
+
+#@export
+@BindToLibGHDL("name_table__get_name_ptr")
+def _Get_Name_Ptr(Id: NameId) -> c_char_p:
+    """"""
 
 
 @export
 def Get_Name_Ptr(Id: NameId) -> str:
     """
-    Get the string corresponding to identifier ID.  The address is valid until
+    Get the string corresponding to identifier ID. The address is valid until
     the next call to Get_Identifier (which may reallocate the string table).
     The string is NUL-terminated (this is done by get_identifier).
 
     :param Id: NameId for the identifier to query.
-    :return:
+    :return:   Identifier as string.
     """
-    func = libghdl.name_table__get_name_ptr
-    func.restype = c_char_p
+    return _Get_Name_Ptr(Id).decode("utf-8")
 
-    return func(Id).decode("utf-8")
+
+#@export
+@BindToLibGHDL("name_table__get_character")
+def _Get_Character(Id: NameId) -> c_char:
+    """"""
 
 
 @export
@@ -76,13 +87,20 @@ def Get_Character(Id: NameId) -> str:
     """
     Get the string corresponding to character identifier ID.
 
-    :param Id: NameId for the identifier to query.
-    :return:
-    """
-    func = libghdl.name_table__get_character
-    func.restype = c_char
+    .. note::
 
-    return func(Id).decode("utf-8")
+       This is used for character literals and enumeration literals.
+
+    :param Id: NameId for the identifier to query.
+    :return:   Get the character of the identifier.
+    """
+    return _Get_Character(Id).decode("utf-8")
+
+
+#@export
+@BindToLibGHDL("name_table__get_identifier_with_len")
+def _Get_Identifier(string: c_char_p, length: int) -> NameId:
+    """"""
 
 
 @export
@@ -100,4 +118,4 @@ def Get_Identifier(string: str) -> NameId:
     :return:       Id in name table.
     """
     string = string.encode("utf-8")
-    return libghdl.name_table__get_identifier_with_len(c_char_p(string), len(string))
+    return _Get_Identifier(c_char_p(string), len(string))

--- a/pyGHDL/libghdl/std_names.py
+++ b/pyGHDL/libghdl/std_names.py
@@ -1,6 +1,7 @@
 # Auto generated Python source file from Ada sources
 # Call 'make' in 'src/vhdl' to regenerate:
 #
+from enum import IntEnum, unique
 from pydecor import export
 
 

--- a/pyGHDL/libghdl/utils.py
+++ b/pyGHDL/libghdl/utils.py
@@ -6,14 +6,14 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
+# Authors:
+#   Tristan Gingold
 #
 # Package module:   Generators/iterators and low-level helpers for pyGHDL.libghdl.
 #
 # License:
 # ============================================================================
-#  Copyright (C) 2019-2020 Tristan Gingold
+#  Copyright (C) 2019-2021 Tristan Gingold
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -52,25 +52,25 @@ def name_image(Id: NameId) -> str:
     return name_table.Get_Name_Ptr(Id)
 
 
-# @export # FIXME: see above
+@export
 @EnumLookupTable(nodes_meta.fields)
 def fields_image(idx: int) -> str:
     """String representation of Nodes_Meta.fields :obj:`idx`."""
 
 
-# @export # FIXME: see above
+@export
 @EnumLookupTable(nodes.Iir_Kind)
 def kind_image(k: int) -> str:
     """String representation of Nodes.Iir_Kind :obj:`k`."""
 
 
-# @export # FIXME: see above
+@export
 @EnumLookupTable(nodes_meta.types)
 def types_image(t: int) -> str:
     """String representation of Nodes_Meta.Types :obj:`t`."""
 
 
-# @export # FIXME: see above
+@export
 @EnumLookupTable(nodes_meta.Attr)
 def attr_image(a: int) -> str:
     """String representation of Nodes_Meta.Attr :obj:`a`."""

--- a/pyGHDL/libghdl/vhdl/__init__.py
+++ b/pyGHDL/libghdl/vhdl/__init__.py
@@ -6,14 +6,14 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
+# Authors:
+#   Tristan Gingold
 #
 # Package package:  Python binding and low-level API for shared library 'libghdl'.
 #
 # License:
 # ============================================================================
-#  Copyright (C) 2019-2020 Tristan Gingold
+#  Copyright (C) 2019-2021 Tristan Gingold
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/pyGHDL/libghdl/vhdl/canon.py
+++ b/pyGHDL/libghdl/vhdl/canon.py
@@ -6,9 +6,9 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
-#    Patrick Lehmann
+# Authors:
+#   Tristan Gingold
+#   Patrick Lehmann
 #
 # Package module:   Python binding and low-level API for shared library 'libghdl'.
 #
@@ -36,16 +36,16 @@ from ctypes import c_bool
 
 from pyGHDL.libghdl import libghdl
 
-__all__ = ["Flag_Concurrent_Stmts", "Flag_Configurations", "Flag_Associations"]
+__all__ = [
+    "Flag_Concurrent_Stmts",
+    "Flag_Configurations",
+    "Flag_Associations"
+]
 
-Flag_Concurrent_Stmts = c_bool.in_dll(
-    libghdl, "vhdl__canon__canon_flag_concurrent_stmts"
-)
+Flag_Concurrent_Stmts = c_bool.in_dll(libghdl, "vhdl__canon__canon_flag_concurrent_stmts")
 
 Flag_Configurations = c_bool.in_dll(libghdl, "vhdl__canon__canon_flag_configurations")
 
 Flag_Associations = c_bool.in_dll(libghdl, "vhdl__canon__canon_flag_associations")
 
-# Extract_Sequential_Statement_Chain_Sensitivity = (
-#    libghdl.vhdl__canon__canon_extract_sequential_statement_chain_sensitivity
-# )
+# Extract_Sequential_Statement_Chain_Sensitivity = (libghdl.vhdl__canon__canon_extract_sequential_statement_chain_sensitivity)

--- a/pyGHDL/libghdl/vhdl/canon.py
+++ b/pyGHDL/libghdl/vhdl/canon.py
@@ -36,13 +36,11 @@ from ctypes import c_bool
 
 from pyGHDL.libghdl import libghdl
 
-__all__ = [
-    "Flag_Concurrent_Stmts",
-    "Flag_Configurations",
-    "Flag_Associations"
-]
+__all__ = ["Flag_Concurrent_Stmts", "Flag_Configurations", "Flag_Associations"]
 
-Flag_Concurrent_Stmts = c_bool.in_dll(libghdl, "vhdl__canon__canon_flag_concurrent_stmts")
+Flag_Concurrent_Stmts = c_bool.in_dll(
+    libghdl, "vhdl__canon__canon_flag_concurrent_stmts"
+)
 
 Flag_Configurations = c_bool.in_dll(libghdl, "vhdl__canon__canon_flag_configurations")
 

--- a/pyGHDL/libghdl/vhdl/elocations.py
+++ b/pyGHDL/libghdl/vhdl/elocations.py
@@ -1,53 +1,166 @@
 # Auto generated Python source file from Ada sources
 # Call 'make' in 'src/vhdl' to regenerate:
 #
+from enum import IntEnum, unique
 from pydecor import export
 from pyGHDL.libghdl import libghdl
 
-Get_Start_Location = libghdl.vhdl__elocations__get_start_location
-Set_Start_Location = libghdl.vhdl__elocations__set_start_location
 
-Get_Right_Paren_Location = libghdl.vhdl__elocations__get_right_paren_location
-Set_Right_Paren_Location = libghdl.vhdl__elocations__set_right_paren_location
+@export
+def Get_Start_Location(obj):
+    return libghdl.vhdl__elocations__get_start_location(obj)
 
-Get_End_Location = libghdl.vhdl__elocations__get_end_location
-Set_End_Location = libghdl.vhdl__elocations__set_end_location
 
-Get_Is_Location = libghdl.vhdl__elocations__get_is_location
-Set_Is_Location = libghdl.vhdl__elocations__set_is_location
+@export
+def Set_Start_Location(obj, value) -> None:
+    libghdl.vhdl__elocations__set_start_location(obj, value)
 
-Get_Begin_Location = libghdl.vhdl__elocations__get_begin_location
-Set_Begin_Location = libghdl.vhdl__elocations__set_begin_location
 
-Get_Then_Location = libghdl.vhdl__elocations__get_then_location
-Set_Then_Location = libghdl.vhdl__elocations__set_then_location
+@export
+def Get_Right_Paren_Location(obj):
+    return libghdl.vhdl__elocations__get_right_paren_location(obj)
 
-Get_Use_Location = libghdl.vhdl__elocations__get_use_location
-Set_Use_Location = libghdl.vhdl__elocations__set_use_location
 
-Get_Loop_Location = libghdl.vhdl__elocations__get_loop_location
-Set_Loop_Location = libghdl.vhdl__elocations__set_loop_location
+@export
+def Set_Right_Paren_Location(obj, value) -> None:
+    libghdl.vhdl__elocations__set_right_paren_location(obj, value)
 
-Get_Generate_Location = libghdl.vhdl__elocations__get_generate_location
-Set_Generate_Location = libghdl.vhdl__elocations__set_generate_location
 
-Get_Generic_Location = libghdl.vhdl__elocations__get_generic_location
-Set_Generic_Location = libghdl.vhdl__elocations__set_generic_location
+@export
+def Get_End_Location(obj):
+    return libghdl.vhdl__elocations__get_end_location(obj)
 
-Get_Port_Location = libghdl.vhdl__elocations__get_port_location
-Set_Port_Location = libghdl.vhdl__elocations__set_port_location
 
-Get_Generic_Map_Location = libghdl.vhdl__elocations__get_generic_map_location
-Set_Generic_Map_Location = libghdl.vhdl__elocations__set_generic_map_location
+@export
+def Set_End_Location(obj, value) -> None:
+    libghdl.vhdl__elocations__set_end_location(obj, value)
 
-Get_Port_Map_Location = libghdl.vhdl__elocations__get_port_map_location
-Set_Port_Map_Location = libghdl.vhdl__elocations__set_port_map_location
 
-Get_Arrow_Location = libghdl.vhdl__elocations__get_arrow_location
-Set_Arrow_Location = libghdl.vhdl__elocations__set_arrow_location
+@export
+def Get_Is_Location(obj):
+    return libghdl.vhdl__elocations__get_is_location(obj)
 
-Get_Colon_Location = libghdl.vhdl__elocations__get_colon_location
-Set_Colon_Location = libghdl.vhdl__elocations__set_colon_location
 
-Get_Assign_Location = libghdl.vhdl__elocations__get_assign_location
-Set_Assign_Location = libghdl.vhdl__elocations__set_assign_location
+@export
+def Set_Is_Location(obj, value) -> None:
+    libghdl.vhdl__elocations__set_is_location(obj, value)
+
+
+@export
+def Get_Begin_Location(obj):
+    return libghdl.vhdl__elocations__get_begin_location(obj)
+
+
+@export
+def Set_Begin_Location(obj, value) -> None:
+    libghdl.vhdl__elocations__set_begin_location(obj, value)
+
+
+@export
+def Get_Then_Location(obj):
+    return libghdl.vhdl__elocations__get_then_location(obj)
+
+
+@export
+def Set_Then_Location(obj, value) -> None:
+    libghdl.vhdl__elocations__set_then_location(obj, value)
+
+
+@export
+def Get_Use_Location(obj):
+    return libghdl.vhdl__elocations__get_use_location(obj)
+
+
+@export
+def Set_Use_Location(obj, value) -> None:
+    libghdl.vhdl__elocations__set_use_location(obj, value)
+
+
+@export
+def Get_Loop_Location(obj):
+    return libghdl.vhdl__elocations__get_loop_location(obj)
+
+
+@export
+def Set_Loop_Location(obj, value) -> None:
+    libghdl.vhdl__elocations__set_loop_location(obj, value)
+
+
+@export
+def Get_Generate_Location(obj):
+    return libghdl.vhdl__elocations__get_generate_location(obj)
+
+
+@export
+def Set_Generate_Location(obj, value) -> None:
+    libghdl.vhdl__elocations__set_generate_location(obj, value)
+
+
+@export
+def Get_Generic_Location(obj):
+    return libghdl.vhdl__elocations__get_generic_location(obj)
+
+
+@export
+def Set_Generic_Location(obj, value) -> None:
+    libghdl.vhdl__elocations__set_generic_location(obj, value)
+
+
+@export
+def Get_Port_Location(obj):
+    return libghdl.vhdl__elocations__get_port_location(obj)
+
+
+@export
+def Set_Port_Location(obj, value) -> None:
+    libghdl.vhdl__elocations__set_port_location(obj, value)
+
+
+@export
+def Get_Generic_Map_Location(obj):
+    return libghdl.vhdl__elocations__get_generic_map_location(obj)
+
+
+@export
+def Set_Generic_Map_Location(obj, value) -> None:
+    libghdl.vhdl__elocations__set_generic_map_location(obj, value)
+
+
+@export
+def Get_Port_Map_Location(obj):
+    return libghdl.vhdl__elocations__get_port_map_location(obj)
+
+
+@export
+def Set_Port_Map_Location(obj, value) -> None:
+    libghdl.vhdl__elocations__set_port_map_location(obj, value)
+
+
+@export
+def Get_Arrow_Location(obj):
+    return libghdl.vhdl__elocations__get_arrow_location(obj)
+
+
+@export
+def Set_Arrow_Location(obj, value) -> None:
+    libghdl.vhdl__elocations__set_arrow_location(obj, value)
+
+
+@export
+def Get_Colon_Location(obj):
+    return libghdl.vhdl__elocations__get_colon_location(obj)
+
+
+@export
+def Set_Colon_Location(obj, value) -> None:
+    libghdl.vhdl__elocations__set_colon_location(obj, value)
+
+
+@export
+def Get_Assign_Location(obj):
+    return libghdl.vhdl__elocations__get_assign_location(obj)
+
+
+@export
+def Set_Assign_Location(obj, value) -> None:
+    libghdl.vhdl__elocations__set_assign_location(obj, value)

--- a/pyGHDL/libghdl/vhdl/flists.py
+++ b/pyGHDL/libghdl/vhdl/flists.py
@@ -6,9 +6,9 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
-#    Patrick Lehmann
+# Authors:
+#   Tristan Gingold
+#   Patrick Lehmann
 #
 # Package module:   Python binding and low-level API for shared library 'libghdl'.
 #
@@ -31,14 +31,17 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
-
 from ctypes import c_int32
 
 from pydecor import export
 
-from pyGHDL.libghdl import libghdl
+from pyGHDL.libghdl._decorator import BindToLibGHDL
 
-__all__ = ["Flist_Type", "Ffirst"]
+
+__all__ = [
+    "Flist_Type",
+    "Ffirst"
+]
 
 Flist_Type = c_int32  #: First index of a ``FList``.
 
@@ -46,7 +49,8 @@ Ffirst = 0
 
 
 @export
-def Flast(FList) -> int:
+@BindToLibGHDL("vhdl__flists__flast")
+def Flast(FList: int) -> int:
     """
     Last index of :obj:`FList`.
 
@@ -55,22 +59,22 @@ def Flast(FList) -> int:
     :param FList: List to query.
     :return:      Index of the last element in the list.
     """
-    return libghdl.vhdl__flists__flast(FList)
 
 
 @export
-def Length(FList) -> int:
+@BindToLibGHDL("vhdl__flists__length")
+def Length(FList: int) -> int:
     """
     Get the length of :obj:`FList`.
 
     :param FList: List to query.
     :return:      Number of elements in the list.
     """
-    return libghdl.vhdl__flists__length(FList)
 
 
 @export
-def Get_Nth_Element(FList, N: int):
+@BindToLibGHDL("vhdl__flists__get_nth_element")
+def Get_Nth_Element(FList: int, N: int) -> int:
     """
     Get the N-th element of :obj:`FList`.
 
@@ -79,4 +83,3 @@ def Get_Nth_Element(FList, N: int):
     :param FList: List to query.
     :return:      Type: ``El_Type``
     """
-    return libghdl.vhdl__flists__get_nth_element(FList, N)

--- a/pyGHDL/libghdl/vhdl/flists.py
+++ b/pyGHDL/libghdl/vhdl/flists.py
@@ -38,10 +38,7 @@ from pydecor import export
 from pyGHDL.libghdl._decorator import BindToLibGHDL
 
 
-__all__ = [
-    "Flist_Type",
-    "Ffirst"
-]
+__all__ = ["Flist_Type", "Ffirst"]
 
 Flist_Type = c_int32  #: First index of a ``FList``.
 

--- a/pyGHDL/libghdl/vhdl/formatters.py
+++ b/pyGHDL/libghdl/vhdl/formatters.py
@@ -54,7 +54,7 @@ def Indent_String(File: int, Handle: int, FirstLine: int, LastLine: int) -> None
 
 
 @export
-#@BindToLibGHDL("vhdl__formatters__allocate_handle")
+# @BindToLibGHDL("vhdl__formatters__allocate_handle")
 def Allocate_Handle():
     """
     .. todo:: Undocumented in Ada code.
@@ -65,7 +65,7 @@ def Allocate_Handle():
 
 
 @export
-#@BindToLibGHDL("vhdl__formatters__get_length")
+# @BindToLibGHDL("vhdl__formatters__get_length")
 def Get_Length(Handle) -> int:
     """
     .. todo:: Undocumented in Ada code.
@@ -80,7 +80,7 @@ def Get_Length(Handle) -> int:
 
 
 @export
-#@BindToLibGHDL("vhdl__formatters__get_c_string")
+# @BindToLibGHDL("vhdl__formatters__get_c_string")
 def Get_C_String(Handle):
     """
     .. todo:: Undocumented in Ada code.
@@ -95,7 +95,7 @@ def Get_C_String(Handle):
 
 
 @export
-#@BindToLibGHDL("vhdl__formatters__free_handle")
+# @BindToLibGHDL("vhdl__formatters__free_handle")
 def Free_Handle(Handle) -> None:
     """
     .. todo:: Undocumented in Ada code.

--- a/pyGHDL/libghdl/vhdl/formatters.py
+++ b/pyGHDL/libghdl/vhdl/formatters.py
@@ -6,9 +6,9 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
-#    Patrick Lehmann
+# Authors:
+#   Tristan Gingold
+#   Patrick Lehmann
 #
 # Package module:   Python binding and low-level API for shared library 'libghdl'.
 #
@@ -37,10 +37,12 @@ from ctypes import c_int32, c_char_p
 from pydecor import export
 
 from pyGHDL.libghdl import libghdl
+from pyGHDL.libghdl._decorator import BindToLibGHDL
 
 
 @export
-def Indent_String(File, Handle, FirstLine: int, LastLine: int) -> None:
+@BindToLibGHDL("vhdl__formatters__indent_string")
+def Indent_String(File: int, Handle: int, FirstLine: int, LastLine: int) -> None:
     """
     Reindent all lines of F between [First_Line; Last_Line] to :obj:`Handle`.
 
@@ -49,10 +51,10 @@ def Indent_String(File, Handle, FirstLine: int, LastLine: int) -> None:
     :param FirstLine: undocumented.
     :param LastLine:  undocumented.
     """
-    libghdl.vhdl__formatters__indent_string(File, Handle, FirstLine, LastLine)
 
 
 @export
+#@BindToLibGHDL("vhdl__formatters__allocate_handle")
 def Allocate_Handle():
     """
     .. todo:: Undocumented in Ada code.
@@ -63,6 +65,7 @@ def Allocate_Handle():
 
 
 @export
+#@BindToLibGHDL("vhdl__formatters__get_length")
 def Get_Length(Handle) -> int:
     """
     .. todo:: Undocumented in Ada code.
@@ -77,6 +80,7 @@ def Get_Length(Handle) -> int:
 
 
 @export
+#@BindToLibGHDL("vhdl__formatters__get_c_string")
 def Get_C_String(Handle):
     """
     .. todo:: Undocumented in Ada code.
@@ -91,6 +95,7 @@ def Get_C_String(Handle):
 
 
 @export
+#@BindToLibGHDL("vhdl__formatters__free_handle")
 def Free_Handle(Handle) -> None:
     """
     .. todo:: Undocumented in Ada code.

--- a/pyGHDL/libghdl/vhdl/ieee.py
+++ b/pyGHDL/libghdl/vhdl/ieee.py
@@ -6,14 +6,14 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
+# Authors:
+#   Tristan Gingold
 #
 # Package package:  Python binding and low-level API for shared library 'libghdl'.
 #
 # License:
 # ============================================================================
-#  Copyright (C) 2019-2020 Tristan Gingold
+#  Copyright (C) 2019-2021 Tristan Gingold
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -35,21 +35,19 @@ from ctypes import c_int
 
 from pyGHDL.libghdl import libghdl
 
+__all__ = [
+    "Std_Logic_1164_Pkg",
+    "Std_Logic_Type",
+    "Std_Logic_Vector_Type"
+]
 
-__all__ = ["Std_Logic_1164_Pkg", "Std_Logic_Type", "Std_Logic_Vector_Type"]
-
-
-Std_Logic_1164_Pkg = c_int.in_dll(
-    libghdl, "vhdl__ieee__std_logic_1164__std_logic_1164_pkg"
-)
+Std_Logic_1164_Pkg = c_int.in_dll(libghdl, "vhdl__ieee__std_logic_1164__std_logic_1164_pkg")
 
 # Get value
 Std_Logic_Type = c_int.in_dll(libghdl, "vhdl__ieee__std_logic_1164__std_logic_type")
 
 # Get value
-Std_Logic_Vector_Type = c_int.in_dll(
-    libghdl, "vhdl__ieee__std_logic_1164__std_logic_vector_type"
-)
+Std_Logic_Vector_Type = c_int.in_dll(libghdl, "vhdl__ieee__std_logic_1164__std_logic_vector_type")
 
 # Get value
 # Rising_Edge = c_int.in_dll(libghdl, "vhdl__ieee__std_logic_1164__rising_edge")

--- a/pyGHDL/libghdl/vhdl/ieee.py
+++ b/pyGHDL/libghdl/vhdl/ieee.py
@@ -35,19 +35,19 @@ from ctypes import c_int
 
 from pyGHDL.libghdl import libghdl
 
-__all__ = [
-    "Std_Logic_1164_Pkg",
-    "Std_Logic_Type",
-    "Std_Logic_Vector_Type"
-]
+__all__ = ["Std_Logic_1164_Pkg", "Std_Logic_Type", "Std_Logic_Vector_Type"]
 
-Std_Logic_1164_Pkg = c_int.in_dll(libghdl, "vhdl__ieee__std_logic_1164__std_logic_1164_pkg")
+Std_Logic_1164_Pkg = c_int.in_dll(
+    libghdl, "vhdl__ieee__std_logic_1164__std_logic_1164_pkg"
+)
 
 # Get value
 Std_Logic_Type = c_int.in_dll(libghdl, "vhdl__ieee__std_logic_1164__std_logic_type")
 
 # Get value
-Std_Logic_Vector_Type = c_int.in_dll(libghdl, "vhdl__ieee__std_logic_1164__std_logic_vector_type")
+Std_Logic_Vector_Type = c_int.in_dll(
+    libghdl, "vhdl__ieee__std_logic_1164__std_logic_vector_type"
+)
 
 # Get value
 # Rising_Edge = c_int.in_dll(libghdl, "vhdl__ieee__std_logic_1164__rising_edge")

--- a/pyGHDL/libghdl/vhdl/lists.py
+++ b/pyGHDL/libghdl/vhdl/lists.py
@@ -6,9 +6,9 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
-#    Patrick Lehmann
+# Authors:
+#   Tristan Gingold
+#   Patrick Lehmann
 #
 # Package module:   Python binding and low-level API for shared library 'libghdl'.
 #
@@ -37,15 +37,21 @@ from ctypes import c_int32, c_bool, POINTER, Structure
 from pydecor import export
 
 from pyGHDL.libghdl import libghdl
+from pyGHDL.libghdl._decorator import BindToLibGHDL
 
 
 @export
 class Iterator(Structure):
-    _fields_ = [("chunk", c_int32), ("chunk_idx", c_int32), ("remain", c_int32)]
+    _fields_ = [
+        ("chunk", c_int32),
+        ("chunk_idx", c_int32),
+        ("remain", c_int32)
+    ]
 
 
 @export
-def Iterate(List) -> Iterator:
+@BindToLibGHDL("vhdl__lists__iterate")
+def Iterate(List: int) -> Iterator:
     """
     Create an iterator for a given list.
 
@@ -62,20 +68,16 @@ def Iterate(List) -> Iterator:
     :param List: List to create an iterator from.
     :return:     Iterator structure.
     """
-    func = libghdl.vhdl__lists__iterate
-    func.argstype = [c_int32]
-    func.restype = Iterator
-
-    return func(List)
 
 
 @export
+#@BindToLibGHDL("vhdl__lists__is_valid")
 def Is_Valid(it: Iterator) -> bool:
     """
     Check if iterator reached the end.
 
-    :param Iterator: Iterator to check.
-    :return:         False, if iterator has reached the end.
+    :param it: Iterator to check.
+    :return:   ``False``, if iterator has reached the end.
     """
     func = libghdl.vhdl__lists__is_valid
     func.argstype = [POINTER(Iterator)]
@@ -85,27 +87,29 @@ def Is_Valid(it: Iterator) -> bool:
 
 
 @export
-def Next(it: Iterator):
+#@BindToLibGHDL("vhdl__lists__next")
+def Next(it: Iterator) -> bool:
     """
     Move iterator to the next element.
 
-    :param Iterator: Iterator to increment.
-    :return:         False, if iterator has reached the end.
+    :param it: Iterator to increment.
+    :return:   ``False``, if iterator has reached the end.
     """
     func = libghdl.vhdl__lists__next
     func.argstype = [POINTER(Iterator)]
     func.restype = None
 
-    func(it)
+    return func(it)
 
 
 @export
+#@BindToLibGHDL("vhdl__lists__get_element")
 def Get_Element(it: Iterator) -> int:
     """
     Get the current element from iterator.
 
-    :param Iterator: Iterator the get the element from.
-    :return:         The current element the iterator points to. Type: ``El_Type``
+    :param it: Iterator the get the element from.
+    :return:   The current element the iterator points to. Type: ``El_Type``
     """
     func = libghdl.vhdl__lists__get_element
     func.argstype = [POINTER(Iterator)]
@@ -115,7 +119,8 @@ def Get_Element(it: Iterator) -> int:
 
 
 @export
-def Get_Nbr_Elements(List) -> int:
+@BindToLibGHDL("vhdl__lists__get_nbr_elements")
+def Get_Nbr_Elements(List: int) -> int:
     """
     Return the number of elements in the list.
 
@@ -124,28 +129,23 @@ def Get_Nbr_Elements(List) -> int:
     :param List: The list to use.
     :return:     Number of list elements.
     """
-    func = libghdl.vhdl__lists__get_nbr_elements
-    func.argtype = [c_int32]
-    func.restype = c_int32
-
-    return func(List)
 
 
 @export
+@BindToLibGHDL("vhdl__lists__create_list")
 def Create_Iir_List() -> int:
     """
     Create a list.
 
-    :return: Type: ``List_Type``
+    :return: undocumented; Type: ``List_Type``
     """
-    return libghdl.vhdl__lists__create_list()
 
 
 @export
-def Destroy_Iir_List(List) -> None:
+@BindToLibGHDL("vhdl__lists__destroy_list")
+def Destroy_Iir_List(List: int) -> None:
     """
     Destroy a list.
 
     :param List: List to destroy.
     """
-    libghdl.vhdl__lists__destroy_list(List)

--- a/pyGHDL/libghdl/vhdl/lists.py
+++ b/pyGHDL/libghdl/vhdl/lists.py
@@ -42,11 +42,7 @@ from pyGHDL.libghdl._decorator import BindToLibGHDL
 
 @export
 class Iterator(Structure):
-    _fields_ = [
-        ("chunk", c_int32),
-        ("chunk_idx", c_int32),
-        ("remain", c_int32)
-    ]
+    _fields_ = [("chunk", c_int32), ("chunk_idx", c_int32), ("remain", c_int32)]
 
 
 @export
@@ -71,7 +67,7 @@ def Iterate(List: int) -> Iterator:
 
 
 @export
-#@BindToLibGHDL("vhdl__lists__is_valid")
+# @BindToLibGHDL("vhdl__lists__is_valid")
 def Is_Valid(it: Iterator) -> bool:
     """
     Check if iterator reached the end.
@@ -87,7 +83,7 @@ def Is_Valid(it: Iterator) -> bool:
 
 
 @export
-#@BindToLibGHDL("vhdl__lists__next")
+# @BindToLibGHDL("vhdl__lists__next")
 def Next(it: Iterator) -> bool:
     """
     Move iterator to the next element.
@@ -103,7 +99,7 @@ def Next(it: Iterator) -> bool:
 
 
 @export
-#@BindToLibGHDL("vhdl__lists__get_element")
+# @BindToLibGHDL("vhdl__lists__get_element")
 def Get_Element(it: Iterator) -> int:
     """
     Get the current element from iterator.

--- a/pyGHDL/libghdl/vhdl/nodes.py
+++ b/pyGHDL/libghdl/vhdl/nodes.py
@@ -1,8 +1,10 @@
 # Auto generated Python source file from Ada sources
 # Call 'make' in 'src/vhdl' to regenerate:
 #
+from enum import IntEnum, unique
 from pydecor import export
 from pyGHDL.libghdl import libghdl
+from pyGHDL.libghdl._types import Iir
 
 Null_Iir = 0
 
@@ -15,7 +17,8 @@ Iir_Flist_All = 2
 
 
 @export
-class Iir_Kind:
+@unique
+class Iir_Kind(IntEnum):
     Unused = 0
     Error = 1
     Design_File = 2
@@ -1046,7 +1049,8 @@ class Iir_Kinds:
 
 
 @export
-class Iir_Mode:
+@unique
+class Iir_Mode(IntEnum):
     Unknown_Mode = 0
     Linkage_Mode = 1
     Buffer_Mode = 2
@@ -1056,7 +1060,8 @@ class Iir_Mode:
 
 
 @export
-class Iir_Staticness:
+@unique
+class Iir_Staticness(IntEnum):
     Unknown = 0
     PNone = 1
     Globally = 2
@@ -1064,20 +1069,23 @@ class Iir_Staticness:
 
 
 @export
-class Iir_Constraint:
+@unique
+class Iir_Constraint(IntEnum):
     Unconstrained = 0
     Partially_Constrained = 1
     Fully_Constrained = 2
 
 
 @export
-class Iir_Delay_Mechanism:
+@unique
+class Iir_Delay_Mechanism(IntEnum):
     Inertial_Delay = 0
     Transport_Delay = 1
 
 
 @export
-class Date_State:
+@unique
+class Date_State(IntEnum):
     Extern = 0
     Disk = 1
     Parse = 2
@@ -1085,7 +1093,8 @@ class Date_State:
 
 
 @export
-class Iir_Predefined:
+@unique
+class Iir_Predefined(IntEnum):
     Error = 0
     Boolean_And = 1
     Boolean_Or = 2
@@ -1745,1147 +1754,3711 @@ class Iir_Predefined:
     Ieee_Std_Logic_Misc_Xnor_Reduce_Suv = 656
 
 
-Get_Kind = libghdl.vhdl__nodes__get_kind
-Get_Location = libghdl.vhdl__nodes__get_location
+@export
+def Get_Kind(node: int):
+    return libghdl.vhdl__nodes__get_kind(node)
 
-Get_First_Design_Unit = libghdl.vhdl__nodes__get_first_design_unit
-Set_First_Design_Unit = libghdl.vhdl__nodes__set_first_design_unit
 
-Get_Last_Design_Unit = libghdl.vhdl__nodes__get_last_design_unit
-Set_Last_Design_Unit = libghdl.vhdl__nodes__set_last_design_unit
+@export
+def Get_Location(node: Iir):
+    return libghdl.vhdl__nodes__get_location(node)
 
-Get_Library_Declaration = libghdl.vhdl__nodes__get_library_declaration
-Set_Library_Declaration = libghdl.vhdl__nodes__set_library_declaration
 
-Get_File_Checksum = libghdl.vhdl__nodes__get_file_checksum
-Set_File_Checksum = libghdl.vhdl__nodes__set_file_checksum
+@export
+def Get_First_Design_Unit(obj):
+    return libghdl.vhdl__nodes__get_first_design_unit(obj)
 
-Get_Analysis_Time_Stamp = libghdl.vhdl__nodes__get_analysis_time_stamp
-Set_Analysis_Time_Stamp = libghdl.vhdl__nodes__set_analysis_time_stamp
 
-Get_Design_File_Source = libghdl.vhdl__nodes__get_design_file_source
-Set_Design_File_Source = libghdl.vhdl__nodes__set_design_file_source
+@export
+def Set_First_Design_Unit(obj, value) -> None:
+    libghdl.vhdl__nodes__set_first_design_unit(obj, value)
 
-Get_Library = libghdl.vhdl__nodes__get_library
-Set_Library = libghdl.vhdl__nodes__set_library
 
-Get_File_Dependence_List = libghdl.vhdl__nodes__get_file_dependence_list
-Set_File_Dependence_List = libghdl.vhdl__nodes__set_file_dependence_list
+@export
+def Get_Last_Design_Unit(obj):
+    return libghdl.vhdl__nodes__get_last_design_unit(obj)
 
-Get_Design_File_Filename = libghdl.vhdl__nodes__get_design_file_filename
-Set_Design_File_Filename = libghdl.vhdl__nodes__set_design_file_filename
 
-Get_Design_File_Directory = libghdl.vhdl__nodes__get_design_file_directory
-Set_Design_File_Directory = libghdl.vhdl__nodes__set_design_file_directory
+@export
+def Set_Last_Design_Unit(obj, value) -> None:
+    libghdl.vhdl__nodes__set_last_design_unit(obj, value)
 
-Get_Design_File = libghdl.vhdl__nodes__get_design_file
-Set_Design_File = libghdl.vhdl__nodes__set_design_file
 
-Get_Design_File_Chain = libghdl.vhdl__nodes__get_design_file_chain
-Set_Design_File_Chain = libghdl.vhdl__nodes__set_design_file_chain
+@export
+def Get_Library_Declaration(obj):
+    return libghdl.vhdl__nodes__get_library_declaration(obj)
 
-Get_Library_Directory = libghdl.vhdl__nodes__get_library_directory
-Set_Library_Directory = libghdl.vhdl__nodes__set_library_directory
 
-Get_Date = libghdl.vhdl__nodes__get_date
-Set_Date = libghdl.vhdl__nodes__set_date
+@export
+def Set_Library_Declaration(obj, value) -> None:
+    libghdl.vhdl__nodes__set_library_declaration(obj, value)
 
-Get_Context_Items = libghdl.vhdl__nodes__get_context_items
-Set_Context_Items = libghdl.vhdl__nodes__set_context_items
 
-Get_Dependence_List = libghdl.vhdl__nodes__get_dependence_list
-Set_Dependence_List = libghdl.vhdl__nodes__set_dependence_list
+@export
+def Get_File_Checksum(obj):
+    return libghdl.vhdl__nodes__get_file_checksum(obj)
 
-Get_Analysis_Checks_List = libghdl.vhdl__nodes__get_analysis_checks_list
-Set_Analysis_Checks_List = libghdl.vhdl__nodes__set_analysis_checks_list
 
-Get_Date_State = libghdl.vhdl__nodes__get_date_state
-Set_Date_State = libghdl.vhdl__nodes__set_date_state
+@export
+def Set_File_Checksum(obj, value) -> None:
+    libghdl.vhdl__nodes__set_file_checksum(obj, value)
 
-Get_Guarded_Target_State = libghdl.vhdl__nodes__get_guarded_target_state
-Set_Guarded_Target_State = libghdl.vhdl__nodes__set_guarded_target_state
 
-Get_Library_Unit = libghdl.vhdl__nodes__get_library_unit
-Set_Library_Unit = libghdl.vhdl__nodes__set_library_unit
+@export
+def Get_Analysis_Time_Stamp(obj):
+    return libghdl.vhdl__nodes__get_analysis_time_stamp(obj)
 
-Get_Hash_Chain = libghdl.vhdl__nodes__get_hash_chain
-Set_Hash_Chain = libghdl.vhdl__nodes__set_hash_chain
 
-Get_Design_Unit_Source_Pos = libghdl.vhdl__nodes__get_design_unit_source_pos
-Set_Design_Unit_Source_Pos = libghdl.vhdl__nodes__set_design_unit_source_pos
+@export
+def Set_Analysis_Time_Stamp(obj, value) -> None:
+    libghdl.vhdl__nodes__set_analysis_time_stamp(obj, value)
 
-Get_Design_Unit_Source_Line = libghdl.vhdl__nodes__get_design_unit_source_line
-Set_Design_Unit_Source_Line = libghdl.vhdl__nodes__set_design_unit_source_line
 
-Get_Design_Unit_Source_Col = libghdl.vhdl__nodes__get_design_unit_source_col
-Set_Design_Unit_Source_Col = libghdl.vhdl__nodes__set_design_unit_source_col
+@export
+def Get_Design_File_Source(obj):
+    return libghdl.vhdl__nodes__get_design_file_source(obj)
 
-Get_Value = libghdl.vhdl__nodes__get_value
-Set_Value = libghdl.vhdl__nodes__set_value
 
-Get_Enum_Pos = libghdl.vhdl__nodes__get_enum_pos
-Set_Enum_Pos = libghdl.vhdl__nodes__set_enum_pos
+@export
+def Set_Design_File_Source(obj, value) -> None:
+    libghdl.vhdl__nodes__set_design_file_source(obj, value)
 
-Get_Physical_Literal = libghdl.vhdl__nodes__get_physical_literal
-Set_Physical_Literal = libghdl.vhdl__nodes__set_physical_literal
 
-Get_Fp_Value = libghdl.vhdl__nodes__get_fp_value
-Set_Fp_Value = libghdl.vhdl__nodes__set_fp_value
+@export
+def Get_Library(obj):
+    return libghdl.vhdl__nodes__get_library(obj)
 
-Get_Simple_Aggregate_List = libghdl.vhdl__nodes__get_simple_aggregate_list
-Set_Simple_Aggregate_List = libghdl.vhdl__nodes__set_simple_aggregate_list
 
-Get_String8_Id = libghdl.vhdl__nodes__get_string8_id
-Set_String8_Id = libghdl.vhdl__nodes__set_string8_id
+@export
+def Set_Library(obj, value) -> None:
+    libghdl.vhdl__nodes__set_library(obj, value)
 
-Get_String_Length = libghdl.vhdl__nodes__get_string_length
-Set_String_Length = libghdl.vhdl__nodes__set_string_length
 
-Get_Bit_String_Base = libghdl.vhdl__nodes__get_bit_string_base
-Set_Bit_String_Base = libghdl.vhdl__nodes__set_bit_string_base
+@export
+def Get_File_Dependence_List(obj):
+    return libghdl.vhdl__nodes__get_file_dependence_list(obj)
 
-Get_Has_Signed = libghdl.vhdl__nodes__get_has_signed
-Set_Has_Signed = libghdl.vhdl__nodes__set_has_signed
 
-Get_Has_Sign = libghdl.vhdl__nodes__get_has_sign
-Set_Has_Sign = libghdl.vhdl__nodes__set_has_sign
+@export
+def Set_File_Dependence_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_file_dependence_list(obj, value)
 
-Get_Has_Length = libghdl.vhdl__nodes__get_has_length
-Set_Has_Length = libghdl.vhdl__nodes__set_has_length
 
-Get_Literal_Length = libghdl.vhdl__nodes__get_literal_length
-Set_Literal_Length = libghdl.vhdl__nodes__set_literal_length
+@export
+def Get_Design_File_Filename(obj):
+    return libghdl.vhdl__nodes__get_design_file_filename(obj)
 
-Get_Literal_Origin = libghdl.vhdl__nodes__get_literal_origin
-Set_Literal_Origin = libghdl.vhdl__nodes__set_literal_origin
 
-Get_Range_Origin = libghdl.vhdl__nodes__get_range_origin
-Set_Range_Origin = libghdl.vhdl__nodes__set_range_origin
+@export
+def Set_Design_File_Filename(obj, value) -> None:
+    libghdl.vhdl__nodes__set_design_file_filename(obj, value)
 
-Get_Literal_Subtype = libghdl.vhdl__nodes__get_literal_subtype
-Set_Literal_Subtype = libghdl.vhdl__nodes__set_literal_subtype
 
-Get_Allocator_Subtype = libghdl.vhdl__nodes__get_allocator_subtype
-Set_Allocator_Subtype = libghdl.vhdl__nodes__set_allocator_subtype
+@export
+def Get_Design_File_Directory(obj):
+    return libghdl.vhdl__nodes__get_design_file_directory(obj)
 
-Get_Entity_Class = libghdl.vhdl__nodes__get_entity_class
-Set_Entity_Class = libghdl.vhdl__nodes__set_entity_class
 
-Get_Entity_Name_List = libghdl.vhdl__nodes__get_entity_name_list
-Set_Entity_Name_List = libghdl.vhdl__nodes__set_entity_name_list
+@export
+def Set_Design_File_Directory(obj, value) -> None:
+    libghdl.vhdl__nodes__set_design_file_directory(obj, value)
 
-Get_Attribute_Designator = libghdl.vhdl__nodes__get_attribute_designator
-Set_Attribute_Designator = libghdl.vhdl__nodes__set_attribute_designator
 
-Get_Attribute_Specification_Chain = (
-    libghdl.vhdl__nodes__get_attribute_specification_chain
-)
-Set_Attribute_Specification_Chain = (
-    libghdl.vhdl__nodes__set_attribute_specification_chain
-)
+@export
+def Get_Design_File(obj):
+    return libghdl.vhdl__nodes__get_design_file(obj)
 
-Get_Attribute_Specification = libghdl.vhdl__nodes__get_attribute_specification
-Set_Attribute_Specification = libghdl.vhdl__nodes__set_attribute_specification
 
-Get_Static_Attribute_Flag = libghdl.vhdl__nodes__get_static_attribute_flag
-Set_Static_Attribute_Flag = libghdl.vhdl__nodes__set_static_attribute_flag
+@export
+def Set_Design_File(obj, value) -> None:
+    libghdl.vhdl__nodes__set_design_file(obj, value)
 
-Get_Signal_List = libghdl.vhdl__nodes__get_signal_list
-Set_Signal_List = libghdl.vhdl__nodes__set_signal_list
 
-Get_Quantity_List = libghdl.vhdl__nodes__get_quantity_list
-Set_Quantity_List = libghdl.vhdl__nodes__set_quantity_list
+@export
+def Get_Design_File_Chain(obj):
+    return libghdl.vhdl__nodes__get_design_file_chain(obj)
 
-Get_Designated_Entity = libghdl.vhdl__nodes__get_designated_entity
-Set_Designated_Entity = libghdl.vhdl__nodes__set_designated_entity
 
-Get_Formal = libghdl.vhdl__nodes__get_formal
-Set_Formal = libghdl.vhdl__nodes__set_formal
+@export
+def Set_Design_File_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_design_file_chain(obj, value)
 
-Get_Actual = libghdl.vhdl__nodes__get_actual
-Set_Actual = libghdl.vhdl__nodes__set_actual
 
-Get_Actual_Conversion = libghdl.vhdl__nodes__get_actual_conversion
-Set_Actual_Conversion = libghdl.vhdl__nodes__set_actual_conversion
+@export
+def Get_Library_Directory(obj):
+    return libghdl.vhdl__nodes__get_library_directory(obj)
 
-Get_Formal_Conversion = libghdl.vhdl__nodes__get_formal_conversion
-Set_Formal_Conversion = libghdl.vhdl__nodes__set_formal_conversion
 
-Get_Whole_Association_Flag = libghdl.vhdl__nodes__get_whole_association_flag
-Set_Whole_Association_Flag = libghdl.vhdl__nodes__set_whole_association_flag
+@export
+def Set_Library_Directory(obj, value) -> None:
+    libghdl.vhdl__nodes__set_library_directory(obj, value)
 
-Get_Collapse_Signal_Flag = libghdl.vhdl__nodes__get_collapse_signal_flag
-Set_Collapse_Signal_Flag = libghdl.vhdl__nodes__set_collapse_signal_flag
 
-Get_Artificial_Flag = libghdl.vhdl__nodes__get_artificial_flag
-Set_Artificial_Flag = libghdl.vhdl__nodes__set_artificial_flag
+@export
+def Get_Date(obj):
+    return libghdl.vhdl__nodes__get_date(obj)
 
-Get_Open_Flag = libghdl.vhdl__nodes__get_open_flag
-Set_Open_Flag = libghdl.vhdl__nodes__set_open_flag
 
-Get_After_Drivers_Flag = libghdl.vhdl__nodes__get_after_drivers_flag
-Set_After_Drivers_Flag = libghdl.vhdl__nodes__set_after_drivers_flag
+@export
+def Set_Date(obj, value) -> None:
+    libghdl.vhdl__nodes__set_date(obj, value)
 
-Get_We_Value = libghdl.vhdl__nodes__get_we_value
-Set_We_Value = libghdl.vhdl__nodes__set_we_value
 
-Get_Time = libghdl.vhdl__nodes__get_time
-Set_Time = libghdl.vhdl__nodes__set_time
+@export
+def Get_Context_Items(obj):
+    return libghdl.vhdl__nodes__get_context_items(obj)
 
-Get_Associated_Expr = libghdl.vhdl__nodes__get_associated_expr
-Set_Associated_Expr = libghdl.vhdl__nodes__set_associated_expr
 
-Get_Associated_Block = libghdl.vhdl__nodes__get_associated_block
-Set_Associated_Block = libghdl.vhdl__nodes__set_associated_block
+@export
+def Set_Context_Items(obj, value) -> None:
+    libghdl.vhdl__nodes__set_context_items(obj, value)
 
-Get_Associated_Chain = libghdl.vhdl__nodes__get_associated_chain
-Set_Associated_Chain = libghdl.vhdl__nodes__set_associated_chain
 
-Get_Choice_Name = libghdl.vhdl__nodes__get_choice_name
-Set_Choice_Name = libghdl.vhdl__nodes__set_choice_name
+@export
+def Get_Dependence_List(obj):
+    return libghdl.vhdl__nodes__get_dependence_list(obj)
 
-Get_Choice_Expression = libghdl.vhdl__nodes__get_choice_expression
-Set_Choice_Expression = libghdl.vhdl__nodes__set_choice_expression
 
-Get_Choice_Range = libghdl.vhdl__nodes__get_choice_range
-Set_Choice_Range = libghdl.vhdl__nodes__set_choice_range
+@export
+def Set_Dependence_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_dependence_list(obj, value)
 
-Get_Same_Alternative_Flag = libghdl.vhdl__nodes__get_same_alternative_flag
-Set_Same_Alternative_Flag = libghdl.vhdl__nodes__set_same_alternative_flag
 
-Get_Element_Type_Flag = libghdl.vhdl__nodes__get_element_type_flag
-Set_Element_Type_Flag = libghdl.vhdl__nodes__set_element_type_flag
+@export
+def Get_Analysis_Checks_List(obj):
+    return libghdl.vhdl__nodes__get_analysis_checks_list(obj)
 
-Get_Architecture = libghdl.vhdl__nodes__get_architecture
-Set_Architecture = libghdl.vhdl__nodes__set_architecture
 
-Get_Block_Specification = libghdl.vhdl__nodes__get_block_specification
-Set_Block_Specification = libghdl.vhdl__nodes__set_block_specification
+@export
+def Set_Analysis_Checks_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_analysis_checks_list(obj, value)
 
-Get_Prev_Block_Configuration = libghdl.vhdl__nodes__get_prev_block_configuration
-Set_Prev_Block_Configuration = libghdl.vhdl__nodes__set_prev_block_configuration
 
-Get_Configuration_Item_Chain = libghdl.vhdl__nodes__get_configuration_item_chain
-Set_Configuration_Item_Chain = libghdl.vhdl__nodes__set_configuration_item_chain
+@export
+def Get_Date_State(obj):
+    return libghdl.vhdl__nodes__get_date_state(obj)
 
-Get_Attribute_Value_Chain = libghdl.vhdl__nodes__get_attribute_value_chain
-Set_Attribute_Value_Chain = libghdl.vhdl__nodes__set_attribute_value_chain
 
-Get_Spec_Chain = libghdl.vhdl__nodes__get_spec_chain
-Set_Spec_Chain = libghdl.vhdl__nodes__set_spec_chain
+@export
+def Set_Date_State(obj, value) -> None:
+    libghdl.vhdl__nodes__set_date_state(obj, value)
 
-Get_Value_Chain = libghdl.vhdl__nodes__get_value_chain
-Set_Value_Chain = libghdl.vhdl__nodes__set_value_chain
 
-Get_Attribute_Value_Spec_Chain = libghdl.vhdl__nodes__get_attribute_value_spec_chain
-Set_Attribute_Value_Spec_Chain = libghdl.vhdl__nodes__set_attribute_value_spec_chain
+@export
+def Get_Guarded_Target_State(obj):
+    return libghdl.vhdl__nodes__get_guarded_target_state(obj)
 
-Get_Entity_Name = libghdl.vhdl__nodes__get_entity_name
-Set_Entity_Name = libghdl.vhdl__nodes__set_entity_name
 
-Get_Package = libghdl.vhdl__nodes__get_package
-Set_Package = libghdl.vhdl__nodes__set_package
+@export
+def Set_Guarded_Target_State(obj, value) -> None:
+    libghdl.vhdl__nodes__set_guarded_target_state(obj, value)
 
-Get_Package_Body = libghdl.vhdl__nodes__get_package_body
-Set_Package_Body = libghdl.vhdl__nodes__set_package_body
 
-Get_Instance_Package_Body = libghdl.vhdl__nodes__get_instance_package_body
-Set_Instance_Package_Body = libghdl.vhdl__nodes__set_instance_package_body
+@export
+def Get_Library_Unit(obj):
+    return libghdl.vhdl__nodes__get_library_unit(obj)
 
-Get_Need_Body = libghdl.vhdl__nodes__get_need_body
-Set_Need_Body = libghdl.vhdl__nodes__set_need_body
 
-Get_Macro_Expanded_Flag = libghdl.vhdl__nodes__get_macro_expanded_flag
-Set_Macro_Expanded_Flag = libghdl.vhdl__nodes__set_macro_expanded_flag
+@export
+def Set_Library_Unit(obj, value) -> None:
+    libghdl.vhdl__nodes__set_library_unit(obj, value)
 
-Get_Need_Instance_Bodies = libghdl.vhdl__nodes__get_need_instance_bodies
-Set_Need_Instance_Bodies = libghdl.vhdl__nodes__set_need_instance_bodies
 
-Get_Hierarchical_Name = libghdl.vhdl__nodes__get_hierarchical_name
-Set_Hierarchical_Name = libghdl.vhdl__nodes__set_hierarchical_name
+@export
+def Get_Hash_Chain(obj):
+    return libghdl.vhdl__nodes__get_hash_chain(obj)
 
-Get_Inherit_Spec_Chain = libghdl.vhdl__nodes__get_inherit_spec_chain
-Set_Inherit_Spec_Chain = libghdl.vhdl__nodes__set_inherit_spec_chain
 
-Get_Vunit_Item_Chain = libghdl.vhdl__nodes__get_vunit_item_chain
-Set_Vunit_Item_Chain = libghdl.vhdl__nodes__set_vunit_item_chain
+@export
+def Set_Hash_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_hash_chain(obj, value)
 
-Get_Bound_Vunit_Chain = libghdl.vhdl__nodes__get_bound_vunit_chain
-Set_Bound_Vunit_Chain = libghdl.vhdl__nodes__set_bound_vunit_chain
 
-Get_Verification_Block_Configuration = (
-    libghdl.vhdl__nodes__get_verification_block_configuration
-)
-Set_Verification_Block_Configuration = (
-    libghdl.vhdl__nodes__set_verification_block_configuration
-)
+@export
+def Get_Design_Unit_Source_Pos(obj):
+    return libghdl.vhdl__nodes__get_design_unit_source_pos(obj)
 
-Get_Block_Configuration = libghdl.vhdl__nodes__get_block_configuration
-Set_Block_Configuration = libghdl.vhdl__nodes__set_block_configuration
 
-Get_Concurrent_Statement_Chain = libghdl.vhdl__nodes__get_concurrent_statement_chain
-Set_Concurrent_Statement_Chain = libghdl.vhdl__nodes__set_concurrent_statement_chain
+@export
+def Set_Design_Unit_Source_Pos(obj, value) -> None:
+    libghdl.vhdl__nodes__set_design_unit_source_pos(obj, value)
 
-Get_Chain = libghdl.vhdl__nodes__get_chain
-Set_Chain = libghdl.vhdl__nodes__set_chain
 
-Get_Port_Chain = libghdl.vhdl__nodes__get_port_chain
-Set_Port_Chain = libghdl.vhdl__nodes__set_port_chain
+@export
+def Get_Design_Unit_Source_Line(obj):
+    return libghdl.vhdl__nodes__get_design_unit_source_line(obj)
 
-Get_Generic_Chain = libghdl.vhdl__nodes__get_generic_chain
-Set_Generic_Chain = libghdl.vhdl__nodes__set_generic_chain
 
-Get_Type = libghdl.vhdl__nodes__get_type
-Set_Type = libghdl.vhdl__nodes__set_type
+@export
+def Set_Design_Unit_Source_Line(obj, value) -> None:
+    libghdl.vhdl__nodes__set_design_unit_source_line(obj, value)
 
-Get_Subtype_Indication = libghdl.vhdl__nodes__get_subtype_indication
-Set_Subtype_Indication = libghdl.vhdl__nodes__set_subtype_indication
 
-Get_Discrete_Range = libghdl.vhdl__nodes__get_discrete_range
-Set_Discrete_Range = libghdl.vhdl__nodes__set_discrete_range
+@export
+def Get_Design_Unit_Source_Col(obj):
+    return libghdl.vhdl__nodes__get_design_unit_source_col(obj)
 
-Get_Type_Definition = libghdl.vhdl__nodes__get_type_definition
-Set_Type_Definition = libghdl.vhdl__nodes__set_type_definition
 
-Get_Subtype_Definition = libghdl.vhdl__nodes__get_subtype_definition
-Set_Subtype_Definition = libghdl.vhdl__nodes__set_subtype_definition
+@export
+def Set_Design_Unit_Source_Col(obj, value) -> None:
+    libghdl.vhdl__nodes__set_design_unit_source_col(obj, value)
 
-Get_Incomplete_Type_Declaration = libghdl.vhdl__nodes__get_incomplete_type_declaration
-Set_Incomplete_Type_Declaration = libghdl.vhdl__nodes__set_incomplete_type_declaration
 
-Get_Interface_Type_Subprograms = libghdl.vhdl__nodes__get_interface_type_subprograms
-Set_Interface_Type_Subprograms = libghdl.vhdl__nodes__set_interface_type_subprograms
+@export
+def Get_Value(obj):
+    return libghdl.vhdl__nodes__get_value(obj)
 
-Get_Nature_Definition = libghdl.vhdl__nodes__get_nature_definition
-Set_Nature_Definition = libghdl.vhdl__nodes__set_nature_definition
 
-Get_Nature = libghdl.vhdl__nodes__get_nature
-Set_Nature = libghdl.vhdl__nodes__set_nature
+@export
+def Set_Value(obj, value) -> None:
+    libghdl.vhdl__nodes__set_value(obj, value)
 
-Get_Subnature_Indication = libghdl.vhdl__nodes__get_subnature_indication
-Set_Subnature_Indication = libghdl.vhdl__nodes__set_subnature_indication
 
-Get_Mode = libghdl.vhdl__nodes__get_mode
-Set_Mode = libghdl.vhdl__nodes__set_mode
+@export
+def Get_Enum_Pos(obj):
+    return libghdl.vhdl__nodes__get_enum_pos(obj)
 
-Get_Guarded_Signal_Flag = libghdl.vhdl__nodes__get_guarded_signal_flag
-Set_Guarded_Signal_Flag = libghdl.vhdl__nodes__set_guarded_signal_flag
 
-Get_Signal_Kind = libghdl.vhdl__nodes__get_signal_kind
-Set_Signal_Kind = libghdl.vhdl__nodes__set_signal_kind
+@export
+def Set_Enum_Pos(obj, value) -> None:
+    libghdl.vhdl__nodes__set_enum_pos(obj, value)
 
-Get_Base_Name = libghdl.vhdl__nodes__get_base_name
-Set_Base_Name = libghdl.vhdl__nodes__set_base_name
 
-Get_Interface_Declaration_Chain = libghdl.vhdl__nodes__get_interface_declaration_chain
-Set_Interface_Declaration_Chain = libghdl.vhdl__nodes__set_interface_declaration_chain
+@export
+def Get_Physical_Literal(obj):
+    return libghdl.vhdl__nodes__get_physical_literal(obj)
 
-Get_Subprogram_Specification = libghdl.vhdl__nodes__get_subprogram_specification
-Set_Subprogram_Specification = libghdl.vhdl__nodes__set_subprogram_specification
 
-Get_Sequential_Statement_Chain = libghdl.vhdl__nodes__get_sequential_statement_chain
-Set_Sequential_Statement_Chain = libghdl.vhdl__nodes__set_sequential_statement_chain
+@export
+def Set_Physical_Literal(obj, value) -> None:
+    libghdl.vhdl__nodes__set_physical_literal(obj, value)
 
-Get_Simultaneous_Statement_Chain = libghdl.vhdl__nodes__get_simultaneous_statement_chain
-Set_Simultaneous_Statement_Chain = libghdl.vhdl__nodes__set_simultaneous_statement_chain
 
-Get_Subprogram_Body = libghdl.vhdl__nodes__get_subprogram_body
-Set_Subprogram_Body = libghdl.vhdl__nodes__set_subprogram_body
+@export
+def Get_Fp_Value(obj):
+    return libghdl.vhdl__nodes__get_fp_value(obj)
 
-Get_Overload_Number = libghdl.vhdl__nodes__get_overload_number
-Set_Overload_Number = libghdl.vhdl__nodes__set_overload_number
 
-Get_Subprogram_Depth = libghdl.vhdl__nodes__get_subprogram_depth
-Set_Subprogram_Depth = libghdl.vhdl__nodes__set_subprogram_depth
+@export
+def Set_Fp_Value(obj, value) -> None:
+    libghdl.vhdl__nodes__set_fp_value(obj, value)
 
-Get_Subprogram_Hash = libghdl.vhdl__nodes__get_subprogram_hash
-Set_Subprogram_Hash = libghdl.vhdl__nodes__set_subprogram_hash
 
-Get_Impure_Depth = libghdl.vhdl__nodes__get_impure_depth
-Set_Impure_Depth = libghdl.vhdl__nodes__set_impure_depth
+@export
+def Get_Simple_Aggregate_List(obj):
+    return libghdl.vhdl__nodes__get_simple_aggregate_list(obj)
 
-Get_Return_Type = libghdl.vhdl__nodes__get_return_type
-Set_Return_Type = libghdl.vhdl__nodes__set_return_type
 
-Get_Implicit_Definition = libghdl.vhdl__nodes__get_implicit_definition
-Set_Implicit_Definition = libghdl.vhdl__nodes__set_implicit_definition
+@export
+def Set_Simple_Aggregate_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_simple_aggregate_list(obj, value)
 
-Get_Uninstantiated_Subprogram_Name = (
-    libghdl.vhdl__nodes__get_uninstantiated_subprogram_name
-)
-Set_Uninstantiated_Subprogram_Name = (
-    libghdl.vhdl__nodes__set_uninstantiated_subprogram_name
-)
 
-Get_Default_Value = libghdl.vhdl__nodes__get_default_value
-Set_Default_Value = libghdl.vhdl__nodes__set_default_value
+@export
+def Get_String8_Id(obj):
+    return libghdl.vhdl__nodes__get_string8_id(obj)
 
-Get_Deferred_Declaration = libghdl.vhdl__nodes__get_deferred_declaration
-Set_Deferred_Declaration = libghdl.vhdl__nodes__set_deferred_declaration
 
-Get_Deferred_Declaration_Flag = libghdl.vhdl__nodes__get_deferred_declaration_flag
-Set_Deferred_Declaration_Flag = libghdl.vhdl__nodes__set_deferred_declaration_flag
+@export
+def Set_String8_Id(obj, value) -> None:
+    libghdl.vhdl__nodes__set_string8_id(obj, value)
 
-Get_Shared_Flag = libghdl.vhdl__nodes__get_shared_flag
-Set_Shared_Flag = libghdl.vhdl__nodes__set_shared_flag
 
-Get_Design_Unit = libghdl.vhdl__nodes__get_design_unit
-Set_Design_Unit = libghdl.vhdl__nodes__set_design_unit
+@export
+def Get_String_Length(obj):
+    return libghdl.vhdl__nodes__get_string_length(obj)
 
-Get_Block_Statement = libghdl.vhdl__nodes__get_block_statement
-Set_Block_Statement = libghdl.vhdl__nodes__set_block_statement
 
-Get_Signal_Driver = libghdl.vhdl__nodes__get_signal_driver
-Set_Signal_Driver = libghdl.vhdl__nodes__set_signal_driver
+@export
+def Set_String_Length(obj, value) -> None:
+    libghdl.vhdl__nodes__set_string_length(obj, value)
 
-Get_Declaration_Chain = libghdl.vhdl__nodes__get_declaration_chain
-Set_Declaration_Chain = libghdl.vhdl__nodes__set_declaration_chain
 
-Get_File_Logical_Name = libghdl.vhdl__nodes__get_file_logical_name
-Set_File_Logical_Name = libghdl.vhdl__nodes__set_file_logical_name
+@export
+def Get_Bit_String_Base(obj):
+    return libghdl.vhdl__nodes__get_bit_string_base(obj)
 
-Get_File_Open_Kind = libghdl.vhdl__nodes__get_file_open_kind
-Set_File_Open_Kind = libghdl.vhdl__nodes__set_file_open_kind
 
-Get_Element_Position = libghdl.vhdl__nodes__get_element_position
-Set_Element_Position = libghdl.vhdl__nodes__set_element_position
+@export
+def Set_Bit_String_Base(obj, value) -> None:
+    libghdl.vhdl__nodes__set_bit_string_base(obj, value)
 
-Get_Use_Clause_Chain = libghdl.vhdl__nodes__get_use_clause_chain
-Set_Use_Clause_Chain = libghdl.vhdl__nodes__set_use_clause_chain
 
-Get_Context_Reference_Chain = libghdl.vhdl__nodes__get_context_reference_chain
-Set_Context_Reference_Chain = libghdl.vhdl__nodes__set_context_reference_chain
+@export
+def Get_Has_Signed(obj):
+    return libghdl.vhdl__nodes__get_has_signed(obj)
 
-Get_Selected_Name = libghdl.vhdl__nodes__get_selected_name
-Set_Selected_Name = libghdl.vhdl__nodes__set_selected_name
 
-Get_Type_Declarator = libghdl.vhdl__nodes__get_type_declarator
-Set_Type_Declarator = libghdl.vhdl__nodes__set_type_declarator
+@export
+def Set_Has_Signed(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_signed(obj, value)
 
-Get_Complete_Type_Definition = libghdl.vhdl__nodes__get_complete_type_definition
-Set_Complete_Type_Definition = libghdl.vhdl__nodes__set_complete_type_definition
 
-Get_Incomplete_Type_Ref_Chain = libghdl.vhdl__nodes__get_incomplete_type_ref_chain
-Set_Incomplete_Type_Ref_Chain = libghdl.vhdl__nodes__set_incomplete_type_ref_chain
+@export
+def Get_Has_Sign(obj):
+    return libghdl.vhdl__nodes__get_has_sign(obj)
 
-Get_Associated_Type = libghdl.vhdl__nodes__get_associated_type
-Set_Associated_Type = libghdl.vhdl__nodes__set_associated_type
 
-Get_Enumeration_Literal_List = libghdl.vhdl__nodes__get_enumeration_literal_list
-Set_Enumeration_Literal_List = libghdl.vhdl__nodes__set_enumeration_literal_list
+@export
+def Set_Has_Sign(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_sign(obj, value)
 
-Get_Entity_Class_Entry_Chain = libghdl.vhdl__nodes__get_entity_class_entry_chain
-Set_Entity_Class_Entry_Chain = libghdl.vhdl__nodes__set_entity_class_entry_chain
 
-Get_Group_Constituent_List = libghdl.vhdl__nodes__get_group_constituent_list
-Set_Group_Constituent_List = libghdl.vhdl__nodes__set_group_constituent_list
+@export
+def Get_Has_Length(obj):
+    return libghdl.vhdl__nodes__get_has_length(obj)
 
-Get_Unit_Chain = libghdl.vhdl__nodes__get_unit_chain
-Set_Unit_Chain = libghdl.vhdl__nodes__set_unit_chain
 
-Get_Primary_Unit = libghdl.vhdl__nodes__get_primary_unit
-Set_Primary_Unit = libghdl.vhdl__nodes__set_primary_unit
+@export
+def Set_Has_Length(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_length(obj, value)
 
-Get_Identifier = libghdl.vhdl__nodes__get_identifier
-Set_Identifier = libghdl.vhdl__nodes__set_identifier
 
-Get_Label = libghdl.vhdl__nodes__get_label
-Set_Label = libghdl.vhdl__nodes__set_label
+@export
+def Get_Literal_Length(obj):
+    return libghdl.vhdl__nodes__get_literal_length(obj)
 
-Get_Visible_Flag = libghdl.vhdl__nodes__get_visible_flag
-Set_Visible_Flag = libghdl.vhdl__nodes__set_visible_flag
 
-Get_Range_Constraint = libghdl.vhdl__nodes__get_range_constraint
-Set_Range_Constraint = libghdl.vhdl__nodes__set_range_constraint
+@export
+def Set_Literal_Length(obj, value) -> None:
+    libghdl.vhdl__nodes__set_literal_length(obj, value)
 
-Get_Direction = libghdl.vhdl__nodes__get_direction
-Set_Direction = libghdl.vhdl__nodes__set_direction
 
-Get_Left_Limit = libghdl.vhdl__nodes__get_left_limit
-Set_Left_Limit = libghdl.vhdl__nodes__set_left_limit
+@export
+def Get_Literal_Origin(obj):
+    return libghdl.vhdl__nodes__get_literal_origin(obj)
 
-Get_Right_Limit = libghdl.vhdl__nodes__get_right_limit
-Set_Right_Limit = libghdl.vhdl__nodes__set_right_limit
 
-Get_Left_Limit_Expr = libghdl.vhdl__nodes__get_left_limit_expr
-Set_Left_Limit_Expr = libghdl.vhdl__nodes__set_left_limit_expr
+@export
+def Set_Literal_Origin(obj, value) -> None:
+    libghdl.vhdl__nodes__set_literal_origin(obj, value)
 
-Get_Right_Limit_Expr = libghdl.vhdl__nodes__get_right_limit_expr
-Set_Right_Limit_Expr = libghdl.vhdl__nodes__set_right_limit_expr
 
-Get_Parent_Type = libghdl.vhdl__nodes__get_parent_type
-Set_Parent_Type = libghdl.vhdl__nodes__set_parent_type
+@export
+def Get_Range_Origin(obj):
+    return libghdl.vhdl__nodes__get_range_origin(obj)
 
-Get_Simple_Nature = libghdl.vhdl__nodes__get_simple_nature
-Set_Simple_Nature = libghdl.vhdl__nodes__set_simple_nature
 
-Get_Base_Nature = libghdl.vhdl__nodes__get_base_nature
-Set_Base_Nature = libghdl.vhdl__nodes__set_base_nature
+@export
+def Set_Range_Origin(obj, value) -> None:
+    libghdl.vhdl__nodes__set_range_origin(obj, value)
 
-Get_Resolution_Indication = libghdl.vhdl__nodes__get_resolution_indication
-Set_Resolution_Indication = libghdl.vhdl__nodes__set_resolution_indication
 
-Get_Record_Element_Resolution_Chain = (
-    libghdl.vhdl__nodes__get_record_element_resolution_chain
-)
-Set_Record_Element_Resolution_Chain = (
-    libghdl.vhdl__nodes__set_record_element_resolution_chain
-)
+@export
+def Get_Literal_Subtype(obj):
+    return libghdl.vhdl__nodes__get_literal_subtype(obj)
 
-Get_Tolerance = libghdl.vhdl__nodes__get_tolerance
-Set_Tolerance = libghdl.vhdl__nodes__set_tolerance
 
-Get_Plus_Terminal_Name = libghdl.vhdl__nodes__get_plus_terminal_name
-Set_Plus_Terminal_Name = libghdl.vhdl__nodes__set_plus_terminal_name
+@export
+def Set_Literal_Subtype(obj, value) -> None:
+    libghdl.vhdl__nodes__set_literal_subtype(obj, value)
 
-Get_Minus_Terminal_Name = libghdl.vhdl__nodes__get_minus_terminal_name
-Set_Minus_Terminal_Name = libghdl.vhdl__nodes__set_minus_terminal_name
 
-Get_Plus_Terminal = libghdl.vhdl__nodes__get_plus_terminal
-Set_Plus_Terminal = libghdl.vhdl__nodes__set_plus_terminal
+@export
+def Get_Allocator_Subtype(obj):
+    return libghdl.vhdl__nodes__get_allocator_subtype(obj)
 
-Get_Minus_Terminal = libghdl.vhdl__nodes__get_minus_terminal
-Set_Minus_Terminal = libghdl.vhdl__nodes__set_minus_terminal
 
-Get_Magnitude_Expression = libghdl.vhdl__nodes__get_magnitude_expression
-Set_Magnitude_Expression = libghdl.vhdl__nodes__set_magnitude_expression
+@export
+def Set_Allocator_Subtype(obj, value) -> None:
+    libghdl.vhdl__nodes__set_allocator_subtype(obj, value)
 
-Get_Phase_Expression = libghdl.vhdl__nodes__get_phase_expression
-Set_Phase_Expression = libghdl.vhdl__nodes__set_phase_expression
 
-Get_Power_Expression = libghdl.vhdl__nodes__get_power_expression
-Set_Power_Expression = libghdl.vhdl__nodes__set_power_expression
+@export
+def Get_Entity_Class(obj):
+    return libghdl.vhdl__nodes__get_entity_class(obj)
 
-Get_Simultaneous_Left = libghdl.vhdl__nodes__get_simultaneous_left
-Set_Simultaneous_Left = libghdl.vhdl__nodes__set_simultaneous_left
 
-Get_Simultaneous_Right = libghdl.vhdl__nodes__get_simultaneous_right
-Set_Simultaneous_Right = libghdl.vhdl__nodes__set_simultaneous_right
+@export
+def Set_Entity_Class(obj, value) -> None:
+    libghdl.vhdl__nodes__set_entity_class(obj, value)
 
-Get_Text_File_Flag = libghdl.vhdl__nodes__get_text_file_flag
-Set_Text_File_Flag = libghdl.vhdl__nodes__set_text_file_flag
 
-Get_Only_Characters_Flag = libghdl.vhdl__nodes__get_only_characters_flag
-Set_Only_Characters_Flag = libghdl.vhdl__nodes__set_only_characters_flag
+@export
+def Get_Entity_Name_List(obj):
+    return libghdl.vhdl__nodes__get_entity_name_list(obj)
 
-Get_Is_Character_Type = libghdl.vhdl__nodes__get_is_character_type
-Set_Is_Character_Type = libghdl.vhdl__nodes__set_is_character_type
 
-Get_Nature_Staticness = libghdl.vhdl__nodes__get_nature_staticness
-Set_Nature_Staticness = libghdl.vhdl__nodes__set_nature_staticness
+@export
+def Set_Entity_Name_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_entity_name_list(obj, value)
 
-Get_Type_Staticness = libghdl.vhdl__nodes__get_type_staticness
-Set_Type_Staticness = libghdl.vhdl__nodes__set_type_staticness
 
-Get_Constraint_State = libghdl.vhdl__nodes__get_constraint_state
-Set_Constraint_State = libghdl.vhdl__nodes__set_constraint_state
+@export
+def Get_Attribute_Designator(obj):
+    return libghdl.vhdl__nodes__get_attribute_designator(obj)
 
-Get_Index_Subtype_List = libghdl.vhdl__nodes__get_index_subtype_list
-Set_Index_Subtype_List = libghdl.vhdl__nodes__set_index_subtype_list
 
-Get_Index_Subtype_Definition_List = (
-    libghdl.vhdl__nodes__get_index_subtype_definition_list
-)
-Set_Index_Subtype_Definition_List = (
-    libghdl.vhdl__nodes__set_index_subtype_definition_list
-)
+@export
+def Set_Attribute_Designator(obj, value) -> None:
+    libghdl.vhdl__nodes__set_attribute_designator(obj, value)
 
-Get_Element_Subtype_Indication = libghdl.vhdl__nodes__get_element_subtype_indication
-Set_Element_Subtype_Indication = libghdl.vhdl__nodes__set_element_subtype_indication
 
-Get_Element_Subtype = libghdl.vhdl__nodes__get_element_subtype
-Set_Element_Subtype = libghdl.vhdl__nodes__set_element_subtype
+@export
+def Get_Attribute_Specification_Chain(obj):
+    return libghdl.vhdl__nodes__get_attribute_specification_chain(obj)
 
-Get_Element_Subnature_Indication = libghdl.vhdl__nodes__get_element_subnature_indication
-Set_Element_Subnature_Indication = libghdl.vhdl__nodes__set_element_subnature_indication
 
-Get_Element_Subnature = libghdl.vhdl__nodes__get_element_subnature
-Set_Element_Subnature = libghdl.vhdl__nodes__set_element_subnature
+@export
+def Set_Attribute_Specification_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_attribute_specification_chain(obj, value)
 
-Get_Index_Constraint_List = libghdl.vhdl__nodes__get_index_constraint_list
-Set_Index_Constraint_List = libghdl.vhdl__nodes__set_index_constraint_list
 
-Get_Array_Element_Constraint = libghdl.vhdl__nodes__get_array_element_constraint
-Set_Array_Element_Constraint = libghdl.vhdl__nodes__set_array_element_constraint
+@export
+def Get_Attribute_Specification(obj):
+    return libghdl.vhdl__nodes__get_attribute_specification(obj)
 
-Get_Has_Array_Constraint_Flag = libghdl.vhdl__nodes__get_has_array_constraint_flag
-Set_Has_Array_Constraint_Flag = libghdl.vhdl__nodes__set_has_array_constraint_flag
 
-Get_Has_Element_Constraint_Flag = libghdl.vhdl__nodes__get_has_element_constraint_flag
-Set_Has_Element_Constraint_Flag = libghdl.vhdl__nodes__set_has_element_constraint_flag
+@export
+def Set_Attribute_Specification(obj, value) -> None:
+    libghdl.vhdl__nodes__set_attribute_specification(obj, value)
 
-Get_Elements_Declaration_List = libghdl.vhdl__nodes__get_elements_declaration_list
-Set_Elements_Declaration_List = libghdl.vhdl__nodes__set_elements_declaration_list
 
-Get_Owned_Elements_Chain = libghdl.vhdl__nodes__get_owned_elements_chain
-Set_Owned_Elements_Chain = libghdl.vhdl__nodes__set_owned_elements_chain
+@export
+def Get_Static_Attribute_Flag(obj):
+    return libghdl.vhdl__nodes__get_static_attribute_flag(obj)
 
-Get_Designated_Type = libghdl.vhdl__nodes__get_designated_type
-Set_Designated_Type = libghdl.vhdl__nodes__set_designated_type
 
-Get_Designated_Subtype_Indication = (
-    libghdl.vhdl__nodes__get_designated_subtype_indication
-)
-Set_Designated_Subtype_Indication = (
-    libghdl.vhdl__nodes__set_designated_subtype_indication
-)
+@export
+def Set_Static_Attribute_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_static_attribute_flag(obj, value)
 
-Get_Index_List = libghdl.vhdl__nodes__get_index_list
-Set_Index_List = libghdl.vhdl__nodes__set_index_list
 
-Get_Reference = libghdl.vhdl__nodes__get_reference
-Set_Reference = libghdl.vhdl__nodes__set_reference
+@export
+def Get_Signal_List(obj):
+    return libghdl.vhdl__nodes__get_signal_list(obj)
 
-Get_Nature_Declarator = libghdl.vhdl__nodes__get_nature_declarator
-Set_Nature_Declarator = libghdl.vhdl__nodes__set_nature_declarator
 
-Get_Across_Type_Mark = libghdl.vhdl__nodes__get_across_type_mark
-Set_Across_Type_Mark = libghdl.vhdl__nodes__set_across_type_mark
+@export
+def Set_Signal_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_signal_list(obj, value)
 
-Get_Through_Type_Mark = libghdl.vhdl__nodes__get_through_type_mark
-Set_Through_Type_Mark = libghdl.vhdl__nodes__set_through_type_mark
 
-Get_Across_Type_Definition = libghdl.vhdl__nodes__get_across_type_definition
-Set_Across_Type_Definition = libghdl.vhdl__nodes__set_across_type_definition
+@export
+def Get_Quantity_List(obj):
+    return libghdl.vhdl__nodes__get_quantity_list(obj)
 
-Get_Through_Type_Definition = libghdl.vhdl__nodes__get_through_type_definition
-Set_Through_Type_Definition = libghdl.vhdl__nodes__set_through_type_definition
 
-Get_Across_Type = libghdl.vhdl__nodes__get_across_type
-Set_Across_Type = libghdl.vhdl__nodes__set_across_type
+@export
+def Set_Quantity_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_quantity_list(obj, value)
 
-Get_Through_Type = libghdl.vhdl__nodes__get_through_type
-Set_Through_Type = libghdl.vhdl__nodes__set_through_type
 
-Get_Target = libghdl.vhdl__nodes__get_target
-Set_Target = libghdl.vhdl__nodes__set_target
+@export
+def Get_Designated_Entity(obj):
+    return libghdl.vhdl__nodes__get_designated_entity(obj)
 
-Get_Waveform_Chain = libghdl.vhdl__nodes__get_waveform_chain
-Set_Waveform_Chain = libghdl.vhdl__nodes__set_waveform_chain
 
-Get_Guard = libghdl.vhdl__nodes__get_guard
-Set_Guard = libghdl.vhdl__nodes__set_guard
+@export
+def Set_Designated_Entity(obj, value) -> None:
+    libghdl.vhdl__nodes__set_designated_entity(obj, value)
 
-Get_Delay_Mechanism = libghdl.vhdl__nodes__get_delay_mechanism
-Set_Delay_Mechanism = libghdl.vhdl__nodes__set_delay_mechanism
 
-Get_Reject_Time_Expression = libghdl.vhdl__nodes__get_reject_time_expression
-Set_Reject_Time_Expression = libghdl.vhdl__nodes__set_reject_time_expression
+@export
+def Get_Formal(obj):
+    return libghdl.vhdl__nodes__get_formal(obj)
 
-Get_Force_Mode = libghdl.vhdl__nodes__get_force_mode
-Set_Force_Mode = libghdl.vhdl__nodes__set_force_mode
 
-Get_Has_Force_Mode = libghdl.vhdl__nodes__get_has_force_mode
-Set_Has_Force_Mode = libghdl.vhdl__nodes__set_has_force_mode
+@export
+def Set_Formal(obj, value) -> None:
+    libghdl.vhdl__nodes__set_formal(obj, value)
 
-Get_Sensitivity_List = libghdl.vhdl__nodes__get_sensitivity_list
-Set_Sensitivity_List = libghdl.vhdl__nodes__set_sensitivity_list
 
-Get_Process_Origin = libghdl.vhdl__nodes__get_process_origin
-Set_Process_Origin = libghdl.vhdl__nodes__set_process_origin
+@export
+def Get_Actual(obj):
+    return libghdl.vhdl__nodes__get_actual(obj)
 
-Get_Package_Origin = libghdl.vhdl__nodes__get_package_origin
-Set_Package_Origin = libghdl.vhdl__nodes__set_package_origin
 
-Get_Condition_Clause = libghdl.vhdl__nodes__get_condition_clause
-Set_Condition_Clause = libghdl.vhdl__nodes__set_condition_clause
+@export
+def Set_Actual(obj, value) -> None:
+    libghdl.vhdl__nodes__set_actual(obj, value)
 
-Get_Break_Element = libghdl.vhdl__nodes__get_break_element
-Set_Break_Element = libghdl.vhdl__nodes__set_break_element
 
-Get_Selector_Quantity = libghdl.vhdl__nodes__get_selector_quantity
-Set_Selector_Quantity = libghdl.vhdl__nodes__set_selector_quantity
+@export
+def Get_Actual_Conversion(obj):
+    return libghdl.vhdl__nodes__get_actual_conversion(obj)
 
-Get_Break_Quantity = libghdl.vhdl__nodes__get_break_quantity
-Set_Break_Quantity = libghdl.vhdl__nodes__set_break_quantity
 
-Get_Timeout_Clause = libghdl.vhdl__nodes__get_timeout_clause
-Set_Timeout_Clause = libghdl.vhdl__nodes__set_timeout_clause
+@export
+def Set_Actual_Conversion(obj, value) -> None:
+    libghdl.vhdl__nodes__set_actual_conversion(obj, value)
 
-Get_Postponed_Flag = libghdl.vhdl__nodes__get_postponed_flag
-Set_Postponed_Flag = libghdl.vhdl__nodes__set_postponed_flag
 
-Get_Callees_List = libghdl.vhdl__nodes__get_callees_list
-Set_Callees_List = libghdl.vhdl__nodes__set_callees_list
+@export
+def Get_Formal_Conversion(obj):
+    return libghdl.vhdl__nodes__get_formal_conversion(obj)
 
-Get_Passive_Flag = libghdl.vhdl__nodes__get_passive_flag
-Set_Passive_Flag = libghdl.vhdl__nodes__set_passive_flag
 
-Get_Resolution_Function_Flag = libghdl.vhdl__nodes__get_resolution_function_flag
-Set_Resolution_Function_Flag = libghdl.vhdl__nodes__set_resolution_function_flag
+@export
+def Set_Formal_Conversion(obj, value) -> None:
+    libghdl.vhdl__nodes__set_formal_conversion(obj, value)
 
-Get_Wait_State = libghdl.vhdl__nodes__get_wait_state
-Set_Wait_State = libghdl.vhdl__nodes__set_wait_state
 
-Get_All_Sensitized_State = libghdl.vhdl__nodes__get_all_sensitized_state
-Set_All_Sensitized_State = libghdl.vhdl__nodes__set_all_sensitized_state
+@export
+def Get_Whole_Association_Flag(obj):
+    return libghdl.vhdl__nodes__get_whole_association_flag(obj)
 
-Get_Seen_Flag = libghdl.vhdl__nodes__get_seen_flag
-Set_Seen_Flag = libghdl.vhdl__nodes__set_seen_flag
 
-Get_Pure_Flag = libghdl.vhdl__nodes__get_pure_flag
-Set_Pure_Flag = libghdl.vhdl__nodes__set_pure_flag
+@export
+def Set_Whole_Association_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_whole_association_flag(obj, value)
 
-Get_Foreign_Flag = libghdl.vhdl__nodes__get_foreign_flag
-Set_Foreign_Flag = libghdl.vhdl__nodes__set_foreign_flag
 
-Get_Resolved_Flag = libghdl.vhdl__nodes__get_resolved_flag
-Set_Resolved_Flag = libghdl.vhdl__nodes__set_resolved_flag
+@export
+def Get_Collapse_Signal_Flag(obj):
+    return libghdl.vhdl__nodes__get_collapse_signal_flag(obj)
 
-Get_Signal_Type_Flag = libghdl.vhdl__nodes__get_signal_type_flag
-Set_Signal_Type_Flag = libghdl.vhdl__nodes__set_signal_type_flag
 
-Get_Has_Signal_Flag = libghdl.vhdl__nodes__get_has_signal_flag
-Set_Has_Signal_Flag = libghdl.vhdl__nodes__set_has_signal_flag
+@export
+def Set_Collapse_Signal_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_collapse_signal_flag(obj, value)
 
-Get_Purity_State = libghdl.vhdl__nodes__get_purity_state
-Set_Purity_State = libghdl.vhdl__nodes__set_purity_state
 
-Get_Elab_Flag = libghdl.vhdl__nodes__get_elab_flag
-Set_Elab_Flag = libghdl.vhdl__nodes__set_elab_flag
+@export
+def Get_Artificial_Flag(obj):
+    return libghdl.vhdl__nodes__get_artificial_flag(obj)
 
-Get_Vendor_Library_Flag = libghdl.vhdl__nodes__get_vendor_library_flag
-Set_Vendor_Library_Flag = libghdl.vhdl__nodes__set_vendor_library_flag
 
-Get_Configuration_Mark_Flag = libghdl.vhdl__nodes__get_configuration_mark_flag
-Set_Configuration_Mark_Flag = libghdl.vhdl__nodes__set_configuration_mark_flag
+@export
+def Set_Artificial_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_artificial_flag(obj, value)
 
-Get_Configuration_Done_Flag = libghdl.vhdl__nodes__get_configuration_done_flag
-Set_Configuration_Done_Flag = libghdl.vhdl__nodes__set_configuration_done_flag
 
-Get_Index_Constraint_Flag = libghdl.vhdl__nodes__get_index_constraint_flag
-Set_Index_Constraint_Flag = libghdl.vhdl__nodes__set_index_constraint_flag
+@export
+def Get_Open_Flag(obj):
+    return libghdl.vhdl__nodes__get_open_flag(obj)
 
-Get_Hide_Implicit_Flag = libghdl.vhdl__nodes__get_hide_implicit_flag
-Set_Hide_Implicit_Flag = libghdl.vhdl__nodes__set_hide_implicit_flag
 
-Get_Assertion_Condition = libghdl.vhdl__nodes__get_assertion_condition
-Set_Assertion_Condition = libghdl.vhdl__nodes__set_assertion_condition
+@export
+def Set_Open_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_open_flag(obj, value)
 
-Get_Report_Expression = libghdl.vhdl__nodes__get_report_expression
-Set_Report_Expression = libghdl.vhdl__nodes__set_report_expression
 
-Get_Severity_Expression = libghdl.vhdl__nodes__get_severity_expression
-Set_Severity_Expression = libghdl.vhdl__nodes__set_severity_expression
+@export
+def Get_After_Drivers_Flag(obj):
+    return libghdl.vhdl__nodes__get_after_drivers_flag(obj)
 
-Get_Instantiated_Unit = libghdl.vhdl__nodes__get_instantiated_unit
-Set_Instantiated_Unit = libghdl.vhdl__nodes__set_instantiated_unit
 
-Get_Generic_Map_Aspect_Chain = libghdl.vhdl__nodes__get_generic_map_aspect_chain
-Set_Generic_Map_Aspect_Chain = libghdl.vhdl__nodes__set_generic_map_aspect_chain
+@export
+def Set_After_Drivers_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_after_drivers_flag(obj, value)
 
-Get_Port_Map_Aspect_Chain = libghdl.vhdl__nodes__get_port_map_aspect_chain
-Set_Port_Map_Aspect_Chain = libghdl.vhdl__nodes__set_port_map_aspect_chain
 
-Get_Configuration_Name = libghdl.vhdl__nodes__get_configuration_name
-Set_Configuration_Name = libghdl.vhdl__nodes__set_configuration_name
+@export
+def Get_We_Value(obj):
+    return libghdl.vhdl__nodes__get_we_value(obj)
 
-Get_Component_Configuration = libghdl.vhdl__nodes__get_component_configuration
-Set_Component_Configuration = libghdl.vhdl__nodes__set_component_configuration
 
-Get_Configuration_Specification = libghdl.vhdl__nodes__get_configuration_specification
-Set_Configuration_Specification = libghdl.vhdl__nodes__set_configuration_specification
+@export
+def Set_We_Value(obj, value) -> None:
+    libghdl.vhdl__nodes__set_we_value(obj, value)
 
-Get_Default_Binding_Indication = libghdl.vhdl__nodes__get_default_binding_indication
-Set_Default_Binding_Indication = libghdl.vhdl__nodes__set_default_binding_indication
 
-Get_Default_Configuration_Declaration = (
-    libghdl.vhdl__nodes__get_default_configuration_declaration
-)
-Set_Default_Configuration_Declaration = (
-    libghdl.vhdl__nodes__set_default_configuration_declaration
-)
+@export
+def Get_Time(obj):
+    return libghdl.vhdl__nodes__get_time(obj)
 
-Get_Expression = libghdl.vhdl__nodes__get_expression
-Set_Expression = libghdl.vhdl__nodes__set_expression
 
-Get_Conditional_Expression_Chain = libghdl.vhdl__nodes__get_conditional_expression_chain
-Set_Conditional_Expression_Chain = libghdl.vhdl__nodes__set_conditional_expression_chain
+@export
+def Set_Time(obj, value) -> None:
+    libghdl.vhdl__nodes__set_time(obj, value)
 
-Get_Allocator_Designated_Type = libghdl.vhdl__nodes__get_allocator_designated_type
-Set_Allocator_Designated_Type = libghdl.vhdl__nodes__set_allocator_designated_type
 
-Get_Selected_Waveform_Chain = libghdl.vhdl__nodes__get_selected_waveform_chain
-Set_Selected_Waveform_Chain = libghdl.vhdl__nodes__set_selected_waveform_chain
+@export
+def Get_Associated_Expr(obj):
+    return libghdl.vhdl__nodes__get_associated_expr(obj)
 
-Get_Conditional_Waveform_Chain = libghdl.vhdl__nodes__get_conditional_waveform_chain
-Set_Conditional_Waveform_Chain = libghdl.vhdl__nodes__set_conditional_waveform_chain
 
-Get_Guard_Expression = libghdl.vhdl__nodes__get_guard_expression
-Set_Guard_Expression = libghdl.vhdl__nodes__set_guard_expression
+@export
+def Set_Associated_Expr(obj, value) -> None:
+    libghdl.vhdl__nodes__set_associated_expr(obj, value)
 
-Get_Guard_Decl = libghdl.vhdl__nodes__get_guard_decl
-Set_Guard_Decl = libghdl.vhdl__nodes__set_guard_decl
 
-Get_Guard_Sensitivity_List = libghdl.vhdl__nodes__get_guard_sensitivity_list
-Set_Guard_Sensitivity_List = libghdl.vhdl__nodes__set_guard_sensitivity_list
+@export
+def Get_Associated_Block(obj):
+    return libghdl.vhdl__nodes__get_associated_block(obj)
 
-Get_Signal_Attribute_Chain = libghdl.vhdl__nodes__get_signal_attribute_chain
-Set_Signal_Attribute_Chain = libghdl.vhdl__nodes__set_signal_attribute_chain
 
-Get_Block_Block_Configuration = libghdl.vhdl__nodes__get_block_block_configuration
-Set_Block_Block_Configuration = libghdl.vhdl__nodes__set_block_block_configuration
+@export
+def Set_Associated_Block(obj, value) -> None:
+    libghdl.vhdl__nodes__set_associated_block(obj, value)
 
-Get_Package_Header = libghdl.vhdl__nodes__get_package_header
-Set_Package_Header = libghdl.vhdl__nodes__set_package_header
 
-Get_Block_Header = libghdl.vhdl__nodes__get_block_header
-Set_Block_Header = libghdl.vhdl__nodes__set_block_header
+@export
+def Get_Associated_Chain(obj):
+    return libghdl.vhdl__nodes__get_associated_chain(obj)
 
-Get_Uninstantiated_Package_Name = libghdl.vhdl__nodes__get_uninstantiated_package_name
-Set_Uninstantiated_Package_Name = libghdl.vhdl__nodes__set_uninstantiated_package_name
 
-Get_Uninstantiated_Package_Decl = libghdl.vhdl__nodes__get_uninstantiated_package_decl
-Set_Uninstantiated_Package_Decl = libghdl.vhdl__nodes__set_uninstantiated_package_decl
+@export
+def Set_Associated_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_associated_chain(obj, value)
 
-Get_Instance_Source_File = libghdl.vhdl__nodes__get_instance_source_file
-Set_Instance_Source_File = libghdl.vhdl__nodes__set_instance_source_file
 
-Get_Generate_Block_Configuration = libghdl.vhdl__nodes__get_generate_block_configuration
-Set_Generate_Block_Configuration = libghdl.vhdl__nodes__set_generate_block_configuration
+@export
+def Get_Choice_Name(obj):
+    return libghdl.vhdl__nodes__get_choice_name(obj)
 
-Get_Generate_Statement_Body = libghdl.vhdl__nodes__get_generate_statement_body
-Set_Generate_Statement_Body = libghdl.vhdl__nodes__set_generate_statement_body
 
-Get_Alternative_Label = libghdl.vhdl__nodes__get_alternative_label
-Set_Alternative_Label = libghdl.vhdl__nodes__set_alternative_label
+@export
+def Set_Choice_Name(obj, value) -> None:
+    libghdl.vhdl__nodes__set_choice_name(obj, value)
 
-Get_Generate_Else_Clause = libghdl.vhdl__nodes__get_generate_else_clause
-Set_Generate_Else_Clause = libghdl.vhdl__nodes__set_generate_else_clause
 
-Get_Condition = libghdl.vhdl__nodes__get_condition
-Set_Condition = libghdl.vhdl__nodes__set_condition
+@export
+def Get_Choice_Expression(obj):
+    return libghdl.vhdl__nodes__get_choice_expression(obj)
 
-Get_Else_Clause = libghdl.vhdl__nodes__get_else_clause
-Set_Else_Clause = libghdl.vhdl__nodes__set_else_clause
 
-Get_Parameter_Specification = libghdl.vhdl__nodes__get_parameter_specification
-Set_Parameter_Specification = libghdl.vhdl__nodes__set_parameter_specification
+@export
+def Set_Choice_Expression(obj, value) -> None:
+    libghdl.vhdl__nodes__set_choice_expression(obj, value)
 
-Get_Parent = libghdl.vhdl__nodes__get_parent
-Set_Parent = libghdl.vhdl__nodes__set_parent
 
-Get_Loop_Label = libghdl.vhdl__nodes__get_loop_label
-Set_Loop_Label = libghdl.vhdl__nodes__set_loop_label
+@export
+def Get_Choice_Range(obj):
+    return libghdl.vhdl__nodes__get_choice_range(obj)
 
-Get_Exit_Flag = libghdl.vhdl__nodes__get_exit_flag
-Set_Exit_Flag = libghdl.vhdl__nodes__set_exit_flag
 
-Get_Next_Flag = libghdl.vhdl__nodes__get_next_flag
-Set_Next_Flag = libghdl.vhdl__nodes__set_next_flag
+@export
+def Set_Choice_Range(obj, value) -> None:
+    libghdl.vhdl__nodes__set_choice_range(obj, value)
 
-Get_Component_Name = libghdl.vhdl__nodes__get_component_name
-Set_Component_Name = libghdl.vhdl__nodes__set_component_name
 
-Get_Instantiation_List = libghdl.vhdl__nodes__get_instantiation_list
-Set_Instantiation_List = libghdl.vhdl__nodes__set_instantiation_list
+@export
+def Get_Same_Alternative_Flag(obj):
+    return libghdl.vhdl__nodes__get_same_alternative_flag(obj)
 
-Get_Entity_Aspect = libghdl.vhdl__nodes__get_entity_aspect
-Set_Entity_Aspect = libghdl.vhdl__nodes__set_entity_aspect
 
-Get_Default_Entity_Aspect = libghdl.vhdl__nodes__get_default_entity_aspect
-Set_Default_Entity_Aspect = libghdl.vhdl__nodes__set_default_entity_aspect
+@export
+def Set_Same_Alternative_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_same_alternative_flag(obj, value)
 
-Get_Binding_Indication = libghdl.vhdl__nodes__get_binding_indication
-Set_Binding_Indication = libghdl.vhdl__nodes__set_binding_indication
 
-Get_Named_Entity = libghdl.vhdl__nodes__get_named_entity
-Set_Named_Entity = libghdl.vhdl__nodes__set_named_entity
+@export
+def Get_Element_Type_Flag(obj):
+    return libghdl.vhdl__nodes__get_element_type_flag(obj)
 
-Get_Referenced_Name = libghdl.vhdl__nodes__get_referenced_name
-Set_Referenced_Name = libghdl.vhdl__nodes__set_referenced_name
 
-Get_Expr_Staticness = libghdl.vhdl__nodes__get_expr_staticness
-Set_Expr_Staticness = libghdl.vhdl__nodes__set_expr_staticness
+@export
+def Set_Element_Type_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_element_type_flag(obj, value)
 
-Get_Scalar_Size = libghdl.vhdl__nodes__get_scalar_size
-Set_Scalar_Size = libghdl.vhdl__nodes__set_scalar_size
 
-Get_Error_Origin = libghdl.vhdl__nodes__get_error_origin
-Set_Error_Origin = libghdl.vhdl__nodes__set_error_origin
+@export
+def Get_Architecture(obj):
+    return libghdl.vhdl__nodes__get_architecture(obj)
 
-Get_Operand = libghdl.vhdl__nodes__get_operand
-Set_Operand = libghdl.vhdl__nodes__set_operand
 
-Get_Left = libghdl.vhdl__nodes__get_left
-Set_Left = libghdl.vhdl__nodes__set_left
+@export
+def Set_Architecture(obj, value) -> None:
+    libghdl.vhdl__nodes__set_architecture(obj, value)
 
-Get_Right = libghdl.vhdl__nodes__get_right
-Set_Right = libghdl.vhdl__nodes__set_right
 
-Get_Unit_Name = libghdl.vhdl__nodes__get_unit_name
-Set_Unit_Name = libghdl.vhdl__nodes__set_unit_name
+@export
+def Get_Block_Specification(obj):
+    return libghdl.vhdl__nodes__get_block_specification(obj)
 
-Get_Name = libghdl.vhdl__nodes__get_name
-Set_Name = libghdl.vhdl__nodes__set_name
 
-Get_Group_Template_Name = libghdl.vhdl__nodes__get_group_template_name
-Set_Group_Template_Name = libghdl.vhdl__nodes__set_group_template_name
+@export
+def Set_Block_Specification(obj, value) -> None:
+    libghdl.vhdl__nodes__set_block_specification(obj, value)
 
-Get_Name_Staticness = libghdl.vhdl__nodes__get_name_staticness
-Set_Name_Staticness = libghdl.vhdl__nodes__set_name_staticness
 
-Get_Prefix = libghdl.vhdl__nodes__get_prefix
-Set_Prefix = libghdl.vhdl__nodes__set_prefix
+@export
+def Get_Prev_Block_Configuration(obj):
+    return libghdl.vhdl__nodes__get_prev_block_configuration(obj)
 
-Get_Signature_Prefix = libghdl.vhdl__nodes__get_signature_prefix
-Set_Signature_Prefix = libghdl.vhdl__nodes__set_signature_prefix
 
-Get_External_Pathname = libghdl.vhdl__nodes__get_external_pathname
-Set_External_Pathname = libghdl.vhdl__nodes__set_external_pathname
+@export
+def Set_Prev_Block_Configuration(obj, value) -> None:
+    libghdl.vhdl__nodes__set_prev_block_configuration(obj, value)
 
-Get_Pathname_Suffix = libghdl.vhdl__nodes__get_pathname_suffix
-Set_Pathname_Suffix = libghdl.vhdl__nodes__set_pathname_suffix
 
-Get_Pathname_Expression = libghdl.vhdl__nodes__get_pathname_expression
-Set_Pathname_Expression = libghdl.vhdl__nodes__set_pathname_expression
+@export
+def Get_Configuration_Item_Chain(obj):
+    return libghdl.vhdl__nodes__get_configuration_item_chain(obj)
 
-Get_In_Formal_Flag = libghdl.vhdl__nodes__get_in_formal_flag
-Set_In_Formal_Flag = libghdl.vhdl__nodes__set_in_formal_flag
 
-Get_Slice_Subtype = libghdl.vhdl__nodes__get_slice_subtype
-Set_Slice_Subtype = libghdl.vhdl__nodes__set_slice_subtype
+@export
+def Set_Configuration_Item_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_configuration_item_chain(obj, value)
 
-Get_Suffix = libghdl.vhdl__nodes__get_suffix
-Set_Suffix = libghdl.vhdl__nodes__set_suffix
 
-Get_Index_Subtype = libghdl.vhdl__nodes__get_index_subtype
-Set_Index_Subtype = libghdl.vhdl__nodes__set_index_subtype
+@export
+def Get_Attribute_Value_Chain(obj):
+    return libghdl.vhdl__nodes__get_attribute_value_chain(obj)
 
-Get_Parameter = libghdl.vhdl__nodes__get_parameter
-Set_Parameter = libghdl.vhdl__nodes__set_parameter
 
-Get_Parameter_2 = libghdl.vhdl__nodes__get_parameter_2
-Set_Parameter_2 = libghdl.vhdl__nodes__set_parameter_2
+@export
+def Set_Attribute_Value_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_attribute_value_chain(obj, value)
 
-Get_Parameter_3 = libghdl.vhdl__nodes__get_parameter_3
-Set_Parameter_3 = libghdl.vhdl__nodes__set_parameter_3
 
-Get_Parameter_4 = libghdl.vhdl__nodes__get_parameter_4
-Set_Parameter_4 = libghdl.vhdl__nodes__set_parameter_4
+@export
+def Get_Spec_Chain(obj):
+    return libghdl.vhdl__nodes__get_spec_chain(obj)
 
-Get_Attr_Chain = libghdl.vhdl__nodes__get_attr_chain
-Set_Attr_Chain = libghdl.vhdl__nodes__set_attr_chain
 
-Get_Signal_Attribute_Declaration = libghdl.vhdl__nodes__get_signal_attribute_declaration
-Set_Signal_Attribute_Declaration = libghdl.vhdl__nodes__set_signal_attribute_declaration
+@export
+def Set_Spec_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_spec_chain(obj, value)
 
-Get_Actual_Type = libghdl.vhdl__nodes__get_actual_type
-Set_Actual_Type = libghdl.vhdl__nodes__set_actual_type
 
-Get_Actual_Type_Definition = libghdl.vhdl__nodes__get_actual_type_definition
-Set_Actual_Type_Definition = libghdl.vhdl__nodes__set_actual_type_definition
+@export
+def Get_Value_Chain(obj):
+    return libghdl.vhdl__nodes__get_value_chain(obj)
 
-Get_Association_Chain = libghdl.vhdl__nodes__get_association_chain
-Set_Association_Chain = libghdl.vhdl__nodes__set_association_chain
 
-Get_Individual_Association_Chain = libghdl.vhdl__nodes__get_individual_association_chain
-Set_Individual_Association_Chain = libghdl.vhdl__nodes__set_individual_association_chain
+@export
+def Set_Value_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_value_chain(obj, value)
 
-Get_Subprogram_Association_Chain = libghdl.vhdl__nodes__get_subprogram_association_chain
-Set_Subprogram_Association_Chain = libghdl.vhdl__nodes__set_subprogram_association_chain
 
-Get_Aggregate_Info = libghdl.vhdl__nodes__get_aggregate_info
-Set_Aggregate_Info = libghdl.vhdl__nodes__set_aggregate_info
+@export
+def Get_Attribute_Value_Spec_Chain(obj):
+    return libghdl.vhdl__nodes__get_attribute_value_spec_chain(obj)
 
-Get_Sub_Aggregate_Info = libghdl.vhdl__nodes__get_sub_aggregate_info
-Set_Sub_Aggregate_Info = libghdl.vhdl__nodes__set_sub_aggregate_info
 
-Get_Aggr_Dynamic_Flag = libghdl.vhdl__nodes__get_aggr_dynamic_flag
-Set_Aggr_Dynamic_Flag = libghdl.vhdl__nodes__set_aggr_dynamic_flag
+@export
+def Set_Attribute_Value_Spec_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_attribute_value_spec_chain(obj, value)
 
-Get_Aggr_Min_Length = libghdl.vhdl__nodes__get_aggr_min_length
-Set_Aggr_Min_Length = libghdl.vhdl__nodes__set_aggr_min_length
 
-Get_Aggr_Low_Limit = libghdl.vhdl__nodes__get_aggr_low_limit
-Set_Aggr_Low_Limit = libghdl.vhdl__nodes__set_aggr_low_limit
+@export
+def Get_Entity_Name(obj):
+    return libghdl.vhdl__nodes__get_entity_name(obj)
 
-Get_Aggr_High_Limit = libghdl.vhdl__nodes__get_aggr_high_limit
-Set_Aggr_High_Limit = libghdl.vhdl__nodes__set_aggr_high_limit
 
-Get_Aggr_Others_Flag = libghdl.vhdl__nodes__get_aggr_others_flag
-Set_Aggr_Others_Flag = libghdl.vhdl__nodes__set_aggr_others_flag
+@export
+def Set_Entity_Name(obj, value) -> None:
+    libghdl.vhdl__nodes__set_entity_name(obj, value)
 
-Get_Aggr_Named_Flag = libghdl.vhdl__nodes__get_aggr_named_flag
-Set_Aggr_Named_Flag = libghdl.vhdl__nodes__set_aggr_named_flag
 
-Get_Aggregate_Expand_Flag = libghdl.vhdl__nodes__get_aggregate_expand_flag
-Set_Aggregate_Expand_Flag = libghdl.vhdl__nodes__set_aggregate_expand_flag
+@export
+def Get_Package(obj):
+    return libghdl.vhdl__nodes__get_package(obj)
 
-Get_Association_Choices_Chain = libghdl.vhdl__nodes__get_association_choices_chain
-Set_Association_Choices_Chain = libghdl.vhdl__nodes__set_association_choices_chain
 
-Get_Case_Statement_Alternative_Chain = (
-    libghdl.vhdl__nodes__get_case_statement_alternative_chain
-)
-Set_Case_Statement_Alternative_Chain = (
-    libghdl.vhdl__nodes__set_case_statement_alternative_chain
-)
+@export
+def Set_Package(obj, value) -> None:
+    libghdl.vhdl__nodes__set_package(obj, value)
 
-Get_Choice_Staticness = libghdl.vhdl__nodes__get_choice_staticness
-Set_Choice_Staticness = libghdl.vhdl__nodes__set_choice_staticness
 
-Get_Procedure_Call = libghdl.vhdl__nodes__get_procedure_call
-Set_Procedure_Call = libghdl.vhdl__nodes__set_procedure_call
+@export
+def Get_Package_Body(obj):
+    return libghdl.vhdl__nodes__get_package_body(obj)
 
-Get_Implementation = libghdl.vhdl__nodes__get_implementation
-Set_Implementation = libghdl.vhdl__nodes__set_implementation
 
-Get_Parameter_Association_Chain = libghdl.vhdl__nodes__get_parameter_association_chain
-Set_Parameter_Association_Chain = libghdl.vhdl__nodes__set_parameter_association_chain
+@export
+def Set_Package_Body(obj, value) -> None:
+    libghdl.vhdl__nodes__set_package_body(obj, value)
 
-Get_Method_Object = libghdl.vhdl__nodes__get_method_object
-Set_Method_Object = libghdl.vhdl__nodes__set_method_object
 
-Get_Subtype_Type_Mark = libghdl.vhdl__nodes__get_subtype_type_mark
-Set_Subtype_Type_Mark = libghdl.vhdl__nodes__set_subtype_type_mark
+@export
+def Get_Instance_Package_Body(obj):
+    return libghdl.vhdl__nodes__get_instance_package_body(obj)
 
-Get_Subnature_Nature_Mark = libghdl.vhdl__nodes__get_subnature_nature_mark
-Set_Subnature_Nature_Mark = libghdl.vhdl__nodes__set_subnature_nature_mark
 
-Get_Type_Conversion_Subtype = libghdl.vhdl__nodes__get_type_conversion_subtype
-Set_Type_Conversion_Subtype = libghdl.vhdl__nodes__set_type_conversion_subtype
+@export
+def Set_Instance_Package_Body(obj, value) -> None:
+    libghdl.vhdl__nodes__set_instance_package_body(obj, value)
 
-Get_Type_Mark = libghdl.vhdl__nodes__get_type_mark
-Set_Type_Mark = libghdl.vhdl__nodes__set_type_mark
 
-Get_File_Type_Mark = libghdl.vhdl__nodes__get_file_type_mark
-Set_File_Type_Mark = libghdl.vhdl__nodes__set_file_type_mark
+@export
+def Get_Need_Body(obj):
+    return libghdl.vhdl__nodes__get_need_body(obj)
 
-Get_Return_Type_Mark = libghdl.vhdl__nodes__get_return_type_mark
-Set_Return_Type_Mark = libghdl.vhdl__nodes__set_return_type_mark
 
-Get_Has_Disconnect_Flag = libghdl.vhdl__nodes__get_has_disconnect_flag
-Set_Has_Disconnect_Flag = libghdl.vhdl__nodes__set_has_disconnect_flag
+@export
+def Set_Need_Body(obj, value) -> None:
+    libghdl.vhdl__nodes__set_need_body(obj, value)
 
-Get_Has_Active_Flag = libghdl.vhdl__nodes__get_has_active_flag
-Set_Has_Active_Flag = libghdl.vhdl__nodes__set_has_active_flag
 
-Get_Is_Within_Flag = libghdl.vhdl__nodes__get_is_within_flag
-Set_Is_Within_Flag = libghdl.vhdl__nodes__set_is_within_flag
+@export
+def Get_Macro_Expanded_Flag(obj):
+    return libghdl.vhdl__nodes__get_macro_expanded_flag(obj)
 
-Get_Type_Marks_List = libghdl.vhdl__nodes__get_type_marks_list
-Set_Type_Marks_List = libghdl.vhdl__nodes__set_type_marks_list
 
-Get_Implicit_Alias_Flag = libghdl.vhdl__nodes__get_implicit_alias_flag
-Set_Implicit_Alias_Flag = libghdl.vhdl__nodes__set_implicit_alias_flag
+@export
+def Set_Macro_Expanded_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_macro_expanded_flag(obj, value)
 
-Get_Alias_Signature = libghdl.vhdl__nodes__get_alias_signature
-Set_Alias_Signature = libghdl.vhdl__nodes__set_alias_signature
 
-Get_Attribute_Signature = libghdl.vhdl__nodes__get_attribute_signature
-Set_Attribute_Signature = libghdl.vhdl__nodes__set_attribute_signature
+@export
+def Get_Need_Instance_Bodies(obj):
+    return libghdl.vhdl__nodes__get_need_instance_bodies(obj)
 
-Get_Overload_List = libghdl.vhdl__nodes__get_overload_list
-Set_Overload_List = libghdl.vhdl__nodes__set_overload_list
 
-Get_Simple_Name_Identifier = libghdl.vhdl__nodes__get_simple_name_identifier
-Set_Simple_Name_Identifier = libghdl.vhdl__nodes__set_simple_name_identifier
+@export
+def Set_Need_Instance_Bodies(obj, value) -> None:
+    libghdl.vhdl__nodes__set_need_instance_bodies(obj, value)
 
-Get_Simple_Name_Subtype = libghdl.vhdl__nodes__get_simple_name_subtype
-Set_Simple_Name_Subtype = libghdl.vhdl__nodes__set_simple_name_subtype
 
-Get_Protected_Type_Body = libghdl.vhdl__nodes__get_protected_type_body
-Set_Protected_Type_Body = libghdl.vhdl__nodes__set_protected_type_body
+@export
+def Get_Hierarchical_Name(obj):
+    return libghdl.vhdl__nodes__get_hierarchical_name(obj)
 
-Get_Protected_Type_Declaration = libghdl.vhdl__nodes__get_protected_type_declaration
-Set_Protected_Type_Declaration = libghdl.vhdl__nodes__set_protected_type_declaration
 
-Get_Use_Flag = libghdl.vhdl__nodes__get_use_flag
-Set_Use_Flag = libghdl.vhdl__nodes__set_use_flag
+@export
+def Set_Hierarchical_Name(obj, value) -> None:
+    libghdl.vhdl__nodes__set_hierarchical_name(obj, value)
 
-Get_End_Has_Reserved_Id = libghdl.vhdl__nodes__get_end_has_reserved_id
-Set_End_Has_Reserved_Id = libghdl.vhdl__nodes__set_end_has_reserved_id
 
-Get_End_Has_Identifier = libghdl.vhdl__nodes__get_end_has_identifier
-Set_End_Has_Identifier = libghdl.vhdl__nodes__set_end_has_identifier
+@export
+def Get_Inherit_Spec_Chain(obj):
+    return libghdl.vhdl__nodes__get_inherit_spec_chain(obj)
 
-Get_End_Has_Postponed = libghdl.vhdl__nodes__get_end_has_postponed
-Set_End_Has_Postponed = libghdl.vhdl__nodes__set_end_has_postponed
 
-Get_Has_Label = libghdl.vhdl__nodes__get_has_label
-Set_Has_Label = libghdl.vhdl__nodes__set_has_label
+@export
+def Set_Inherit_Spec_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_inherit_spec_chain(obj, value)
 
-Get_Has_Begin = libghdl.vhdl__nodes__get_has_begin
-Set_Has_Begin = libghdl.vhdl__nodes__set_has_begin
 
-Get_Has_End = libghdl.vhdl__nodes__get_has_end
-Set_Has_End = libghdl.vhdl__nodes__set_has_end
+@export
+def Get_Vunit_Item_Chain(obj):
+    return libghdl.vhdl__nodes__get_vunit_item_chain(obj)
 
-Get_Has_Is = libghdl.vhdl__nodes__get_has_is
-Set_Has_Is = libghdl.vhdl__nodes__set_has_is
 
-Get_Has_Pure = libghdl.vhdl__nodes__get_has_pure
-Set_Has_Pure = libghdl.vhdl__nodes__set_has_pure
+@export
+def Set_Vunit_Item_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_vunit_item_chain(obj, value)
 
-Get_Has_Body = libghdl.vhdl__nodes__get_has_body
-Set_Has_Body = libghdl.vhdl__nodes__set_has_body
 
-Get_Has_Parameter = libghdl.vhdl__nodes__get_has_parameter
-Set_Has_Parameter = libghdl.vhdl__nodes__set_has_parameter
+@export
+def Get_Bound_Vunit_Chain(obj):
+    return libghdl.vhdl__nodes__get_bound_vunit_chain(obj)
 
-Get_Has_Component = libghdl.vhdl__nodes__get_has_component
-Set_Has_Component = libghdl.vhdl__nodes__set_has_component
 
-Get_Has_Identifier_List = libghdl.vhdl__nodes__get_has_identifier_list
-Set_Has_Identifier_List = libghdl.vhdl__nodes__set_has_identifier_list
+@export
+def Set_Bound_Vunit_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_bound_vunit_chain(obj, value)
 
-Get_Has_Mode = libghdl.vhdl__nodes__get_has_mode
-Set_Has_Mode = libghdl.vhdl__nodes__set_has_mode
 
-Get_Has_Class = libghdl.vhdl__nodes__get_has_class
-Set_Has_Class = libghdl.vhdl__nodes__set_has_class
+@export
+def Get_Verification_Block_Configuration(obj):
+    return libghdl.vhdl__nodes__get_verification_block_configuration(obj)
 
-Get_Has_Delay_Mechanism = libghdl.vhdl__nodes__get_has_delay_mechanism
-Set_Has_Delay_Mechanism = libghdl.vhdl__nodes__set_has_delay_mechanism
 
-Get_Suspend_Flag = libghdl.vhdl__nodes__get_suspend_flag
-Set_Suspend_Flag = libghdl.vhdl__nodes__set_suspend_flag
+@export
+def Set_Verification_Block_Configuration(obj, value) -> None:
+    libghdl.vhdl__nodes__set_verification_block_configuration(obj, value)
 
-Get_Is_Ref = libghdl.vhdl__nodes__get_is_ref
-Set_Is_Ref = libghdl.vhdl__nodes__set_is_ref
 
-Get_Is_Forward_Ref = libghdl.vhdl__nodes__get_is_forward_ref
-Set_Is_Forward_Ref = libghdl.vhdl__nodes__set_is_forward_ref
+@export
+def Get_Block_Configuration(obj):
+    return libghdl.vhdl__nodes__get_block_configuration(obj)
 
-Get_Psl_Property = libghdl.vhdl__nodes__get_psl_property
-Set_Psl_Property = libghdl.vhdl__nodes__set_psl_property
 
-Get_Psl_Sequence = libghdl.vhdl__nodes__get_psl_sequence
-Set_Psl_Sequence = libghdl.vhdl__nodes__set_psl_sequence
+@export
+def Set_Block_Configuration(obj, value) -> None:
+    libghdl.vhdl__nodes__set_block_configuration(obj, value)
 
-Get_Psl_Declaration = libghdl.vhdl__nodes__get_psl_declaration
-Set_Psl_Declaration = libghdl.vhdl__nodes__set_psl_declaration
 
-Get_Psl_Expression = libghdl.vhdl__nodes__get_psl_expression
-Set_Psl_Expression = libghdl.vhdl__nodes__set_psl_expression
+@export
+def Get_Concurrent_Statement_Chain(obj):
+    return libghdl.vhdl__nodes__get_concurrent_statement_chain(obj)
 
-Get_Psl_Boolean = libghdl.vhdl__nodes__get_psl_boolean
-Set_Psl_Boolean = libghdl.vhdl__nodes__set_psl_boolean
 
-Get_PSL_Clock = libghdl.vhdl__nodes__get_psl_clock
-Set_PSL_Clock = libghdl.vhdl__nodes__set_psl_clock
+@export
+def Set_Concurrent_Statement_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_concurrent_statement_chain(obj, value)
 
-Get_PSL_NFA = libghdl.vhdl__nodes__get_psl_nfa
-Set_PSL_NFA = libghdl.vhdl__nodes__set_psl_nfa
 
-Get_PSL_Nbr_States = libghdl.vhdl__nodes__get_psl_nbr_states
-Set_PSL_Nbr_States = libghdl.vhdl__nodes__set_psl_nbr_states
+@export
+def Get_Chain(obj):
+    return libghdl.vhdl__nodes__get_chain(obj)
 
-Get_PSL_Clock_Sensitivity = libghdl.vhdl__nodes__get_psl_clock_sensitivity
-Set_PSL_Clock_Sensitivity = libghdl.vhdl__nodes__set_psl_clock_sensitivity
 
-Get_PSL_EOS_Flag = libghdl.vhdl__nodes__get_psl_eos_flag
-Set_PSL_EOS_Flag = libghdl.vhdl__nodes__set_psl_eos_flag
+@export
+def Set_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_chain(obj, value)
 
-Get_Count_Expression = libghdl.vhdl__nodes__get_count_expression
-Set_Count_Expression = libghdl.vhdl__nodes__set_count_expression
 
-Get_Clock_Expression = libghdl.vhdl__nodes__get_clock_expression
-Set_Clock_Expression = libghdl.vhdl__nodes__set_clock_expression
+@export
+def Get_Port_Chain(obj):
+    return libghdl.vhdl__nodes__get_port_chain(obj)
 
-Get_Default_Clock = libghdl.vhdl__nodes__get_default_clock
-Set_Default_Clock = libghdl.vhdl__nodes__set_default_clock
 
-Get_Foreign_Node = libghdl.vhdl__nodes__get_foreign_node
-Set_Foreign_Node = libghdl.vhdl__nodes__set_foreign_node
+@export
+def Set_Port_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_port_chain(obj, value)
+
+
+@export
+def Get_Generic_Chain(obj):
+    return libghdl.vhdl__nodes__get_generic_chain(obj)
+
+
+@export
+def Set_Generic_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_generic_chain(obj, value)
+
+
+@export
+def Get_Type(obj):
+    return libghdl.vhdl__nodes__get_type(obj)
+
+
+@export
+def Set_Type(obj, value) -> None:
+    libghdl.vhdl__nodes__set_type(obj, value)
+
+
+@export
+def Get_Subtype_Indication(obj):
+    return libghdl.vhdl__nodes__get_subtype_indication(obj)
+
+
+@export
+def Set_Subtype_Indication(obj, value) -> None:
+    libghdl.vhdl__nodes__set_subtype_indication(obj, value)
+
+
+@export
+def Get_Discrete_Range(obj):
+    return libghdl.vhdl__nodes__get_discrete_range(obj)
+
+
+@export
+def Set_Discrete_Range(obj, value) -> None:
+    libghdl.vhdl__nodes__set_discrete_range(obj, value)
+
+
+@export
+def Get_Type_Definition(obj):
+    return libghdl.vhdl__nodes__get_type_definition(obj)
+
+
+@export
+def Set_Type_Definition(obj, value) -> None:
+    libghdl.vhdl__nodes__set_type_definition(obj, value)
+
+
+@export
+def Get_Subtype_Definition(obj):
+    return libghdl.vhdl__nodes__get_subtype_definition(obj)
+
+
+@export
+def Set_Subtype_Definition(obj, value) -> None:
+    libghdl.vhdl__nodes__set_subtype_definition(obj, value)
+
+
+@export
+def Get_Incomplete_Type_Declaration(obj):
+    return libghdl.vhdl__nodes__get_incomplete_type_declaration(obj)
+
+
+@export
+def Set_Incomplete_Type_Declaration(obj, value) -> None:
+    libghdl.vhdl__nodes__set_incomplete_type_declaration(obj, value)
+
+
+@export
+def Get_Interface_Type_Subprograms(obj):
+    return libghdl.vhdl__nodes__get_interface_type_subprograms(obj)
+
+
+@export
+def Set_Interface_Type_Subprograms(obj, value) -> None:
+    libghdl.vhdl__nodes__set_interface_type_subprograms(obj, value)
+
+
+@export
+def Get_Nature_Definition(obj):
+    return libghdl.vhdl__nodes__get_nature_definition(obj)
+
+
+@export
+def Set_Nature_Definition(obj, value) -> None:
+    libghdl.vhdl__nodes__set_nature_definition(obj, value)
+
+
+@export
+def Get_Nature(obj):
+    return libghdl.vhdl__nodes__get_nature(obj)
+
+
+@export
+def Set_Nature(obj, value) -> None:
+    libghdl.vhdl__nodes__set_nature(obj, value)
+
+
+@export
+def Get_Subnature_Indication(obj):
+    return libghdl.vhdl__nodes__get_subnature_indication(obj)
+
+
+@export
+def Set_Subnature_Indication(obj, value) -> None:
+    libghdl.vhdl__nodes__set_subnature_indication(obj, value)
+
+
+@export
+def Get_Mode(obj):
+    return libghdl.vhdl__nodes__get_mode(obj)
+
+
+@export
+def Set_Mode(obj, value) -> None:
+    libghdl.vhdl__nodes__set_mode(obj, value)
+
+
+@export
+def Get_Guarded_Signal_Flag(obj):
+    return libghdl.vhdl__nodes__get_guarded_signal_flag(obj)
+
+
+@export
+def Set_Guarded_Signal_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_guarded_signal_flag(obj, value)
+
+
+@export
+def Get_Signal_Kind(obj):
+    return libghdl.vhdl__nodes__get_signal_kind(obj)
+
+
+@export
+def Set_Signal_Kind(obj, value) -> None:
+    libghdl.vhdl__nodes__set_signal_kind(obj, value)
+
+
+@export
+def Get_Base_Name(obj):
+    return libghdl.vhdl__nodes__get_base_name(obj)
+
+
+@export
+def Set_Base_Name(obj, value) -> None:
+    libghdl.vhdl__nodes__set_base_name(obj, value)
+
+
+@export
+def Get_Interface_Declaration_Chain(obj):
+    return libghdl.vhdl__nodes__get_interface_declaration_chain(obj)
+
+
+@export
+def Set_Interface_Declaration_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_interface_declaration_chain(obj, value)
+
+
+@export
+def Get_Subprogram_Specification(obj):
+    return libghdl.vhdl__nodes__get_subprogram_specification(obj)
+
+
+@export
+def Set_Subprogram_Specification(obj, value) -> None:
+    libghdl.vhdl__nodes__set_subprogram_specification(obj, value)
+
+
+@export
+def Get_Sequential_Statement_Chain(obj):
+    return libghdl.vhdl__nodes__get_sequential_statement_chain(obj)
+
+
+@export
+def Set_Sequential_Statement_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_sequential_statement_chain(obj, value)
+
+
+@export
+def Get_Simultaneous_Statement_Chain(obj):
+    return libghdl.vhdl__nodes__get_simultaneous_statement_chain(obj)
+
+
+@export
+def Set_Simultaneous_Statement_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_simultaneous_statement_chain(obj, value)
+
+
+@export
+def Get_Subprogram_Body(obj):
+    return libghdl.vhdl__nodes__get_subprogram_body(obj)
+
+
+@export
+def Set_Subprogram_Body(obj, value) -> None:
+    libghdl.vhdl__nodes__set_subprogram_body(obj, value)
+
+
+@export
+def Get_Overload_Number(obj):
+    return libghdl.vhdl__nodes__get_overload_number(obj)
+
+
+@export
+def Set_Overload_Number(obj, value) -> None:
+    libghdl.vhdl__nodes__set_overload_number(obj, value)
+
+
+@export
+def Get_Subprogram_Depth(obj):
+    return libghdl.vhdl__nodes__get_subprogram_depth(obj)
+
+
+@export
+def Set_Subprogram_Depth(obj, value) -> None:
+    libghdl.vhdl__nodes__set_subprogram_depth(obj, value)
+
+
+@export
+def Get_Subprogram_Hash(obj):
+    return libghdl.vhdl__nodes__get_subprogram_hash(obj)
+
+
+@export
+def Set_Subprogram_Hash(obj, value) -> None:
+    libghdl.vhdl__nodes__set_subprogram_hash(obj, value)
+
+
+@export
+def Get_Impure_Depth(obj):
+    return libghdl.vhdl__nodes__get_impure_depth(obj)
+
+
+@export
+def Set_Impure_Depth(obj, value) -> None:
+    libghdl.vhdl__nodes__set_impure_depth(obj, value)
+
+
+@export
+def Get_Return_Type(obj):
+    return libghdl.vhdl__nodes__get_return_type(obj)
+
+
+@export
+def Set_Return_Type(obj, value) -> None:
+    libghdl.vhdl__nodes__set_return_type(obj, value)
+
+
+@export
+def Get_Implicit_Definition(obj):
+    return libghdl.vhdl__nodes__get_implicit_definition(obj)
+
+
+@export
+def Set_Implicit_Definition(obj, value) -> None:
+    libghdl.vhdl__nodes__set_implicit_definition(obj, value)
+
+
+@export
+def Get_Uninstantiated_Subprogram_Name(obj):
+    return libghdl.vhdl__nodes__get_uninstantiated_subprogram_name(obj)
+
+
+@export
+def Set_Uninstantiated_Subprogram_Name(obj, value) -> None:
+    libghdl.vhdl__nodes__set_uninstantiated_subprogram_name(obj, value)
+
+
+@export
+def Get_Default_Value(obj):
+    return libghdl.vhdl__nodes__get_default_value(obj)
+
+
+@export
+def Set_Default_Value(obj, value) -> None:
+    libghdl.vhdl__nodes__set_default_value(obj, value)
+
+
+@export
+def Get_Deferred_Declaration(obj):
+    return libghdl.vhdl__nodes__get_deferred_declaration(obj)
+
+
+@export
+def Set_Deferred_Declaration(obj, value) -> None:
+    libghdl.vhdl__nodes__set_deferred_declaration(obj, value)
+
+
+@export
+def Get_Deferred_Declaration_Flag(obj):
+    return libghdl.vhdl__nodes__get_deferred_declaration_flag(obj)
+
+
+@export
+def Set_Deferred_Declaration_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_deferred_declaration_flag(obj, value)
+
+
+@export
+def Get_Shared_Flag(obj):
+    return libghdl.vhdl__nodes__get_shared_flag(obj)
+
+
+@export
+def Set_Shared_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_shared_flag(obj, value)
+
+
+@export
+def Get_Design_Unit(obj):
+    return libghdl.vhdl__nodes__get_design_unit(obj)
+
+
+@export
+def Set_Design_Unit(obj, value) -> None:
+    libghdl.vhdl__nodes__set_design_unit(obj, value)
+
+
+@export
+def Get_Block_Statement(obj):
+    return libghdl.vhdl__nodes__get_block_statement(obj)
+
+
+@export
+def Set_Block_Statement(obj, value) -> None:
+    libghdl.vhdl__nodes__set_block_statement(obj, value)
+
+
+@export
+def Get_Signal_Driver(obj):
+    return libghdl.vhdl__nodes__get_signal_driver(obj)
+
+
+@export
+def Set_Signal_Driver(obj, value) -> None:
+    libghdl.vhdl__nodes__set_signal_driver(obj, value)
+
+
+@export
+def Get_Declaration_Chain(obj):
+    return libghdl.vhdl__nodes__get_declaration_chain(obj)
+
+
+@export
+def Set_Declaration_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_declaration_chain(obj, value)
+
+
+@export
+def Get_File_Logical_Name(obj):
+    return libghdl.vhdl__nodes__get_file_logical_name(obj)
+
+
+@export
+def Set_File_Logical_Name(obj, value) -> None:
+    libghdl.vhdl__nodes__set_file_logical_name(obj, value)
+
+
+@export
+def Get_File_Open_Kind(obj):
+    return libghdl.vhdl__nodes__get_file_open_kind(obj)
+
+
+@export
+def Set_File_Open_Kind(obj, value) -> None:
+    libghdl.vhdl__nodes__set_file_open_kind(obj, value)
+
+
+@export
+def Get_Element_Position(obj):
+    return libghdl.vhdl__nodes__get_element_position(obj)
+
+
+@export
+def Set_Element_Position(obj, value) -> None:
+    libghdl.vhdl__nodes__set_element_position(obj, value)
+
+
+@export
+def Get_Use_Clause_Chain(obj):
+    return libghdl.vhdl__nodes__get_use_clause_chain(obj)
+
+
+@export
+def Set_Use_Clause_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_use_clause_chain(obj, value)
+
+
+@export
+def Get_Context_Reference_Chain(obj):
+    return libghdl.vhdl__nodes__get_context_reference_chain(obj)
+
+
+@export
+def Set_Context_Reference_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_context_reference_chain(obj, value)
+
+
+@export
+def Get_Selected_Name(obj):
+    return libghdl.vhdl__nodes__get_selected_name(obj)
+
+
+@export
+def Set_Selected_Name(obj, value) -> None:
+    libghdl.vhdl__nodes__set_selected_name(obj, value)
+
+
+@export
+def Get_Type_Declarator(obj):
+    return libghdl.vhdl__nodes__get_type_declarator(obj)
+
+
+@export
+def Set_Type_Declarator(obj, value) -> None:
+    libghdl.vhdl__nodes__set_type_declarator(obj, value)
+
+
+@export
+def Get_Complete_Type_Definition(obj):
+    return libghdl.vhdl__nodes__get_complete_type_definition(obj)
+
+
+@export
+def Set_Complete_Type_Definition(obj, value) -> None:
+    libghdl.vhdl__nodes__set_complete_type_definition(obj, value)
+
+
+@export
+def Get_Incomplete_Type_Ref_Chain(obj):
+    return libghdl.vhdl__nodes__get_incomplete_type_ref_chain(obj)
+
+
+@export
+def Set_Incomplete_Type_Ref_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_incomplete_type_ref_chain(obj, value)
+
+
+@export
+def Get_Associated_Type(obj):
+    return libghdl.vhdl__nodes__get_associated_type(obj)
+
+
+@export
+def Set_Associated_Type(obj, value) -> None:
+    libghdl.vhdl__nodes__set_associated_type(obj, value)
+
+
+@export
+def Get_Enumeration_Literal_List(obj):
+    return libghdl.vhdl__nodes__get_enumeration_literal_list(obj)
+
+
+@export
+def Set_Enumeration_Literal_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_enumeration_literal_list(obj, value)
+
+
+@export
+def Get_Entity_Class_Entry_Chain(obj):
+    return libghdl.vhdl__nodes__get_entity_class_entry_chain(obj)
+
+
+@export
+def Set_Entity_Class_Entry_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_entity_class_entry_chain(obj, value)
+
+
+@export
+def Get_Group_Constituent_List(obj):
+    return libghdl.vhdl__nodes__get_group_constituent_list(obj)
+
+
+@export
+def Set_Group_Constituent_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_group_constituent_list(obj, value)
+
+
+@export
+def Get_Unit_Chain(obj):
+    return libghdl.vhdl__nodes__get_unit_chain(obj)
+
+
+@export
+def Set_Unit_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_unit_chain(obj, value)
+
+
+@export
+def Get_Primary_Unit(obj):
+    return libghdl.vhdl__nodes__get_primary_unit(obj)
+
+
+@export
+def Set_Primary_Unit(obj, value) -> None:
+    libghdl.vhdl__nodes__set_primary_unit(obj, value)
+
+
+@export
+def Get_Identifier(obj):
+    return libghdl.vhdl__nodes__get_identifier(obj)
+
+
+@export
+def Set_Identifier(obj, value) -> None:
+    libghdl.vhdl__nodes__set_identifier(obj, value)
+
+
+@export
+def Get_Label(obj):
+    return libghdl.vhdl__nodes__get_label(obj)
+
+
+@export
+def Set_Label(obj, value) -> None:
+    libghdl.vhdl__nodes__set_label(obj, value)
+
+
+@export
+def Get_Visible_Flag(obj):
+    return libghdl.vhdl__nodes__get_visible_flag(obj)
+
+
+@export
+def Set_Visible_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_visible_flag(obj, value)
+
+
+@export
+def Get_Range_Constraint(obj):
+    return libghdl.vhdl__nodes__get_range_constraint(obj)
+
+
+@export
+def Set_Range_Constraint(obj, value) -> None:
+    libghdl.vhdl__nodes__set_range_constraint(obj, value)
+
+
+@export
+def Get_Direction(obj):
+    return libghdl.vhdl__nodes__get_direction(obj)
+
+
+@export
+def Set_Direction(obj, value) -> None:
+    libghdl.vhdl__nodes__set_direction(obj, value)
+
+
+@export
+def Get_Left_Limit(obj):
+    return libghdl.vhdl__nodes__get_left_limit(obj)
+
+
+@export
+def Set_Left_Limit(obj, value) -> None:
+    libghdl.vhdl__nodes__set_left_limit(obj, value)
+
+
+@export
+def Get_Right_Limit(obj):
+    return libghdl.vhdl__nodes__get_right_limit(obj)
+
+
+@export
+def Set_Right_Limit(obj, value) -> None:
+    libghdl.vhdl__nodes__set_right_limit(obj, value)
+
+
+@export
+def Get_Left_Limit_Expr(obj):
+    return libghdl.vhdl__nodes__get_left_limit_expr(obj)
+
+
+@export
+def Set_Left_Limit_Expr(obj, value) -> None:
+    libghdl.vhdl__nodes__set_left_limit_expr(obj, value)
+
+
+@export
+def Get_Right_Limit_Expr(obj):
+    return libghdl.vhdl__nodes__get_right_limit_expr(obj)
+
+
+@export
+def Set_Right_Limit_Expr(obj, value) -> None:
+    libghdl.vhdl__nodes__set_right_limit_expr(obj, value)
+
+
+@export
+def Get_Parent_Type(obj):
+    return libghdl.vhdl__nodes__get_parent_type(obj)
+
+
+@export
+def Set_Parent_Type(obj, value) -> None:
+    libghdl.vhdl__nodes__set_parent_type(obj, value)
+
+
+@export
+def Get_Simple_Nature(obj):
+    return libghdl.vhdl__nodes__get_simple_nature(obj)
+
+
+@export
+def Set_Simple_Nature(obj, value) -> None:
+    libghdl.vhdl__nodes__set_simple_nature(obj, value)
+
+
+@export
+def Get_Base_Nature(obj):
+    return libghdl.vhdl__nodes__get_base_nature(obj)
+
+
+@export
+def Set_Base_Nature(obj, value) -> None:
+    libghdl.vhdl__nodes__set_base_nature(obj, value)
+
+
+@export
+def Get_Resolution_Indication(obj):
+    return libghdl.vhdl__nodes__get_resolution_indication(obj)
+
+
+@export
+def Set_Resolution_Indication(obj, value) -> None:
+    libghdl.vhdl__nodes__set_resolution_indication(obj, value)
+
+
+@export
+def Get_Record_Element_Resolution_Chain(obj):
+    return libghdl.vhdl__nodes__get_record_element_resolution_chain(obj)
+
+
+@export
+def Set_Record_Element_Resolution_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_record_element_resolution_chain(obj, value)
+
+
+@export
+def Get_Tolerance(obj):
+    return libghdl.vhdl__nodes__get_tolerance(obj)
+
+
+@export
+def Set_Tolerance(obj, value) -> None:
+    libghdl.vhdl__nodes__set_tolerance(obj, value)
+
+
+@export
+def Get_Plus_Terminal_Name(obj):
+    return libghdl.vhdl__nodes__get_plus_terminal_name(obj)
+
+
+@export
+def Set_Plus_Terminal_Name(obj, value) -> None:
+    libghdl.vhdl__nodes__set_plus_terminal_name(obj, value)
+
+
+@export
+def Get_Minus_Terminal_Name(obj):
+    return libghdl.vhdl__nodes__get_minus_terminal_name(obj)
+
+
+@export
+def Set_Minus_Terminal_Name(obj, value) -> None:
+    libghdl.vhdl__nodes__set_minus_terminal_name(obj, value)
+
+
+@export
+def Get_Plus_Terminal(obj):
+    return libghdl.vhdl__nodes__get_plus_terminal(obj)
+
+
+@export
+def Set_Plus_Terminal(obj, value) -> None:
+    libghdl.vhdl__nodes__set_plus_terminal(obj, value)
+
+
+@export
+def Get_Minus_Terminal(obj):
+    return libghdl.vhdl__nodes__get_minus_terminal(obj)
+
+
+@export
+def Set_Minus_Terminal(obj, value) -> None:
+    libghdl.vhdl__nodes__set_minus_terminal(obj, value)
+
+
+@export
+def Get_Magnitude_Expression(obj):
+    return libghdl.vhdl__nodes__get_magnitude_expression(obj)
+
+
+@export
+def Set_Magnitude_Expression(obj, value) -> None:
+    libghdl.vhdl__nodes__set_magnitude_expression(obj, value)
+
+
+@export
+def Get_Phase_Expression(obj):
+    return libghdl.vhdl__nodes__get_phase_expression(obj)
+
+
+@export
+def Set_Phase_Expression(obj, value) -> None:
+    libghdl.vhdl__nodes__set_phase_expression(obj, value)
+
+
+@export
+def Get_Power_Expression(obj):
+    return libghdl.vhdl__nodes__get_power_expression(obj)
+
+
+@export
+def Set_Power_Expression(obj, value) -> None:
+    libghdl.vhdl__nodes__set_power_expression(obj, value)
+
+
+@export
+def Get_Simultaneous_Left(obj):
+    return libghdl.vhdl__nodes__get_simultaneous_left(obj)
+
+
+@export
+def Set_Simultaneous_Left(obj, value) -> None:
+    libghdl.vhdl__nodes__set_simultaneous_left(obj, value)
+
+
+@export
+def Get_Simultaneous_Right(obj):
+    return libghdl.vhdl__nodes__get_simultaneous_right(obj)
+
+
+@export
+def Set_Simultaneous_Right(obj, value) -> None:
+    libghdl.vhdl__nodes__set_simultaneous_right(obj, value)
+
+
+@export
+def Get_Text_File_Flag(obj):
+    return libghdl.vhdl__nodes__get_text_file_flag(obj)
+
+
+@export
+def Set_Text_File_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_text_file_flag(obj, value)
+
+
+@export
+def Get_Only_Characters_Flag(obj):
+    return libghdl.vhdl__nodes__get_only_characters_flag(obj)
+
+
+@export
+def Set_Only_Characters_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_only_characters_flag(obj, value)
+
+
+@export
+def Get_Is_Character_Type(obj):
+    return libghdl.vhdl__nodes__get_is_character_type(obj)
+
+
+@export
+def Set_Is_Character_Type(obj, value) -> None:
+    libghdl.vhdl__nodes__set_is_character_type(obj, value)
+
+
+@export
+def Get_Nature_Staticness(obj):
+    return libghdl.vhdl__nodes__get_nature_staticness(obj)
+
+
+@export
+def Set_Nature_Staticness(obj, value) -> None:
+    libghdl.vhdl__nodes__set_nature_staticness(obj, value)
+
+
+@export
+def Get_Type_Staticness(obj):
+    return libghdl.vhdl__nodes__get_type_staticness(obj)
+
+
+@export
+def Set_Type_Staticness(obj, value) -> None:
+    libghdl.vhdl__nodes__set_type_staticness(obj, value)
+
+
+@export
+def Get_Constraint_State(obj):
+    return libghdl.vhdl__nodes__get_constraint_state(obj)
+
+
+@export
+def Set_Constraint_State(obj, value) -> None:
+    libghdl.vhdl__nodes__set_constraint_state(obj, value)
+
+
+@export
+def Get_Index_Subtype_List(obj):
+    return libghdl.vhdl__nodes__get_index_subtype_list(obj)
+
+
+@export
+def Set_Index_Subtype_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_index_subtype_list(obj, value)
+
+
+@export
+def Get_Index_Subtype_Definition_List(obj):
+    return libghdl.vhdl__nodes__get_index_subtype_definition_list(obj)
+
+
+@export
+def Set_Index_Subtype_Definition_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_index_subtype_definition_list(obj, value)
+
+
+@export
+def Get_Element_Subtype_Indication(obj):
+    return libghdl.vhdl__nodes__get_element_subtype_indication(obj)
+
+
+@export
+def Set_Element_Subtype_Indication(obj, value) -> None:
+    libghdl.vhdl__nodes__set_element_subtype_indication(obj, value)
+
+
+@export
+def Get_Element_Subtype(obj):
+    return libghdl.vhdl__nodes__get_element_subtype(obj)
+
+
+@export
+def Set_Element_Subtype(obj, value) -> None:
+    libghdl.vhdl__nodes__set_element_subtype(obj, value)
+
+
+@export
+def Get_Element_Subnature_Indication(obj):
+    return libghdl.vhdl__nodes__get_element_subnature_indication(obj)
+
+
+@export
+def Set_Element_Subnature_Indication(obj, value) -> None:
+    libghdl.vhdl__nodes__set_element_subnature_indication(obj, value)
+
+
+@export
+def Get_Element_Subnature(obj):
+    return libghdl.vhdl__nodes__get_element_subnature(obj)
+
+
+@export
+def Set_Element_Subnature(obj, value) -> None:
+    libghdl.vhdl__nodes__set_element_subnature(obj, value)
+
+
+@export
+def Get_Index_Constraint_List(obj):
+    return libghdl.vhdl__nodes__get_index_constraint_list(obj)
+
+
+@export
+def Set_Index_Constraint_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_index_constraint_list(obj, value)
+
+
+@export
+def Get_Array_Element_Constraint(obj):
+    return libghdl.vhdl__nodes__get_array_element_constraint(obj)
+
+
+@export
+def Set_Array_Element_Constraint(obj, value) -> None:
+    libghdl.vhdl__nodes__set_array_element_constraint(obj, value)
+
+
+@export
+def Get_Has_Array_Constraint_Flag(obj):
+    return libghdl.vhdl__nodes__get_has_array_constraint_flag(obj)
+
+
+@export
+def Set_Has_Array_Constraint_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_array_constraint_flag(obj, value)
+
+
+@export
+def Get_Has_Element_Constraint_Flag(obj):
+    return libghdl.vhdl__nodes__get_has_element_constraint_flag(obj)
+
+
+@export
+def Set_Has_Element_Constraint_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_element_constraint_flag(obj, value)
+
+
+@export
+def Get_Elements_Declaration_List(obj):
+    return libghdl.vhdl__nodes__get_elements_declaration_list(obj)
+
+
+@export
+def Set_Elements_Declaration_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_elements_declaration_list(obj, value)
+
+
+@export
+def Get_Owned_Elements_Chain(obj):
+    return libghdl.vhdl__nodes__get_owned_elements_chain(obj)
+
+
+@export
+def Set_Owned_Elements_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_owned_elements_chain(obj, value)
+
+
+@export
+def Get_Designated_Type(obj):
+    return libghdl.vhdl__nodes__get_designated_type(obj)
+
+
+@export
+def Set_Designated_Type(obj, value) -> None:
+    libghdl.vhdl__nodes__set_designated_type(obj, value)
+
+
+@export
+def Get_Designated_Subtype_Indication(obj):
+    return libghdl.vhdl__nodes__get_designated_subtype_indication(obj)
+
+
+@export
+def Set_Designated_Subtype_Indication(obj, value) -> None:
+    libghdl.vhdl__nodes__set_designated_subtype_indication(obj, value)
+
+
+@export
+def Get_Index_List(obj):
+    return libghdl.vhdl__nodes__get_index_list(obj)
+
+
+@export
+def Set_Index_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_index_list(obj, value)
+
+
+@export
+def Get_Reference(obj):
+    return libghdl.vhdl__nodes__get_reference(obj)
+
+
+@export
+def Set_Reference(obj, value) -> None:
+    libghdl.vhdl__nodes__set_reference(obj, value)
+
+
+@export
+def Get_Nature_Declarator(obj):
+    return libghdl.vhdl__nodes__get_nature_declarator(obj)
+
+
+@export
+def Set_Nature_Declarator(obj, value) -> None:
+    libghdl.vhdl__nodes__set_nature_declarator(obj, value)
+
+
+@export
+def Get_Across_Type_Mark(obj):
+    return libghdl.vhdl__nodes__get_across_type_mark(obj)
+
+
+@export
+def Set_Across_Type_Mark(obj, value) -> None:
+    libghdl.vhdl__nodes__set_across_type_mark(obj, value)
+
+
+@export
+def Get_Through_Type_Mark(obj):
+    return libghdl.vhdl__nodes__get_through_type_mark(obj)
+
+
+@export
+def Set_Through_Type_Mark(obj, value) -> None:
+    libghdl.vhdl__nodes__set_through_type_mark(obj, value)
+
+
+@export
+def Get_Across_Type_Definition(obj):
+    return libghdl.vhdl__nodes__get_across_type_definition(obj)
+
+
+@export
+def Set_Across_Type_Definition(obj, value) -> None:
+    libghdl.vhdl__nodes__set_across_type_definition(obj, value)
+
+
+@export
+def Get_Through_Type_Definition(obj):
+    return libghdl.vhdl__nodes__get_through_type_definition(obj)
+
+
+@export
+def Set_Through_Type_Definition(obj, value) -> None:
+    libghdl.vhdl__nodes__set_through_type_definition(obj, value)
+
+
+@export
+def Get_Across_Type(obj):
+    return libghdl.vhdl__nodes__get_across_type(obj)
+
+
+@export
+def Set_Across_Type(obj, value) -> None:
+    libghdl.vhdl__nodes__set_across_type(obj, value)
+
+
+@export
+def Get_Through_Type(obj):
+    return libghdl.vhdl__nodes__get_through_type(obj)
+
+
+@export
+def Set_Through_Type(obj, value) -> None:
+    libghdl.vhdl__nodes__set_through_type(obj, value)
+
+
+@export
+def Get_Target(obj):
+    return libghdl.vhdl__nodes__get_target(obj)
+
+
+@export
+def Set_Target(obj, value) -> None:
+    libghdl.vhdl__nodes__set_target(obj, value)
+
+
+@export
+def Get_Waveform_Chain(obj):
+    return libghdl.vhdl__nodes__get_waveform_chain(obj)
+
+
+@export
+def Set_Waveform_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_waveform_chain(obj, value)
+
+
+@export
+def Get_Guard(obj):
+    return libghdl.vhdl__nodes__get_guard(obj)
+
+
+@export
+def Set_Guard(obj, value) -> None:
+    libghdl.vhdl__nodes__set_guard(obj, value)
+
+
+@export
+def Get_Delay_Mechanism(obj):
+    return libghdl.vhdl__nodes__get_delay_mechanism(obj)
+
+
+@export
+def Set_Delay_Mechanism(obj, value) -> None:
+    libghdl.vhdl__nodes__set_delay_mechanism(obj, value)
+
+
+@export
+def Get_Reject_Time_Expression(obj):
+    return libghdl.vhdl__nodes__get_reject_time_expression(obj)
+
+
+@export
+def Set_Reject_Time_Expression(obj, value) -> None:
+    libghdl.vhdl__nodes__set_reject_time_expression(obj, value)
+
+
+@export
+def Get_Force_Mode(obj):
+    return libghdl.vhdl__nodes__get_force_mode(obj)
+
+
+@export
+def Set_Force_Mode(obj, value) -> None:
+    libghdl.vhdl__nodes__set_force_mode(obj, value)
+
+
+@export
+def Get_Has_Force_Mode(obj):
+    return libghdl.vhdl__nodes__get_has_force_mode(obj)
+
+
+@export
+def Set_Has_Force_Mode(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_force_mode(obj, value)
+
+
+@export
+def Get_Sensitivity_List(obj):
+    return libghdl.vhdl__nodes__get_sensitivity_list(obj)
+
+
+@export
+def Set_Sensitivity_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_sensitivity_list(obj, value)
+
+
+@export
+def Get_Process_Origin(obj):
+    return libghdl.vhdl__nodes__get_process_origin(obj)
+
+
+@export
+def Set_Process_Origin(obj, value) -> None:
+    libghdl.vhdl__nodes__set_process_origin(obj, value)
+
+
+@export
+def Get_Package_Origin(obj):
+    return libghdl.vhdl__nodes__get_package_origin(obj)
+
+
+@export
+def Set_Package_Origin(obj, value) -> None:
+    libghdl.vhdl__nodes__set_package_origin(obj, value)
+
+
+@export
+def Get_Condition_Clause(obj):
+    return libghdl.vhdl__nodes__get_condition_clause(obj)
+
+
+@export
+def Set_Condition_Clause(obj, value) -> None:
+    libghdl.vhdl__nodes__set_condition_clause(obj, value)
+
+
+@export
+def Get_Break_Element(obj):
+    return libghdl.vhdl__nodes__get_break_element(obj)
+
+
+@export
+def Set_Break_Element(obj, value) -> None:
+    libghdl.vhdl__nodes__set_break_element(obj, value)
+
+
+@export
+def Get_Selector_Quantity(obj):
+    return libghdl.vhdl__nodes__get_selector_quantity(obj)
+
+
+@export
+def Set_Selector_Quantity(obj, value) -> None:
+    libghdl.vhdl__nodes__set_selector_quantity(obj, value)
+
+
+@export
+def Get_Break_Quantity(obj):
+    return libghdl.vhdl__nodes__get_break_quantity(obj)
+
+
+@export
+def Set_Break_Quantity(obj, value) -> None:
+    libghdl.vhdl__nodes__set_break_quantity(obj, value)
+
+
+@export
+def Get_Timeout_Clause(obj):
+    return libghdl.vhdl__nodes__get_timeout_clause(obj)
+
+
+@export
+def Set_Timeout_Clause(obj, value) -> None:
+    libghdl.vhdl__nodes__set_timeout_clause(obj, value)
+
+
+@export
+def Get_Postponed_Flag(obj):
+    return libghdl.vhdl__nodes__get_postponed_flag(obj)
+
+
+@export
+def Set_Postponed_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_postponed_flag(obj, value)
+
+
+@export
+def Get_Callees_List(obj):
+    return libghdl.vhdl__nodes__get_callees_list(obj)
+
+
+@export
+def Set_Callees_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_callees_list(obj, value)
+
+
+@export
+def Get_Passive_Flag(obj):
+    return libghdl.vhdl__nodes__get_passive_flag(obj)
+
+
+@export
+def Set_Passive_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_passive_flag(obj, value)
+
+
+@export
+def Get_Resolution_Function_Flag(obj):
+    return libghdl.vhdl__nodes__get_resolution_function_flag(obj)
+
+
+@export
+def Set_Resolution_Function_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_resolution_function_flag(obj, value)
+
+
+@export
+def Get_Wait_State(obj):
+    return libghdl.vhdl__nodes__get_wait_state(obj)
+
+
+@export
+def Set_Wait_State(obj, value) -> None:
+    libghdl.vhdl__nodes__set_wait_state(obj, value)
+
+
+@export
+def Get_All_Sensitized_State(obj):
+    return libghdl.vhdl__nodes__get_all_sensitized_state(obj)
+
+
+@export
+def Set_All_Sensitized_State(obj, value) -> None:
+    libghdl.vhdl__nodes__set_all_sensitized_state(obj, value)
+
+
+@export
+def Get_Seen_Flag(obj):
+    return libghdl.vhdl__nodes__get_seen_flag(obj)
+
+
+@export
+def Set_Seen_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_seen_flag(obj, value)
+
+
+@export
+def Get_Pure_Flag(obj):
+    return libghdl.vhdl__nodes__get_pure_flag(obj)
+
+
+@export
+def Set_Pure_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_pure_flag(obj, value)
+
+
+@export
+def Get_Foreign_Flag(obj):
+    return libghdl.vhdl__nodes__get_foreign_flag(obj)
+
+
+@export
+def Set_Foreign_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_foreign_flag(obj, value)
+
+
+@export
+def Get_Resolved_Flag(obj):
+    return libghdl.vhdl__nodes__get_resolved_flag(obj)
+
+
+@export
+def Set_Resolved_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_resolved_flag(obj, value)
+
+
+@export
+def Get_Signal_Type_Flag(obj):
+    return libghdl.vhdl__nodes__get_signal_type_flag(obj)
+
+
+@export
+def Set_Signal_Type_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_signal_type_flag(obj, value)
+
+
+@export
+def Get_Has_Signal_Flag(obj):
+    return libghdl.vhdl__nodes__get_has_signal_flag(obj)
+
+
+@export
+def Set_Has_Signal_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_signal_flag(obj, value)
+
+
+@export
+def Get_Purity_State(obj):
+    return libghdl.vhdl__nodes__get_purity_state(obj)
+
+
+@export
+def Set_Purity_State(obj, value) -> None:
+    libghdl.vhdl__nodes__set_purity_state(obj, value)
+
+
+@export
+def Get_Elab_Flag(obj):
+    return libghdl.vhdl__nodes__get_elab_flag(obj)
+
+
+@export
+def Set_Elab_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_elab_flag(obj, value)
+
+
+@export
+def Get_Vendor_Library_Flag(obj):
+    return libghdl.vhdl__nodes__get_vendor_library_flag(obj)
+
+
+@export
+def Set_Vendor_Library_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_vendor_library_flag(obj, value)
+
+
+@export
+def Get_Configuration_Mark_Flag(obj):
+    return libghdl.vhdl__nodes__get_configuration_mark_flag(obj)
+
+
+@export
+def Set_Configuration_Mark_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_configuration_mark_flag(obj, value)
+
+
+@export
+def Get_Configuration_Done_Flag(obj):
+    return libghdl.vhdl__nodes__get_configuration_done_flag(obj)
+
+
+@export
+def Set_Configuration_Done_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_configuration_done_flag(obj, value)
+
+
+@export
+def Get_Index_Constraint_Flag(obj):
+    return libghdl.vhdl__nodes__get_index_constraint_flag(obj)
+
+
+@export
+def Set_Index_Constraint_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_index_constraint_flag(obj, value)
+
+
+@export
+def Get_Hide_Implicit_Flag(obj):
+    return libghdl.vhdl__nodes__get_hide_implicit_flag(obj)
+
+
+@export
+def Set_Hide_Implicit_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_hide_implicit_flag(obj, value)
+
+
+@export
+def Get_Assertion_Condition(obj):
+    return libghdl.vhdl__nodes__get_assertion_condition(obj)
+
+
+@export
+def Set_Assertion_Condition(obj, value) -> None:
+    libghdl.vhdl__nodes__set_assertion_condition(obj, value)
+
+
+@export
+def Get_Report_Expression(obj):
+    return libghdl.vhdl__nodes__get_report_expression(obj)
+
+
+@export
+def Set_Report_Expression(obj, value) -> None:
+    libghdl.vhdl__nodes__set_report_expression(obj, value)
+
+
+@export
+def Get_Severity_Expression(obj):
+    return libghdl.vhdl__nodes__get_severity_expression(obj)
+
+
+@export
+def Set_Severity_Expression(obj, value) -> None:
+    libghdl.vhdl__nodes__set_severity_expression(obj, value)
+
+
+@export
+def Get_Instantiated_Unit(obj):
+    return libghdl.vhdl__nodes__get_instantiated_unit(obj)
+
+
+@export
+def Set_Instantiated_Unit(obj, value) -> None:
+    libghdl.vhdl__nodes__set_instantiated_unit(obj, value)
+
+
+@export
+def Get_Generic_Map_Aspect_Chain(obj):
+    return libghdl.vhdl__nodes__get_generic_map_aspect_chain(obj)
+
+
+@export
+def Set_Generic_Map_Aspect_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_generic_map_aspect_chain(obj, value)
+
+
+@export
+def Get_Port_Map_Aspect_Chain(obj):
+    return libghdl.vhdl__nodes__get_port_map_aspect_chain(obj)
+
+
+@export
+def Set_Port_Map_Aspect_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_port_map_aspect_chain(obj, value)
+
+
+@export
+def Get_Configuration_Name(obj):
+    return libghdl.vhdl__nodes__get_configuration_name(obj)
+
+
+@export
+def Set_Configuration_Name(obj, value) -> None:
+    libghdl.vhdl__nodes__set_configuration_name(obj, value)
+
+
+@export
+def Get_Component_Configuration(obj):
+    return libghdl.vhdl__nodes__get_component_configuration(obj)
+
+
+@export
+def Set_Component_Configuration(obj, value) -> None:
+    libghdl.vhdl__nodes__set_component_configuration(obj, value)
+
+
+@export
+def Get_Configuration_Specification(obj):
+    return libghdl.vhdl__nodes__get_configuration_specification(obj)
+
+
+@export
+def Set_Configuration_Specification(obj, value) -> None:
+    libghdl.vhdl__nodes__set_configuration_specification(obj, value)
+
+
+@export
+def Get_Default_Binding_Indication(obj):
+    return libghdl.vhdl__nodes__get_default_binding_indication(obj)
+
+
+@export
+def Set_Default_Binding_Indication(obj, value) -> None:
+    libghdl.vhdl__nodes__set_default_binding_indication(obj, value)
+
+
+@export
+def Get_Default_Configuration_Declaration(obj):
+    return libghdl.vhdl__nodes__get_default_configuration_declaration(obj)
+
+
+@export
+def Set_Default_Configuration_Declaration(obj, value) -> None:
+    libghdl.vhdl__nodes__set_default_configuration_declaration(obj, value)
+
+
+@export
+def Get_Expression(obj):
+    return libghdl.vhdl__nodes__get_expression(obj)
+
+
+@export
+def Set_Expression(obj, value) -> None:
+    libghdl.vhdl__nodes__set_expression(obj, value)
+
+
+@export
+def Get_Conditional_Expression_Chain(obj):
+    return libghdl.vhdl__nodes__get_conditional_expression_chain(obj)
+
+
+@export
+def Set_Conditional_Expression_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_conditional_expression_chain(obj, value)
+
+
+@export
+def Get_Allocator_Designated_Type(obj):
+    return libghdl.vhdl__nodes__get_allocator_designated_type(obj)
+
+
+@export
+def Set_Allocator_Designated_Type(obj, value) -> None:
+    libghdl.vhdl__nodes__set_allocator_designated_type(obj, value)
+
+
+@export
+def Get_Selected_Waveform_Chain(obj):
+    return libghdl.vhdl__nodes__get_selected_waveform_chain(obj)
+
+
+@export
+def Set_Selected_Waveform_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_selected_waveform_chain(obj, value)
+
+
+@export
+def Get_Conditional_Waveform_Chain(obj):
+    return libghdl.vhdl__nodes__get_conditional_waveform_chain(obj)
+
+
+@export
+def Set_Conditional_Waveform_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_conditional_waveform_chain(obj, value)
+
+
+@export
+def Get_Guard_Expression(obj):
+    return libghdl.vhdl__nodes__get_guard_expression(obj)
+
+
+@export
+def Set_Guard_Expression(obj, value) -> None:
+    libghdl.vhdl__nodes__set_guard_expression(obj, value)
+
+
+@export
+def Get_Guard_Decl(obj):
+    return libghdl.vhdl__nodes__get_guard_decl(obj)
+
+
+@export
+def Set_Guard_Decl(obj, value) -> None:
+    libghdl.vhdl__nodes__set_guard_decl(obj, value)
+
+
+@export
+def Get_Guard_Sensitivity_List(obj):
+    return libghdl.vhdl__nodes__get_guard_sensitivity_list(obj)
+
+
+@export
+def Set_Guard_Sensitivity_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_guard_sensitivity_list(obj, value)
+
+
+@export
+def Get_Signal_Attribute_Chain(obj):
+    return libghdl.vhdl__nodes__get_signal_attribute_chain(obj)
+
+
+@export
+def Set_Signal_Attribute_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_signal_attribute_chain(obj, value)
+
+
+@export
+def Get_Block_Block_Configuration(obj):
+    return libghdl.vhdl__nodes__get_block_block_configuration(obj)
+
+
+@export
+def Set_Block_Block_Configuration(obj, value) -> None:
+    libghdl.vhdl__nodes__set_block_block_configuration(obj, value)
+
+
+@export
+def Get_Package_Header(obj):
+    return libghdl.vhdl__nodes__get_package_header(obj)
+
+
+@export
+def Set_Package_Header(obj, value) -> None:
+    libghdl.vhdl__nodes__set_package_header(obj, value)
+
+
+@export
+def Get_Block_Header(obj):
+    return libghdl.vhdl__nodes__get_block_header(obj)
+
+
+@export
+def Set_Block_Header(obj, value) -> None:
+    libghdl.vhdl__nodes__set_block_header(obj, value)
+
+
+@export
+def Get_Uninstantiated_Package_Name(obj):
+    return libghdl.vhdl__nodes__get_uninstantiated_package_name(obj)
+
+
+@export
+def Set_Uninstantiated_Package_Name(obj, value) -> None:
+    libghdl.vhdl__nodes__set_uninstantiated_package_name(obj, value)
+
+
+@export
+def Get_Uninstantiated_Package_Decl(obj):
+    return libghdl.vhdl__nodes__get_uninstantiated_package_decl(obj)
+
+
+@export
+def Set_Uninstantiated_Package_Decl(obj, value) -> None:
+    libghdl.vhdl__nodes__set_uninstantiated_package_decl(obj, value)
+
+
+@export
+def Get_Instance_Source_File(obj):
+    return libghdl.vhdl__nodes__get_instance_source_file(obj)
+
+
+@export
+def Set_Instance_Source_File(obj, value) -> None:
+    libghdl.vhdl__nodes__set_instance_source_file(obj, value)
+
+
+@export
+def Get_Generate_Block_Configuration(obj):
+    return libghdl.vhdl__nodes__get_generate_block_configuration(obj)
+
+
+@export
+def Set_Generate_Block_Configuration(obj, value) -> None:
+    libghdl.vhdl__nodes__set_generate_block_configuration(obj, value)
+
+
+@export
+def Get_Generate_Statement_Body(obj):
+    return libghdl.vhdl__nodes__get_generate_statement_body(obj)
+
+
+@export
+def Set_Generate_Statement_Body(obj, value) -> None:
+    libghdl.vhdl__nodes__set_generate_statement_body(obj, value)
+
+
+@export
+def Get_Alternative_Label(obj):
+    return libghdl.vhdl__nodes__get_alternative_label(obj)
+
+
+@export
+def Set_Alternative_Label(obj, value) -> None:
+    libghdl.vhdl__nodes__set_alternative_label(obj, value)
+
+
+@export
+def Get_Generate_Else_Clause(obj):
+    return libghdl.vhdl__nodes__get_generate_else_clause(obj)
+
+
+@export
+def Set_Generate_Else_Clause(obj, value) -> None:
+    libghdl.vhdl__nodes__set_generate_else_clause(obj, value)
+
+
+@export
+def Get_Condition(obj):
+    return libghdl.vhdl__nodes__get_condition(obj)
+
+
+@export
+def Set_Condition(obj, value) -> None:
+    libghdl.vhdl__nodes__set_condition(obj, value)
+
+
+@export
+def Get_Else_Clause(obj):
+    return libghdl.vhdl__nodes__get_else_clause(obj)
+
+
+@export
+def Set_Else_Clause(obj, value) -> None:
+    libghdl.vhdl__nodes__set_else_clause(obj, value)
+
+
+@export
+def Get_Parameter_Specification(obj):
+    return libghdl.vhdl__nodes__get_parameter_specification(obj)
+
+
+@export
+def Set_Parameter_Specification(obj, value) -> None:
+    libghdl.vhdl__nodes__set_parameter_specification(obj, value)
+
+
+@export
+def Get_Parent(obj):
+    return libghdl.vhdl__nodes__get_parent(obj)
+
+
+@export
+def Set_Parent(obj, value) -> None:
+    libghdl.vhdl__nodes__set_parent(obj, value)
+
+
+@export
+def Get_Loop_Label(obj):
+    return libghdl.vhdl__nodes__get_loop_label(obj)
+
+
+@export
+def Set_Loop_Label(obj, value) -> None:
+    libghdl.vhdl__nodes__set_loop_label(obj, value)
+
+
+@export
+def Get_Exit_Flag(obj):
+    return libghdl.vhdl__nodes__get_exit_flag(obj)
+
+
+@export
+def Set_Exit_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_exit_flag(obj, value)
+
+
+@export
+def Get_Next_Flag(obj):
+    return libghdl.vhdl__nodes__get_next_flag(obj)
+
+
+@export
+def Set_Next_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_next_flag(obj, value)
+
+
+@export
+def Get_Component_Name(obj):
+    return libghdl.vhdl__nodes__get_component_name(obj)
+
+
+@export
+def Set_Component_Name(obj, value) -> None:
+    libghdl.vhdl__nodes__set_component_name(obj, value)
+
+
+@export
+def Get_Instantiation_List(obj):
+    return libghdl.vhdl__nodes__get_instantiation_list(obj)
+
+
+@export
+def Set_Instantiation_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_instantiation_list(obj, value)
+
+
+@export
+def Get_Entity_Aspect(obj):
+    return libghdl.vhdl__nodes__get_entity_aspect(obj)
+
+
+@export
+def Set_Entity_Aspect(obj, value) -> None:
+    libghdl.vhdl__nodes__set_entity_aspect(obj, value)
+
+
+@export
+def Get_Default_Entity_Aspect(obj):
+    return libghdl.vhdl__nodes__get_default_entity_aspect(obj)
+
+
+@export
+def Set_Default_Entity_Aspect(obj, value) -> None:
+    libghdl.vhdl__nodes__set_default_entity_aspect(obj, value)
+
+
+@export
+def Get_Binding_Indication(obj):
+    return libghdl.vhdl__nodes__get_binding_indication(obj)
+
+
+@export
+def Set_Binding_Indication(obj, value) -> None:
+    libghdl.vhdl__nodes__set_binding_indication(obj, value)
+
+
+@export
+def Get_Named_Entity(obj):
+    return libghdl.vhdl__nodes__get_named_entity(obj)
+
+
+@export
+def Set_Named_Entity(obj, value) -> None:
+    libghdl.vhdl__nodes__set_named_entity(obj, value)
+
+
+@export
+def Get_Referenced_Name(obj):
+    return libghdl.vhdl__nodes__get_referenced_name(obj)
+
+
+@export
+def Set_Referenced_Name(obj, value) -> None:
+    libghdl.vhdl__nodes__set_referenced_name(obj, value)
+
+
+@export
+def Get_Expr_Staticness(obj):
+    return libghdl.vhdl__nodes__get_expr_staticness(obj)
+
+
+@export
+def Set_Expr_Staticness(obj, value) -> None:
+    libghdl.vhdl__nodes__set_expr_staticness(obj, value)
+
+
+@export
+def Get_Scalar_Size(obj):
+    return libghdl.vhdl__nodes__get_scalar_size(obj)
+
+
+@export
+def Set_Scalar_Size(obj, value) -> None:
+    libghdl.vhdl__nodes__set_scalar_size(obj, value)
+
+
+@export
+def Get_Error_Origin(obj):
+    return libghdl.vhdl__nodes__get_error_origin(obj)
+
+
+@export
+def Set_Error_Origin(obj, value) -> None:
+    libghdl.vhdl__nodes__set_error_origin(obj, value)
+
+
+@export
+def Get_Operand(obj):
+    return libghdl.vhdl__nodes__get_operand(obj)
+
+
+@export
+def Set_Operand(obj, value) -> None:
+    libghdl.vhdl__nodes__set_operand(obj, value)
+
+
+@export
+def Get_Left(obj):
+    return libghdl.vhdl__nodes__get_left(obj)
+
+
+@export
+def Set_Left(obj, value) -> None:
+    libghdl.vhdl__nodes__set_left(obj, value)
+
+
+@export
+def Get_Right(obj):
+    return libghdl.vhdl__nodes__get_right(obj)
+
+
+@export
+def Set_Right(obj, value) -> None:
+    libghdl.vhdl__nodes__set_right(obj, value)
+
+
+@export
+def Get_Unit_Name(obj):
+    return libghdl.vhdl__nodes__get_unit_name(obj)
+
+
+@export
+def Set_Unit_Name(obj, value) -> None:
+    libghdl.vhdl__nodes__set_unit_name(obj, value)
+
+
+@export
+def Get_Name(obj):
+    return libghdl.vhdl__nodes__get_name(obj)
+
+
+@export
+def Set_Name(obj, value) -> None:
+    libghdl.vhdl__nodes__set_name(obj, value)
+
+
+@export
+def Get_Group_Template_Name(obj):
+    return libghdl.vhdl__nodes__get_group_template_name(obj)
+
+
+@export
+def Set_Group_Template_Name(obj, value) -> None:
+    libghdl.vhdl__nodes__set_group_template_name(obj, value)
+
+
+@export
+def Get_Name_Staticness(obj):
+    return libghdl.vhdl__nodes__get_name_staticness(obj)
+
+
+@export
+def Set_Name_Staticness(obj, value) -> None:
+    libghdl.vhdl__nodes__set_name_staticness(obj, value)
+
+
+@export
+def Get_Prefix(obj):
+    return libghdl.vhdl__nodes__get_prefix(obj)
+
+
+@export
+def Set_Prefix(obj, value) -> None:
+    libghdl.vhdl__nodes__set_prefix(obj, value)
+
+
+@export
+def Get_Signature_Prefix(obj):
+    return libghdl.vhdl__nodes__get_signature_prefix(obj)
+
+
+@export
+def Set_Signature_Prefix(obj, value) -> None:
+    libghdl.vhdl__nodes__set_signature_prefix(obj, value)
+
+
+@export
+def Get_External_Pathname(obj):
+    return libghdl.vhdl__nodes__get_external_pathname(obj)
+
+
+@export
+def Set_External_Pathname(obj, value) -> None:
+    libghdl.vhdl__nodes__set_external_pathname(obj, value)
+
+
+@export
+def Get_Pathname_Suffix(obj):
+    return libghdl.vhdl__nodes__get_pathname_suffix(obj)
+
+
+@export
+def Set_Pathname_Suffix(obj, value) -> None:
+    libghdl.vhdl__nodes__set_pathname_suffix(obj, value)
+
+
+@export
+def Get_Pathname_Expression(obj):
+    return libghdl.vhdl__nodes__get_pathname_expression(obj)
+
+
+@export
+def Set_Pathname_Expression(obj, value) -> None:
+    libghdl.vhdl__nodes__set_pathname_expression(obj, value)
+
+
+@export
+def Get_In_Formal_Flag(obj):
+    return libghdl.vhdl__nodes__get_in_formal_flag(obj)
+
+
+@export
+def Set_In_Formal_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_in_formal_flag(obj, value)
+
+
+@export
+def Get_Slice_Subtype(obj):
+    return libghdl.vhdl__nodes__get_slice_subtype(obj)
+
+
+@export
+def Set_Slice_Subtype(obj, value) -> None:
+    libghdl.vhdl__nodes__set_slice_subtype(obj, value)
+
+
+@export
+def Get_Suffix(obj):
+    return libghdl.vhdl__nodes__get_suffix(obj)
+
+
+@export
+def Set_Suffix(obj, value) -> None:
+    libghdl.vhdl__nodes__set_suffix(obj, value)
+
+
+@export
+def Get_Index_Subtype(obj):
+    return libghdl.vhdl__nodes__get_index_subtype(obj)
+
+
+@export
+def Set_Index_Subtype(obj, value) -> None:
+    libghdl.vhdl__nodes__set_index_subtype(obj, value)
+
+
+@export
+def Get_Parameter(obj):
+    return libghdl.vhdl__nodes__get_parameter(obj)
+
+
+@export
+def Set_Parameter(obj, value) -> None:
+    libghdl.vhdl__nodes__set_parameter(obj, value)
+
+
+@export
+def Get_Parameter_2(obj):
+    return libghdl.vhdl__nodes__get_parameter_2(obj)
+
+
+@export
+def Set_Parameter_2(obj, value) -> None:
+    libghdl.vhdl__nodes__set_parameter_2(obj, value)
+
+
+@export
+def Get_Parameter_3(obj):
+    return libghdl.vhdl__nodes__get_parameter_3(obj)
+
+
+@export
+def Set_Parameter_3(obj, value) -> None:
+    libghdl.vhdl__nodes__set_parameter_3(obj, value)
+
+
+@export
+def Get_Parameter_4(obj):
+    return libghdl.vhdl__nodes__get_parameter_4(obj)
+
+
+@export
+def Set_Parameter_4(obj, value) -> None:
+    libghdl.vhdl__nodes__set_parameter_4(obj, value)
+
+
+@export
+def Get_Attr_Chain(obj):
+    return libghdl.vhdl__nodes__get_attr_chain(obj)
+
+
+@export
+def Set_Attr_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_attr_chain(obj, value)
+
+
+@export
+def Get_Signal_Attribute_Declaration(obj):
+    return libghdl.vhdl__nodes__get_signal_attribute_declaration(obj)
+
+
+@export
+def Set_Signal_Attribute_Declaration(obj, value) -> None:
+    libghdl.vhdl__nodes__set_signal_attribute_declaration(obj, value)
+
+
+@export
+def Get_Actual_Type(obj):
+    return libghdl.vhdl__nodes__get_actual_type(obj)
+
+
+@export
+def Set_Actual_Type(obj, value) -> None:
+    libghdl.vhdl__nodes__set_actual_type(obj, value)
+
+
+@export
+def Get_Actual_Type_Definition(obj):
+    return libghdl.vhdl__nodes__get_actual_type_definition(obj)
+
+
+@export
+def Set_Actual_Type_Definition(obj, value) -> None:
+    libghdl.vhdl__nodes__set_actual_type_definition(obj, value)
+
+
+@export
+def Get_Association_Chain(obj):
+    return libghdl.vhdl__nodes__get_association_chain(obj)
+
+
+@export
+def Set_Association_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_association_chain(obj, value)
+
+
+@export
+def Get_Individual_Association_Chain(obj):
+    return libghdl.vhdl__nodes__get_individual_association_chain(obj)
+
+
+@export
+def Set_Individual_Association_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_individual_association_chain(obj, value)
+
+
+@export
+def Get_Subprogram_Association_Chain(obj):
+    return libghdl.vhdl__nodes__get_subprogram_association_chain(obj)
+
+
+@export
+def Set_Subprogram_Association_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_subprogram_association_chain(obj, value)
+
+
+@export
+def Get_Aggregate_Info(obj):
+    return libghdl.vhdl__nodes__get_aggregate_info(obj)
+
+
+@export
+def Set_Aggregate_Info(obj, value) -> None:
+    libghdl.vhdl__nodes__set_aggregate_info(obj, value)
+
+
+@export
+def Get_Sub_Aggregate_Info(obj):
+    return libghdl.vhdl__nodes__get_sub_aggregate_info(obj)
+
+
+@export
+def Set_Sub_Aggregate_Info(obj, value) -> None:
+    libghdl.vhdl__nodes__set_sub_aggregate_info(obj, value)
+
+
+@export
+def Get_Aggr_Dynamic_Flag(obj):
+    return libghdl.vhdl__nodes__get_aggr_dynamic_flag(obj)
+
+
+@export
+def Set_Aggr_Dynamic_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_aggr_dynamic_flag(obj, value)
+
+
+@export
+def Get_Aggr_Min_Length(obj):
+    return libghdl.vhdl__nodes__get_aggr_min_length(obj)
+
+
+@export
+def Set_Aggr_Min_Length(obj, value) -> None:
+    libghdl.vhdl__nodes__set_aggr_min_length(obj, value)
+
+
+@export
+def Get_Aggr_Low_Limit(obj):
+    return libghdl.vhdl__nodes__get_aggr_low_limit(obj)
+
+
+@export
+def Set_Aggr_Low_Limit(obj, value) -> None:
+    libghdl.vhdl__nodes__set_aggr_low_limit(obj, value)
+
+
+@export
+def Get_Aggr_High_Limit(obj):
+    return libghdl.vhdl__nodes__get_aggr_high_limit(obj)
+
+
+@export
+def Set_Aggr_High_Limit(obj, value) -> None:
+    libghdl.vhdl__nodes__set_aggr_high_limit(obj, value)
+
+
+@export
+def Get_Aggr_Others_Flag(obj):
+    return libghdl.vhdl__nodes__get_aggr_others_flag(obj)
+
+
+@export
+def Set_Aggr_Others_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_aggr_others_flag(obj, value)
+
+
+@export
+def Get_Aggr_Named_Flag(obj):
+    return libghdl.vhdl__nodes__get_aggr_named_flag(obj)
+
+
+@export
+def Set_Aggr_Named_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_aggr_named_flag(obj, value)
+
+
+@export
+def Get_Aggregate_Expand_Flag(obj):
+    return libghdl.vhdl__nodes__get_aggregate_expand_flag(obj)
+
+
+@export
+def Set_Aggregate_Expand_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_aggregate_expand_flag(obj, value)
+
+
+@export
+def Get_Association_Choices_Chain(obj):
+    return libghdl.vhdl__nodes__get_association_choices_chain(obj)
+
+
+@export
+def Set_Association_Choices_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_association_choices_chain(obj, value)
+
+
+@export
+def Get_Case_Statement_Alternative_Chain(obj):
+    return libghdl.vhdl__nodes__get_case_statement_alternative_chain(obj)
+
+
+@export
+def Set_Case_Statement_Alternative_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_case_statement_alternative_chain(obj, value)
+
+
+@export
+def Get_Choice_Staticness(obj):
+    return libghdl.vhdl__nodes__get_choice_staticness(obj)
+
+
+@export
+def Set_Choice_Staticness(obj, value) -> None:
+    libghdl.vhdl__nodes__set_choice_staticness(obj, value)
+
+
+@export
+def Get_Procedure_Call(obj):
+    return libghdl.vhdl__nodes__get_procedure_call(obj)
+
+
+@export
+def Set_Procedure_Call(obj, value) -> None:
+    libghdl.vhdl__nodes__set_procedure_call(obj, value)
+
+
+@export
+def Get_Implementation(obj):
+    return libghdl.vhdl__nodes__get_implementation(obj)
+
+
+@export
+def Set_Implementation(obj, value) -> None:
+    libghdl.vhdl__nodes__set_implementation(obj, value)
+
+
+@export
+def Get_Parameter_Association_Chain(obj):
+    return libghdl.vhdl__nodes__get_parameter_association_chain(obj)
+
+
+@export
+def Set_Parameter_Association_Chain(obj, value) -> None:
+    libghdl.vhdl__nodes__set_parameter_association_chain(obj, value)
+
+
+@export
+def Get_Method_Object(obj):
+    return libghdl.vhdl__nodes__get_method_object(obj)
+
+
+@export
+def Set_Method_Object(obj, value) -> None:
+    libghdl.vhdl__nodes__set_method_object(obj, value)
+
+
+@export
+def Get_Subtype_Type_Mark(obj):
+    return libghdl.vhdl__nodes__get_subtype_type_mark(obj)
+
+
+@export
+def Set_Subtype_Type_Mark(obj, value) -> None:
+    libghdl.vhdl__nodes__set_subtype_type_mark(obj, value)
+
+
+@export
+def Get_Subnature_Nature_Mark(obj):
+    return libghdl.vhdl__nodes__get_subnature_nature_mark(obj)
+
+
+@export
+def Set_Subnature_Nature_Mark(obj, value) -> None:
+    libghdl.vhdl__nodes__set_subnature_nature_mark(obj, value)
+
+
+@export
+def Get_Type_Conversion_Subtype(obj):
+    return libghdl.vhdl__nodes__get_type_conversion_subtype(obj)
+
+
+@export
+def Set_Type_Conversion_Subtype(obj, value) -> None:
+    libghdl.vhdl__nodes__set_type_conversion_subtype(obj, value)
+
+
+@export
+def Get_Type_Mark(obj):
+    return libghdl.vhdl__nodes__get_type_mark(obj)
+
+
+@export
+def Set_Type_Mark(obj, value) -> None:
+    libghdl.vhdl__nodes__set_type_mark(obj, value)
+
+
+@export
+def Get_File_Type_Mark(obj):
+    return libghdl.vhdl__nodes__get_file_type_mark(obj)
+
+
+@export
+def Set_File_Type_Mark(obj, value) -> None:
+    libghdl.vhdl__nodes__set_file_type_mark(obj, value)
+
+
+@export
+def Get_Return_Type_Mark(obj):
+    return libghdl.vhdl__nodes__get_return_type_mark(obj)
+
+
+@export
+def Set_Return_Type_Mark(obj, value) -> None:
+    libghdl.vhdl__nodes__set_return_type_mark(obj, value)
+
+
+@export
+def Get_Has_Disconnect_Flag(obj):
+    return libghdl.vhdl__nodes__get_has_disconnect_flag(obj)
+
+
+@export
+def Set_Has_Disconnect_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_disconnect_flag(obj, value)
+
+
+@export
+def Get_Has_Active_Flag(obj):
+    return libghdl.vhdl__nodes__get_has_active_flag(obj)
+
+
+@export
+def Set_Has_Active_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_active_flag(obj, value)
+
+
+@export
+def Get_Is_Within_Flag(obj):
+    return libghdl.vhdl__nodes__get_is_within_flag(obj)
+
+
+@export
+def Set_Is_Within_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_is_within_flag(obj, value)
+
+
+@export
+def Get_Type_Marks_List(obj):
+    return libghdl.vhdl__nodes__get_type_marks_list(obj)
+
+
+@export
+def Set_Type_Marks_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_type_marks_list(obj, value)
+
+
+@export
+def Get_Implicit_Alias_Flag(obj):
+    return libghdl.vhdl__nodes__get_implicit_alias_flag(obj)
+
+
+@export
+def Set_Implicit_Alias_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_implicit_alias_flag(obj, value)
+
+
+@export
+def Get_Alias_Signature(obj):
+    return libghdl.vhdl__nodes__get_alias_signature(obj)
+
+
+@export
+def Set_Alias_Signature(obj, value) -> None:
+    libghdl.vhdl__nodes__set_alias_signature(obj, value)
+
+
+@export
+def Get_Attribute_Signature(obj):
+    return libghdl.vhdl__nodes__get_attribute_signature(obj)
+
+
+@export
+def Set_Attribute_Signature(obj, value) -> None:
+    libghdl.vhdl__nodes__set_attribute_signature(obj, value)
+
+
+@export
+def Get_Overload_List(obj):
+    return libghdl.vhdl__nodes__get_overload_list(obj)
+
+
+@export
+def Set_Overload_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_overload_list(obj, value)
+
+
+@export
+def Get_Simple_Name_Identifier(obj):
+    return libghdl.vhdl__nodes__get_simple_name_identifier(obj)
+
+
+@export
+def Set_Simple_Name_Identifier(obj, value) -> None:
+    libghdl.vhdl__nodes__set_simple_name_identifier(obj, value)
+
+
+@export
+def Get_Simple_Name_Subtype(obj):
+    return libghdl.vhdl__nodes__get_simple_name_subtype(obj)
+
+
+@export
+def Set_Simple_Name_Subtype(obj, value) -> None:
+    libghdl.vhdl__nodes__set_simple_name_subtype(obj, value)
+
+
+@export
+def Get_Protected_Type_Body(obj):
+    return libghdl.vhdl__nodes__get_protected_type_body(obj)
+
+
+@export
+def Set_Protected_Type_Body(obj, value) -> None:
+    libghdl.vhdl__nodes__set_protected_type_body(obj, value)
+
+
+@export
+def Get_Protected_Type_Declaration(obj):
+    return libghdl.vhdl__nodes__get_protected_type_declaration(obj)
+
+
+@export
+def Set_Protected_Type_Declaration(obj, value) -> None:
+    libghdl.vhdl__nodes__set_protected_type_declaration(obj, value)
+
+
+@export
+def Get_Use_Flag(obj):
+    return libghdl.vhdl__nodes__get_use_flag(obj)
+
+
+@export
+def Set_Use_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_use_flag(obj, value)
+
+
+@export
+def Get_End_Has_Reserved_Id(obj):
+    return libghdl.vhdl__nodes__get_end_has_reserved_id(obj)
+
+
+@export
+def Set_End_Has_Reserved_Id(obj, value) -> None:
+    libghdl.vhdl__nodes__set_end_has_reserved_id(obj, value)
+
+
+@export
+def Get_End_Has_Identifier(obj):
+    return libghdl.vhdl__nodes__get_end_has_identifier(obj)
+
+
+@export
+def Set_End_Has_Identifier(obj, value) -> None:
+    libghdl.vhdl__nodes__set_end_has_identifier(obj, value)
+
+
+@export
+def Get_End_Has_Postponed(obj):
+    return libghdl.vhdl__nodes__get_end_has_postponed(obj)
+
+
+@export
+def Set_End_Has_Postponed(obj, value) -> None:
+    libghdl.vhdl__nodes__set_end_has_postponed(obj, value)
+
+
+@export
+def Get_Has_Label(obj):
+    return libghdl.vhdl__nodes__get_has_label(obj)
+
+
+@export
+def Set_Has_Label(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_label(obj, value)
+
+
+@export
+def Get_Has_Begin(obj):
+    return libghdl.vhdl__nodes__get_has_begin(obj)
+
+
+@export
+def Set_Has_Begin(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_begin(obj, value)
+
+
+@export
+def Get_Has_End(obj):
+    return libghdl.vhdl__nodes__get_has_end(obj)
+
+
+@export
+def Set_Has_End(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_end(obj, value)
+
+
+@export
+def Get_Has_Is(obj):
+    return libghdl.vhdl__nodes__get_has_is(obj)
+
+
+@export
+def Set_Has_Is(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_is(obj, value)
+
+
+@export
+def Get_Has_Pure(obj):
+    return libghdl.vhdl__nodes__get_has_pure(obj)
+
+
+@export
+def Set_Has_Pure(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_pure(obj, value)
+
+
+@export
+def Get_Has_Body(obj):
+    return libghdl.vhdl__nodes__get_has_body(obj)
+
+
+@export
+def Set_Has_Body(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_body(obj, value)
+
+
+@export
+def Get_Has_Parameter(obj):
+    return libghdl.vhdl__nodes__get_has_parameter(obj)
+
+
+@export
+def Set_Has_Parameter(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_parameter(obj, value)
+
+
+@export
+def Get_Has_Component(obj):
+    return libghdl.vhdl__nodes__get_has_component(obj)
+
+
+@export
+def Set_Has_Component(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_component(obj, value)
+
+
+@export
+def Get_Has_Identifier_List(obj):
+    return libghdl.vhdl__nodes__get_has_identifier_list(obj)
+
+
+@export
+def Set_Has_Identifier_List(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_identifier_list(obj, value)
+
+
+@export
+def Get_Has_Mode(obj):
+    return libghdl.vhdl__nodes__get_has_mode(obj)
+
+
+@export
+def Set_Has_Mode(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_mode(obj, value)
+
+
+@export
+def Get_Has_Class(obj):
+    return libghdl.vhdl__nodes__get_has_class(obj)
+
+
+@export
+def Set_Has_Class(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_class(obj, value)
+
+
+@export
+def Get_Has_Delay_Mechanism(obj):
+    return libghdl.vhdl__nodes__get_has_delay_mechanism(obj)
+
+
+@export
+def Set_Has_Delay_Mechanism(obj, value) -> None:
+    libghdl.vhdl__nodes__set_has_delay_mechanism(obj, value)
+
+
+@export
+def Get_Suspend_Flag(obj):
+    return libghdl.vhdl__nodes__get_suspend_flag(obj)
+
+
+@export
+def Set_Suspend_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_suspend_flag(obj, value)
+
+
+@export
+def Get_Is_Ref(obj):
+    return libghdl.vhdl__nodes__get_is_ref(obj)
+
+
+@export
+def Set_Is_Ref(obj, value) -> None:
+    libghdl.vhdl__nodes__set_is_ref(obj, value)
+
+
+@export
+def Get_Is_Forward_Ref(obj):
+    return libghdl.vhdl__nodes__get_is_forward_ref(obj)
+
+
+@export
+def Set_Is_Forward_Ref(obj, value) -> None:
+    libghdl.vhdl__nodes__set_is_forward_ref(obj, value)
+
+
+@export
+def Get_Psl_Property(obj):
+    return libghdl.vhdl__nodes__get_psl_property(obj)
+
+
+@export
+def Set_Psl_Property(obj, value) -> None:
+    libghdl.vhdl__nodes__set_psl_property(obj, value)
+
+
+@export
+def Get_Psl_Sequence(obj):
+    return libghdl.vhdl__nodes__get_psl_sequence(obj)
+
+
+@export
+def Set_Psl_Sequence(obj, value) -> None:
+    libghdl.vhdl__nodes__set_psl_sequence(obj, value)
+
+
+@export
+def Get_Psl_Declaration(obj):
+    return libghdl.vhdl__nodes__get_psl_declaration(obj)
+
+
+@export
+def Set_Psl_Declaration(obj, value) -> None:
+    libghdl.vhdl__nodes__set_psl_declaration(obj, value)
+
+
+@export
+def Get_Psl_Expression(obj):
+    return libghdl.vhdl__nodes__get_psl_expression(obj)
+
+
+@export
+def Set_Psl_Expression(obj, value) -> None:
+    libghdl.vhdl__nodes__set_psl_expression(obj, value)
+
+
+@export
+def Get_Psl_Boolean(obj):
+    return libghdl.vhdl__nodes__get_psl_boolean(obj)
+
+
+@export
+def Set_Psl_Boolean(obj, value) -> None:
+    libghdl.vhdl__nodes__set_psl_boolean(obj, value)
+
+
+@export
+def Get_PSL_Clock(obj):
+    return libghdl.vhdl__nodes__get_psl_clock(obj)
+
+
+@export
+def Set_PSL_Clock(obj, value) -> None:
+    libghdl.vhdl__nodes__set_psl_clock(obj, value)
+
+
+@export
+def Get_PSL_NFA(obj):
+    return libghdl.vhdl__nodes__get_psl_nfa(obj)
+
+
+@export
+def Set_PSL_NFA(obj, value) -> None:
+    libghdl.vhdl__nodes__set_psl_nfa(obj, value)
+
+
+@export
+def Get_PSL_Nbr_States(obj):
+    return libghdl.vhdl__nodes__get_psl_nbr_states(obj)
+
+
+@export
+def Set_PSL_Nbr_States(obj, value) -> None:
+    libghdl.vhdl__nodes__set_psl_nbr_states(obj, value)
+
+
+@export
+def Get_PSL_Clock_Sensitivity(obj):
+    return libghdl.vhdl__nodes__get_psl_clock_sensitivity(obj)
+
+
+@export
+def Set_PSL_Clock_Sensitivity(obj, value) -> None:
+    libghdl.vhdl__nodes__set_psl_clock_sensitivity(obj, value)
+
+
+@export
+def Get_PSL_EOS_Flag(obj):
+    return libghdl.vhdl__nodes__get_psl_eos_flag(obj)
+
+
+@export
+def Set_PSL_EOS_Flag(obj, value) -> None:
+    libghdl.vhdl__nodes__set_psl_eos_flag(obj, value)
+
+
+@export
+def Get_Count_Expression(obj):
+    return libghdl.vhdl__nodes__get_count_expression(obj)
+
+
+@export
+def Set_Count_Expression(obj, value) -> None:
+    libghdl.vhdl__nodes__set_count_expression(obj, value)
+
+
+@export
+def Get_Clock_Expression(obj):
+    return libghdl.vhdl__nodes__get_clock_expression(obj)
+
+
+@export
+def Set_Clock_Expression(obj, value) -> None:
+    libghdl.vhdl__nodes__set_clock_expression(obj, value)
+
+
+@export
+def Get_Default_Clock(obj):
+    return libghdl.vhdl__nodes__get_default_clock(obj)
+
+
+@export
+def Set_Default_Clock(obj, value) -> None:
+    libghdl.vhdl__nodes__set_default_clock(obj, value)
+
+
+@export
+def Get_Foreign_Node(obj):
+    return libghdl.vhdl__nodes__get_foreign_node(obj)
+
+
+@export
+def Set_Foreign_Node(obj, value) -> None:
+    libghdl.vhdl__nodes__set_foreign_node(obj, value)

--- a/pyGHDL/libghdl/vhdl/nodes_meta.py
+++ b/pyGHDL/libghdl/vhdl/nodes_meta.py
@@ -1,25 +1,63 @@
 # Auto generated Python source file from Ada sources
 # Call 'make' in 'src/vhdl' to regenerate:
 #
+from enum import IntEnum, unique
 from pydecor import export
 from pyGHDL.libghdl import libghdl
 from pyGHDL.libghdl._types import IirKind
 
 
 # From nodes_meta
-get_fields_first = libghdl.vhdl__nodes_meta__get_fields_first
+@export
+def get_fields_first(K: IirKind) -> int:
+    """
+    Return the list of fields for node :obj:`K`.
 
-get_fields_last = libghdl.vhdl__nodes_meta__get_fields_last
+    In Ada ``Vhdl.Nodes_Meta.Get_Fields`` returns a ``Fields_Array``. To emulate
+    this array access, the API provides ``get_fields_first`` and :func:`get_fields_last`.
 
-get_field_by_index = libghdl.vhdl__nodes_meta__get_field_by_index
+    The fields are sorted: first the non nodes/list of nodes, then the
+    nodes/lists that aren't reference, and then the reference.
 
-get_field_type = libghdl.vhdl__nodes_meta__get_field_type
-
-get_field_attribute = libghdl.vhdl__nodes_meta__get_field_attribute
+    :param K: Node to get first array index from.
+    """
+    return libghdl.vhdl__nodes_meta__get_fields_first(K)
 
 
 @export
-class types:
+def get_fields_last(K: IirKind) -> int:
+    """
+    Return the list of fields for node :obj:`K`.
+
+    In Ada ``Vhdl.Nodes_Meta.Get_Fields`` returns a ``Fields_Array``. To emulate
+    this array access, the API provides :func:`get_fields_first` and ``get_fields_last``.
+
+    The fields are sorted: first the non nodes/list of nodes, then the
+    nodes/lists that aren't reference, and then the reference.
+
+    :param K: Node to get last array index from.
+    """
+    return libghdl.vhdl__nodes_meta__get_fields_last(K)
+
+
+@export
+def get_field_by_index(K: IirKind) -> int:
+    return libghdl.vhdl__nodes_meta__get_field_by_index(K)
+
+
+@export
+def get_field_type(*args):
+    return libghdl.vhdl__nodes_meta__get_field_type(*args)
+
+
+@export
+def get_field_attribute(*args):
+    return libghdl.vhdl__nodes_meta__get_field_attribute(*args)
+
+
+@export
+@unique
+class types(IntEnum):
     Boolean = 0
     Date_State_Type = 1
     Date_Type = 2
@@ -56,7 +94,8 @@ class types:
 
 
 @export
-class Attr:
+@unique
+class Attr(IntEnum):
     ANone = 0
     Chain = 1
     Chain_Next = 2
@@ -69,7 +108,8 @@ class Attr:
 
 
 @export
-class fields:
+@unique
+class fields(IntEnum):
     First_Design_Unit = 0
     Last_Design_Unit = 1
     Library_Declaration = 2
@@ -442,869 +482,1613 @@ class fields:
     Foreign_Node = 369
 
 
-Get_Boolean = libghdl.vhdl__nodes_meta__get_boolean
+def Get_Boolean(node, field):
+    return libghdl.vhdl__nodes_meta__get_boolean(node, field)
 
-Get_Date_State_Type = libghdl.vhdl__nodes_meta__get_date_state_type
 
-Get_Date_Type = libghdl.vhdl__nodes_meta__get_date_type
+def Get_Date_State_Type(node, field):
+    return libghdl.vhdl__nodes_meta__get_date_state_type(node, field)
 
-Get_Direction_Type = libghdl.vhdl__nodes_meta__get_direction_type
 
-Get_File_Checksum_Id = libghdl.vhdl__nodes_meta__get_file_checksum_id
+def Get_Date_Type(node, field):
+    return libghdl.vhdl__nodes_meta__get_date_type(node, field)
 
-Get_Fp64 = libghdl.vhdl__nodes_meta__get_fp64
 
-Get_Iir = libghdl.vhdl__nodes_meta__get_iir
+def Get_Direction_Type(node, field):
+    return libghdl.vhdl__nodes_meta__get_direction_type(node, field)
 
-Get_Iir_All_Sensitized = libghdl.vhdl__nodes_meta__get_iir_all_sensitized
 
-Get_Iir_Constraint = libghdl.vhdl__nodes_meta__get_iir_constraint
+def Get_File_Checksum_Id(node, field):
+    return libghdl.vhdl__nodes_meta__get_file_checksum_id(node, field)
 
-Get_Iir_Delay_Mechanism = libghdl.vhdl__nodes_meta__get_iir_delay_mechanism
 
-Get_Iir_Flist = libghdl.vhdl__nodes_meta__get_iir_flist
+def Get_Fp64(node, field):
+    return libghdl.vhdl__nodes_meta__get_fp64(node, field)
 
-Get_Iir_Force_Mode = libghdl.vhdl__nodes_meta__get_iir_force_mode
 
-Get_Iir_Index32 = libghdl.vhdl__nodes_meta__get_iir_index32
+def Get_Iir(node, field):
+    return libghdl.vhdl__nodes_meta__get_iir(node, field)
 
-Get_Iir_Int32 = libghdl.vhdl__nodes_meta__get_iir_int32
 
-Get_Iir_List = libghdl.vhdl__nodes_meta__get_iir_list
+def Get_Iir_All_Sensitized(node, field):
+    return libghdl.vhdl__nodes_meta__get_iir_all_sensitized(node, field)
 
-Get_Iir_Mode = libghdl.vhdl__nodes_meta__get_iir_mode
 
-Get_Iir_Predefined_Functions = libghdl.vhdl__nodes_meta__get_iir_predefined_functions
+def Get_Iir_Constraint(node, field):
+    return libghdl.vhdl__nodes_meta__get_iir_constraint(node, field)
 
-Get_Iir_Pure_State = libghdl.vhdl__nodes_meta__get_iir_pure_state
 
-Get_Iir_Signal_Kind = libghdl.vhdl__nodes_meta__get_iir_signal_kind
+def Get_Iir_Delay_Mechanism(node, field):
+    return libghdl.vhdl__nodes_meta__get_iir_delay_mechanism(node, field)
 
-Get_Iir_Staticness = libghdl.vhdl__nodes_meta__get_iir_staticness
 
-Get_Int32 = libghdl.vhdl__nodes_meta__get_int32
+def Get_Iir_Flist(node, field):
+    return libghdl.vhdl__nodes_meta__get_iir_flist(node, field)
 
-Get_Int64 = libghdl.vhdl__nodes_meta__get_int64
 
-Get_Name_Id = libghdl.vhdl__nodes_meta__get_name_id
+def Get_Iir_Force_Mode(node, field):
+    return libghdl.vhdl__nodes_meta__get_iir_force_mode(node, field)
 
-Get_Number_Base_Type = libghdl.vhdl__nodes_meta__get_number_base_type
 
-Get_PSL_NFA = libghdl.vhdl__nodes_meta__get_psl_nfa
+def Get_Iir_Index32(node, field):
+    return libghdl.vhdl__nodes_meta__get_iir_index32(node, field)
 
-Get_PSL_Node = libghdl.vhdl__nodes_meta__get_psl_node
 
-Get_Scalar_Size = libghdl.vhdl__nodes_meta__get_scalar_size
+def Get_Iir_Int32(node, field):
+    return libghdl.vhdl__nodes_meta__get_iir_int32(node, field)
 
-Get_Source_File_Entry = libghdl.vhdl__nodes_meta__get_source_file_entry
 
-Get_Source_Ptr = libghdl.vhdl__nodes_meta__get_source_ptr
+def Get_Iir_List(node, field):
+    return libghdl.vhdl__nodes_meta__get_iir_list(node, field)
 
-Get_String8_Id = libghdl.vhdl__nodes_meta__get_string8_id
 
-Get_Time_Stamp_Id = libghdl.vhdl__nodes_meta__get_time_stamp_id
+def Get_Iir_Mode(node, field):
+    return libghdl.vhdl__nodes_meta__get_iir_mode(node, field)
 
-Get_Token_Type = libghdl.vhdl__nodes_meta__get_token_type
 
-Get_Tri_State_Type = libghdl.vhdl__nodes_meta__get_tri_state_type
+def Get_Iir_Predefined_Functions(node, field):
+    return libghdl.vhdl__nodes_meta__get_iir_predefined_functions(node, field)
 
 
-Has_First_Design_Unit = libghdl.vhdl__nodes_meta__has_first_design_unit
+def Get_Iir_Pure_State(node, field):
+    return libghdl.vhdl__nodes_meta__get_iir_pure_state(node, field)
 
-Has_Last_Design_Unit = libghdl.vhdl__nodes_meta__has_last_design_unit
 
-Has_Library_Declaration = libghdl.vhdl__nodes_meta__has_library_declaration
+def Get_Iir_Signal_Kind(node, field):
+    return libghdl.vhdl__nodes_meta__get_iir_signal_kind(node, field)
 
-Has_File_Checksum = libghdl.vhdl__nodes_meta__has_file_checksum
 
-Has_Analysis_Time_Stamp = libghdl.vhdl__nodes_meta__has_analysis_time_stamp
+def Get_Iir_Staticness(node, field):
+    return libghdl.vhdl__nodes_meta__get_iir_staticness(node, field)
 
-Has_Design_File_Source = libghdl.vhdl__nodes_meta__has_design_file_source
 
-Has_Library = libghdl.vhdl__nodes_meta__has_library
+def Get_Int32(node, field):
+    return libghdl.vhdl__nodes_meta__get_int32(node, field)
 
-Has_File_Dependence_List = libghdl.vhdl__nodes_meta__has_file_dependence_list
 
-Has_Design_File_Filename = libghdl.vhdl__nodes_meta__has_design_file_filename
+def Get_Int64(node, field):
+    return libghdl.vhdl__nodes_meta__get_int64(node, field)
 
-Has_Design_File_Directory = libghdl.vhdl__nodes_meta__has_design_file_directory
 
-Has_Design_File = libghdl.vhdl__nodes_meta__has_design_file
+def Get_Name_Id(node, field):
+    return libghdl.vhdl__nodes_meta__get_name_id(node, field)
 
-Has_Design_File_Chain = libghdl.vhdl__nodes_meta__has_design_file_chain
 
-Has_Library_Directory = libghdl.vhdl__nodes_meta__has_library_directory
+def Get_Number_Base_Type(node, field):
+    return libghdl.vhdl__nodes_meta__get_number_base_type(node, field)
 
-Has_Date = libghdl.vhdl__nodes_meta__has_date
 
-Has_Context_Items = libghdl.vhdl__nodes_meta__has_context_items
+def Get_PSL_NFA(node, field):
+    return libghdl.vhdl__nodes_meta__get_psl_nfa(node, field)
 
-Has_Dependence_List = libghdl.vhdl__nodes_meta__has_dependence_list
 
-Has_Analysis_Checks_List = libghdl.vhdl__nodes_meta__has_analysis_checks_list
+def Get_PSL_Node(node, field):
+    return libghdl.vhdl__nodes_meta__get_psl_node(node, field)
 
-Has_Date_State = libghdl.vhdl__nodes_meta__has_date_state
 
-Has_Guarded_Target_State = libghdl.vhdl__nodes_meta__has_guarded_target_state
+def Get_Scalar_Size(node, field):
+    return libghdl.vhdl__nodes_meta__get_scalar_size(node, field)
 
-Has_Library_Unit = libghdl.vhdl__nodes_meta__has_library_unit
 
-Has_Hash_Chain = libghdl.vhdl__nodes_meta__has_hash_chain
+def Get_Source_File_Entry(node, field):
+    return libghdl.vhdl__nodes_meta__get_source_file_entry(node, field)
 
-Has_Design_Unit_Source_Pos = libghdl.vhdl__nodes_meta__has_design_unit_source_pos
 
-Has_Design_Unit_Source_Line = libghdl.vhdl__nodes_meta__has_design_unit_source_line
+def Get_Source_Ptr(node, field):
+    return libghdl.vhdl__nodes_meta__get_source_ptr(node, field)
 
-Has_Design_Unit_Source_Col = libghdl.vhdl__nodes_meta__has_design_unit_source_col
 
-Has_Value = libghdl.vhdl__nodes_meta__has_value
+def Get_String8_Id(node, field):
+    return libghdl.vhdl__nodes_meta__get_string8_id(node, field)
 
-Has_Enum_Pos = libghdl.vhdl__nodes_meta__has_enum_pos
 
-Has_Physical_Literal = libghdl.vhdl__nodes_meta__has_physical_literal
+def Get_Time_Stamp_Id(node, field):
+    return libghdl.vhdl__nodes_meta__get_time_stamp_id(node, field)
 
-Has_Fp_Value = libghdl.vhdl__nodes_meta__has_fp_value
 
-Has_Simple_Aggregate_List = libghdl.vhdl__nodes_meta__has_simple_aggregate_list
+def Get_Token_Type(node, field):
+    return libghdl.vhdl__nodes_meta__get_token_type(node, field)
 
-Has_String8_Id = libghdl.vhdl__nodes_meta__has_string8_id
 
-Has_String_Length = libghdl.vhdl__nodes_meta__has_string_length
+def Get_Tri_State_Type(node, field):
+    return libghdl.vhdl__nodes_meta__get_tri_state_type(node, field)
 
-Has_Bit_String_Base = libghdl.vhdl__nodes_meta__has_bit_string_base
 
-Has_Has_Signed = libghdl.vhdl__nodes_meta__has_has_signed
+def Has_First_Design_Unit(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_first_design_unit(kind)
 
-Has_Has_Sign = libghdl.vhdl__nodes_meta__has_has_sign
 
-Has_Has_Length = libghdl.vhdl__nodes_meta__has_has_length
+def Has_Last_Design_Unit(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_last_design_unit(kind)
 
-Has_Literal_Length = libghdl.vhdl__nodes_meta__has_literal_length
 
-Has_Literal_Origin = libghdl.vhdl__nodes_meta__has_literal_origin
+def Has_Library_Declaration(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_library_declaration(kind)
 
-Has_Range_Origin = libghdl.vhdl__nodes_meta__has_range_origin
 
-Has_Literal_Subtype = libghdl.vhdl__nodes_meta__has_literal_subtype
+def Has_File_Checksum(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_file_checksum(kind)
 
-Has_Allocator_Subtype = libghdl.vhdl__nodes_meta__has_allocator_subtype
 
-Has_Entity_Class = libghdl.vhdl__nodes_meta__has_entity_class
+def Has_Analysis_Time_Stamp(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_analysis_time_stamp(kind)
 
-Has_Entity_Name_List = libghdl.vhdl__nodes_meta__has_entity_name_list
 
-Has_Attribute_Designator = libghdl.vhdl__nodes_meta__has_attribute_designator
+def Has_Design_File_Source(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_design_file_source(kind)
 
-Has_Attribute_Specification_Chain = (
-    libghdl.vhdl__nodes_meta__has_attribute_specification_chain
-)
 
-Has_Attribute_Specification = libghdl.vhdl__nodes_meta__has_attribute_specification
+def Has_Library(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_library(kind)
 
-Has_Static_Attribute_Flag = libghdl.vhdl__nodes_meta__has_static_attribute_flag
 
-Has_Signal_List = libghdl.vhdl__nodes_meta__has_signal_list
+def Has_File_Dependence_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_file_dependence_list(kind)
 
-Has_Quantity_List = libghdl.vhdl__nodes_meta__has_quantity_list
 
-Has_Designated_Entity = libghdl.vhdl__nodes_meta__has_designated_entity
+def Has_Design_File_Filename(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_design_file_filename(kind)
 
-Has_Formal = libghdl.vhdl__nodes_meta__has_formal
 
-Has_Actual = libghdl.vhdl__nodes_meta__has_actual
+def Has_Design_File_Directory(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_design_file_directory(kind)
 
-Has_Actual_Conversion = libghdl.vhdl__nodes_meta__has_actual_conversion
 
-Has_Formal_Conversion = libghdl.vhdl__nodes_meta__has_formal_conversion
+def Has_Design_File(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_design_file(kind)
 
-Has_Whole_Association_Flag = libghdl.vhdl__nodes_meta__has_whole_association_flag
 
-Has_Collapse_Signal_Flag = libghdl.vhdl__nodes_meta__has_collapse_signal_flag
+def Has_Design_File_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_design_file_chain(kind)
 
-Has_Artificial_Flag = libghdl.vhdl__nodes_meta__has_artificial_flag
 
-Has_Open_Flag = libghdl.vhdl__nodes_meta__has_open_flag
+def Has_Library_Directory(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_library_directory(kind)
 
-Has_After_Drivers_Flag = libghdl.vhdl__nodes_meta__has_after_drivers_flag
 
-Has_We_Value = libghdl.vhdl__nodes_meta__has_we_value
+def Has_Date(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_date(kind)
 
-Has_Time = libghdl.vhdl__nodes_meta__has_time
 
-Has_Associated_Expr = libghdl.vhdl__nodes_meta__has_associated_expr
+def Has_Context_Items(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_context_items(kind)
 
-Has_Associated_Block = libghdl.vhdl__nodes_meta__has_associated_block
 
-Has_Associated_Chain = libghdl.vhdl__nodes_meta__has_associated_chain
+def Has_Dependence_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_dependence_list(kind)
 
-Has_Choice_Name = libghdl.vhdl__nodes_meta__has_choice_name
 
-Has_Choice_Expression = libghdl.vhdl__nodes_meta__has_choice_expression
+def Has_Analysis_Checks_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_analysis_checks_list(kind)
 
-Has_Choice_Range = libghdl.vhdl__nodes_meta__has_choice_range
 
-Has_Same_Alternative_Flag = libghdl.vhdl__nodes_meta__has_same_alternative_flag
+def Has_Date_State(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_date_state(kind)
 
-Has_Element_Type_Flag = libghdl.vhdl__nodes_meta__has_element_type_flag
 
-Has_Architecture = libghdl.vhdl__nodes_meta__has_architecture
+def Has_Guarded_Target_State(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_guarded_target_state(kind)
 
-Has_Block_Specification = libghdl.vhdl__nodes_meta__has_block_specification
 
-Has_Prev_Block_Configuration = libghdl.vhdl__nodes_meta__has_prev_block_configuration
+def Has_Library_Unit(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_library_unit(kind)
 
-Has_Configuration_Item_Chain = libghdl.vhdl__nodes_meta__has_configuration_item_chain
 
-Has_Attribute_Value_Chain = libghdl.vhdl__nodes_meta__has_attribute_value_chain
+def Has_Hash_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_hash_chain(kind)
 
-Has_Spec_Chain = libghdl.vhdl__nodes_meta__has_spec_chain
 
-Has_Value_Chain = libghdl.vhdl__nodes_meta__has_value_chain
+def Has_Design_Unit_Source_Pos(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_design_unit_source_pos(kind)
 
-Has_Attribute_Value_Spec_Chain = (
-    libghdl.vhdl__nodes_meta__has_attribute_value_spec_chain
-)
 
-Has_Entity_Name = libghdl.vhdl__nodes_meta__has_entity_name
+def Has_Design_Unit_Source_Line(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_design_unit_source_line(kind)
 
-Has_Package = libghdl.vhdl__nodes_meta__has_package
 
-Has_Package_Body = libghdl.vhdl__nodes_meta__has_package_body
+def Has_Design_Unit_Source_Col(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_design_unit_source_col(kind)
 
-Has_Instance_Package_Body = libghdl.vhdl__nodes_meta__has_instance_package_body
 
-Has_Need_Body = libghdl.vhdl__nodes_meta__has_need_body
+def Has_Value(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_value(kind)
 
-Has_Macro_Expanded_Flag = libghdl.vhdl__nodes_meta__has_macro_expanded_flag
 
-Has_Need_Instance_Bodies = libghdl.vhdl__nodes_meta__has_need_instance_bodies
+def Has_Enum_Pos(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_enum_pos(kind)
 
-Has_Hierarchical_Name = libghdl.vhdl__nodes_meta__has_hierarchical_name
 
-Has_Inherit_Spec_Chain = libghdl.vhdl__nodes_meta__has_inherit_spec_chain
+def Has_Physical_Literal(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_physical_literal(kind)
 
-Has_Vunit_Item_Chain = libghdl.vhdl__nodes_meta__has_vunit_item_chain
 
-Has_Bound_Vunit_Chain = libghdl.vhdl__nodes_meta__has_bound_vunit_chain
+def Has_Fp_Value(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_fp_value(kind)
 
-Has_Verification_Block_Configuration = (
-    libghdl.vhdl__nodes_meta__has_verification_block_configuration
-)
 
-Has_Block_Configuration = libghdl.vhdl__nodes_meta__has_block_configuration
+def Has_Simple_Aggregate_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_simple_aggregate_list(kind)
 
-Has_Concurrent_Statement_Chain = (
-    libghdl.vhdl__nodes_meta__has_concurrent_statement_chain
-)
 
-Has_Chain = libghdl.vhdl__nodes_meta__has_chain
+def Has_String8_Id(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_string8_id(kind)
 
-Has_Port_Chain = libghdl.vhdl__nodes_meta__has_port_chain
 
-Has_Generic_Chain = libghdl.vhdl__nodes_meta__has_generic_chain
+def Has_String_Length(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_string_length(kind)
 
-Has_Type = libghdl.vhdl__nodes_meta__has_type
 
-Has_Subtype_Indication = libghdl.vhdl__nodes_meta__has_subtype_indication
+def Has_Bit_String_Base(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_bit_string_base(kind)
 
-Has_Discrete_Range = libghdl.vhdl__nodes_meta__has_discrete_range
 
-Has_Type_Definition = libghdl.vhdl__nodes_meta__has_type_definition
+def Has_Has_Signed(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_signed(kind)
 
-Has_Subtype_Definition = libghdl.vhdl__nodes_meta__has_subtype_definition
 
-Has_Incomplete_Type_Declaration = (
-    libghdl.vhdl__nodes_meta__has_incomplete_type_declaration
-)
+def Has_Has_Sign(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_sign(kind)
 
-Has_Interface_Type_Subprograms = (
-    libghdl.vhdl__nodes_meta__has_interface_type_subprograms
-)
 
-Has_Nature_Definition = libghdl.vhdl__nodes_meta__has_nature_definition
+def Has_Has_Length(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_length(kind)
 
-Has_Nature = libghdl.vhdl__nodes_meta__has_nature
 
-Has_Subnature_Indication = libghdl.vhdl__nodes_meta__has_subnature_indication
+def Has_Literal_Length(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_literal_length(kind)
 
-Has_Mode = libghdl.vhdl__nodes_meta__has_mode
 
-Has_Guarded_Signal_Flag = libghdl.vhdl__nodes_meta__has_guarded_signal_flag
+def Has_Literal_Origin(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_literal_origin(kind)
 
-Has_Signal_Kind = libghdl.vhdl__nodes_meta__has_signal_kind
 
-Has_Base_Name = libghdl.vhdl__nodes_meta__has_base_name
+def Has_Range_Origin(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_range_origin(kind)
 
-Has_Interface_Declaration_Chain = (
-    libghdl.vhdl__nodes_meta__has_interface_declaration_chain
-)
 
-Has_Subprogram_Specification = libghdl.vhdl__nodes_meta__has_subprogram_specification
+def Has_Literal_Subtype(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_literal_subtype(kind)
 
-Has_Sequential_Statement_Chain = (
-    libghdl.vhdl__nodes_meta__has_sequential_statement_chain
-)
 
-Has_Simultaneous_Statement_Chain = (
-    libghdl.vhdl__nodes_meta__has_simultaneous_statement_chain
-)
+def Has_Allocator_Subtype(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_allocator_subtype(kind)
 
-Has_Subprogram_Body = libghdl.vhdl__nodes_meta__has_subprogram_body
 
-Has_Overload_Number = libghdl.vhdl__nodes_meta__has_overload_number
+def Has_Entity_Class(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_entity_class(kind)
 
-Has_Subprogram_Depth = libghdl.vhdl__nodes_meta__has_subprogram_depth
 
-Has_Subprogram_Hash = libghdl.vhdl__nodes_meta__has_subprogram_hash
+def Has_Entity_Name_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_entity_name_list(kind)
 
-Has_Impure_Depth = libghdl.vhdl__nodes_meta__has_impure_depth
 
-Has_Return_Type = libghdl.vhdl__nodes_meta__has_return_type
+def Has_Attribute_Designator(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_attribute_designator(kind)
 
-Has_Implicit_Definition = libghdl.vhdl__nodes_meta__has_implicit_definition
 
-Has_Uninstantiated_Subprogram_Name = (
-    libghdl.vhdl__nodes_meta__has_uninstantiated_subprogram_name
-)
+def Has_Attribute_Specification_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_attribute_specification_chain(kind)
 
-Has_Default_Value = libghdl.vhdl__nodes_meta__has_default_value
 
-Has_Deferred_Declaration = libghdl.vhdl__nodes_meta__has_deferred_declaration
+def Has_Attribute_Specification(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_attribute_specification(kind)
 
-Has_Deferred_Declaration_Flag = libghdl.vhdl__nodes_meta__has_deferred_declaration_flag
 
-Has_Shared_Flag = libghdl.vhdl__nodes_meta__has_shared_flag
+def Has_Static_Attribute_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_static_attribute_flag(kind)
 
-Has_Design_Unit = libghdl.vhdl__nodes_meta__has_design_unit
 
-Has_Block_Statement = libghdl.vhdl__nodes_meta__has_block_statement
+def Has_Signal_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_signal_list(kind)
 
-Has_Signal_Driver = libghdl.vhdl__nodes_meta__has_signal_driver
 
-Has_Declaration_Chain = libghdl.vhdl__nodes_meta__has_declaration_chain
+def Has_Quantity_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_quantity_list(kind)
 
-Has_File_Logical_Name = libghdl.vhdl__nodes_meta__has_file_logical_name
 
-Has_File_Open_Kind = libghdl.vhdl__nodes_meta__has_file_open_kind
+def Has_Designated_Entity(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_designated_entity(kind)
 
-Has_Element_Position = libghdl.vhdl__nodes_meta__has_element_position
 
-Has_Use_Clause_Chain = libghdl.vhdl__nodes_meta__has_use_clause_chain
+def Has_Formal(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_formal(kind)
 
-Has_Context_Reference_Chain = libghdl.vhdl__nodes_meta__has_context_reference_chain
 
-Has_Selected_Name = libghdl.vhdl__nodes_meta__has_selected_name
+def Has_Actual(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_actual(kind)
 
-Has_Type_Declarator = libghdl.vhdl__nodes_meta__has_type_declarator
 
-Has_Complete_Type_Definition = libghdl.vhdl__nodes_meta__has_complete_type_definition
+def Has_Actual_Conversion(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_actual_conversion(kind)
 
-Has_Incomplete_Type_Ref_Chain = libghdl.vhdl__nodes_meta__has_incomplete_type_ref_chain
 
-Has_Associated_Type = libghdl.vhdl__nodes_meta__has_associated_type
+def Has_Formal_Conversion(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_formal_conversion(kind)
 
-Has_Enumeration_Literal_List = libghdl.vhdl__nodes_meta__has_enumeration_literal_list
 
-Has_Entity_Class_Entry_Chain = libghdl.vhdl__nodes_meta__has_entity_class_entry_chain
+def Has_Whole_Association_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_whole_association_flag(kind)
 
-Has_Group_Constituent_List = libghdl.vhdl__nodes_meta__has_group_constituent_list
 
-Has_Unit_Chain = libghdl.vhdl__nodes_meta__has_unit_chain
+def Has_Collapse_Signal_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_collapse_signal_flag(kind)
 
-Has_Primary_Unit = libghdl.vhdl__nodes_meta__has_primary_unit
 
-Has_Identifier = libghdl.vhdl__nodes_meta__has_identifier
+def Has_Artificial_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_artificial_flag(kind)
 
-Has_Label = libghdl.vhdl__nodes_meta__has_label
 
-Has_Visible_Flag = libghdl.vhdl__nodes_meta__has_visible_flag
+def Has_Open_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_open_flag(kind)
 
-Has_Range_Constraint = libghdl.vhdl__nodes_meta__has_range_constraint
 
-Has_Direction = libghdl.vhdl__nodes_meta__has_direction
+def Has_After_Drivers_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_after_drivers_flag(kind)
 
-Has_Left_Limit = libghdl.vhdl__nodes_meta__has_left_limit
 
-Has_Right_Limit = libghdl.vhdl__nodes_meta__has_right_limit
+def Has_We_Value(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_we_value(kind)
 
-Has_Left_Limit_Expr = libghdl.vhdl__nodes_meta__has_left_limit_expr
 
-Has_Right_Limit_Expr = libghdl.vhdl__nodes_meta__has_right_limit_expr
+def Has_Time(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_time(kind)
 
-Has_Parent_Type = libghdl.vhdl__nodes_meta__has_parent_type
 
-Has_Simple_Nature = libghdl.vhdl__nodes_meta__has_simple_nature
+def Has_Associated_Expr(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_associated_expr(kind)
 
-Has_Base_Nature = libghdl.vhdl__nodes_meta__has_base_nature
 
-Has_Resolution_Indication = libghdl.vhdl__nodes_meta__has_resolution_indication
+def Has_Associated_Block(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_associated_block(kind)
 
-Has_Record_Element_Resolution_Chain = (
-    libghdl.vhdl__nodes_meta__has_record_element_resolution_chain
-)
 
-Has_Tolerance = libghdl.vhdl__nodes_meta__has_tolerance
+def Has_Associated_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_associated_chain(kind)
 
-Has_Plus_Terminal_Name = libghdl.vhdl__nodes_meta__has_plus_terminal_name
 
-Has_Minus_Terminal_Name = libghdl.vhdl__nodes_meta__has_minus_terminal_name
+def Has_Choice_Name(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_choice_name(kind)
 
-Has_Plus_Terminal = libghdl.vhdl__nodes_meta__has_plus_terminal
 
-Has_Minus_Terminal = libghdl.vhdl__nodes_meta__has_minus_terminal
+def Has_Choice_Expression(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_choice_expression(kind)
 
-Has_Magnitude_Expression = libghdl.vhdl__nodes_meta__has_magnitude_expression
 
-Has_Phase_Expression = libghdl.vhdl__nodes_meta__has_phase_expression
+def Has_Choice_Range(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_choice_range(kind)
 
-Has_Power_Expression = libghdl.vhdl__nodes_meta__has_power_expression
 
-Has_Simultaneous_Left = libghdl.vhdl__nodes_meta__has_simultaneous_left
+def Has_Same_Alternative_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_same_alternative_flag(kind)
 
-Has_Simultaneous_Right = libghdl.vhdl__nodes_meta__has_simultaneous_right
 
-Has_Text_File_Flag = libghdl.vhdl__nodes_meta__has_text_file_flag
+def Has_Element_Type_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_element_type_flag(kind)
 
-Has_Only_Characters_Flag = libghdl.vhdl__nodes_meta__has_only_characters_flag
 
-Has_Is_Character_Type = libghdl.vhdl__nodes_meta__has_is_character_type
+def Has_Architecture(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_architecture(kind)
 
-Has_Nature_Staticness = libghdl.vhdl__nodes_meta__has_nature_staticness
 
-Has_Type_Staticness = libghdl.vhdl__nodes_meta__has_type_staticness
+def Has_Block_Specification(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_block_specification(kind)
 
-Has_Constraint_State = libghdl.vhdl__nodes_meta__has_constraint_state
 
-Has_Index_Subtype_List = libghdl.vhdl__nodes_meta__has_index_subtype_list
+def Has_Prev_Block_Configuration(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_prev_block_configuration(kind)
 
-Has_Index_Subtype_Definition_List = (
-    libghdl.vhdl__nodes_meta__has_index_subtype_definition_list
-)
 
-Has_Element_Subtype_Indication = (
-    libghdl.vhdl__nodes_meta__has_element_subtype_indication
-)
+def Has_Configuration_Item_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_configuration_item_chain(kind)
 
-Has_Element_Subtype = libghdl.vhdl__nodes_meta__has_element_subtype
 
-Has_Element_Subnature_Indication = (
-    libghdl.vhdl__nodes_meta__has_element_subnature_indication
-)
+def Has_Attribute_Value_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_attribute_value_chain(kind)
 
-Has_Element_Subnature = libghdl.vhdl__nodes_meta__has_element_subnature
 
-Has_Index_Constraint_List = libghdl.vhdl__nodes_meta__has_index_constraint_list
+def Has_Spec_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_spec_chain(kind)
 
-Has_Array_Element_Constraint = libghdl.vhdl__nodes_meta__has_array_element_constraint
 
-Has_Has_Array_Constraint_Flag = libghdl.vhdl__nodes_meta__has_has_array_constraint_flag
+def Has_Value_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_value_chain(kind)
 
-Has_Has_Element_Constraint_Flag = (
-    libghdl.vhdl__nodes_meta__has_has_element_constraint_flag
-)
 
-Has_Elements_Declaration_List = libghdl.vhdl__nodes_meta__has_elements_declaration_list
+def Has_Attribute_Value_Spec_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_attribute_value_spec_chain(kind)
 
-Has_Owned_Elements_Chain = libghdl.vhdl__nodes_meta__has_owned_elements_chain
 
-Has_Designated_Type = libghdl.vhdl__nodes_meta__has_designated_type
+def Has_Entity_Name(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_entity_name(kind)
 
-Has_Designated_Subtype_Indication = (
-    libghdl.vhdl__nodes_meta__has_designated_subtype_indication
-)
 
-Has_Index_List = libghdl.vhdl__nodes_meta__has_index_list
+def Has_Package(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_package(kind)
 
-Has_Reference = libghdl.vhdl__nodes_meta__has_reference
 
-Has_Nature_Declarator = libghdl.vhdl__nodes_meta__has_nature_declarator
+def Has_Package_Body(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_package_body(kind)
 
-Has_Across_Type_Mark = libghdl.vhdl__nodes_meta__has_across_type_mark
 
-Has_Through_Type_Mark = libghdl.vhdl__nodes_meta__has_through_type_mark
+def Has_Instance_Package_Body(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_instance_package_body(kind)
 
-Has_Across_Type_Definition = libghdl.vhdl__nodes_meta__has_across_type_definition
 
-Has_Through_Type_Definition = libghdl.vhdl__nodes_meta__has_through_type_definition
+def Has_Need_Body(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_need_body(kind)
 
-Has_Across_Type = libghdl.vhdl__nodes_meta__has_across_type
 
-Has_Through_Type = libghdl.vhdl__nodes_meta__has_through_type
+def Has_Macro_Expanded_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_macro_expanded_flag(kind)
 
-Has_Target = libghdl.vhdl__nodes_meta__has_target
 
-Has_Waveform_Chain = libghdl.vhdl__nodes_meta__has_waveform_chain
+def Has_Need_Instance_Bodies(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_need_instance_bodies(kind)
 
-Has_Guard = libghdl.vhdl__nodes_meta__has_guard
 
-Has_Delay_Mechanism = libghdl.vhdl__nodes_meta__has_delay_mechanism
+def Has_Hierarchical_Name(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_hierarchical_name(kind)
 
-Has_Reject_Time_Expression = libghdl.vhdl__nodes_meta__has_reject_time_expression
 
-Has_Force_Mode = libghdl.vhdl__nodes_meta__has_force_mode
+def Has_Inherit_Spec_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_inherit_spec_chain(kind)
 
-Has_Has_Force_Mode = libghdl.vhdl__nodes_meta__has_has_force_mode
 
-Has_Sensitivity_List = libghdl.vhdl__nodes_meta__has_sensitivity_list
+def Has_Vunit_Item_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_vunit_item_chain(kind)
 
-Has_Process_Origin = libghdl.vhdl__nodes_meta__has_process_origin
 
-Has_Package_Origin = libghdl.vhdl__nodes_meta__has_package_origin
+def Has_Bound_Vunit_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_bound_vunit_chain(kind)
 
-Has_Condition_Clause = libghdl.vhdl__nodes_meta__has_condition_clause
 
-Has_Break_Element = libghdl.vhdl__nodes_meta__has_break_element
+def Has_Verification_Block_Configuration(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_verification_block_configuration(kind)
 
-Has_Selector_Quantity = libghdl.vhdl__nodes_meta__has_selector_quantity
 
-Has_Break_Quantity = libghdl.vhdl__nodes_meta__has_break_quantity
+def Has_Block_Configuration(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_block_configuration(kind)
 
-Has_Timeout_Clause = libghdl.vhdl__nodes_meta__has_timeout_clause
 
-Has_Postponed_Flag = libghdl.vhdl__nodes_meta__has_postponed_flag
+def Has_Concurrent_Statement_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_concurrent_statement_chain(kind)
 
-Has_Callees_List = libghdl.vhdl__nodes_meta__has_callees_list
 
-Has_Passive_Flag = libghdl.vhdl__nodes_meta__has_passive_flag
+def Has_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_chain(kind)
 
-Has_Resolution_Function_Flag = libghdl.vhdl__nodes_meta__has_resolution_function_flag
 
-Has_Wait_State = libghdl.vhdl__nodes_meta__has_wait_state
+def Has_Port_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_port_chain(kind)
 
-Has_All_Sensitized_State = libghdl.vhdl__nodes_meta__has_all_sensitized_state
 
-Has_Seen_Flag = libghdl.vhdl__nodes_meta__has_seen_flag
+def Has_Generic_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_generic_chain(kind)
 
-Has_Pure_Flag = libghdl.vhdl__nodes_meta__has_pure_flag
 
-Has_Foreign_Flag = libghdl.vhdl__nodes_meta__has_foreign_flag
+def Has_Type(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_type(kind)
 
-Has_Resolved_Flag = libghdl.vhdl__nodes_meta__has_resolved_flag
 
-Has_Signal_Type_Flag = libghdl.vhdl__nodes_meta__has_signal_type_flag
+def Has_Subtype_Indication(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_subtype_indication(kind)
 
-Has_Has_Signal_Flag = libghdl.vhdl__nodes_meta__has_has_signal_flag
 
-Has_Purity_State = libghdl.vhdl__nodes_meta__has_purity_state
+def Has_Discrete_Range(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_discrete_range(kind)
 
-Has_Elab_Flag = libghdl.vhdl__nodes_meta__has_elab_flag
 
-Has_Vendor_Library_Flag = libghdl.vhdl__nodes_meta__has_vendor_library_flag
+def Has_Type_Definition(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_type_definition(kind)
 
-Has_Configuration_Mark_Flag = libghdl.vhdl__nodes_meta__has_configuration_mark_flag
 
-Has_Configuration_Done_Flag = libghdl.vhdl__nodes_meta__has_configuration_done_flag
+def Has_Subtype_Definition(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_subtype_definition(kind)
 
-Has_Index_Constraint_Flag = libghdl.vhdl__nodes_meta__has_index_constraint_flag
 
-Has_Hide_Implicit_Flag = libghdl.vhdl__nodes_meta__has_hide_implicit_flag
+def Has_Incomplete_Type_Declaration(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_incomplete_type_declaration(kind)
 
-Has_Assertion_Condition = libghdl.vhdl__nodes_meta__has_assertion_condition
 
-Has_Report_Expression = libghdl.vhdl__nodes_meta__has_report_expression
+def Has_Interface_Type_Subprograms(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_interface_type_subprograms(kind)
 
-Has_Severity_Expression = libghdl.vhdl__nodes_meta__has_severity_expression
 
-Has_Instantiated_Unit = libghdl.vhdl__nodes_meta__has_instantiated_unit
+def Has_Nature_Definition(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_nature_definition(kind)
 
-Has_Generic_Map_Aspect_Chain = libghdl.vhdl__nodes_meta__has_generic_map_aspect_chain
 
-Has_Port_Map_Aspect_Chain = libghdl.vhdl__nodes_meta__has_port_map_aspect_chain
+def Has_Nature(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_nature(kind)
 
-Has_Configuration_Name = libghdl.vhdl__nodes_meta__has_configuration_name
 
-Has_Component_Configuration = libghdl.vhdl__nodes_meta__has_component_configuration
+def Has_Subnature_Indication(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_subnature_indication(kind)
 
-Has_Configuration_Specification = (
-    libghdl.vhdl__nodes_meta__has_configuration_specification
-)
 
-Has_Default_Binding_Indication = (
-    libghdl.vhdl__nodes_meta__has_default_binding_indication
-)
+def Has_Mode(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_mode(kind)
 
-Has_Default_Configuration_Declaration = (
-    libghdl.vhdl__nodes_meta__has_default_configuration_declaration
-)
 
-Has_Expression = libghdl.vhdl__nodes_meta__has_expression
+def Has_Guarded_Signal_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_guarded_signal_flag(kind)
 
-Has_Conditional_Expression_Chain = (
-    libghdl.vhdl__nodes_meta__has_conditional_expression_chain
-)
 
-Has_Allocator_Designated_Type = libghdl.vhdl__nodes_meta__has_allocator_designated_type
+def Has_Signal_Kind(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_signal_kind(kind)
 
-Has_Selected_Waveform_Chain = libghdl.vhdl__nodes_meta__has_selected_waveform_chain
 
-Has_Conditional_Waveform_Chain = (
-    libghdl.vhdl__nodes_meta__has_conditional_waveform_chain
-)
+def Has_Base_Name(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_base_name(kind)
 
-Has_Guard_Expression = libghdl.vhdl__nodes_meta__has_guard_expression
 
-Has_Guard_Decl = libghdl.vhdl__nodes_meta__has_guard_decl
+def Has_Interface_Declaration_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_interface_declaration_chain(kind)
 
-Has_Guard_Sensitivity_List = libghdl.vhdl__nodes_meta__has_guard_sensitivity_list
 
-Has_Signal_Attribute_Chain = libghdl.vhdl__nodes_meta__has_signal_attribute_chain
+def Has_Subprogram_Specification(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_subprogram_specification(kind)
 
-Has_Block_Block_Configuration = libghdl.vhdl__nodes_meta__has_block_block_configuration
 
-Has_Package_Header = libghdl.vhdl__nodes_meta__has_package_header
+def Has_Sequential_Statement_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_sequential_statement_chain(kind)
 
-Has_Block_Header = libghdl.vhdl__nodes_meta__has_block_header
 
-Has_Uninstantiated_Package_Name = (
-    libghdl.vhdl__nodes_meta__has_uninstantiated_package_name
-)
+def Has_Simultaneous_Statement_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_simultaneous_statement_chain(kind)
 
-Has_Uninstantiated_Package_Decl = (
-    libghdl.vhdl__nodes_meta__has_uninstantiated_package_decl
-)
 
-Has_Instance_Source_File = libghdl.vhdl__nodes_meta__has_instance_source_file
+def Has_Subprogram_Body(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_subprogram_body(kind)
 
-Has_Generate_Block_Configuration = (
-    libghdl.vhdl__nodes_meta__has_generate_block_configuration
-)
 
-Has_Generate_Statement_Body = libghdl.vhdl__nodes_meta__has_generate_statement_body
+def Has_Overload_Number(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_overload_number(kind)
 
-Has_Alternative_Label = libghdl.vhdl__nodes_meta__has_alternative_label
 
-Has_Generate_Else_Clause = libghdl.vhdl__nodes_meta__has_generate_else_clause
+def Has_Subprogram_Depth(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_subprogram_depth(kind)
 
-Has_Condition = libghdl.vhdl__nodes_meta__has_condition
 
-Has_Else_Clause = libghdl.vhdl__nodes_meta__has_else_clause
+def Has_Subprogram_Hash(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_subprogram_hash(kind)
 
-Has_Parameter_Specification = libghdl.vhdl__nodes_meta__has_parameter_specification
 
-Has_Parent = libghdl.vhdl__nodes_meta__has_parent
+def Has_Impure_Depth(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_impure_depth(kind)
 
-Has_Loop_Label = libghdl.vhdl__nodes_meta__has_loop_label
 
-Has_Exit_Flag = libghdl.vhdl__nodes_meta__has_exit_flag
+def Has_Return_Type(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_return_type(kind)
 
-Has_Next_Flag = libghdl.vhdl__nodes_meta__has_next_flag
 
-Has_Component_Name = libghdl.vhdl__nodes_meta__has_component_name
+def Has_Implicit_Definition(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_implicit_definition(kind)
 
-Has_Instantiation_List = libghdl.vhdl__nodes_meta__has_instantiation_list
 
-Has_Entity_Aspect = libghdl.vhdl__nodes_meta__has_entity_aspect
+def Has_Uninstantiated_Subprogram_Name(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_uninstantiated_subprogram_name(kind)
 
-Has_Default_Entity_Aspect = libghdl.vhdl__nodes_meta__has_default_entity_aspect
 
-Has_Binding_Indication = libghdl.vhdl__nodes_meta__has_binding_indication
+def Has_Default_Value(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_default_value(kind)
 
-Has_Named_Entity = libghdl.vhdl__nodes_meta__has_named_entity
 
-Has_Referenced_Name = libghdl.vhdl__nodes_meta__has_referenced_name
+def Has_Deferred_Declaration(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_deferred_declaration(kind)
 
-Has_Expr_Staticness = libghdl.vhdl__nodes_meta__has_expr_staticness
 
-Has_Scalar_Size = libghdl.vhdl__nodes_meta__has_scalar_size
+def Has_Deferred_Declaration_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_deferred_declaration_flag(kind)
 
-Has_Error_Origin = libghdl.vhdl__nodes_meta__has_error_origin
 
-Has_Operand = libghdl.vhdl__nodes_meta__has_operand
+def Has_Shared_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_shared_flag(kind)
 
-Has_Left = libghdl.vhdl__nodes_meta__has_left
 
-Has_Right = libghdl.vhdl__nodes_meta__has_right
+def Has_Design_Unit(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_design_unit(kind)
 
-Has_Unit_Name = libghdl.vhdl__nodes_meta__has_unit_name
 
-Has_Name = libghdl.vhdl__nodes_meta__has_name
+def Has_Block_Statement(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_block_statement(kind)
 
-Has_Group_Template_Name = libghdl.vhdl__nodes_meta__has_group_template_name
 
-Has_Name_Staticness = libghdl.vhdl__nodes_meta__has_name_staticness
+def Has_Signal_Driver(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_signal_driver(kind)
 
-Has_Prefix = libghdl.vhdl__nodes_meta__has_prefix
 
-Has_Signature_Prefix = libghdl.vhdl__nodes_meta__has_signature_prefix
+def Has_Declaration_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_declaration_chain(kind)
 
-Has_External_Pathname = libghdl.vhdl__nodes_meta__has_external_pathname
 
-Has_Pathname_Suffix = libghdl.vhdl__nodes_meta__has_pathname_suffix
+def Has_File_Logical_Name(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_file_logical_name(kind)
 
-Has_Pathname_Expression = libghdl.vhdl__nodes_meta__has_pathname_expression
 
-Has_In_Formal_Flag = libghdl.vhdl__nodes_meta__has_in_formal_flag
+def Has_File_Open_Kind(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_file_open_kind(kind)
 
-Has_Slice_Subtype = libghdl.vhdl__nodes_meta__has_slice_subtype
 
-Has_Suffix = libghdl.vhdl__nodes_meta__has_suffix
+def Has_Element_Position(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_element_position(kind)
 
-Has_Index_Subtype = libghdl.vhdl__nodes_meta__has_index_subtype
 
-Has_Parameter = libghdl.vhdl__nodes_meta__has_parameter
+def Has_Use_Clause_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_use_clause_chain(kind)
 
-Has_Parameter_2 = libghdl.vhdl__nodes_meta__has_parameter_2
 
-Has_Parameter_3 = libghdl.vhdl__nodes_meta__has_parameter_3
+def Has_Context_Reference_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_context_reference_chain(kind)
 
-Has_Parameter_4 = libghdl.vhdl__nodes_meta__has_parameter_4
 
-Has_Attr_Chain = libghdl.vhdl__nodes_meta__has_attr_chain
+def Has_Selected_Name(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_selected_name(kind)
 
-Has_Signal_Attribute_Declaration = (
-    libghdl.vhdl__nodes_meta__has_signal_attribute_declaration
-)
 
-Has_Actual_Type = libghdl.vhdl__nodes_meta__has_actual_type
+def Has_Type_Declarator(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_type_declarator(kind)
 
-Has_Actual_Type_Definition = libghdl.vhdl__nodes_meta__has_actual_type_definition
 
-Has_Association_Chain = libghdl.vhdl__nodes_meta__has_association_chain
+def Has_Complete_Type_Definition(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_complete_type_definition(kind)
 
-Has_Individual_Association_Chain = (
-    libghdl.vhdl__nodes_meta__has_individual_association_chain
-)
 
-Has_Subprogram_Association_Chain = (
-    libghdl.vhdl__nodes_meta__has_subprogram_association_chain
-)
+def Has_Incomplete_Type_Ref_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_incomplete_type_ref_chain(kind)
 
-Has_Aggregate_Info = libghdl.vhdl__nodes_meta__has_aggregate_info
 
-Has_Sub_Aggregate_Info = libghdl.vhdl__nodes_meta__has_sub_aggregate_info
+def Has_Associated_Type(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_associated_type(kind)
 
-Has_Aggr_Dynamic_Flag = libghdl.vhdl__nodes_meta__has_aggr_dynamic_flag
 
-Has_Aggr_Min_Length = libghdl.vhdl__nodes_meta__has_aggr_min_length
+def Has_Enumeration_Literal_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_enumeration_literal_list(kind)
 
-Has_Aggr_Low_Limit = libghdl.vhdl__nodes_meta__has_aggr_low_limit
 
-Has_Aggr_High_Limit = libghdl.vhdl__nodes_meta__has_aggr_high_limit
+def Has_Entity_Class_Entry_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_entity_class_entry_chain(kind)
 
-Has_Aggr_Others_Flag = libghdl.vhdl__nodes_meta__has_aggr_others_flag
 
-Has_Aggr_Named_Flag = libghdl.vhdl__nodes_meta__has_aggr_named_flag
+def Has_Group_Constituent_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_group_constituent_list(kind)
 
-Has_Aggregate_Expand_Flag = libghdl.vhdl__nodes_meta__has_aggregate_expand_flag
 
-Has_Association_Choices_Chain = libghdl.vhdl__nodes_meta__has_association_choices_chain
+def Has_Unit_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_unit_chain(kind)
 
-Has_Case_Statement_Alternative_Chain = (
-    libghdl.vhdl__nodes_meta__has_case_statement_alternative_chain
-)
 
-Has_Choice_Staticness = libghdl.vhdl__nodes_meta__has_choice_staticness
+def Has_Primary_Unit(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_primary_unit(kind)
 
-Has_Procedure_Call = libghdl.vhdl__nodes_meta__has_procedure_call
 
-Has_Implementation = libghdl.vhdl__nodes_meta__has_implementation
+def Has_Identifier(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_identifier(kind)
 
-Has_Parameter_Association_Chain = (
-    libghdl.vhdl__nodes_meta__has_parameter_association_chain
-)
 
-Has_Method_Object = libghdl.vhdl__nodes_meta__has_method_object
+def Has_Label(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_label(kind)
 
-Has_Subtype_Type_Mark = libghdl.vhdl__nodes_meta__has_subtype_type_mark
 
-Has_Subnature_Nature_Mark = libghdl.vhdl__nodes_meta__has_subnature_nature_mark
+def Has_Visible_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_visible_flag(kind)
 
-Has_Type_Conversion_Subtype = libghdl.vhdl__nodes_meta__has_type_conversion_subtype
 
-Has_Type_Mark = libghdl.vhdl__nodes_meta__has_type_mark
+def Has_Range_Constraint(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_range_constraint(kind)
 
-Has_File_Type_Mark = libghdl.vhdl__nodes_meta__has_file_type_mark
 
-Has_Return_Type_Mark = libghdl.vhdl__nodes_meta__has_return_type_mark
+def Has_Direction(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_direction(kind)
 
-Has_Has_Disconnect_Flag = libghdl.vhdl__nodes_meta__has_has_disconnect_flag
 
-Has_Has_Active_Flag = libghdl.vhdl__nodes_meta__has_has_active_flag
+def Has_Left_Limit(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_left_limit(kind)
 
-Has_Is_Within_Flag = libghdl.vhdl__nodes_meta__has_is_within_flag
 
-Has_Type_Marks_List = libghdl.vhdl__nodes_meta__has_type_marks_list
+def Has_Right_Limit(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_right_limit(kind)
 
-Has_Implicit_Alias_Flag = libghdl.vhdl__nodes_meta__has_implicit_alias_flag
 
-Has_Alias_Signature = libghdl.vhdl__nodes_meta__has_alias_signature
+def Has_Left_Limit_Expr(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_left_limit_expr(kind)
 
-Has_Attribute_Signature = libghdl.vhdl__nodes_meta__has_attribute_signature
 
-Has_Overload_List = libghdl.vhdl__nodes_meta__has_overload_list
+def Has_Right_Limit_Expr(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_right_limit_expr(kind)
 
-Has_Simple_Name_Identifier = libghdl.vhdl__nodes_meta__has_simple_name_identifier
 
-Has_Simple_Name_Subtype = libghdl.vhdl__nodes_meta__has_simple_name_subtype
+def Has_Parent_Type(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_parent_type(kind)
 
-Has_Protected_Type_Body = libghdl.vhdl__nodes_meta__has_protected_type_body
 
-Has_Protected_Type_Declaration = (
-    libghdl.vhdl__nodes_meta__has_protected_type_declaration
-)
+def Has_Simple_Nature(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_simple_nature(kind)
 
-Has_Use_Flag = libghdl.vhdl__nodes_meta__has_use_flag
 
-Has_End_Has_Reserved_Id = libghdl.vhdl__nodes_meta__has_end_has_reserved_id
+def Has_Base_Nature(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_base_nature(kind)
 
-Has_End_Has_Identifier = libghdl.vhdl__nodes_meta__has_end_has_identifier
 
-Has_End_Has_Postponed = libghdl.vhdl__nodes_meta__has_end_has_postponed
+def Has_Resolution_Indication(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_resolution_indication(kind)
 
-Has_Has_Label = libghdl.vhdl__nodes_meta__has_has_label
 
-Has_Has_Begin = libghdl.vhdl__nodes_meta__has_has_begin
+def Has_Record_Element_Resolution_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_record_element_resolution_chain(kind)
 
-Has_Has_End = libghdl.vhdl__nodes_meta__has_has_end
 
-Has_Has_Is = libghdl.vhdl__nodes_meta__has_has_is
+def Has_Tolerance(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_tolerance(kind)
 
-Has_Has_Pure = libghdl.vhdl__nodes_meta__has_has_pure
 
-Has_Has_Body = libghdl.vhdl__nodes_meta__has_has_body
+def Has_Plus_Terminal_Name(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_plus_terminal_name(kind)
 
-Has_Has_Parameter = libghdl.vhdl__nodes_meta__has_has_parameter
 
-Has_Has_Component = libghdl.vhdl__nodes_meta__has_has_component
+def Has_Minus_Terminal_Name(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_minus_terminal_name(kind)
 
-Has_Has_Identifier_List = libghdl.vhdl__nodes_meta__has_has_identifier_list
 
-Has_Has_Mode = libghdl.vhdl__nodes_meta__has_has_mode
+def Has_Plus_Terminal(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_plus_terminal(kind)
 
-Has_Has_Class = libghdl.vhdl__nodes_meta__has_has_class
 
-Has_Has_Delay_Mechanism = libghdl.vhdl__nodes_meta__has_has_delay_mechanism
+def Has_Minus_Terminal(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_minus_terminal(kind)
 
-Has_Suspend_Flag = libghdl.vhdl__nodes_meta__has_suspend_flag
 
-Has_Is_Ref = libghdl.vhdl__nodes_meta__has_is_ref
+def Has_Magnitude_Expression(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_magnitude_expression(kind)
 
-Has_Is_Forward_Ref = libghdl.vhdl__nodes_meta__has_is_forward_ref
 
-Has_Psl_Property = libghdl.vhdl__nodes_meta__has_psl_property
+def Has_Phase_Expression(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_phase_expression(kind)
 
-Has_Psl_Sequence = libghdl.vhdl__nodes_meta__has_psl_sequence
 
-Has_Psl_Declaration = libghdl.vhdl__nodes_meta__has_psl_declaration
+def Has_Power_Expression(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_power_expression(kind)
 
-Has_Psl_Expression = libghdl.vhdl__nodes_meta__has_psl_expression
 
-Has_Psl_Boolean = libghdl.vhdl__nodes_meta__has_psl_boolean
+def Has_Simultaneous_Left(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_simultaneous_left(kind)
 
-Has_PSL_Clock = libghdl.vhdl__nodes_meta__has_psl_clock
 
-Has_PSL_NFA = libghdl.vhdl__nodes_meta__has_psl_nfa
+def Has_Simultaneous_Right(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_simultaneous_right(kind)
 
-Has_PSL_Nbr_States = libghdl.vhdl__nodes_meta__has_psl_nbr_states
 
-Has_PSL_Clock_Sensitivity = libghdl.vhdl__nodes_meta__has_psl_clock_sensitivity
+def Has_Text_File_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_text_file_flag(kind)
 
-Has_PSL_EOS_Flag = libghdl.vhdl__nodes_meta__has_psl_eos_flag
 
-Has_Count_Expression = libghdl.vhdl__nodes_meta__has_count_expression
+def Has_Only_Characters_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_only_characters_flag(kind)
 
-Has_Clock_Expression = libghdl.vhdl__nodes_meta__has_clock_expression
 
-Has_Default_Clock = libghdl.vhdl__nodes_meta__has_default_clock
+def Has_Is_Character_Type(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_is_character_type(kind)
 
-Has_Foreign_Node = libghdl.vhdl__nodes_meta__has_foreign_node
+
+def Has_Nature_Staticness(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_nature_staticness(kind)
+
+
+def Has_Type_Staticness(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_type_staticness(kind)
+
+
+def Has_Constraint_State(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_constraint_state(kind)
+
+
+def Has_Index_Subtype_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_index_subtype_list(kind)
+
+
+def Has_Index_Subtype_Definition_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_index_subtype_definition_list(kind)
+
+
+def Has_Element_Subtype_Indication(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_element_subtype_indication(kind)
+
+
+def Has_Element_Subtype(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_element_subtype(kind)
+
+
+def Has_Element_Subnature_Indication(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_element_subnature_indication(kind)
+
+
+def Has_Element_Subnature(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_element_subnature(kind)
+
+
+def Has_Index_Constraint_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_index_constraint_list(kind)
+
+
+def Has_Array_Element_Constraint(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_array_element_constraint(kind)
+
+
+def Has_Has_Array_Constraint_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_array_constraint_flag(kind)
+
+
+def Has_Has_Element_Constraint_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_element_constraint_flag(kind)
+
+
+def Has_Elements_Declaration_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_elements_declaration_list(kind)
+
+
+def Has_Owned_Elements_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_owned_elements_chain(kind)
+
+
+def Has_Designated_Type(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_designated_type(kind)
+
+
+def Has_Designated_Subtype_Indication(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_designated_subtype_indication(kind)
+
+
+def Has_Index_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_index_list(kind)
+
+
+def Has_Reference(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_reference(kind)
+
+
+def Has_Nature_Declarator(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_nature_declarator(kind)
+
+
+def Has_Across_Type_Mark(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_across_type_mark(kind)
+
+
+def Has_Through_Type_Mark(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_through_type_mark(kind)
+
+
+def Has_Across_Type_Definition(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_across_type_definition(kind)
+
+
+def Has_Through_Type_Definition(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_through_type_definition(kind)
+
+
+def Has_Across_Type(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_across_type(kind)
+
+
+def Has_Through_Type(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_through_type(kind)
+
+
+def Has_Target(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_target(kind)
+
+
+def Has_Waveform_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_waveform_chain(kind)
+
+
+def Has_Guard(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_guard(kind)
+
+
+def Has_Delay_Mechanism(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_delay_mechanism(kind)
+
+
+def Has_Reject_Time_Expression(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_reject_time_expression(kind)
+
+
+def Has_Force_Mode(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_force_mode(kind)
+
+
+def Has_Has_Force_Mode(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_force_mode(kind)
+
+
+def Has_Sensitivity_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_sensitivity_list(kind)
+
+
+def Has_Process_Origin(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_process_origin(kind)
+
+
+def Has_Package_Origin(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_package_origin(kind)
+
+
+def Has_Condition_Clause(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_condition_clause(kind)
+
+
+def Has_Break_Element(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_break_element(kind)
+
+
+def Has_Selector_Quantity(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_selector_quantity(kind)
+
+
+def Has_Break_Quantity(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_break_quantity(kind)
+
+
+def Has_Timeout_Clause(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_timeout_clause(kind)
+
+
+def Has_Postponed_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_postponed_flag(kind)
+
+
+def Has_Callees_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_callees_list(kind)
+
+
+def Has_Passive_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_passive_flag(kind)
+
+
+def Has_Resolution_Function_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_resolution_function_flag(kind)
+
+
+def Has_Wait_State(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_wait_state(kind)
+
+
+def Has_All_Sensitized_State(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_all_sensitized_state(kind)
+
+
+def Has_Seen_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_seen_flag(kind)
+
+
+def Has_Pure_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_pure_flag(kind)
+
+
+def Has_Foreign_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_foreign_flag(kind)
+
+
+def Has_Resolved_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_resolved_flag(kind)
+
+
+def Has_Signal_Type_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_signal_type_flag(kind)
+
+
+def Has_Has_Signal_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_signal_flag(kind)
+
+
+def Has_Purity_State(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_purity_state(kind)
+
+
+def Has_Elab_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_elab_flag(kind)
+
+
+def Has_Vendor_Library_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_vendor_library_flag(kind)
+
+
+def Has_Configuration_Mark_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_configuration_mark_flag(kind)
+
+
+def Has_Configuration_Done_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_configuration_done_flag(kind)
+
+
+def Has_Index_Constraint_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_index_constraint_flag(kind)
+
+
+def Has_Hide_Implicit_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_hide_implicit_flag(kind)
+
+
+def Has_Assertion_Condition(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_assertion_condition(kind)
+
+
+def Has_Report_Expression(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_report_expression(kind)
+
+
+def Has_Severity_Expression(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_severity_expression(kind)
+
+
+def Has_Instantiated_Unit(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_instantiated_unit(kind)
+
+
+def Has_Generic_Map_Aspect_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_generic_map_aspect_chain(kind)
+
+
+def Has_Port_Map_Aspect_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_port_map_aspect_chain(kind)
+
+
+def Has_Configuration_Name(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_configuration_name(kind)
+
+
+def Has_Component_Configuration(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_component_configuration(kind)
+
+
+def Has_Configuration_Specification(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_configuration_specification(kind)
+
+
+def Has_Default_Binding_Indication(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_default_binding_indication(kind)
+
+
+def Has_Default_Configuration_Declaration(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_default_configuration_declaration(kind)
+
+
+def Has_Expression(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_expression(kind)
+
+
+def Has_Conditional_Expression_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_conditional_expression_chain(kind)
+
+
+def Has_Allocator_Designated_Type(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_allocator_designated_type(kind)
+
+
+def Has_Selected_Waveform_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_selected_waveform_chain(kind)
+
+
+def Has_Conditional_Waveform_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_conditional_waveform_chain(kind)
+
+
+def Has_Guard_Expression(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_guard_expression(kind)
+
+
+def Has_Guard_Decl(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_guard_decl(kind)
+
+
+def Has_Guard_Sensitivity_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_guard_sensitivity_list(kind)
+
+
+def Has_Signal_Attribute_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_signal_attribute_chain(kind)
+
+
+def Has_Block_Block_Configuration(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_block_block_configuration(kind)
+
+
+def Has_Package_Header(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_package_header(kind)
+
+
+def Has_Block_Header(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_block_header(kind)
+
+
+def Has_Uninstantiated_Package_Name(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_uninstantiated_package_name(kind)
+
+
+def Has_Uninstantiated_Package_Decl(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_uninstantiated_package_decl(kind)
+
+
+def Has_Instance_Source_File(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_instance_source_file(kind)
+
+
+def Has_Generate_Block_Configuration(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_generate_block_configuration(kind)
+
+
+def Has_Generate_Statement_Body(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_generate_statement_body(kind)
+
+
+def Has_Alternative_Label(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_alternative_label(kind)
+
+
+def Has_Generate_Else_Clause(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_generate_else_clause(kind)
+
+
+def Has_Condition(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_condition(kind)
+
+
+def Has_Else_Clause(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_else_clause(kind)
+
+
+def Has_Parameter_Specification(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_parameter_specification(kind)
+
+
+def Has_Parent(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_parent(kind)
+
+
+def Has_Loop_Label(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_loop_label(kind)
+
+
+def Has_Exit_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_exit_flag(kind)
+
+
+def Has_Next_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_next_flag(kind)
+
+
+def Has_Component_Name(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_component_name(kind)
+
+
+def Has_Instantiation_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_instantiation_list(kind)
+
+
+def Has_Entity_Aspect(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_entity_aspect(kind)
+
+
+def Has_Default_Entity_Aspect(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_default_entity_aspect(kind)
+
+
+def Has_Binding_Indication(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_binding_indication(kind)
+
+
+def Has_Named_Entity(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_named_entity(kind)
+
+
+def Has_Referenced_Name(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_referenced_name(kind)
+
+
+def Has_Expr_Staticness(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_expr_staticness(kind)
+
+
+def Has_Scalar_Size(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_scalar_size(kind)
+
+
+def Has_Error_Origin(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_error_origin(kind)
+
+
+def Has_Operand(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_operand(kind)
+
+
+def Has_Left(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_left(kind)
+
+
+def Has_Right(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_right(kind)
+
+
+def Has_Unit_Name(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_unit_name(kind)
+
+
+def Has_Name(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_name(kind)
+
+
+def Has_Group_Template_Name(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_group_template_name(kind)
+
+
+def Has_Name_Staticness(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_name_staticness(kind)
+
+
+def Has_Prefix(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_prefix(kind)
+
+
+def Has_Signature_Prefix(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_signature_prefix(kind)
+
+
+def Has_External_Pathname(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_external_pathname(kind)
+
+
+def Has_Pathname_Suffix(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_pathname_suffix(kind)
+
+
+def Has_Pathname_Expression(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_pathname_expression(kind)
+
+
+def Has_In_Formal_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_in_formal_flag(kind)
+
+
+def Has_Slice_Subtype(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_slice_subtype(kind)
+
+
+def Has_Suffix(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_suffix(kind)
+
+
+def Has_Index_Subtype(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_index_subtype(kind)
+
+
+def Has_Parameter(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_parameter(kind)
+
+
+def Has_Parameter_2(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_parameter_2(kind)
+
+
+def Has_Parameter_3(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_parameter_3(kind)
+
+
+def Has_Parameter_4(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_parameter_4(kind)
+
+
+def Has_Attr_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_attr_chain(kind)
+
+
+def Has_Signal_Attribute_Declaration(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_signal_attribute_declaration(kind)
+
+
+def Has_Actual_Type(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_actual_type(kind)
+
+
+def Has_Actual_Type_Definition(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_actual_type_definition(kind)
+
+
+def Has_Association_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_association_chain(kind)
+
+
+def Has_Individual_Association_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_individual_association_chain(kind)
+
+
+def Has_Subprogram_Association_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_subprogram_association_chain(kind)
+
+
+def Has_Aggregate_Info(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_aggregate_info(kind)
+
+
+def Has_Sub_Aggregate_Info(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_sub_aggregate_info(kind)
+
+
+def Has_Aggr_Dynamic_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_aggr_dynamic_flag(kind)
+
+
+def Has_Aggr_Min_Length(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_aggr_min_length(kind)
+
+
+def Has_Aggr_Low_Limit(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_aggr_low_limit(kind)
+
+
+def Has_Aggr_High_Limit(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_aggr_high_limit(kind)
+
+
+def Has_Aggr_Others_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_aggr_others_flag(kind)
+
+
+def Has_Aggr_Named_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_aggr_named_flag(kind)
+
+
+def Has_Aggregate_Expand_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_aggregate_expand_flag(kind)
+
+
+def Has_Association_Choices_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_association_choices_chain(kind)
+
+
+def Has_Case_Statement_Alternative_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_case_statement_alternative_chain(kind)
+
+
+def Has_Choice_Staticness(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_choice_staticness(kind)
+
+
+def Has_Procedure_Call(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_procedure_call(kind)
+
+
+def Has_Implementation(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_implementation(kind)
+
+
+def Has_Parameter_Association_Chain(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_parameter_association_chain(kind)
+
+
+def Has_Method_Object(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_method_object(kind)
+
+
+def Has_Subtype_Type_Mark(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_subtype_type_mark(kind)
+
+
+def Has_Subnature_Nature_Mark(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_subnature_nature_mark(kind)
+
+
+def Has_Type_Conversion_Subtype(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_type_conversion_subtype(kind)
+
+
+def Has_Type_Mark(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_type_mark(kind)
+
+
+def Has_File_Type_Mark(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_file_type_mark(kind)
+
+
+def Has_Return_Type_Mark(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_return_type_mark(kind)
+
+
+def Has_Has_Disconnect_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_disconnect_flag(kind)
+
+
+def Has_Has_Active_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_active_flag(kind)
+
+
+def Has_Is_Within_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_is_within_flag(kind)
+
+
+def Has_Type_Marks_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_type_marks_list(kind)
+
+
+def Has_Implicit_Alias_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_implicit_alias_flag(kind)
+
+
+def Has_Alias_Signature(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_alias_signature(kind)
+
+
+def Has_Attribute_Signature(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_attribute_signature(kind)
+
+
+def Has_Overload_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_overload_list(kind)
+
+
+def Has_Simple_Name_Identifier(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_simple_name_identifier(kind)
+
+
+def Has_Simple_Name_Subtype(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_simple_name_subtype(kind)
+
+
+def Has_Protected_Type_Body(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_protected_type_body(kind)
+
+
+def Has_Protected_Type_Declaration(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_protected_type_declaration(kind)
+
+
+def Has_Use_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_use_flag(kind)
+
+
+def Has_End_Has_Reserved_Id(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_end_has_reserved_id(kind)
+
+
+def Has_End_Has_Identifier(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_end_has_identifier(kind)
+
+
+def Has_End_Has_Postponed(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_end_has_postponed(kind)
+
+
+def Has_Has_Label(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_label(kind)
+
+
+def Has_Has_Begin(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_begin(kind)
+
+
+def Has_Has_End(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_end(kind)
+
+
+def Has_Has_Is(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_is(kind)
+
+
+def Has_Has_Pure(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_pure(kind)
+
+
+def Has_Has_Body(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_body(kind)
+
+
+def Has_Has_Parameter(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_parameter(kind)
+
+
+def Has_Has_Component(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_component(kind)
+
+
+def Has_Has_Identifier_List(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_identifier_list(kind)
+
+
+def Has_Has_Mode(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_mode(kind)
+
+
+def Has_Has_Class(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_class(kind)
+
+
+def Has_Has_Delay_Mechanism(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_has_delay_mechanism(kind)
+
+
+def Has_Suspend_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_suspend_flag(kind)
+
+
+def Has_Is_Ref(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_is_ref(kind)
+
+
+def Has_Is_Forward_Ref(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_is_forward_ref(kind)
+
+
+def Has_Psl_Property(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_psl_property(kind)
+
+
+def Has_Psl_Sequence(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_psl_sequence(kind)
+
+
+def Has_Psl_Declaration(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_psl_declaration(kind)
+
+
+def Has_Psl_Expression(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_psl_expression(kind)
+
+
+def Has_Psl_Boolean(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_psl_boolean(kind)
+
+
+def Has_PSL_Clock(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_psl_clock(kind)
+
+
+def Has_PSL_NFA(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_psl_nfa(kind)
+
+
+def Has_PSL_Nbr_States(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_psl_nbr_states(kind)
+
+
+def Has_PSL_Clock_Sensitivity(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_psl_clock_sensitivity(kind)
+
+
+def Has_PSL_EOS_Flag(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_psl_eos_flag(kind)
+
+
+def Has_Count_Expression(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_count_expression(kind)
+
+
+def Has_Clock_Expression(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_clock_expression(kind)
+
+
+def Has_Default_Clock(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_default_clock(kind)
+
+
+def Has_Foreign_Node(kind) -> bool:
+    return libghdl.vhdl__nodes_meta__has_foreign_node(kind)

--- a/pyGHDL/libghdl/vhdl/nodes_utils.py
+++ b/pyGHDL/libghdl/vhdl/nodes_utils.py
@@ -34,7 +34,7 @@
 
 from pydecor import export
 
-from pyGHDL.libghdl._types     import Iir
+from pyGHDL.libghdl._types import Iir
 from pyGHDL.libghdl._decorator import BindToLibGHDL
 
 

--- a/pyGHDL/libghdl/vhdl/nodes_utils.py
+++ b/pyGHDL/libghdl/vhdl/nodes_utils.py
@@ -7,8 +7,8 @@
 # |_|    |___/                                     |___/
 # =============================================================================
 # Authors:
-#    Tristan Gingold
-#    Patrick Lehmann
+#   Tristan Gingold
+#   Patrick Lehmann
 #
 # Package module:   Python binding and low-level API for shared library 'libghdl'.
 #
@@ -34,10 +34,12 @@
 
 from pydecor import export
 
-from pyGHDL.libghdl import libghdl, Iir
+from pyGHDL.libghdl._types     import Iir
+from pyGHDL.libghdl._decorator import BindToLibGHDL
 
 
 @export
+@BindToLibGHDL("vhdl__utils__strip_denoting_name")
 def Strip_Denoting_Name(Name: Iir) -> Iir:
     """
     If :obj:`Name` is a simple or an expanded name, return the denoted declaration.
@@ -46,10 +48,10 @@ def Strip_Denoting_Name(Name: Iir) -> Iir:
     :param Name: Simple or an expanded name.
     :return:     Denoted declaration.
     """
-    return libghdl.vhdl__utils__strip_denoting_name(Name)
 
 
 @export
+@BindToLibGHDL("vhdl__utils__get_entity")
 def Get_Entity(Decl: Iir) -> Iir:
     """
     This is a wrapper around ``Get_Entity_Name`` to return the entity declaration
@@ -58,10 +60,10 @@ def Get_Entity(Decl: Iir) -> Iir:
     :param Decl: Declaration
     :return:     Entity
     """
-    return libghdl.vhdl__utils__get_entity(Decl)
 
 
 @export
+@BindToLibGHDL("vhdl__utils__is_second_subprogram_specification")
 def Is_Second_Subprogram_Specification(Spec: Iir) -> bool:
     """
     Check if :obj:`Spec` is the subprogram specification of a subprogram body
@@ -71,10 +73,10 @@ def Is_Second_Subprogram_Specification(Spec: Iir) -> bool:
     :param Spec: Specification
     :return:     ``True`` if subprogram specification and previously declared subprogram body match
     """
-    return libghdl.vhdl__utils__is_second_subprogram_specification(Spec)
 
 
 @export
+@BindToLibGHDL("vhdl__utils__get_entity_from_entity_aspect")
 def Get_Entity_From_Entity_Aspect(Aspect: Iir) -> Iir:
     """
     Extract the entity from :obj:`Aspect`.
@@ -85,10 +87,10 @@ def Get_Entity_From_Entity_Aspect(Aspect: Iir) -> Iir:
     :param Aspect: Aspect
     :return:       Entity
     """
-    return libghdl.vhdl__utils__get_entity_from_entity_aspect(Aspect)
 
 
 @export
+@BindToLibGHDL("vhdl__utils__get_interface_of_formal")
 def Get_Interface_Of_Formal(Formal: Iir) -> Iir:
     """
     Get the interface corresponding to the formal name :obj:`Formal`. This is
@@ -97,4 +99,3 @@ def Get_Interface_Of_Formal(Formal: Iir) -> Iir:
     :param Formal: The formal.
     :return:       The corresponding interface.
     """
-    return libghdl.vhdl__utils__get_interface_of_formal(Formal)

--- a/pyGHDL/libghdl/vhdl/parse.py
+++ b/pyGHDL/libghdl/vhdl/parse.py
@@ -6,9 +6,9 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
-#    Patrick Lehmann
+# Authors:
+#   Tristan Gingold
+#   Patrick Lehmann
 #
 # Package module:   Python binding and low-level API for shared library 'libghdl'.
 #
@@ -37,15 +37,21 @@ from ctypes import c_bool
 from pydecor import export
 
 from pyGHDL.libghdl import libghdl
+from pyGHDL.libghdl._types import Iir
+from pyGHDL.libghdl._decorator import BindToLibGHDL
 
-__all__ = ["Flag_Parse_Parenthesis"]
+
+__all__ = [
+    "Flag_Parse_Parenthesis"
+]
 
 
 Flag_Parse_Parenthesis = c_bool.in_dll(libghdl, "vhdl__parse__flag_parse_parenthesis")
 
 
 @export
-def Parse_Design_File():
+@BindToLibGHDL("vhdl__parse__parse_design_file")
+def Parse_Design_File() -> Iir:
     """
     Parse a file.
 
@@ -53,4 +59,3 @@ def Parse_Design_File():
 
     :return: Return :obj:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` in case of error. Type: ``Iir_Design_File``
     """
-    return libghdl.vhdl__parse__parse_design_file()

--- a/pyGHDL/libghdl/vhdl/parse.py
+++ b/pyGHDL/libghdl/vhdl/parse.py
@@ -41,9 +41,7 @@ from pyGHDL.libghdl._types import Iir
 from pyGHDL.libghdl._decorator import BindToLibGHDL
 
 
-__all__ = [
-    "Flag_Parse_Parenthesis"
-]
+__all__ = ["Flag_Parse_Parenthesis"]
 
 
 Flag_Parse_Parenthesis = c_bool.in_dll(libghdl, "vhdl__parse__flag_parse_parenthesis")

--- a/pyGHDL/libghdl/vhdl/scanner.py
+++ b/pyGHDL/libghdl/vhdl/scanner.py
@@ -6,9 +6,9 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
-#    Patrick Lehmann
+# Authors:
+#   Tristan Gingold
+#   Patrick Lehmann
 #
 # Package module:   Python binding and low-level API for shared library 'libghdl'.
 #
@@ -38,9 +38,13 @@ from pydecor import export
 
 from pyGHDL.libghdl import libghdl
 from pyGHDL.libghdl._types import SourceFileEntry, NameId
+from pyGHDL.libghdl._decorator import BindToLibGHDL
 
 
-__all__ = ["Current_Token", "Flag_Comment"]
+__all__ = [
+    "Current_Token",
+    "Flag_Comment"
+]
 
 # This is a c_int, so you want to use its .value
 Current_Token = c_int.in_dll(libghdl, "vhdl__scanner__current_token")
@@ -48,28 +52,29 @@ Flag_Comment = c_bool.in_dll(libghdl, "vhdl__scanner__flag_comment")
 
 
 @export
+@BindToLibGHDL("vhdl__scanner__set_file")
 def Set_File(SourceFile: SourceFileEntry) -> None:
     """
     Initialize the scanner with file :obj:`SourceFile`.
 
     :param SourceFile: File to scan.
     """
-    libghdl.vhdl__scanner__set_file(SourceFile)
 
 
 @export
+@BindToLibGHDL("vhdl__scanner__close_file")
 def Close_File() -> None:
     """Finalize the scanner."""
-    libghdl.vhdl__scanner__close_file()
 
 
 @export
+@BindToLibGHDL("vhdl__scanner__scan")
 def Scan() -> None:
     """Get a new token."""
-    libghdl.vhdl__scanner__scan()
 
 
 @export
+@BindToLibGHDL("vhdl__scanner__get_current_line")
 def Get_Current_Line() -> int:
     """
     Get the current location, or the location of the current token.
@@ -79,40 +84,40 @@ def Get_Current_Line() -> int:
 
     :return: Current token's line.
     """
-    return libghdl.vhdl__scanner__get_current_line()
 
 
 @export
+@BindToLibGHDL("vhdl__scanner__get_token_offset")
 def Get_Token_Offset() -> int:
     """
     Get the current token's offset in the current line.
 
     :return: Current token's offset.
     """
-    return libghdl.vhdl__scanner__get_token_offset()
 
 
 @export
+@BindToLibGHDL("vhdl__scanner__get_token_position")
 def Get_Token_Position():
     """
     Get the current token's position.
 
     :return: Current token's position. Type: ``Source_Ptr``
     """
-    return libghdl.vhdl__scanner__get_token_position()
 
 
 @export
+@BindToLibGHDL("vhdl__scanner__get_position")
 def Get_Position():
     """
     Get the current position.
 
     :return: Current position. Type: ``Source_Ptr``
     """
-    return libghdl.vhdl__scanner__get_position()
 
 
 @export
+@BindToLibGHDL("vhdl__scanner__current_identifier")
 def Current_Identifier() -> NameId:
     """
     When :attr:`~pyGHDL.libghdl.vhdl.scanner.Current_Token` is an
@@ -121,4 +126,3 @@ def Current_Identifier() -> NameId:
 
     :return: NameId of the current token.
     """
-    return libghdl.vhdl__scanner__current_identifier()

--- a/pyGHDL/libghdl/vhdl/scanner.py
+++ b/pyGHDL/libghdl/vhdl/scanner.py
@@ -41,10 +41,7 @@ from pyGHDL.libghdl._types import SourceFileEntry, NameId
 from pyGHDL.libghdl._decorator import BindToLibGHDL
 
 
-__all__ = [
-    "Current_Token",
-    "Flag_Comment"
-]
+__all__ = ["Current_Token", "Flag_Comment"]
 
 # This is a c_int, so you want to use its .value
 Current_Token = c_int.in_dll(libghdl, "vhdl__scanner__current_token")

--- a/pyGHDL/libghdl/vhdl/sem.py
+++ b/pyGHDL/libghdl/vhdl/sem.py
@@ -6,9 +6,9 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
-#    Patrick Lehmann
+# Authors:
+#   Tristan Gingold
+#   Patrick Lehmann
 #
 # Package module:   Python binding and low-level API for shared library 'libghdl'.
 #
@@ -34,11 +34,13 @@
 
 from pydecor import export
 
-from pyGHDL.libghdl import libghdl
+from pyGHDL.libghdl._types import Iir_Design_Unit
+from pyGHDL.libghdl._decorator import BindToLibGHDL
 
 
 @export
-def Semantic(DesignUnit) -> None:
+@BindToLibGHDL("vhdl__sem__semantic")
+def Semantic(DesignUnit: Iir_Design_Unit) -> None:
     """
     Do the semantic analysis of design unit :obj:`DesignUnit`.
 
@@ -47,4 +49,3 @@ def Semantic(DesignUnit) -> None:
 
     :param DesignUnit: Design unit to semantically analyze. Type: ``Iir_Design_Unit``
     """
-    libghdl.vhdl__sem__semantic(DesignUnit)

--- a/pyGHDL/libghdl/vhdl/sem_lib.py
+++ b/pyGHDL/libghdl/vhdl/sem_lib.py
@@ -34,7 +34,7 @@
 
 from pydecor import export
 
-from pyGHDL.libghdl._types     import SourceFileEntry, Iir_Design_File, Iir_Design_Unit
+from pyGHDL.libghdl._types import SourceFileEntry, Iir_Design_File, Iir_Design_Unit
 from pyGHDL.libghdl._decorator import BindToLibGHDL
 
 

--- a/pyGHDL/libghdl/vhdl/sem_lib.py
+++ b/pyGHDL/libghdl/vhdl/sem_lib.py
@@ -6,9 +6,9 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
-#    Patrick Lehmann
+# Authors:
+#   Tristan Gingold
+#   Patrick Lehmann
 #
 # Package module:   Python binding and low-level API for shared library 'libghdl'.
 #
@@ -34,37 +34,37 @@
 
 from pydecor import export
 
-from pyGHDL.libghdl import libghdl
-from pyGHDL.libghdl._types import SourceFileEntry
+from pyGHDL.libghdl._types     import SourceFileEntry, Iir_Design_File, Iir_Design_Unit
+from pyGHDL.libghdl._decorator import BindToLibGHDL
 
 
 @export
-def Load_File(File: SourceFileEntry):
+@BindToLibGHDL("vhdl__sem_lib__load_file")
+def Load_File(File: SourceFileEntry) -> Iir_Design_File:
     """
     Start to analyse a file (i.e. load and parse it).
 
     :param File: File to analyse.
     :return:     Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` in case of parse error. Type: ``Iir_Design_File``
     """
-    return libghdl.vhdl__sem_lib__load_file(File)
 
 
 @export
-def Finish_Compilation(Unit, Main: bool = False) -> None:
+@BindToLibGHDL("vhdl__sem_lib__finish_compilation")
+def Finish_Compilation(Unit: Iir_Design_Unit, Main: bool = False) -> None:
     """
     Analyze :obj:`Unit`.
 
     :param Unit: Design unit to analyze.
     :param Main: Is main unit.
     """
-    libghdl.vhdl__sem_lib__finish_compilation(Unit, Main)
 
 
 @export
-def Free_Dependence_List(Design) -> None:
+@BindToLibGHDL("vhdl__sem_lib__free_dependence_list")
+def Free_Dependence_List(Design: Iir_Design_Unit) -> None:
     """
     Free the dependence list of :obj:`Design`.
 
     :param Design: Design unit to free dependencies for.
     """
-    libghdl.vhdl__sem_lib__free_dependence_list(Design)

--- a/pyGHDL/libghdl/vhdl/std_package.py
+++ b/pyGHDL/libghdl/vhdl/std_package.py
@@ -35,21 +35,25 @@
 from ctypes import c_int32
 
 from pyGHDL.libghdl import libghdl
-from pyGHDL.libghdl._types import Location_Type, Iir_Package_Declaration, Iir_Enumeration_Type_Definition
+from pyGHDL.libghdl._types import (
+    Location_Type,
+    Iir_Package_Declaration,
+    Iir_Enumeration_Type_Definition,
+)
 
 
-__all__ = [
-    "Std_Location",
-    "Standard_Package",
-    "Character_Type_Definition"
-]
+__all__ = ["Std_Location", "Standard_Package", "Character_Type_Definition"]
 
 
 Std_Location: Location_Type = c_int32.in_dll(libghdl, "vhdl__std_package__std_location")
 """Virtual location for the ``std.standard`` package. Use ``.value`` to access this variable inside libghdl."""
 
-Standard_Package: Iir_Package_Declaration = c_int32.in_dll(libghdl, "vhdl__std_package__standard_package")
+Standard_Package: Iir_Package_Declaration = c_int32.in_dll(
+    libghdl, "vhdl__std_package__standard_package"
+)
 """Virtual package ``std.package``. Use ``.value`` to access this variable inside libghdl."""
 
-Character_Type_Definition: Iir_Enumeration_Type_Definition = c_int32.in_dll(libghdl, "vhdl__std_package__character_type_definition")
+Character_Type_Definition: Iir_Enumeration_Type_Definition = c_int32.in_dll(
+    libghdl, "vhdl__std_package__character_type_definition"
+)
 """Predefined character. Use ``.value`` to access this variable inside libghdl."""

--- a/pyGHDL/libghdl/vhdl/std_package.py
+++ b/pyGHDL/libghdl/vhdl/std_package.py
@@ -6,9 +6,9 @@
 # | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
 # |_|    |___/                                     |___/
 # =============================================================================
-#  Authors:
-#    Tristan Gingold
-#    Patrick Lehmann
+# Authors:
+#   Tristan Gingold
+#   Patrick Lehmann
 #
 # Package module:   Python binding and low-level API for shared library 'libghdl'.
 #
@@ -35,15 +35,21 @@
 from ctypes import c_int32
 
 from pyGHDL.libghdl import libghdl
+from pyGHDL.libghdl._types import Location_Type, Iir_Package_Declaration, Iir_Enumeration_Type_Definition
 
-__all__ = ["Std_Location", "Standard_Package", "Character_Type_Definition"]
 
-Std_Location = c_int32.in_dll(
-    libghdl, "vhdl__std_package__std_location"
-)  #: Virtual location for the ``std.standard`` package. Type ``Location_Type``. Use ``.value`` to access this variable inside libghdl.
-Standard_Package = c_int32.in_dll(
-    libghdl, "vhdl__std_package__standard_package"
-)  #: Virtual package ``std.package``. Type ``Iir_Package_Declaration``. Use ``.value`` to access this variable inside libghdl.
-Character_Type_Definition = c_int32.in_dll(
-    libghdl, "vhdl__std_package__character_type_definition"
-)  #: Predefined character. Type ``Iir_Enumeration_Type_Definition``. Use ``.value`` to access this variable inside libghdl.
+__all__ = [
+    "Std_Location",
+    "Standard_Package",
+    "Character_Type_Definition"
+]
+
+
+Std_Location: Location_Type = c_int32.in_dll(libghdl, "vhdl__std_package__std_location")
+"""Virtual location for the ``std.standard`` package. Use ``.value`` to access this variable inside libghdl."""
+
+Standard_Package: Iir_Package_Declaration = c_int32.in_dll(libghdl, "vhdl__std_package__standard_package")
+"""Virtual package ``std.package``. Use ``.value`` to access this variable inside libghdl."""
+
+Character_Type_Definition: Iir_Enumeration_Type_Definition = c_int32.in_dll(libghdl, "vhdl__std_package__character_type_definition")
+"""Predefined character. Use ``.value`` to access this variable inside libghdl."""

--- a/pyGHDL/libghdl/vhdl/tokens.py
+++ b/pyGHDL/libghdl/vhdl/tokens.py
@@ -1,11 +1,13 @@
 # Auto generated Python source file from Ada sources
 # Call 'make' in 'src/vhdl' to regenerate:
 #
+from enum import IntEnum, unique
 from pydecor import export
 
 
 @export
-class Tok:
+@unique
+class Tok(IntEnum):
     Invalid = 0
     Eof = 1
     Newline = 2

--- a/pyGHDL/lsp/document.py
+++ b/pyGHDL/lsp/document.py
@@ -79,7 +79,7 @@ class Document(object):
         end_line = change_range["end"]["line"]
         end_col = change_range["end"]["character"]
 
-        status = files_map_editor.Replace_Text(
+        status = files_map_editor._Replace_Text(
             self._fe,
             start_line + 1,
             start_col,

--- a/scripts/pnodes.py
+++ b/scripts/pnodes.py
@@ -76,7 +76,6 @@ class ParseError(Exception):
         return ("Parse error at {lr.filename}:{lr.lineno}: {msg}".format(lr=self.lr, msg=self.msg))
 
 
-
 # Return fields description.
 # This is a dictionary.  The keys represent the possible format of a node.
 # The values are dictionaries representing fields.  Keys are fields name, and
@@ -201,7 +200,7 @@ def read_kinds(filename):
             name = m.group(1)
             if not name.startswith(prefix_range_name):
                 raise ParseError(lr, "incorrect prefix for subtype")
-            name = name[len(prefix_range_name) :]
+            name = name[len(prefix_range_name):]
             l = lr.get()
             mf = pat_first.match(l)
             if not mf:
@@ -235,7 +234,7 @@ def read_kinds(filename):
                             )
                         break
                     raise ParseError(lr, "unhandled line in subtype")
-            kinds_ranges[name] = kinds[first : last + 1]
+            kinds_ranges[name] = kinds[first: last + 1]
     return (kinds, kinds_ranges)
 
 

--- a/testsuite/pyunit/SimplePackage.vhdl
+++ b/testsuite/pyunit/SimplePackage.vhdl
@@ -3,20 +3,11 @@ use     ieee.std_logic_1164.all;
 use     ieee.numeric_std.all;
 
 package pack_1 is
-	constant const_1 : boolean;
+	constant const_1 : boolean := false;
 
-	type matrix is array(natural range <>, natural range <>) of std_logic;
-
-	subtype matrix8x8 is matrix(7 downto 0, 7 downto 0);
-
-	function func1(value : unsigned) return natural;
 end package;
 
 package body pack_1 is
 	constant const_1 : boolean := true;
 
-	function func1(value : unsigned) return natural is
-	begin
-		return to_integer(value);
-	end function;
 end package body;


### PR DESCRIPTION
This is a follow up on #1587.

# Changes
* A new decorator to create binding functions from Python to libghdl using annotations (type hints), ctypes and dynamic function compilation at startup.

# Dependency
For testing, a working lsp testsuite in `pyunit` would be needed.
Work started in #1585.