### PR TITLE
pyGHDL: fix import path for libghdl.so in build directory

### DIFF
--- a/pyGHDL/libghdl/__init__.py
+++ b/pyGHDL/libghdl/__init__.py
@@ -116,7 +116,7 @@ def _get_libghdl_path():
         pass
 
     # Try when running from the build directory
-    r = (r.parent / "../../lib").resolve()
+    r = (r.parent / "../..").resolve()
     try:
         return _check_libghdl_libdir(r, basename)
     except (TypeError, FileNotFoundError):


### PR DESCRIPTION
**Description**

When trying to run the testsuite from the build directory, pyghdl fails to import libghdl:

```
$ ./configure --enable-libghdl
$ make -j4
$ env GHDL_PREFIX=$PWD/lib/ghdl GHDL=$PWD/ghdl_mcode testsuite/testsuite.sh
[...]
Exception: Cannot find libghdl libghdl-2_0_0_dev.so
```

This is because the path in `libghdl/__init__.py` that is supposed to find the library in this configuration tries to find it in `/lib`, while the Makefile actually builds it to the root directory: https://github.com/ghdl/ghdl/blob/b3c17274354dd048af202eed86d3ef4f7ceb7bfa/Makefile.in#L414-L427

Changing the path to remove the extra `/lib` fixes the problem.