### PR TITLE
testsuite: add suite_driver.sh

### DIFF
--- a/testsuite/gna/testsuite.sh
+++ b/testsuite/gna/testsuite.sh
@@ -1,53 +1,5 @@
 #! /bin/sh
 
-# Driver for a testsuite.
-
 set -e
 
-# This is the only place where test dirs are specified.  Do not duplicate this
-# line
-dirs="*[0-9]"
-
-failures=""
-full=n
-
-for opt; do
-  case "$opt" in
-  -k | --keep-going)  full=y ;;
-  --dir=*) dirs=`echo $opt | sed -e 's/--dir=//'` ;;
-  --skip=*) d=`echo $opt | sed -e 's/--skip=//'`
-            dirs=`echo "" $dirs | sed -e "s/ $d//"` ;;
-  --start-at=*) d=`echo $opt | sed -e 's/--start-at=//'`
-            dirs=`echo "" $dirs | sed -e "s/^.* $d//"`
-            dirs="$d $dirs" ;;
-  --list-tests) echo $dirs; exit 0;;
-  *) echo "Unknown option $opt"
-     exit 2
-     ;;
-  esac
-done
-
-singlerun() {
-  echo ""
-  echo "dir $1:"
-  cd $1
-  if ! ./testsuite.sh; then
-    echo "#################################################################"
-    echo "######### FAILURE: $1"
-    echo "#################################################################"
-    if [ $2 = "y" ]; then
-      failures="$failures $1"
-    else
-      exit 1;
-    fi
-  fi
-  cd ..
-}
-
-for i in $dirs; do singlerun $i $full; done
-
-if [ x"$failures" = x"" ]; then
-    echo "tests are successful" && exit 0
-else
-    echo "test failed ($failures)" && exit 1
-fi
+`dirname $0`/../suite_driver.sh gna $@

--- a/testsuite/sanity/testsuite.sh
+++ b/testsuite/sanity/testsuite.sh
@@ -1,45 +1,5 @@
 #! /bin/sh
 
-# Driver for sanity checks
-
 set -e
 
-dirs="[0-9]*"
-
-failures=""
-full=n
-
-for opt; do
-  case "$opt" in
-  -k | --keep-going)  full=y ;;
-  --list-tests) echo $dirs; exit 0;;
-  *) echo "Unknown option $opt"
-     exit 2
-     ;;
-  esac
-done
-
-singlerun() {
-  echo ""
-  echo "sanity $1:"
-  cd $1
-  if ! ./testsuite.sh; then
-    echo "#################################################################"
-    echo "######### FAILURE: $1"
-    echo "#################################################################"
-    if [ $2 = "y" ]; then
-      failures="$failures $1"
-    else
-      exit 1;
-    fi
-  fi
-  cd ..
-}
-
-for i in $dirs; do singlerun $i $full; done
-
-if [ x"$failures" = x"" ]; then
-    echo "sanity tests are successful" && exit 0
-else
-    echo "sanity test failed ($failures)" && exit 1
-fi
+`dirname $0`/../suite_driver.sh sanity $@

--- a/testsuite/suite_driver.sh
+++ b/testsuite/suite_driver.sh
@@ -1,0 +1,61 @@
+#! /bin/sh
+
+# Driver for a testsuite
+# The first positional argument is required, it's the name of the suite to be executed
+
+set -e
+
+ANSI_GREEN="\033[32m"
+ANSI_RED="\033[31m"
+ANSI_NOCOLOR="\033[0m"
+
+_suite="$1"
+shift
+
+# This is the only place where test dirs are specified.
+#Do not duplicate this line
+dirs="*[0-9]"
+
+failures=""
+full=n
+
+for opt; do
+  case "$opt" in
+  -k | --keep-going)  full=y ;;
+  --dir=*) dirs=`echo $opt | sed -e 's/--dir=//'` ;;
+  --skip=*) d=`echo $opt | sed -e 's/--skip=//'`
+            dirs=`echo "" $dirs | sed -e "s/ $d//"` ;;
+  --start-at=*) d=`echo $opt | sed -e 's/--start-at=//'`
+            dirs=`echo "" $dirs | sed -e "s/^.* $d//"`
+            dirs="$d $dirs" ;;
+  --list-tests) echo $dirs; exit 0;;
+  *) echo "Unknown option $opt"
+     exit 2
+     ;;
+  esac
+done
+
+singlerun() {
+  cd $1
+  if ./testsuite.sh > test.log 2>&1 ; then
+    printf "$_suite $1: ${ANSI_GREEN}ok${ANSI_NOCOLOR}\n"
+    # Don't disp log
+  else
+    printf "$_suite $1: ${ANSI_RED}failed${ANSI_NOCOLOR}\n"
+    cat test.log
+    if [ $2 = "y" ]; then
+      failures="$failures $1"
+    else
+      exit 1;
+    fi
+  fi
+  cd ..
+}
+
+for i in $dirs; do singlerun $i $full; done
+
+if [ x"$failures" = x"" ]; then
+    echo "$_suite tests are successful" && exit 0
+else
+    echo "$_suite test failed ($failures)" && exit 1
+fi

--- a/testsuite/synth/testsuite.sh
+++ b/testsuite/synth/testsuite.sh
@@ -1,53 +1,5 @@
 #! /bin/sh
 
-# Driver for a testsuite.
-
 set -e
 
-# This is the only place where test dirs are specified.  Do not duplicate this
-# line
-dirs="*[0-9]"
-
-failures=""
-full=n
-
-for opt; do
-  case "$opt" in
-  -k | --keep-going)  full=y ;;
-  --dir=*) dirs=`echo $opt | sed -e 's/--dir=//'` ;;
-  --skip=*) d=`echo $opt | sed -e 's/--skip=//'`
-            dirs=`echo "" $dirs | sed -e "s/ $d//"` ;;
-  --start-at=*) d=`echo $opt | sed -e 's/--start-at=//'`
-            dirs=`echo "" $dirs | sed -e "s/^.* $d//"`
-            dirs="$d $dirs" ;;
-  --list-tests) echo $dirs; exit 0;;
-  *) echo "Unknown option $opt"
-     exit 2
-     ;;
-  esac
-done
-
-singlerun() {
-  echo ""
-  echo "dir $1:"
-  cd $1
-  if ! ./testsuite.sh; then
-    echo "#################################################################"
-    echo "######### FAILURE: $1"
-    echo "#################################################################"
-    if [ $2 = "y" ]; then
-      failures="$failures $1"
-    else
-      exit 1;
-    fi
-  fi
-  cd ..
-}
-
-for i in $dirs; do singlerun $i $full; done
-
-if [ x"$failures" = x"" ]; then
-    echo "tests are successful" && exit 0
-else
-    echo "test failed ($failures)" && exit 1
-fi
+`dirname $0`/../suite_driver.sh synth $@

--- a/testsuite/vpi/testsuite.sh
+++ b/testsuite/vpi/testsuite.sh
@@ -1,53 +1,5 @@
 #! /bin/sh
 
-# Driver for a testsuite.
-
 set -e
 
-# This is the only place where test dirs are specified.  Do not duplicate this
-# line
-dirs="*[0-9]"
-
-failures=""
-full=n
-
-for opt; do
-  case "$opt" in
-  -k | --keep-going)  full=y ;;
-  --dir=*) dirs=`echo $opt | sed -e 's/--dir=//'` ;;
-  --skip=*) d=`echo $opt | sed -e 's/--skip=//'`
-            dirs=`echo "" $dirs | sed -e "s/ $d//"` ;;
-  --start-at=*) d=`echo $opt | sed -e 's/--start-at=//'`
-            dirs=`echo "" $dirs | sed -e "s/^.* $d//"`
-            dirs="$d $dirs" ;;
-  --list-tests) echo $dirs; exit 0;;
-  *) echo "Unknown option $opt"
-     exit 2
-     ;;
-  esac
-done
-
-singlerun() {
-  echo ""
-  echo "dir $1:"
-  cd $1
-  if ! ./testsuite.sh; then
-    echo "#################################################################"
-    echo "######### FAILURE: $1"
-    echo "#################################################################"
-    if [ $2 = "y" ]; then
-      failures="$failures $1"
-    else
-      exit 1;
-    fi
-  fi
-  cd ..
-}
-
-for i in $dirs; do singlerun $i $full; done
-
-if [ x"$failures" = x"" ]; then
-    echo "tests are successful" && exit 0
-else
-    echo "test failed ($failures)" && exit 1
-fi
+`dirname $0`/../suite_driver.sh vpi $@


### PR DESCRIPTION
Close #723

`testsuite/gna/testsuite.sh`, `testsuite/sanity/testsuite.sh`, `testsuite/synth/testsuite.sh` and `testsuite/vpi/testsuite.sh` are almost identical. In this PR, `testsuite/suite_driver.sh` is created, which takes the target suite name as the first argument. Then, those four testsuites are rewritten for calling the suite_driver. At the same time `testsuite/testsuite.sh` is updated for calling the suite_driver directly. BTW, positional arguments to be passed to the suite_driver are supported:

```sh
# All test suites, no opts
./testsuite.sh

# Test suite gna only, no opts
./testsuite.sh gna

# Test suite gna only, opt keep-going
./testsuite.sh gna -- -k

# All the test suites, opt keep-going
./testsuite.sh -- -k
```