### PR TITLE
Check argument types of PSL functions onehot(), onehot0(), rose() & fell()

### DIFF
--- a/src/vhdl/vhdl-sem_psl.adb
+++ b/src/vhdl/vhdl-sem_psl.adb
@@ -61,6 +61,8 @@ package body Vhdl.Sem_Psl is
       return Is_Psl_Boolean_Type (Get_Type (Expr));
    end Is_Psl_Boolean_Expr;
 
+   --  Return TRUE iff Atype is a PSL bit type.
+   --  See PSL1.1 5.1.1  Bit expressions
    function Is_Psl_Bit_Type (Atype : Iir) return Boolean
    is
       Btype : constant Iir := Get_Base_Type (Atype);
@@ -69,6 +71,14 @@ package body Vhdl.Sem_Psl is
         or else Btype = Vhdl.Ieee.Std_Logic_1164.Std_Ulogic_Type;
    end Is_Psl_Bit_Type;
 
+   --  Return TRUE iff Expr is a PSL bit type.
+   function Is_Psl_Bit_Expr (Expr : Iir) return Boolean is
+   begin
+      return Is_Psl_Bit_Type (Get_Type (Expr));
+   end Is_Psl_Bit_Expr;
+
+   --  Return TRUE iff Atype is a PSL bitvector type.
+   --  See PSL1.1 5.1.3  Bit expressions
    function Is_Psl_Bitvector_Type (Atype : Iir) return Boolean is
    begin
       if not Is_One_Dimensional_Array_Type (Atype) then
@@ -77,6 +87,14 @@ package body Vhdl.Sem_Psl is
       return Is_Psl_Bit_Type (Get_Element_Subtype (Atype));
    end Is_Psl_Bitvector_Type;
 
+   --  Return TRUE iff Expr is a PSL bitvector type.
+   function Is_Psl_Bitvector_Expr (Expr : Iir) return Boolean is
+   begin
+      return Is_Psl_Bitvector_Type (Get_Type (Expr));
+   end Is_Psl_Bitvector_Expr;
+
+   -- Semantic analysis of prev() built-in function
+   -- See PSL1.1 5.2.3.1 prev()
    function Sem_Prev_Builtin (Call : Iir; Atype : Iir) return Iir
    is
       use Vhdl.Sem_Expr;
@@ -121,6 +139,8 @@ package body Vhdl.Sem_Psl is
       return Call;
    end Sem_Prev_Builtin;
 
+   -- Semantic analysis of stable() built-in function
+   -- See PSL1.1 5.2.3.3 stable()
    function Sem_Stable_Builtin (Call : Iir) return Iir
    is
       use Vhdl.Sem_Expr;
@@ -156,6 +176,8 @@ package body Vhdl.Sem_Psl is
       return Call;
    end Sem_Stable_Builtin;
 
+   -- Semantic analysis of rose() built-in function
+   -- See PSL1.1 5.2.3.4 rose()
    function Sem_Rose_Builtin (Call : Iir) return Iir
    is
       use Vhdl.Sem_Expr;
@@ -171,6 +193,10 @@ package body Vhdl.Sem_Psl is
          Set_Expression (Call, Expr);
          Set_Type (Call, Vhdl.Std_Package.Boolean_Type_Definition);
          Set_Expr_Staticness (Call, None);
+      end if;
+
+      if not Is_Psl_Bit_Expr (Expr) then
+         Error_Msg_Sem (+Call, "type of parameter must be PSL bit");
       end if;
 
       if First then
@@ -191,6 +217,8 @@ package body Vhdl.Sem_Psl is
       return Call;
    end Sem_Rose_Builtin;
 
+   -- Semantic analysis of fell() built-in function
+   -- See PSL1.1 5.2.3.5 fell()
    function Sem_Fell_Builtin (Call : Iir) return Iir
    is
       use Vhdl.Sem_Expr;
@@ -206,6 +234,10 @@ package body Vhdl.Sem_Psl is
          Set_Expression (Call, Expr);
          Set_Type (Call, Vhdl.Std_Package.Boolean_Type_Definition);
          Set_Expr_Staticness (Call, None);
+      end if;
+
+      if not Is_Psl_Bit_Expr (Expr) then
+         Error_Msg_Sem (+Call, "type of parameter must be PSL bit");
       end if;
 
       if First then
@@ -226,6 +258,8 @@ package body Vhdl.Sem_Psl is
       return Call;
    end Sem_Fell_Builtin;
 
+   -- Semantic analysis of onehot() built-in function
+   -- See PSL1.1 5.2.3.8 onehot(), onehot0()
    function Sem_Onehot_Builtin (Call : Iir) return Iir
    is
       use Vhdl.Sem_Expr;
@@ -238,25 +272,17 @@ package body Vhdl.Sem_Psl is
          Set_Expression (Call, Expr);
          Set_Type (Call, Vhdl.Std_Package.Boolean_Type_Definition);
          Set_Expr_Staticness (Call, None);
+         if not Is_Psl_Bitvector_Expr (Expr) then
+            Error_Msg_Sem (+Call, "type of parameter must be PSL bitvector");
+         end if;
       end if;
       return Call;
    end Sem_Onehot_Builtin;
 
-   function Sem_Onehot0_Builtin (Call : Iir) return Iir
-   is
-      use Vhdl.Sem_Expr;
-      use Vhdl.Std_Package;
-      Expr : Iir;
-   begin
-      Expr := Get_Expression (Call);
-      Expr := Sem_Expression (Expr, Null_Iir);
-      if Expr /= Null_Iir then
-         Set_Expression (Call, Expr);
-         Set_Type (Call, Vhdl.Std_Package.Boolean_Type_Definition);
-         Set_Expr_Staticness (Call, None);
-      end if;
-      return Call;
-   end Sem_Onehot0_Builtin;
+   -- Semantic analysis of onehot0() built-in function
+   -- See PSL1.1 5.2.3.8 onehot(), onehot0()
+   function Sem_Onehot0_Builtin (Call : Iir) return Iir renames
+     Sem_Onehot_Builtin;
 
    --  Convert VHDL and/or/not nodes to PSL nodes.
    function Convert_Bool (Expr : Iir) return PSL_Node;

--- a/testsuite/synth/issue662/psl_onehot.vhdl
+++ b/testsuite/synth/issue662/psl_onehot.vhdl
@@ -23,6 +23,6 @@ begin
   ONEHOT_1_a : assert always onehot(b);
 
   -- This assertion fails at cycle 12
-  ONEHOT_2_a : assert always onehot(c);
+  ONEHOT_2_a : assert always onehot(to_unsigned(c, 4));
 
 end architecture psl;

--- a/testsuite/synth/issue662/psl_onehot0.vhdl
+++ b/testsuite/synth/issue662/psl_onehot0.vhdl
@@ -1,5 +1,6 @@
 library ieee;
 use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
 
 entity psl_onehot0 is
   port (clk  : in std_logic;
@@ -22,6 +23,6 @@ begin
   ONEHOT0_1_a : assert always onehot0(b);
 
   -- This assertion fails at cycle 15
-  ONEHOT0_2_a : assert always onehot(c);
+  ONEHOT0_2_a : assert always onehot(to_unsigned(c, 4));
 
 end architecture psl;


### PR DESCRIPTION
Checking the types of some PSL functions was omitted when implementing them. So, this PR adds type checking for the parameters of the onehot(), onehot0(), rose() & fell() functions.

#### PSL standard 1850-2005, section 5.2.3:

```
Built_In_Function_Call ::=
...
  | rose ( Bit [ , Clock_Expression ] )
  | fell ( Bit [ , Clock_Expression ] )
...
  | onehot ( BitVector )
  | onehot0 ( BitVector )
...
```
@tgingold Fell free to close this PR if you have an own solution.