### PR TITLE
Improvements to the UVVM pre-compile scripts.

### DIFF
--- a/libraries/vendors/README.md
+++ b/libraries/vendors/README.md
@@ -115,15 +115,17 @@ For a detailed documentation and all command line options see
 
 - OSVVM
   - switch / search directories if normal OSVVM or OsvvmLibraries is specified as source
-
 - Missing features
-  - Implement `--clean` commands
-
+  - Implement `-Clean` ```--clean` commands
 - describe usage with -P
-
 - document offered procedures and functions
-
 - don't enforce `--output` if `--source` is used.
+- UVVM (OSVVM)
+  - create a list of components as array and generate from that:
+	  - variables
+	  - cli options
+	  - help text
+	  - default values
 
 ------------------------
 Author: Patrick Lehmann  

--- a/libraries/vendors/compile-uvvm.ps1
+++ b/libraries/vendors/compile-uvvm.ps1
@@ -40,8 +40,8 @@ param(
 	[switch]$UVVM =               $false,
 		# Compile all UVVM Utility packages.
 		[switch]$UVVM_Utilities =           $false,
-		# Compile all UVVM VCC Framework packages.
-		[switch]$UVVM_VCC_Framework =       $false,
+		# Compile all UVVM VVC Framework packages.
+		[switch]$UVVM_VVC_Framework =       $false,
 	# Compile all UVVM Verification IPs (VIPs).
 	[switch]$UVVM_VIP =           $false,
 	  # Compile VIP: Avalon Memory Mapped
@@ -131,7 +131,7 @@ if ($All)
 }
 if ($UVVM)
 {	$UVVM_Utilities =           $true
-	$UVVM_VCC_Framework =       $true
+	$UVVM_VVC_Framework =       $true
 }
 if ($UVVM_VIP)
 {	$UVVM_VIP_Avalon_MM =       $true
@@ -211,12 +211,15 @@ $VIP_Files = [ordered]@{}
 foreach ($VIPName in (Get-Content "$SourceDirectory\script\component_list.txt"))
 {	if ($VIPName.StartsWith("uvvm"))
 	{ $VIPVariable = $VIPName.Substring(5).ToUpper()
-		$VIPVariable = $VIPVariable.Replace("UTIL", "UTILITIES")
+		$VIPVariable = $VIPVariable.Replace("UTIL", "Utilities")
 	}
 	elseif ($VIPName.StartsWith("bitvis"))
 	{	$VIPVariable = $VIPName.Substring(7).ToUpper()
-		$VIPVariable = $VIPVariable.Replace("AXI", "AXI_")
+		$VIPVariable = $VIPVariable.Replace("AXILITE", "AXI_LITE")
+		$VIPVariable = $VIPVariable.Replace("AXISTREAM", "AXI_STREAM")
+		$VIPVariable = $VIPVariable.Replace("HVVC_TO_VVC_BRIDGE", "HVVC2VVC")
 	}
+	$VIPVariable = "UVVM_$VIPVariable"
 
 	$EnableVerbose -and (Write-Host "  Found VIP: $VIPName"    -ForegroundColor Gray                                                                ) | Out-Null
 	$EnableDebug -and   (Write-Host "    Reading compile order from '$SourceDirectory\$VIPName\script\compile_order.txt'" -ForegroundColor DarkGray ) | Out-Null
@@ -243,9 +246,9 @@ foreach ($VIPName in (Get-Content "$SourceDirectory\script\component_list.txt"))
 	}
 
 	$VIP_Files[$VIPName] = @{
-	  "Variable" =  "UVVM_$VIPVariable";
-	  "Library" =    $VIPName;
-	  "Files" =      $VIPFiles
+	  "Variable" =  $VIPVariable;
+	  "Library" =   $VIPName;
+	  "Files" =     $VIPFiles
 	}
 }
 

--- a/libraries/vendors/shared.sh
+++ b/libraries/vendors/shared.sh
@@ -266,9 +266,7 @@ AnalyzeVHDL() {
 		 local PiplineStatus=("${PIPESTATUS[@]}")
 		 if [[ ${PiplineStatus[0]}  -ne 0 ]]; then
 			 echo 1>&2 -e "$Filter_Indent${COLORED_ERROR} While analyzing '$File'. ExitCode: ${PiplineStatus[0]}${ANSI_NOCOLOR}"
-			 if [[ $CONTINUE_ON_ERROR -eq 1 ]]; then
-				 exit 1;
-			 fi
+			 test $CONTINUE_ON_ERROR -eq 0 && exit 1
 		 elif [[ ${PiplineStatus[1]}  -ne 0 ]]; then
 			 case $(( ${PiplineStatus[1]} % 4 )) in
 				 # TODO: implement CONTINUE_ON_ERROR in cases ...


### PR DESCRIPTION
**Changes:**
* Fixed `ccv` vs. `vvc` typo.
* Read `component_list.txt` also in Bash-based script.
* `--halt-on-error` to work for Bash-based script.
* Handle `\n` / `\r\n` problem.

It was tested with uvvm/uvvm@51f9287.
A problem was reported to UVVM as uvvm/uvvm#130.

Thanks to @tpcorrea.