### PR TITLE
pyGHDL: auto-format python code

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -88,6 +88,7 @@ jobs:
       run: |
         sudo apt update -qq
         sudo apt install -y gnat
+        python -m pip install black
 
     - name: Update Python bindings
       run: ./scripts/update_py_bindings.sh
@@ -97,9 +98,8 @@ jobs:
         git diff --stat
         git diff --exit-code
 
-#    - run: python -m pip install black
-#
-#    - run: python -m black --check pyGHDL
+    - name: Check if python follows code formatting standards
+      run: python -m black --check pyGHDL
 
 #
 # GPL

--- a/pyGHDL/cli/lsp.py
+++ b/pyGHDL/cli/lsp.py
@@ -42,9 +42,9 @@ import os
 from pydecor import export
 
 import pyGHDL.libghdl as libghdl
-from pyGHDL.libghdl     import version, errorout_console
-from pyGHDL.lsp         import LSPConnTrace
-from pyGHDL.lsp.lsp     import LSPConn, LanguageProtocolServer
+from pyGHDL.libghdl import version, errorout_console
+from pyGHDL.lsp import LSPConnTrace
+from pyGHDL.lsp.lsp import LSPConn, LanguageProtocolServer
 from pyGHDL.lsp.vhdl_ls import VhdlLanguageServer
 
 __loggerName = "ghdl-ls"
@@ -62,7 +62,9 @@ def __rotate_log_files(basename: str, num: int):
 
 def _generateCLIParser() -> ArgumentParser:
     """Creates an CLI argument parser based on ``argparse``."""
-    parser = ArgumentParser(description="VHDL Language Protocol Server. Find info about clients in `ghdl/ghdl-language-server <https://github.com/ghdl/ghdl-language-server>`__.")
+    parser = ArgumentParser(
+        description="VHDL Language Protocol Server. Find info about clients in `ghdl/ghdl-language-server <https://github.com/ghdl/ghdl-language-server>`__."
+    )
     parser.add_argument(
         "--version", "-V", action="version", version="%(prog)s " + version.__version__
     )
@@ -72,7 +74,10 @@ def _generateCLIParser() -> ArgumentParser:
     parser.add_argument(
         "--log-file", help="Redirect logs to the given file instead of stderr"
     )
-    parser.add_argument("--trace-file", help="Save RPC data to FILE.in and FILE.out (overrides :envvar:`GHDL_LS_TRACE`)")
+    parser.add_argument(
+        "--trace-file",
+        help="Save RPC data to FILE.in and FILE.out (overrides :envvar:`GHDL_LS_TRACE`)",
+    )
     parser.add_argument("--input", "-i", help="Read request from file")
     parser.add_argument(
         "--disp-config",
@@ -151,5 +156,5 @@ def main():
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/pyGHDL/dom/Common.py
+++ b/pyGHDL/dom/Common.py
@@ -39,46 +39,46 @@ from pydecor import export
 
 from pyVHDLModel.VHDLModel import Mode
 
-from pyGHDL.libghdl        import name_table
-from pyGHDL.libghdl.vhdl   import nodes
+from pyGHDL.libghdl import name_table
+from pyGHDL.libghdl.vhdl import nodes
 
 __all__ = []
 
 
 @export
 class GHDLBaseException(Exception):
-	pass
+    pass
 
 
 @export
 class LibGHDLException(GHDLBaseException):
-	pass
+    pass
 
 
 @export
 class GHDLException(GHDLBaseException):
-	pass
+    pass
 
 
 @export
 class GHDLMixin:
-	_MODE_TRANSLATION = {
-		nodes.Iir_Mode.In_Mode:      Mode.In,
-		nodes.Iir_Mode.Out_Mode:     Mode.Out,
-		nodes.Iir_Mode.Inout_Mode:   Mode.InOut,
-		nodes.Iir_Mode.Buffer_Mode:  Mode.Buffer,
-		nodes.Iir_Mode.Linkage_Mode: Mode.Linkage
-	}
+    _MODE_TRANSLATION = {
+        nodes.Iir_Mode.In_Mode: Mode.In,
+        nodes.Iir_Mode.Out_Mode: Mode.Out,
+        nodes.Iir_Mode.Inout_Mode: Mode.InOut,
+        nodes.Iir_Mode.Buffer_Mode: Mode.Buffer,
+        nodes.Iir_Mode.Linkage_Mode: Mode.Linkage,
+    }
 
-	@classmethod
-	def _ghdlNodeToName(cls, node) -> str:
-		"""Return the python string from node :obj:`node` identifier"""
-		return name_table.Get_Name_Ptr(nodes.Get_Identifier(node))
+    @classmethod
+    def _ghdlNodeToName(cls, node) -> str:
+        """Return the python string from node :obj:`node` identifier"""
+        return name_table.Get_Name_Ptr(nodes.Get_Identifier(node))
 
-	@classmethod
-	def _ghdlPortToMode(cls, port):
-		"""Return the mode of a :obj:`port`."""
-		try:
-			return cls._MODE_TRANSLATION[nodes.Get_Mode(port)]
-		except KeyError:
-			raise LibGHDLException("Unknown mode.")
+    @classmethod
+    def _ghdlPortToMode(cls, port):
+        """Return the mode of a :obj:`port`."""
+        try:
+            return cls._MODE_TRANSLATION[nodes.Get_Mode(port)]
+        except KeyError:
+            raise LibGHDLException("Unknown mode.")

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -41,100 +41,103 @@ This module contains all DOM classes for VHDL's design units (:class:`entity <En
 """
 from pydecor import export
 
-from pyVHDLModel.VHDLModel import Entity        as VHDLModel_Entity
-from pyVHDLModel.VHDLModel import Architecture  as VHDLModel_Architecture
-from pyVHDLModel.VHDLModel import Package       as VHDLModel_Package
-from pyVHDLModel.VHDLModel import PackageBody   as VHDLModel_PackageBody
-from pyVHDLModel.VHDLModel import Context       as VHDLModel_Context
+from pyVHDLModel.VHDLModel import Entity as VHDLModel_Entity
+from pyVHDLModel.VHDLModel import Architecture as VHDLModel_Architecture
+from pyVHDLModel.VHDLModel import Package as VHDLModel_Package
+from pyVHDLModel.VHDLModel import PackageBody as VHDLModel_PackageBody
+from pyVHDLModel.VHDLModel import Context as VHDLModel_Context
 from pyVHDLModel.VHDLModel import Configuration as VHDLModel_Configuration
 
-from pyGHDL.libghdl.vhdl   import nodes
+from pyGHDL.libghdl.vhdl import nodes
 import pyGHDL.libghdl.utils as pyutils
 
-from pyGHDL.dom.Common        import GHDLMixin
-from pyGHDL.dom.InterfaceItem import GenericConstantInterfaceItem, PortSignalInterfaceItem
+from pyGHDL.dom.Common import GHDLMixin
+from pyGHDL.dom.InterfaceItem import (
+    GenericConstantInterfaceItem,
+    PortSignalInterfaceItem,
+)
 
 __all__ = []
 
 
 @export
 class Entity(VHDLModel_Entity, GHDLMixin):
+    @classmethod
+    def parse(cls, libraryUnit):
+        name = cls._ghdlNodeToName(libraryUnit)
+        entity = cls(name)
 
-	@classmethod
-	def parse(cls, libraryUnit):
-		name = cls._ghdlNodeToName(libraryUnit)
-		entity = cls(name)
+        cls.__parseGenerics(libraryUnit, entity)
+        cls.__parsePorts(libraryUnit, entity)
 
-		cls.__parseGenerics(libraryUnit, entity)
-		cls.__parsePorts(libraryUnit, entity)
+        return entity
 
-		return entity
+    @classmethod
+    def __ghdlGetGenerics(cls, entity):
+        return pyutils.chain_iter(nodes.Get_Generic_Chain(entity))
 
-	@classmethod
-	def __ghdlGetGenerics(cls, entity):
-		return pyutils.chain_iter(nodes.Get_Generic_Chain(entity))
+    @classmethod
+    def __ghdlGetPorts(cls, entity):
+        return pyutils.chain_iter(nodes.Get_Port_Chain(entity))
 
-	@classmethod
-	def __ghdlGetPorts(cls, entity):
-		return pyutils.chain_iter(nodes.Get_Port_Chain(entity))
+    @classmethod
+    def __parseGenerics(cls, libraryUnit, entity):
+        for generic in cls.__ghdlGetGenerics(libraryUnit):
+            genericConstant = GenericConstantInterfaceItem.parse(generic)
+            entity.GenericItems.append(genericConstant)
 
-	@classmethod
-	def __parseGenerics(cls, libraryUnit, entity):
-		for generic in cls.__ghdlGetGenerics(libraryUnit):
-			genericConstant = GenericConstantInterfaceItem.parse(generic)
-			entity.GenericItems.append(genericConstant)
+    @classmethod
+    def __parsePorts(cls, libraryUnit, entity):
+        for port in cls.__ghdlGetPorts(libraryUnit):
+            signalPort = PortSignalInterfaceItem.parse(port)
+            entity.PortItems.append(signalPort)
 
-	@classmethod
-	def __parsePorts(cls, libraryUnit, entity):
-		for port in cls.__ghdlGetPorts(libraryUnit):
-			signalPort = PortSignalInterfaceItem.parse(port)
-			entity.PortItems.append(signalPort)
 
 @export
 class Architecture(VHDLModel_Architecture, GHDLMixin):
-	def __init__(self, name: str, entityName: str):
-		super().__init__(name)
+    def __init__(self, name: str, entityName: str):
+        super().__init__(name)
 
-		self.__entityName = entityName
+        self.__entityName = entityName
 
-	@classmethod
-	def parse(cls, libraryUnit):
-		name = cls._ghdlNodeToName(libraryUnit)
-		entityName = cls._ghdlNodeToName(nodes.Get_Entity_Name(libraryUnit))
+    @classmethod
+    def parse(cls, libraryUnit):
+        name = cls._ghdlNodeToName(libraryUnit)
+        entityName = cls._ghdlNodeToName(nodes.Get_Entity_Name(libraryUnit))
 
-		return cls(name, entityName)
+        return cls(name, entityName)
 
-	def resolve(self):
-		pass
+    def resolve(self):
+        pass
+
 
 @export
 class Package(VHDLModel_Package, GHDLMixin):
+    @classmethod
+    def parse(cls, libraryUnit):
+        name = cls._ghdlNodeToName(libraryUnit)
+        return cls(name)
 
-	@classmethod
-	def parse(cls, libraryUnit):
-		name = cls._ghdlNodeToName(libraryUnit)
-		return cls(name)
 
 @export
 class PackageBody(VHDLModel_PackageBody, GHDLMixin):
+    @classmethod
+    def parse(cls, libraryUnit):
+        name = cls._ghdlNodeToName(libraryUnit)
+        return cls(name)
 
-	@classmethod
-	def parse(cls, libraryUnit):
-		name = cls._ghdlNodeToName(libraryUnit)
-		return cls(name)
 
 @export
 class Context(VHDLModel_Context, GHDLMixin):
+    @classmethod
+    def parse(cls, libraryUnit):
+        name = cls._ghdlNodeToName(libraryUnit)
+        return cls(name)
 
-	@classmethod
-	def parse(cls, libraryUnit):
-		name = cls._ghdlNodeToName(libraryUnit)
-		return cls(name)
 
 @export
 class Configuration(VHDLModel_Configuration, GHDLMixin):
-
-	@classmethod
-	def parse(cls, libraryUnit):
-		name = cls._ghdlNodeToName(libraryUnit)
-		return cls(name)
+    @classmethod
+    def parse(cls, libraryUnit):
+        name = cls._ghdlNodeToName(libraryUnit)
+        return cls(name)

--- a/pyGHDL/dom/InterfaceItem.py
+++ b/pyGHDL/dom/InterfaceItem.py
@@ -31,35 +31,39 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 
-from pydecor                import export
+from pydecor import export
 
-from pyVHDLModel.VHDLModel  import PortSignalInterfaceItem as VHDLModel_PortSignalInterfaceItem
-from pyVHDLModel.VHDLModel  import GenericConstantInterfaceItem as VHDLModel_GenericConstantInterfaceItem
+from pyVHDLModel.VHDLModel import (
+    PortSignalInterfaceItem as VHDLModel_PortSignalInterfaceItem,
+)
+from pyVHDLModel.VHDLModel import (
+    GenericConstantInterfaceItem as VHDLModel_GenericConstantInterfaceItem,
+)
 
-from pyGHDL.dom.Common      import GHDLMixin
+from pyGHDL.dom.Common import GHDLMixin
 
 __all__ = []
 
 
 @export
 class GenericConstantInterfaceItem(VHDLModel_GenericConstantInterfaceItem, GHDLMixin):
-	@classmethod
-	def parse(cls, generic):
-		name = cls._ghdlNodeToName(generic)
-		mode = cls._ghdlPortToMode(generic)
+    @classmethod
+    def parse(cls, generic):
+        name = cls._ghdlNodeToName(generic)
+        mode = cls._ghdlPortToMode(generic)
 
-		generic = cls(name, mode)
+        generic = cls(name, mode)
 
-		return generic
+        return generic
 
 
 @export
 class PortSignalInterfaceItem(VHDLModel_PortSignalInterfaceItem, GHDLMixin):
-	@classmethod
-	def parse(cls, port):
-		name = cls._ghdlNodeToName(port)
-		mode = cls._ghdlPortToMode(port)
+    @classmethod
+    def parse(cls, port):
+        name = cls._ghdlNodeToName(port)
+        mode = cls._ghdlPortToMode(port)
 
-		port = cls(name, mode)
+        port = cls(name, mode)
 
-		return port
+        return port

--- a/pyGHDL/dom/Misc.py
+++ b/pyGHDL/dom/Misc.py
@@ -36,106 +36,115 @@
    Add a module documentation.
 """
 from pathlib import Path
-from typing  import Any
+from typing import Any
 
 from pydecor import export
 
-from pyVHDLModel.VHDLModel  import Design        as VHDLModel_Design
-from pyVHDLModel.VHDLModel  import Library       as VHDLModel_Library
-from pyVHDLModel.VHDLModel  import Document      as VHDLModel_Document
+from pyVHDLModel.VHDLModel import Design as VHDLModel_Design
+from pyVHDLModel.VHDLModel import Library as VHDLModel_Library
+from pyVHDLModel.VHDLModel import Document as VHDLModel_Document
 
-import pyGHDL.libghdl       as libghdl
-from pyGHDL.libghdl         import name_table, files_map, errorout_memory
-from pyGHDL.libghdl.vhdl    import nodes, sem_lib
+import pyGHDL.libghdl as libghdl
+from pyGHDL.libghdl import name_table, files_map, errorout_memory
+from pyGHDL.libghdl.vhdl import nodes, sem_lib
 
-from pyGHDL.dom.Common      import LibGHDLException, GHDLException
-from pyGHDL.dom.DesignUnit  import Entity, Architecture, Package, PackageBody, Context, Configuration
+from pyGHDL.dom.Common import LibGHDLException, GHDLException
+from pyGHDL.dom.DesignUnit import (
+    Entity,
+    Architecture,
+    Package,
+    PackageBody,
+    Context,
+    Configuration,
+)
 
 __all__ = []
 
 
 @export
 class Design(VHDLModel_Design):
-	def __init__(self):
-		super().__init__()
+    def __init__(self):
+        super().__init__()
 
-		self.__ghdl_init()
+        self.__ghdl_init()
 
-	def __ghdl_init(self):
-		"""Initialization: set options and then load libraries"""
-		# Initialize libghdl
-		libghdl.finalize()
-		libghdl.initialize()
+    def __ghdl_init(self):
+        """Initialization: set options and then load libraries"""
+        # Initialize libghdl
+        libghdl.finalize()
+        libghdl.initialize()
 
-		# Collect error messages in memory
-		errorout_memory.Install_Handler()
+        # Collect error messages in memory
+        errorout_memory.Install_Handler()
 
-		libghdl.set_option("--std=08")
+        libghdl.set_option("--std=08")
 
-		# Finish initialization. This will load the standard package.
-		if libghdl.analyze_init_status() != 0:
-			raise LibGHDLException("Error initializing 'libghdl'.")
+        # Finish initialization. This will load the standard package.
+        if libghdl.analyze_init_status() != 0:
+            raise LibGHDLException("Error initializing 'libghdl'.")
 
 
 @export
 class Library(VHDLModel_Library):
-	pass
+    pass
 
 
 @export
 class Document(VHDLModel_Document):
-	__ghdlFileID:           Any
-	__ghdlSourceFileEntry:  Any
-	__ghdlFile:             Any
+    __ghdlFileID: Any
+    __ghdlSourceFileEntry: Any
+    __ghdlFile: Any
 
-	def __init__(self, path : Path = None, dontParse: bool = False):
-		super().__init__(path)
+    def __init__(self, path: Path = None, dontParse: bool = False):
+        super().__init__(path)
 
-		self.__ghdl_init()
-		if (dontParse == False):
-			self.parse()
+        self.__ghdl_init()
+        if dontParse == False:
+            self.parse()
 
-	def __ghdl_init(self):
-		# Read input file
-		self.__ghdlFileID = name_table.Get_Identifier(str(self.Path))
-		self.__ghdlSourceFileEntry = files_map.Read_Source_File(name_table.Null_Identifier, self.__ghdlFileID)
-		if self.__ghdlSourceFileEntry == files_map.No_Source_File_Entry:
-			raise LibGHDLException("Cannot load file '{!s}'".format(self.Path))
+    def __ghdl_init(self):
+        # Read input file
+        self.__ghdlFileID = name_table.Get_Identifier(str(self.Path))
+        self.__ghdlSourceFileEntry = files_map.Read_Source_File(
+            name_table.Null_Identifier, self.__ghdlFileID
+        )
+        if self.__ghdlSourceFileEntry == files_map.No_Source_File_Entry:
+            raise LibGHDLException("Cannot load file '{!s}'".format(self.Path))
 
-		# parse
-		self.__ghdlFile =  sem_lib.Load_File(self.__ghdlSourceFileEntry)
+        # parse
+        self.__ghdlFile = sem_lib.Load_File(self.__ghdlSourceFileEntry)
 
-	def parse(self):
-		unit = nodes.Get_First_Design_Unit(self.__ghdlFile)
-		while unit != nodes.Null_Iir:
-			libraryUnit = nodes.Get_Library_Unit(unit)
-			nodeKind = nodes.Get_Kind(libraryUnit)
+    def parse(self):
+        unit = nodes.Get_First_Design_Unit(self.__ghdlFile)
+        while unit != nodes.Null_Iir:
+            libraryUnit = nodes.Get_Library_Unit(unit)
+            nodeKind = nodes.Get_Kind(libraryUnit)
 
-			if (nodeKind == nodes.Iir_Kind.Entity_Declaration):
-				entity = Entity.parse(libraryUnit)
-				self.Entities.append(entity)
+            if nodeKind == nodes.Iir_Kind.Entity_Declaration:
+                entity = Entity.parse(libraryUnit)
+                self.Entities.append(entity)
 
-			elif (nodeKind == nodes.Iir_Kind.Architecture_Body):
-				architecture = Architecture.parse(libraryUnit)
-				self.Architectures.append(architecture)
+            elif nodeKind == nodes.Iir_Kind.Architecture_Body:
+                architecture = Architecture.parse(libraryUnit)
+                self.Architectures.append(architecture)
 
-			elif (nodeKind == nodes.Iir_Kind.Package_Declaration):
-				package = Package.parse(libraryUnit)
-				self.Packages.append(package)
+            elif nodeKind == nodes.Iir_Kind.Package_Declaration:
+                package = Package.parse(libraryUnit)
+                self.Packages.append(package)
 
-			elif (nodeKind == nodes.Iir_Kind.Package_Body):
-				packageBody = PackageBody.parse(libraryUnit)
-				self.PackageBodies.append(packageBody)
+            elif nodeKind == nodes.Iir_Kind.Package_Body:
+                packageBody = PackageBody.parse(libraryUnit)
+                self.PackageBodies.append(packageBody)
 
-			elif (nodeKind == nodes.Iir_Kind.Context_Declaration):
-				context = Context.parse(libraryUnit)
-				self.Contexts.append(context)
+            elif nodeKind == nodes.Iir_Kind.Context_Declaration:
+                context = Context.parse(libraryUnit)
+                self.Contexts.append(context)
 
-			elif (nodeKind == nodes.Iir_Kind.Configuration_Declaration):
-				configuration = Configuration.parse(libraryUnit)
-				self.Configurations.append(configuration)
+            elif nodeKind == nodes.Iir_Kind.Configuration_Declaration:
+                configuration = Configuration.parse(libraryUnit)
+                self.Configurations.append(configuration)
 
-			else:
-				raise GHDLException("Unknown design unit kind.")
+            else:
+                raise GHDLException("Unknown design unit kind.")
 
-			unit = nodes.Get_Chain(unit)
+            unit = nodes.Get_Chain(unit)

--- a/pyGHDL/dom/__init__.py
+++ b/pyGHDL/dom/__init__.py
@@ -31,6 +31,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 
-from pydecor            import export
+from pydecor import export
 
 __all__ = []

--- a/pyGHDL/libghdl/__init__.py
+++ b/pyGHDL/libghdl/__init__.py
@@ -45,103 +45,105 @@ from pyGHDL.libghdl.version import __version__
 
 
 def _get_libghdl_name() -> Path:
-	"""Get the name of the libghdl library (with version and extension)"""
-	ver = __version__.replace("-", "_").replace(".", "_")
-	ext = {"win32": "dll", "cygwin": "dll", "darwin": "dylib"}.get(sys.platform, "so")
-	return Path("libghdl-{version}.{ext}".format(version=ver, ext=ext))
+    """Get the name of the libghdl library (with version and extension)"""
+    ver = __version__.replace("-", "_").replace(".", "_")
+    ext = {"win32": "dll", "cygwin": "dll", "darwin": "dylib"}.get(sys.platform, "so")
+    return Path("libghdl-{version}.{ext}".format(version=ver, ext=ext))
 
 
 def _check_libghdl_libdir(libdir: Path, basename: Path) -> Path:
-	"""Returns libghdl path in :obj:`libdir`, if found."""
-	if libdir is None:
-		raise ValueError("Parameter 'libdir' is None.")
-	# print('libghdl: check in {}'.format(libdir))
-	res = libdir / basename
-	if res.exists():
-		return res
+    """Returns libghdl path in :obj:`libdir`, if found."""
+    if libdir is None:
+        raise ValueError("Parameter 'libdir' is None.")
+    # print('libghdl: check in {}'.format(libdir))
+    res = libdir / basename
+    if res.exists():
+        return res
 
-	raise FileNotFoundError(str(res))
+    raise FileNotFoundError(str(res))
 
 
 def _check_libghdl_bindir(bindir: Path, basename: Path) -> Path:
-	if bindir is None:
-		raise ValueError("Parameter 'bindir' is None.")
+    if bindir is None:
+        raise ValueError("Parameter 'bindir' is None.")
 
-	return _check_libghdl_libdir((bindir / "../lib").resolve(), basename)
+    return _check_libghdl_libdir((bindir / "../lib").resolve(), basename)
 
 
 def _get_libghdl_path():
-	"""
-	Locate the directory where the shared library is installed.
+    """
+    Locate the directory where the shared library is installed.
 
-	Search order:
+    Search order:
 
-	1. `GHDL_PREFIX` - directory (prefix) of the vhdl libraries.
-	2. `VUNIT_GHDL_PATH` - path of the `ghdl` binary when using VUnit.
-	3. `GHDL` - name of, or path to the `ghdl` binary.
-	4. Try within `libghdl/` Python installation.
-	5. Try when running from the build directory.
-	"""
-	basename = _get_libghdl_name()
+    1. `GHDL_PREFIX` - directory (prefix) of the vhdl libraries.
+    2. `VUNIT_GHDL_PATH` - path of the `ghdl` binary when using VUnit.
+    3. `GHDL` - name of, or path to the `ghdl` binary.
+    4. Try within `libghdl/` Python installation.
+    5. Try when running from the build directory.
+    """
+    basename = _get_libghdl_name()
 
-	# Try GHDL_PREFIX
-	# GHDL_PREFIX is the prefix of the vhdl libraries, so remove the
-	# last path component.
-	r = os.environ.get("GHDL_PREFIX")
-	try:
-		return _check_libghdl_libdir(Path(r).parent, basename)
-	except (TypeError, FileNotFoundError):
-		pass
+    # Try GHDL_PREFIX
+    # GHDL_PREFIX is the prefix of the vhdl libraries, so remove the
+    # last path component.
+    r = os.environ.get("GHDL_PREFIX")
+    try:
+        return _check_libghdl_libdir(Path(r).parent, basename)
+    except (TypeError, FileNotFoundError):
+        pass
 
-	# Try VUNIT_GHDL_PATH (path of the ghdl binary when using VUnit).
-	r = os.environ.get("VUNIT_GHDL_PATH")
-	try:
-		return _check_libghdl_bindir(Path(r), basename)
-	except (TypeError, FileNotFoundError):
-		pass
+    # Try VUNIT_GHDL_PATH (path of the ghdl binary when using VUnit).
+    r = os.environ.get("VUNIT_GHDL_PATH")
+    try:
+        return _check_libghdl_bindir(Path(r), basename)
+    except (TypeError, FileNotFoundError):
+        pass
 
-	# Try GHDL (name/path of the ghdl binary)
-	r = os.environ.get("GHDL", "ghdl")
-	r = which(r)
-	try:
-		return _check_libghdl_bindir(Path(r).parent, basename)
-	except (TypeError, FileNotFoundError):
-		pass
+    # Try GHDL (name/path of the ghdl binary)
+    r = os.environ.get("GHDL", "ghdl")
+    r = which(r)
+    try:
+        return _check_libghdl_bindir(Path(r).parent, basename)
+    except (TypeError, FileNotFoundError):
+        pass
 
-	# Try within libghdl/ python installation
-	r = Path(__file__)
-	try:
-		return _check_libghdl_bindir(r.parent, basename)
-	except (TypeError, FileNotFoundError):
-		pass
+    # Try within libghdl/ python installation
+    r = Path(__file__)
+    try:
+        return _check_libghdl_bindir(r.parent, basename)
+    except (TypeError, FileNotFoundError):
+        pass
 
-	# Try when running from the build directory
-	r = (r.parent / "../../lib").resolve()
-	try:
-		return _check_libghdl_libdir(r, basename)
-	except (TypeError, FileNotFoundError):
-		pass
+    # Try when running from the build directory
+    r = (r.parent / "../../lib").resolve()
+    try:
+        return _check_libghdl_libdir(r, basename)
+    except (TypeError, FileNotFoundError):
+        pass
 
-	# Failed.
-	raise Exception("Cannot find libghdl {}".format(basename))
+    # Failed.
+    raise Exception("Cannot find libghdl {}".format(basename))
+
 
 def _initialize():
-	# Load the shared library
-	_libghdl_path = _get_libghdl_path()
-	# print("Load {}".format(_libghdl_path))
-	libghdl = CDLL(str(_libghdl_path))
+    # Load the shared library
+    _libghdl_path = _get_libghdl_path()
+    # print("Load {}".format(_libghdl_path))
+    libghdl = CDLL(str(_libghdl_path))
 
-	# Initialize it.
-	# First Ada elaboration (must be the first call)
-	libghdl.libghdl_init()
-	# Then 'normal' initialization (set hooks)
-	libghdl.libghdl__set_hooks_for_analysis()
+    # Initialize it.
+    # First Ada elaboration (must be the first call)
+    libghdl.libghdl_init()
+    # Then 'normal' initialization (set hooks)
+    libghdl.libghdl__set_hooks_for_analysis()
 
-	# Set the prefix in order to locate the VHDL libraries.
-	prefix = str(_libghdl_path.parent.parent).encode("utf-8")
-	libghdl.libghdl__set_exec_prefix(c_char_p(prefix), len(prefix))
+    # Set the prefix in order to locate the VHDL libraries.
+    prefix = str(_libghdl_path.parent.parent).encode("utf-8")
+    libghdl.libghdl__set_exec_prefix(c_char_p(prefix), len(prefix))
 
-	return libghdl
+    return libghdl
+
 
 # Initialize shared library when package is loaded
 libghdl = _initialize()
@@ -149,62 +151,62 @@ libghdl = _initialize()
 
 @export
 def finalize() -> None:
-	"""Free all the memory, be ready for a new initialization."""
-	libghdl.options__finalize()
+    """Free all the memory, be ready for a new initialization."""
+    libghdl.options__finalize()
 
 
 @export
 def initialize() -> None:
-	"""Initialize or re-initialize the shared library."""
-	libghdl.options__initialize()
+    """Initialize or re-initialize the shared library."""
+    libghdl.options__initialize()
 
 
 @export
 def set_option(Opt: str) -> bool:
-	"""
-	Set option :obj:`opt`.
+    """
+    Set option :obj:`opt`.
 
-	:param Opt: Option to set.
-	:return:    Return ``True``, if the option is known and handled.
-	"""
-	Opt = Opt.encode("utf-8")
-	return libghdl.libghdl__set_option(c_char_p(Opt), len(Opt)) == 0
+    :param Opt: Option to set.
+    :return:    Return ``True``, if the option is known and handled.
+    """
+    Opt = Opt.encode("utf-8")
+    return libghdl.libghdl__set_option(c_char_p(Opt), len(Opt)) == 0
 
 
 @export
 def analyze_init() -> None:
-	"""
-	Initialize the analyzer.
+    """
+    Initialize the analyzer.
 
-	.. deprecated:: 1.0.0
-	   Deprecated as it may raise an exception. Use :func:`analyze_init_status`.
-	"""
-	libghdl.libghdl__analyze_init()
+    .. deprecated:: 1.0.0
+       Deprecated as it may raise an exception. Use :func:`analyze_init_status`.
+    """
+    libghdl.libghdl__analyze_init()
 
 
 @export
 def analyze_init_status() -> int:
-	"""
-	Initialize the analyzer.
+    """
+    Initialize the analyzer.
 
-	:return: Returns 0 in case of success.
-	"""
-	return libghdl.libghdl__analyze_init_status()
+    :return: Returns 0 in case of success.
+    """
+    return libghdl.libghdl__analyze_init_status()
 
 
 @export
 def analyze_file(fname: str) -> Iir:
-	"""
-	Analyze a given filename :obj:`fname`.
+    """
+    Analyze a given filename :obj:`fname`.
 
-	:param fname: File name
-	:return:      Internal Intermediate Representation (IIR)
-	"""
-	fname = fname.encode("utf-8")
-	return libghdl.libghdl__analyze_file(c_char_p(fname), len(fname))
+    :param fname: File name
+    :return:      Internal Intermediate Representation (IIR)
+    """
+    fname = fname.encode("utf-8")
+    return libghdl.libghdl__analyze_file(c_char_p(fname), len(fname))
 
 
 @export
 def disp_config() -> None:
-	"""Display the configured prefixes for libghdl."""
-	libghdl.ghdllocal__disp_config_prefixes()
+    """Display the configured prefixes for libghdl."""
+    libghdl.ghdllocal__disp_config_prefixes()

--- a/pyGHDL/libghdl/_decorator.py
+++ b/pyGHDL/libghdl/_decorator.py
@@ -38,28 +38,29 @@ from pydecor import export
 
 @export
 def EnumLookupTable(cls) -> Callable:
-	"""
-	Decorator to precalculate a enum lookup table (LUT) for enum position to
-	enum literal name.
+    """
+    Decorator to precalculate a enum lookup table (LUT) for enum position to
+    enum literal name.
 
-	.. todo:: Make compatible to chained decorators
+    .. todo:: Make compatible to chained decorators
 
-	:param cls: Enumerator class for which a LUT shall be pre-calculated.
-	"""
-	def decorator(func) -> Callable:
-		def gen() -> List[str]:
-			d = [e for e in dir(cls) if e[0] != "_"]
-			res = [None] * len(d)
-			for e in d:
-				res[getattr(cls, e)] = e
-			return res
+    :param cls: Enumerator class for which a LUT shall be pre-calculated.
+    """
 
-		__lut = gen()
+    def decorator(func) -> Callable:
+        def gen() -> List[str]:
+            d = [e for e in dir(cls) if e[0] != "_"]
+            res = [None] * len(d)
+            for e in d:
+                res[getattr(cls, e)] = e
+            return res
 
-		def wrapper(id: int) -> str:
-			# function that replaces the placeholder function
-			return __lut[id]
+        __lut = gen()
 
-		return wrapper
+        def wrapper(id: int) -> str:
+            # function that replaces the placeholder function
+            return __lut[id]
 
-	return decorator
+        return wrapper
+
+    return decorator

--- a/pyGHDL/libghdl/_types.py
+++ b/pyGHDL/libghdl/_types.py
@@ -34,18 +34,18 @@
 from typing import TypeVar
 
 __all__ = [
-	'ErrorIndex',
-	'MessageIdWarnings',
-	'NameId',
-	'SourceFileEntry',
-	'Iir',
-	'IirKind'
+    "ErrorIndex",
+    "MessageIdWarnings",
+    "NameId",
+    "SourceFileEntry",
+    "Iir",
+    "IirKind",
 ]
 
-ErrorIndex =  TypeVar('ErrorIndex', bound=int)
-MessageIdWarnings = TypeVar('MessageIdWarnings', bound=int)
-NameId = TypeVar('NameId', bound=int)
-SourceFileEntry = TypeVar('SourceFileEntry', bound=int)
+ErrorIndex = TypeVar("ErrorIndex", bound=int)
+MessageIdWarnings = TypeVar("MessageIdWarnings", bound=int)
+NameId = TypeVar("NameId", bound=int)
+SourceFileEntry = TypeVar("SourceFileEntry", bound=int)
 
-Iir = TypeVar('Iir', bound=int)
-IirKind = TypeVar('IirKind', bound=int)
+Iir = TypeVar("Iir", bound=int)
+IirKind = TypeVar("IirKind", bound=int)

--- a/pyGHDL/libghdl/errorout.py
+++ b/pyGHDL/libghdl/errorout.py
@@ -4,6 +4,7 @@
 from pydecor import export
 from pyGHDL.libghdl import libghdl
 
+
 @export
 def Enable_Warning(Id: int, Enable: bool) -> None:
     libghdl.errorout__enable_warning(Id, Enable)

--- a/pyGHDL/libghdl/errorout_console.py
+++ b/pyGHDL/libghdl/errorout_console.py
@@ -39,5 +39,5 @@ from pyGHDL.libghdl import libghdl
 
 @export
 def Install_Handler() -> None:
-	"""Install the handlers for reporting errors."""
-	libghdl.errorout__console__install_handler()
+    """Install the handlers for reporting errors."""
+    libghdl.errorout__console__install_handler()

--- a/pyGHDL/libghdl/errorout_memory.py
+++ b/pyGHDL/libghdl/errorout_memory.py
@@ -42,34 +42,35 @@ from pyGHDL.libghdl._types import ErrorIndex
 
 @export
 class Error_Message(Structure):
-	"""
-	Id : Msgid_Type
-	  Message error/warning id
+    """
+    Id : Msgid_Type
+      Message error/warning id
 
-	Group : Group_Type;
-	  Whether this is an single message or a related one.
+    Group : Group_Type;
+      Whether this is an single message or a related one.
 
-	File : Source_File_Entry;
-	  Error soure file.
+    File : Source_File_Entry;
+      Error soure file.
 
-	Line : Natural;
-	  The first line is line 1, 0 can be used when line number is not relevant.
+    Line : Natural;
+      The first line is line 1, 0 can be used when line number is not relevant.
 
-	Offset : Natural;
-	  Offset in the line.  The first character is at offset 0.
+    Offset : Natural;
+      Offset in the line.  The first character is at offset 0.
 
-	Length : Natural;
-	  Length of the location (for a range). It is assumed to be on the same line;
-	  use 0 when unknown.
-	"""
-	_fields_ = [
-	    ("id", c_int8),
-	    ("group", c_int8),
-	    ("file", c_int32),
-	    ("line", c_int32),
-	    ("offset", c_int32),
-	    ("length", c_int32),
-	]
+    Length : Natural;
+      Length of the location (for a range). It is assumed to be on the same line;
+      use 0 when unknown.
+    """
+
+    _fields_ = [
+        ("id", c_int8),
+        ("group", c_int8),
+        ("file", c_int32),
+        ("line", c_int32),
+        ("offset", c_int32),
+        ("length", c_int32),
+    ]
 
 
 # Values for group:
@@ -81,51 +82,51 @@ Msg_Last = 3
 
 @export
 def Install_Handler() -> None:
-	"""Install the handlers for reporting errors."""
-	libghdl.errorout__memory__install_handler()
+    """Install the handlers for reporting errors."""
+    libghdl.errorout__memory__install_handler()
 
 
 @export
 def Get_Nbr_Messages() -> ErrorIndex:
-	"""
-	Get number of error messages available.
+    """
+    Get number of error messages available.
 
-	:return: Number of messages available.
-	"""
-	return libghdl.errorout__memory__get_nbr_messages()
+    :return: Number of messages available.
+    """
+    return libghdl.errorout__memory__get_nbr_messages()
 
 
 @export
 def Get_Error_Record(Idx: ErrorIndex) -> Error_Message:
-	"""
-	Get error messages by index :obj:`Idy` as structure :class:`Error_Message`.
+    """
+    Get error messages by index :obj:`Idy` as structure :class:`Error_Message`.
 
-	:param Idx: Index from 1 to ``Nbr_Messages`` See :func:`Get_Nbr_Messages`.
-	:return:    Type: ``Error_Message``
-	"""
-	func = libghdl.errorout__memory__get_error_record
-	func.argstypes = [c_int32]
-	func.restype = Error_Message
+    :param Idx: Index from 1 to ``Nbr_Messages`` See :func:`Get_Nbr_Messages`.
+    :return:    Type: ``Error_Message``
+    """
+    func = libghdl.errorout__memory__get_error_record
+    func.argstypes = [c_int32]
+    func.restype = Error_Message
 
-	return func(Idx)
+    return func(Idx)
 
 
 @export
 def Get_Error_Message(Idx: ErrorIndex) -> str:
-	"""
-	Get error messages by index :obj:`Idy` as string.
+    """
+    Get error messages by index :obj:`Idy` as string.
 
-	:param Idx: Index from 1 to ``Nbr_Messages`` See :func:`Get_Nbr_Messages`.
-	:return:    Type: ``Error_Message``
-	"""
-	func = libghdl.errorout__memory__get_error_message_addr
-	func.argstype = [c_int32]
-	func.restype = c_char_p
+    :param Idx: Index from 1 to ``Nbr_Messages`` See :func:`Get_Nbr_Messages`.
+    :return:    Type: ``Error_Message``
+    """
+    func = libghdl.errorout__memory__get_error_message_addr
+    func.argstype = [c_int32]
+    func.restype = c_char_p
 
-	return func(Idx).decode("utf-8")
+    return func(Idx).decode("utf-8")
 
 
 @export
 def Clear_Errors() -> None:
-	"""Remove all error messages."""
-	libghdl.errorout__memory__clear_errors()
+    """Remove all error messages."""
+    libghdl.errorout__memory__clear_errors()

--- a/pyGHDL/libghdl/files_map.py
+++ b/pyGHDL/libghdl/files_map.py
@@ -40,9 +40,9 @@ from pyGHDL.libghdl import libghdl
 from pyGHDL.libghdl._types import NameId, SourceFileEntry
 
 __all__ = [
-	'EOT',
-	'No_Source_File_Entry',
-	'No_Location',
+    "EOT",
+    "No_Source_File_Entry",
+    "No_Location",
 ]
 
 EOT = b"\x04"
@@ -54,219 +54,220 @@ No_Location = 0
 
 @export
 def Location_To_File(Location) -> SourceFileEntry:
-	"""
-	Convert :obj:`Location` to a source file.
+    """
+    Convert :obj:`Location` to a source file.
 
-	:param Location: Location
-	:return:         Source file. Return ``No_Source_File_Entry`` if location is incorrect.
-	"""
-	return libghdl.files_map__location_to_file(Location)
+    :param Location: Location
+    :return:         Source file. Return ``No_Source_File_Entry`` if location is incorrect.
+    """
+    return libghdl.files_map__location_to_file(Location)
 
 
 @export
 def Location_File_To_Pos(Location, File: SourceFileEntry) -> int:
-	"""
-	Convert :obj:`Location` and :obj:`File` to a position (offset) into the source file.
+    """
+    Convert :obj:`Location` and :obj:`File` to a position (offset) into the source file.
 
-	:param Location: Location
-	:param File:     Source file
-	:return:         Offset
-	"""
-	return libghdl.files_map__location_file_to_pos(Location, File)
+    :param Location: Location
+    :param File:     Source file
+    :return:         Offset
+    """
+    return libghdl.files_map__location_file_to_pos(Location, File)
 
 
 @export
 def Location_File_To_Line(Location, File: SourceFileEntry) -> int:
-	"""
-	Convert :obj:`Location` and :obj:`File` to a line number.
+    """
+    Convert :obj:`Location` and :obj:`File` to a line number.
 
-	:param Location: Location
-	:param File:     Source file
-	:return:         Line number
-	"""
-	return libghdl.files_map__location_file_to_line(Location, File)
+    :param Location: Location
+    :param File:     Source file
+    :return:         Line number
+    """
+    return libghdl.files_map__location_file_to_line(Location, File)
 
 
 @export
 def Location_File_Line_To_Offset(Location, File: SourceFileEntry, Line: int) -> int:
-	"""
-	Get the offset in :obj:`Line` of :obj:`Location`.
+    """
+    Get the offset in :obj:`Line` of :obj:`Location`.
 
-	:param Location: Location
-	:param File:     Source file
-	:param Line:     Line number
-	:return:         Offset
-	"""
-	return libghdl.files_map__location_file_line_to_offset(Location, File, Line)
+    :param Location: Location
+    :param File:     Source file
+    :param Line:     Line number
+    :return:         Offset
+    """
+    return libghdl.files_map__location_file_line_to_offset(Location, File, Line)
 
 
 @export
 def Location_File_Line_To_Col(Location, File: SourceFileEntry, Line: int) -> int:
-	"""
-	Get logical column (with HT expanded) from :obj:`Location`, :obj:`File` and
-	:obj:`Line`.
+    """
+    Get logical column (with HT expanded) from :obj:`Location`, :obj:`File` and
+    :obj:`Line`.
 
-	:param Location: Location
-	:param File:     Source file
-	:param Line:     Line number
-	:return:         logical column (horizontal tabs are expanded)
-	"""
-	return libghdl.files_map__location_file_line_to_col(Location, File, Line)
+    :param Location: Location
+    :param File:     Source file
+    :param Line:     Line number
+    :return:         logical column (horizontal tabs are expanded)
+    """
+    return libghdl.files_map__location_file_line_to_col(Location, File, Line)
 
 
 @export
 def File_To_Location(File: SourceFileEntry):
-	"""Convert a :obj:`File` into a location.
+    """Convert a :obj:`File` into a location.
 
-	:param File: Source file
-	:return:     Location. Type: ``Location_Type``
-	"""
-	return libghdl.files_map__file_to_location(File)
+    :param File: Source file
+    :return:     Location. Type: ``Location_Type``
+    """
+    return libghdl.files_map__file_to_location(File)
 
 
 @export
 def File_Pos_To_Location(File: SourceFileEntry, Pos: int):
-	"""
-	Convert a :obj:`File` and an offset :obj:`Pos` in the file into a location.
+    """
+    Convert a :obj:`File` and an offset :obj:`Pos` in the file into a location.
 
-	:param File: Source file
-	:param Pos:  Offset in the file
-	:return:     Location. Type: ``Location_Type``
-	"""
-	return libghdl.files_map__file_pos_to_location(File, Pos)
+    :param File: Source file
+    :param Pos:  Offset in the file
+    :return:     Location. Type: ``Location_Type``
+    """
+    return libghdl.files_map__file_pos_to_location(File, Pos)
 
 
 @export
 def File_Line_To_Position(File: SourceFileEntry, Line: int) -> int:
-	"""
-	Convert a :obj:`File` and :obj:`Line` into a position.
+    """
+    Convert a :obj:`File` and :obj:`Line` into a position.
 
-	:param File: Source file
-	:param Line: Line number
-	:return:     Return ``Source_Ptr_Bad`` in case of error (:obj:`Line` out of bounds).
-	"""
-	return libghdl.files_map__file_line_to_position(File, Line)
+    :param File: Source file
+    :param Line: Line number
+    :return:     Return ``Source_Ptr_Bad`` in case of error (:obj:`Line` out of bounds).
+    """
+    return libghdl.files_map__file_line_to_position(File, Line)
 
 
 @export
 def Get_File_Name(File: SourceFileEntry) -> NameId:
-	"""
-	Return the name of the file.
+    """
+    Return the name of the file.
 
-	:param File: Source file to get the filename from.
-	:return:     NameId for the filename.
-	"""
-	return libghdl.files_map__get_file_name(File)
+    :param File: Source file to get the filename from.
+    :return:     NameId for the filename.
+    """
+    return libghdl.files_map__get_file_name(File)
 
 
 @export
 def Get_Directory_Name(File: SourceFileEntry) -> NameId:
-	"""
-	Return the directory of the file.
+    """
+    Return the directory of the file.
 
-	:param File: Source file to get the directory name from.
-	:return:     NameId for the directory.
-	"""
-	return libghdl.files_map__get_directory_name(File)
+    :param File: Source file to get the directory name from.
+    :return:     NameId for the directory.
+    """
+    return libghdl.files_map__get_directory_name(File)
 
 
 @export
 def Get_File_Buffer(File: SourceFileEntry) -> bytes:
-	"""
-	Return a buffer (access to the contents of the file) for a file entry.
+    """
+    Return a buffer (access to the contents of the file) for a file entry.
 
-	:param File: Source file to get the buffer from.
-	:return:     Type: ``File_Buffer_Ptr``
-	"""
-	func = libghdl.files_map__get_file_buffer
-	func.restype = c_void_p
+    :param File: Source file to get the buffer from.
+    :return:     Type: ``File_Buffer_Ptr``
+    """
+    func = libghdl.files_map__get_file_buffer
+    func.restype = c_void_p
 
-	return func(File)
+    return func(File)
 
 
 @export
 def Get_File_Length(File: SourceFileEntry) -> int:
-	"""
-	Get the position of the first EOT character.
+    """
+    Get the position of the first EOT character.
 
-	:param File: Source file
-	:return:     Type: ``Source_Ptr``
-	"""
-	return libghdl.files_map__get_file_length(File)
+    :param File: Source file
+    :return:     Type: ``Source_Ptr``
+    """
+    return libghdl.files_map__get_file_length(File)
 
 
 @export
 def Set_File_Length(File: SourceFileEntry, Length: int) -> None:
-	"""
-	Set the length of the file (which is less than the size of the file buffer).
+    """
+    Set the length of the file (which is less than the size of the file buffer).
 
-	Set also append two EOT at the end of the file.
+    Set also append two EOT at the end of the file.
 
-	:param File:   Source file
-	:param Length: Length for the file. Type: ``Source_Ptr``
-	"""
-	libghdl.files_map__set_file_length(File, Length)
+    :param File:   Source file
+    :param Length: Length for the file. Type: ``Source_Ptr``
+    """
+    libghdl.files_map__set_file_length(File, Length)
 
 
 @export
 def Read_Source_File(Directory: NameId, Name: NameId) -> SourceFileEntry:
-	"""
-	Return an entry for a filename.
+    """
+    Return an entry for a filename.
 
-	Load the filename if necessary.
+    Load the filename if necessary.
 
-	:param Directory: ``Null_Identifier`` for :obj:`DirectoryId` means current directory.
-	:param Name:      File name
-	:return:          Return ``No_Source_File_Entry``, if the file does not exist.
-	"""
-	return libghdl.files_map__read_source_file(Directory, Name)
+    :param Directory: ``Null_Identifier`` for :obj:`DirectoryId` means current directory.
+    :param Name:      File name
+    :return:          Return ``No_Source_File_Entry``, if the file does not exist.
+    """
+    return libghdl.files_map__read_source_file(Directory, Name)
 
 
 @export
 def Reserve_Source_File(Directory: NameId, Name: NameId, Length) -> SourceFileEntry:
-	"""
-	Reserve an entry, but do not read any file.
+    """
+    Reserve an entry, but do not read any file.
 
-	The length should includes the two terminal EOT.
+    The length should includes the two terminal EOT.
 
-	:param Directory: Directory name
-	:param Name:      File name
-	:param Length:    Length to reserve. Type: ``Source_Ptr``
-	:return:          SourceFile
-	"""
-	return libghdl.files_map__reserve_source_file(Directory, Name, Length)
+    :param Directory: Directory name
+    :param Name:      File name
+    :param Length:    Length to reserve. Type: ``Source_Ptr``
+    :return:          SourceFile
+    """
+    return libghdl.files_map__reserve_source_file(Directory, Name, Length)
+
 
 @export
 def Discard_Source_File(File: SourceFileEntry) -> None:
-	"""
-	Mark :obj:`File` as unavailable: clear the name and directory.
+    """
+    Mark :obj:`File` as unavailable: clear the name and directory.
 
-	.. hint:: This is needed before creating a new source file with the same name.
+    .. hint:: This is needed before creating a new source file with the same name.
 
-	:param File: Source file to discard.
-	"""
-	libghdl.files_map__discard_source_file(File)
+    :param File: Source file to discard.
+    """
+    libghdl.files_map__discard_source_file(File)
 
 
 @export
 def Free_Source_File(File: SourceFileEntry) -> None:
-	"""
-	Free resources used by :obj:`File`, but keep the entry.
+    """
+    Free resources used by :obj:`File`, but keep the entry.
 
-	.. note:: It could be recycled for files that could fit - not implemented.
+    .. note:: It could be recycled for files that could fit - not implemented.
 
-	:param File: Source file to free.
-	"""
-	libghdl.files_map__free_source_file(File)
+    :param File: Source file to free.
+    """
+    libghdl.files_map__free_source_file(File)
 
 
 @export
 def Get_Last_Source_File_Entry() -> SourceFileEntry:
-	"""
-	Returns the entry of the last known file.
+    """
+    Returns the entry of the last known file.
 
-	.. hint:: This allows creating a table of ``SourceFileEntry``.
+    .. hint:: This allows creating a table of ``SourceFileEntry``.
 
-	:return: Last SourceFileEntry. Type: ``SourceFileEntry``
-	"""
-	return libghdl.files_map__get_last_source_file_entry()
+    :return: Last SourceFileEntry. Type: ``SourceFileEntry``
+    """
+    return libghdl.files_map__get_last_source_file_entry()

--- a/pyGHDL/libghdl/files_map_editor.py
+++ b/pyGHDL/libghdl/files_map_editor.py
@@ -41,61 +41,73 @@ from pyGHDL.libghdl._types import SourceFileEntry
 
 
 @export
-def Replace_Text(File: SourceFileEntry, Start_Line: int, Start_Offset: int, End_Line: int, End_Offset: int, Text_Pointer, Text_Length: int) -> bool:
-	""" Replace [START; END) by TEXT.
+def Replace_Text(
+    File: SourceFileEntry,
+    Start_Line: int,
+    Start_Offset: int,
+    End_Line: int,
+    End_Offset: int,
+    Text_Pointer,
+    Text_Length: int,
+) -> bool:
+    """Replace [START; END) by TEXT.
 
-	.. todo:: Replace ``Text_Pointer`` and ``Text_Length`` with Python string
+    .. todo:: Replace ``Text_Pointer`` and ``Text_Length`` with Python string
 
-	:param File:         File where to replace a text section.
-	:param Start_Line:
-	:param Start_Offset:
-	:param End_Line:
-	:param End_Offset:
-	:param Text_Pointer: Type: ``File_Buffer_Ptr``
-	:param Text_Length:  Type: ``Source_Ptr``
-	:return:             Return True in case of success, False in case of failure (the gap is too small).
-	"""
-	func = libghdl.files_map__editor__replace_text_ptr
-	func.argstype = [c_int32, c_int32, c_int32, c_int32, c_char_p, c_int32]
-	func.restype = c_bool
+    :param File:         File where to replace a text section.
+    :param Start_Line:
+    :param Start_Offset:
+    :param End_Line:
+    :param End_Offset:
+    :param Text_Pointer: Type: ``File_Buffer_Ptr``
+    :param Text_Length:  Type: ``Source_Ptr``
+    :return:             Return True in case of success, False in case of failure (the gap is too small).
+    """
+    func = libghdl.files_map__editor__replace_text_ptr
+    func.argstype = [c_int32, c_int32, c_int32, c_int32, c_char_p, c_int32]
+    func.restype = c_bool
 
-	return func(File, Start_Line, Start_Offset, End_Line, End_Offset, Text_Pointer, Text_Length)
+    return func(
+        File, Start_Line, Start_Offset, End_Line, End_Offset, Text_Pointer, Text_Length
+    )
 
 
 @export
 def Fill_Text(File: SourceFileEntry, Text_Pointer, Text_Length: int) -> None:
-	"""Replace the content of :obj:`File` with TEXT.
+    """Replace the content of :obj:`File` with TEXT.
 
-	.. todo:: Replace ``Text_Pointer`` and ``Text_Length`` with Python string
+    .. todo:: Replace ``Text_Pointer`` and ``Text_Length`` with Python string
 
-	:param File:         File where to replace the content.
-	:param Text_Pointer: Type: ``File_Buffer_Ptr``
-	:param Text_Length:  Type: ``Source_Ptr``
-	"""
-	libghdl.files_map__editor__fill_text_ptr(File, Text_Pointer, Text_Length)
+    :param File:         File where to replace the content.
+    :param Text_Pointer: Type: ``File_Buffer_Ptr``
+    :param Text_Length:  Type: ``Source_Ptr``
+    """
+    libghdl.files_map__editor__fill_text_ptr(File, Text_Pointer, Text_Length)
 
 
 @export
-def Check_Buffer_Content(File: SourceFileEntry, String_Pointer, String_Length: int) -> None:
-	"""
-	Check that content of :obj:`File` is STR[1 .. STR_LEN].
+def Check_Buffer_Content(
+    File: SourceFileEntry, String_Pointer, String_Length: int
+) -> None:
+    """
+    Check that content of :obj:`File` is STR[1 .. STR_LEN].
 
-	.. todo:: Replace ``String_Pointer`` and ``String_Length`` with Python string
+    .. todo:: Replace ``String_Pointer`` and ``String_Length`` with Python string
 
-	:param File:           File to check the content.
-	:param String_Pointer: Type: ``File_Buffer_Ptr``
-	:param String_Length:  Type: ``Source_Ptr``
-	"""
-	libghdl.files_map__editor__check_buffer_content(File, String_Pointer, String_Length)
+    :param File:           File to check the content.
+    :param String_Pointer: Type: ``File_Buffer_Ptr``
+    :param String_Length:  Type: ``Source_Ptr``
+    """
+    libghdl.files_map__editor__check_buffer_content(File, String_Pointer, String_Length)
 
 
 @export
 def Copy_Source_File(Dest: SourceFileEntry, Src: SourceFileEntry) -> None:
-	"""
-	Copy content of :obj:`Src` to :obj:`Dest`.
+    """
+    Copy content of :obj:`Src` to :obj:`Dest`.
 
-	.. warning:: The size of :obj:`Dest` must be large enough.
+    .. warning:: The size of :obj:`Dest` must be large enough.
 
-	Clear lines table of :obj:`Dest`.
-	"""
-	return libghdl.files_map__editor__copy_source_file(Dest, Src)
+    Clear lines table of :obj:`Dest`.
+    """
+    return libghdl.files_map__editor__copy_source_file(Dest, Src)

--- a/pyGHDL/libghdl/flags.py
+++ b/pyGHDL/libghdl/flags.py
@@ -37,10 +37,10 @@ from ctypes import c_bool, sizeof
 from pyGHDL.libghdl import libghdl
 
 __all__ = [
-	'Flag_Elocations',
-	'Verbose',
-	'Flag_Elaborate_With_Outdated',
-	'Flag_Force_Analysis'
+    "Flag_Elocations",
+    "Verbose",
+    "Flag_Elaborate_With_Outdated",
+    "Flag_Force_Analysis",
 ]
 
 assert sizeof(c_bool) == 1

--- a/pyGHDL/libghdl/libraries.py
+++ b/pyGHDL/libghdl/libraries.py
@@ -38,90 +38,91 @@ from pydecor import export
 
 from pyGHDL.libghdl import libghdl
 
-__all__ = [
-	'Library_Location',
-	'Work_Library'
-]
+__all__ = ["Library_Location", "Work_Library"]
 
 from pyGHDL.libghdl._types import NameId
 
 
-Library_Location = c_int32.in_dll(libghdl, "libraries__library_location")   #: A location for library declarations (such as library WORK). Type ``Location_Type``. Use ``.value`` to access this variable inside libghdl
-Work_Library = c_int32.in_dll(libghdl, "libraries__work_library")           #: Library declaration for the work library. Note: the identifier of the work_library is ``work_library_name``, which may be different from 'WORK'. Type: ``Iir_Library_Declaration``. Use ``.value`` to access this variable inside libghdl
+Library_Location = c_int32.in_dll(
+    libghdl, "libraries__library_location"
+)  #: A location for library declarations (such as library WORK). Type ``Location_Type``. Use ``.value`` to access this variable inside libghdl
+Work_Library = c_int32.in_dll(
+    libghdl, "libraries__work_library"
+)  #: Library declaration for the work library. Note: the identifier of the work_library is ``work_library_name``, which may be different from 'WORK'. Type: ``Iir_Library_Declaration``. Use ``.value`` to access this variable inside libghdl
 
 
 @export
 def Get_Libraries_Chain():
-	"""
-	Get the chain of libraries.  Can be used only to read (it mustn't be modified).
+    """
+    Get the chain of libraries.  Can be used only to read (it mustn't be modified).
 
-	:return: Type ``Iir_Library_Declaration``
-	"""
-	return libghdl.libraries__get_libraries_chain()
+    :return: Type ``Iir_Library_Declaration``
+    """
+    return libghdl.libraries__get_libraries_chain()
 
 
 @export
 def Add_Design_Unit_Into_Library(Unit, Keep_Obsolete: bool = False) -> None:
-	"""
-	Add or replace an design unit in the work library. DECL must not have a chain
-	(because it may be modified).
+    """
+    Add or replace an design unit in the work library. DECL must not have a chain
+    (because it may be modified).
 
-	If the design_file of UNIT is not already in the library, a new one is created.
+    If the design_file of UNIT is not already in the library, a new one is created.
 
-	Units are always appended to the design_file. Therefore, the order is kept.
+    Units are always appended to the design_file. Therefore, the order is kept.
 
-	:param Unit:          Type: ``Iir_Design_Unit``
-	:param Keep_Obsolete: If :obj:`Keep_Obsolete` is True, obsoleted units are
-	                      kept in the library.
+    :param Unit:          Type: ``Iir_Design_Unit``
+    :param Keep_Obsolete: If :obj:`Keep_Obsolete` is True, obsoleted units are
+                          kept in the library.
 
-	                      This is used when a whole design file has to be added
-	                      in the library and then processed (without that feature,
-	                      redefined units would disappear).
-	"""
-	libghdl.libraries__add_design_unit_into_library(Unit, Keep_Obsolete)
+                          This is used when a whole design file has to be added
+                          in the library and then processed (without that feature,
+                          redefined units would disappear).
+    """
+    libghdl.libraries__add_design_unit_into_library(Unit, Keep_Obsolete)
 
 
 @export
 def Purge_Design_File(Design_File) -> None:
-	"""
-	Remove the same file as DESIGN_FILE from work library and all of its units.
+    """
+    Remove the same file as DESIGN_FILE from work library and all of its units.
 
-	:param Design_File: Type: ``Iir_Design_File``
-	"""
-	libghdl.libraries__purge_design_file(Design_File)
+    :param Design_File: Type: ``Iir_Design_File``
+    """
+    libghdl.libraries__purge_design_file(Design_File)
 
 
 @export
 def Find_Entity_For_Component(Name: NameId):
-	"""
-	Find an entity whose name is :obj:`Name` in any library. |br|
-	If there is no such entity, return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`. |br|
-	If there are several entities, return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`;
+    """
+    Find an entity whose name is :obj:`Name` in any library. |br|
+    If there is no such entity, return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`. |br|
+    If there are several entities, return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`;
 
-	:param Name: Entity name to search for.
-	:return:     Type: ``Iir_Design_Unit``
-	"""
-	return libghdl.libraries__find_entity_for_component(Name)
+    :param Name: Entity name to search for.
+    :return:     Type: ``Iir_Design_Unit``
+    """
+    return libghdl.libraries__find_entity_for_component(Name)
 
 
 @export
 def Get_Library_No_Create(Ident: NameId):
-	"""
-	Get the library named :obj:`Ident`.
+    """
+    Get the library named :obj:`Ident`.
 
-	:param Ident: Libryr to look for.
-	:return:      Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` if it doesn't exist. Type ``Iir_Library_Declaration``
-	"""
-	return libghdl.libraries__get_library_no_create(Ident)
+    :param Ident: Libryr to look for.
+    :return:      Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` if it doesn't exist. Type ``Iir_Library_Declaration``
+    """
+    return libghdl.libraries__get_library_no_create(Ident)
 
 
 @export
 def Find_Primary_Unit(Library, Name: NameId):
-	"""
-	Just return the design_unit for :obj:`Name`, or ``NULL`` if not found.
+    """
+    Just return the design_unit for :obj:`Name`, or ``NULL`` if not found.
 
-	:param Library: Library to look in. Type: ``Iir_Library_Declaration``
-	:param Name:    Primary unit to search for.
-	:return:        Type: ``Iir_Design_Unit``
-	"""
-	return libghdl.libraries__find_primary_unit(Library, Name)
+    :param Library: Library to look in. Type: ``Iir_Library_Declaration``
+    :param Name:    Primary unit to search for.
+    :return:        Type: ``Iir_Design_Unit``
+    """
+    return libghdl.libraries__find_primary_unit(Library, Name)

--- a/pyGHDL/libghdl/name_table.py
+++ b/pyGHDL/libghdl/name_table.py
@@ -39,53 +39,51 @@ from pydecor import export
 from pyGHDL.libghdl import libghdl
 from pyGHDL.libghdl._types import NameId
 
-__all__ = [
-	'Null_Identifier'
-]
+__all__ = ["Null_Identifier"]
 
 Null_Identifier = 0
 
 
 @export
 def Get_Name_Length(Id: NameId) -> int:
-	"""
-	Get the length of an identifier denoted by a ``NameId``.
+    """
+    Get the length of an identifier denoted by a ``NameId``.
 
-	:param Id: NameId for the identifier to query.
-	:return:   Length of the identifier.
-	"""
-	return libghdl.name_table__get_name_length(Id)
+    :param Id: NameId for the identifier to query.
+    :return:   Length of the identifier.
+    """
+    return libghdl.name_table__get_name_length(Id)
 
 
 @export
 def Get_Name_Ptr(Id: NameId) -> str:
-	"""
-	Get the address of the first character of ID.  The address is valid until
-	the next call to Get_Identifier (which may reallocate the string table).
-	The string is NUL-terminated (this is done by get_identifier).
+    """
+    Get the address of the first character of ID.  The address is valid until
+    the next call to Get_Identifier (which may reallocate the string table).
+    The string is NUL-terminated (this is done by get_identifier).
 
-	:param Id: NameId for the identifier to query.
-	:return:
-	"""
-	func = libghdl.name_table__get_name_ptr
-	func.restype = c_char_p
+    :param Id: NameId for the identifier to query.
+    :return:
+    """
+    func = libghdl.name_table__get_name_ptr
+    func.restype = c_char_p
 
-	return func(Id).decode("utf-8")
+    return func(Id).decode("utf-8")
 
 
 @export
 def Get_Identifier(string: str) -> NameId:
-	"""
-	Get or create an entry in the name table.
+    """
+    Get or create an entry in the name table.
 
-	.. note::
+    .. note::
 
-	   * an identifier is represented in all lower case letter,
-	   * an extended identifier is represented in backslashes, double internal
-	     backslashes are simplified.
+       * an identifier is represented in all lower case letter,
+       * an extended identifier is represented in backslashes, double internal
+         backslashes are simplified.
 
-	:param string: String to create or lookup.
-	:return:       Id in name table.
-	"""
-	string = string.encode("utf-8")
-	return libghdl.name_table__get_identifier_with_len(c_char_p(string), len(string))
+    :param string: String to create or lookup.
+    :return:       Id in name table.
+    """
+    string = string.encode("utf-8")
+    return libghdl.name_table__get_identifier_with_len(c_char_p(string), len(string))

--- a/pyGHDL/libghdl/utils.py
+++ b/pyGHDL/libghdl/utils.py
@@ -52,25 +52,25 @@ def name_image(Id: NameId) -> str:
     return name_table.Get_Name_Ptr(Id)
 
 
-#@export # FIXME: see above
+# @export # FIXME: see above
 @EnumLookupTable(nodes_meta.fields)
 def fields_image(idx: int) -> str:
     """String representation of Nodes_Meta.fields :obj:`idx`."""
 
 
-#@export # FIXME: see above
+# @export # FIXME: see above
 @EnumLookupTable(nodes.Iir_Kind)
 def kind_image(k: int) -> str:
     """String representation of Nodes.Iir_Kind :obj:`k`."""
 
 
-#@export # FIXME: see above
+# @export # FIXME: see above
 @EnumLookupTable(nodes_meta.types)
 def types_image(t: int) -> str:
     """String representation of Nodes_Meta.Types :obj:`t`."""
 
 
-#@export # FIXME: see above
+# @export # FIXME: see above
 @EnumLookupTable(nodes_meta.Attr)
 def attr_image(a: int) -> str:
     """String representation of Nodes_Meta.Attr :obj:`a`."""
@@ -309,7 +309,7 @@ def concurrent_stmts_iter(n) -> Generator[Any, None, None]:
     elif k in (
         nodes.Iir_Kind.Entity_Declaration,
         nodes.Iir_Kind.Architecture_Body,
-        nodes.Iir_Kind.Block_Statement
+        nodes.Iir_Kind.Block_Statement,
     ):
         for n1 in chain_iter(nodes.Get_Concurrent_Statement_Chain(n)):
             yield n1

--- a/pyGHDL/libghdl/vhdl/canon.py
+++ b/pyGHDL/libghdl/vhdl/canon.py
@@ -36,11 +36,7 @@ from ctypes import c_bool
 
 from pyGHDL.libghdl import libghdl
 
-__all__ = [
-	'Flag_Concurrent_Stmts',
-	'Flag_Configurations',
-	'Flag_Associations'
-]
+__all__ = ["Flag_Concurrent_Stmts", "Flag_Configurations", "Flag_Associations"]
 
 Flag_Concurrent_Stmts = c_bool.in_dll(
     libghdl, "vhdl__canon__canon_flag_concurrent_stmts"

--- a/pyGHDL/libghdl/vhdl/elocations.py
+++ b/pyGHDL/libghdl/vhdl/elocations.py
@@ -51,4 +51,3 @@ Set_Colon_Location = libghdl.vhdl__elocations__set_colon_location
 
 Get_Assign_Location = libghdl.vhdl__elocations__get_assign_location
 Set_Assign_Location = libghdl.vhdl__elocations__set_assign_location
-

--- a/pyGHDL/libghdl/vhdl/flists.py
+++ b/pyGHDL/libghdl/vhdl/flists.py
@@ -38,47 +38,45 @@ from pydecor import export
 
 from pyGHDL.libghdl import libghdl
 
-__all__ = [
-	'Flist_Type',
-	'Ffirst'
-]
+__all__ = ["Flist_Type", "Ffirst"]
 
 Flist_Type = c_int32  #: First index of a ``FList``.
 
 Ffirst = 0
 
+
 @export
 def Flast(FList) -> int:
-	"""
-	Last index of :obj:`FList`.
+    """
+    Last index of :obj:`FList`.
 
-	.. hint:: Could be used to iterate.
+    .. hint:: Could be used to iterate.
 
-	:param FList: List to query.
-	:return:      Index of the last element in the list.
-	"""
-	return libghdl.vhdl__flists__flast(FList)
+    :param FList: List to query.
+    :return:      Index of the last element in the list.
+    """
+    return libghdl.vhdl__flists__flast(FList)
 
 
 @export
 def Length(FList) -> int:
-	"""
-	Get the length of :obj:`FList`.
+    """
+    Get the length of :obj:`FList`.
 
-	:param FList: List to query.
-	:return:      Number of elements in the list.
-	"""
-	return libghdl.vhdl__flists__length(FList)
+    :param FList: List to query.
+    :return:      Number of elements in the list.
+    """
+    return libghdl.vhdl__flists__length(FList)
 
 
 @export
 def Get_Nth_Element(FList, N: int):
-	"""
-	Get the N-th element of :obj:`FList`.
+    """
+    Get the N-th element of :obj:`FList`.
 
-	First element has index 0.
+    First element has index 0.
 
-	:param FList: List to query.
-	:return:      Type: ``El_Type``
-	"""
-	return libghdl.vhdl__flists__get_nth_element(FList, N)
+    :param FList: List to query.
+    :return:      Type: ``El_Type``
+    """
+    return libghdl.vhdl__flists__get_nth_element(FList, N)

--- a/pyGHDL/libghdl/vhdl/formatters.py
+++ b/pyGHDL/libghdl/vhdl/formatters.py
@@ -41,60 +41,60 @@ from pyGHDL.libghdl import libghdl
 
 @export
 def Indent_String(File, Handle, FirstLine: int, LastLine: int) -> None:
-	"""
-	Reindent all lines of F between [First_Line; Last_Line] to :obj:`Handle`.
+    """
+    Reindent all lines of F between [First_Line; Last_Line] to :obj:`Handle`.
 
-	:param File:      File to indent lines within. Type: ``Iir_Design_File``
-	:param Handle:    undocumented. Type: ``Vstring_Acc``
-	:param FirstLine: undocumented.
-	:param LastLine:  undocumented.
-	"""
-	libghdl.vhdl__formatters__indent_string(File, Handle, FirstLine, LastLine)
+    :param File:      File to indent lines within. Type: ``Iir_Design_File``
+    :param Handle:    undocumented. Type: ``Vstring_Acc``
+    :param FirstLine: undocumented.
+    :param LastLine:  undocumented.
+    """
+    libghdl.vhdl__formatters__indent_string(File, Handle, FirstLine, LastLine)
 
 
 @export
 def Allocate_Handle():
-	"""
-	.. todo:: Undocumented in Ada code.
+    """
+    .. todo:: Undocumented in Ada code.
 
-	:return: undocumented. Type: ``Vstring_Acc``
-	"""
-	return libghdl.vhdl__formatters__allocate_handle()
+    :return: undocumented. Type: ``Vstring_Acc``
+    """
+    return libghdl.vhdl__formatters__allocate_handle()
 
 
 @export
 def Get_Length(Handle) -> int:
-	"""
-	.. todo:: Undocumented in Ada code.
+    """
+    .. todo:: Undocumented in Ada code.
 
-	:param Handle: undocumented. Type: ``Vstring_Acc``
-	:return:       undocumented.
-	"""
-	func = libghdl.vhdl__formatters__get_length
-	func.restype = c_int32
+    :param Handle: undocumented. Type: ``Vstring_Acc``
+    :return:       undocumented.
+    """
+    func = libghdl.vhdl__formatters__get_length
+    func.restype = c_int32
 
-	return func(Handle)
+    return func(Handle)
 
 
 @export
 def Get_C_String(Handle):
-	"""
-	.. todo:: Undocumented in Ada code.
+    """
+    .. todo:: Undocumented in Ada code.
 
-	:param Handle: undocumented. Type: ``Vstring_Acc``
-	:return:       Type: ``Grt.Types.Ghdl_C_String``
-	"""
-	func = libghdl.vhdl__formatters__get_c_string
-	func.restype = c_char_p
+    :param Handle: undocumented. Type: ``Vstring_Acc``
+    :return:       Type: ``Grt.Types.Ghdl_C_String``
+    """
+    func = libghdl.vhdl__formatters__get_c_string
+    func.restype = c_char_p
 
-	return func(Handle)
+    return func(Handle)
 
 
 @export
 def Free_Handle(Handle) -> None:
-	"""
-	.. todo:: Undocumented in Ada code.
+    """
+    .. todo:: Undocumented in Ada code.
 
-	:param Handle: undocumented. Type: ``Vstring_Acc``
-	"""
-	libghdl.vhdl__formatters__free_handle(Handle)
+    :param Handle: undocumented. Type: ``Vstring_Acc``
+    """
+    libghdl.vhdl__formatters__free_handle(Handle)

--- a/pyGHDL/libghdl/vhdl/ieee.py
+++ b/pyGHDL/libghdl/vhdl/ieee.py
@@ -36,11 +36,7 @@ from ctypes import c_int
 from pyGHDL.libghdl import libghdl
 
 
-__all__ = [
-	'Std_Logic_1164_Pkg',
-	'Std_Logic_Type',
-	'Std_Logic_Vector_Type'
-]
+__all__ = ["Std_Logic_1164_Pkg", "Std_Logic_Type", "Std_Logic_Vector_Type"]
 
 
 Std_Logic_1164_Pkg = c_int.in_dll(

--- a/pyGHDL/libghdl/vhdl/lists.py
+++ b/pyGHDL/libghdl/vhdl/lists.py
@@ -41,115 +41,111 @@ from pyGHDL.libghdl import libghdl
 
 @export
 class Iterator(Structure):
-	_fields_ = [
-		("chunk", c_int32),
-		("chunk_idx", c_int32),
-		("remain", c_int32)
-	]
+    _fields_ = [("chunk", c_int32), ("chunk_idx", c_int32), ("remain", c_int32)]
 
 
 @export
 def Iterate(List) -> Iterator:
-	"""
-	Create an iterator for a given list.
+    """
+    Create an iterator for a given list.
 
-	The idiomatic way to iterate is:
+    The idiomatic way to iterate is:
 
-	.. code-block:: Python
+    .. code-block:: Python
 
-	   It = Iterate(List)
-	   while Is_Valid(It):
-	     El = Get_Element(It)
-	       # ...
-	     Next(It)
+       It = Iterate(List)
+       while Is_Valid(It):
+         El = Get_Element(It)
+           # ...
+         Next(It)
 
-	:param List: List to create an iterator from.
-	:return:     Iterator structure.
-	"""
-	func = libghdl.vhdl__lists__iterate
-	func.argstype = [c_int32]
-	func.restype = Iterator
+    :param List: List to create an iterator from.
+    :return:     Iterator structure.
+    """
+    func = libghdl.vhdl__lists__iterate
+    func.argstype = [c_int32]
+    func.restype = Iterator
 
-	return func(List)
+    return func(List)
 
 
 @export
 def Is_Valid(it: Iterator) -> bool:
-	"""
-	Check if iterator reached the end.
+    """
+    Check if iterator reached the end.
 
-	:param Iterator: Iterator to check.
-	:return:         False, if iterator has reached the end.
-	"""
-	func = libghdl.vhdl__lists__is_valid
-	func.argstype = [POINTER(Iterator)]
-	func.restype = c_bool
+    :param Iterator: Iterator to check.
+    :return:         False, if iterator has reached the end.
+    """
+    func = libghdl.vhdl__lists__is_valid
+    func.argstype = [POINTER(Iterator)]
+    func.restype = c_bool
 
-	return func(it)
+    return func(it)
 
 
 @export
 def Next(it: Iterator):
-	"""
-	Move iterator to the next element.
+    """
+    Move iterator to the next element.
 
-	:param Iterator: Iterator to increment.
-	:return:         False, if iterator has reached the end.
-	"""
-	func = libghdl.vhdl__lists__next
-	func.argstype = [POINTER(Iterator)]
-	func.restype = None
+    :param Iterator: Iterator to increment.
+    :return:         False, if iterator has reached the end.
+    """
+    func = libghdl.vhdl__lists__next
+    func.argstype = [POINTER(Iterator)]
+    func.restype = None
 
-	func(it)
+    func(it)
 
 
 @export
 def Get_Element(it: Iterator) -> int:
-	"""
-	Get the current element from iterator.
+    """
+    Get the current element from iterator.
 
-	:param Iterator: Iterator the get the element from.
-	:return:         The current element the iterator points to. Type: ``El_Type``
-	"""
-	func = libghdl.vhdl__lists__get_element
-	func.argstype = [POINTER(Iterator)]
-	func.restype = c_int32
+    :param Iterator: Iterator the get the element from.
+    :return:         The current element the iterator points to. Type: ``El_Type``
+    """
+    func = libghdl.vhdl__lists__get_element
+    func.argstype = [POINTER(Iterator)]
+    func.restype = c_int32
 
-	return func(it)
+    return func(it)
 
 
 @export
 def Get_Nbr_Elements(List) -> int:
-	"""
-	Return the number of elements in the list.
+    """
+    Return the number of elements in the list.
 
-	.. hint:: This is also 1 + the position of the last element.
+    .. hint:: This is also 1 + the position of the last element.
 
-	:param List: The list to use.
-	:return:     Number of list elements.
-	"""
-	func = libghdl.vhdl__lists__get_nbr_elements
-	func.argtype = [c_int32]
-	func.restype = c_int32
+    :param List: The list to use.
+    :return:     Number of list elements.
+    """
+    func = libghdl.vhdl__lists__get_nbr_elements
+    func.argtype = [c_int32]
+    func.restype = c_int32
 
-	return func(List)
+    return func(List)
 
 
 @export
 def Create_Iir_List() -> int:
-	"""
-	Create a list.
+    """
+    Create a list.
 
-	:return: Type: ``List_Type``
-	"""
-	return libghdl.vhdl__lists__create_list()
+    :return: Type: ``List_Type``
+    """
+    return libghdl.vhdl__lists__create_list()
 
 
 @export
 def Destroy_Iir_List(List) -> None:
-	"""
-	Destroy a list.
+    """
+    Destroy a list.
 
-	:param List: List to destroy.
-	"""
-	libghdl.vhdl__lists__destroy_list(List)
+    :param List: List to destroy.
+    """
+    libghdl.vhdl__lists__destroy_list(List)

--- a/pyGHDL/libghdl/vhdl/nodes.py
+++ b/pyGHDL/libghdl/vhdl/nodes.py
@@ -1039,7 +1039,6 @@ class Iir_Kinds:
     ]
 
 
-
 @export
 class Iir_Mode:
     Unknown_Mode = 0
@@ -1737,6 +1736,7 @@ class Iir_Predefined:
     Ieee_Std_Logic_Misc_Xnor_Reduce_Slv = 653
     Ieee_Std_Logic_Misc_Xnor_Reduce_Suv = 654
 
+
 Get_Kind = libghdl.vhdl__nodes__get_kind
 Get_Location = libghdl.vhdl__nodes__get_location
 
@@ -1869,8 +1869,12 @@ Set_Entity_Name_List = libghdl.vhdl__nodes__set_entity_name_list
 Get_Attribute_Designator = libghdl.vhdl__nodes__get_attribute_designator
 Set_Attribute_Designator = libghdl.vhdl__nodes__set_attribute_designator
 
-Get_Attribute_Specification_Chain = libghdl.vhdl__nodes__get_attribute_specification_chain
-Set_Attribute_Specification_Chain = libghdl.vhdl__nodes__set_attribute_specification_chain
+Get_Attribute_Specification_Chain = (
+    libghdl.vhdl__nodes__get_attribute_specification_chain
+)
+Set_Attribute_Specification_Chain = (
+    libghdl.vhdl__nodes__set_attribute_specification_chain
+)
 
 Get_Attribute_Specification = libghdl.vhdl__nodes__get_attribute_specification
 Set_Attribute_Specification = libghdl.vhdl__nodes__set_attribute_specification
@@ -2001,8 +2005,12 @@ Set_Vunit_Item_Chain = libghdl.vhdl__nodes__set_vunit_item_chain
 Get_Bound_Vunit_Chain = libghdl.vhdl__nodes__get_bound_vunit_chain
 Set_Bound_Vunit_Chain = libghdl.vhdl__nodes__set_bound_vunit_chain
 
-Get_Verification_Block_Configuration = libghdl.vhdl__nodes__get_verification_block_configuration
-Set_Verification_Block_Configuration = libghdl.vhdl__nodes__set_verification_block_configuration
+Get_Verification_Block_Configuration = (
+    libghdl.vhdl__nodes__get_verification_block_configuration
+)
+Set_Verification_Block_Configuration = (
+    libghdl.vhdl__nodes__set_verification_block_configuration
+)
 
 Get_Block_Configuration = libghdl.vhdl__nodes__get_block_configuration
 Set_Block_Configuration = libghdl.vhdl__nodes__set_block_configuration
@@ -2094,8 +2102,12 @@ Set_Return_Type = libghdl.vhdl__nodes__set_return_type
 Get_Implicit_Definition = libghdl.vhdl__nodes__get_implicit_definition
 Set_Implicit_Definition = libghdl.vhdl__nodes__set_implicit_definition
 
-Get_Uninstantiated_Subprogram_Name = libghdl.vhdl__nodes__get_uninstantiated_subprogram_name
-Set_Uninstantiated_Subprogram_Name = libghdl.vhdl__nodes__set_uninstantiated_subprogram_name
+Get_Uninstantiated_Subprogram_Name = (
+    libghdl.vhdl__nodes__get_uninstantiated_subprogram_name
+)
+Set_Uninstantiated_Subprogram_Name = (
+    libghdl.vhdl__nodes__set_uninstantiated_subprogram_name
+)
 
 Get_Default_Value = libghdl.vhdl__nodes__get_default_value
 Set_Default_Value = libghdl.vhdl__nodes__set_default_value
@@ -2205,8 +2217,12 @@ Set_Base_Nature = libghdl.vhdl__nodes__set_base_nature
 Get_Resolution_Indication = libghdl.vhdl__nodes__get_resolution_indication
 Set_Resolution_Indication = libghdl.vhdl__nodes__set_resolution_indication
 
-Get_Record_Element_Resolution_Chain = libghdl.vhdl__nodes__get_record_element_resolution_chain
-Set_Record_Element_Resolution_Chain = libghdl.vhdl__nodes__set_record_element_resolution_chain
+Get_Record_Element_Resolution_Chain = (
+    libghdl.vhdl__nodes__get_record_element_resolution_chain
+)
+Set_Record_Element_Resolution_Chain = (
+    libghdl.vhdl__nodes__set_record_element_resolution_chain
+)
 
 Get_Tolerance = libghdl.vhdl__nodes__get_tolerance
 Set_Tolerance = libghdl.vhdl__nodes__set_tolerance
@@ -2259,8 +2275,12 @@ Set_Constraint_State = libghdl.vhdl__nodes__set_constraint_state
 Get_Index_Subtype_List = libghdl.vhdl__nodes__get_index_subtype_list
 Set_Index_Subtype_List = libghdl.vhdl__nodes__set_index_subtype_list
 
-Get_Index_Subtype_Definition_List = libghdl.vhdl__nodes__get_index_subtype_definition_list
-Set_Index_Subtype_Definition_List = libghdl.vhdl__nodes__set_index_subtype_definition_list
+Get_Index_Subtype_Definition_List = (
+    libghdl.vhdl__nodes__get_index_subtype_definition_list
+)
+Set_Index_Subtype_Definition_List = (
+    libghdl.vhdl__nodes__set_index_subtype_definition_list
+)
 
 Get_Element_Subtype_Indication = libghdl.vhdl__nodes__get_element_subtype_indication
 Set_Element_Subtype_Indication = libghdl.vhdl__nodes__set_element_subtype_indication
@@ -2295,8 +2315,12 @@ Set_Owned_Elements_Chain = libghdl.vhdl__nodes__set_owned_elements_chain
 Get_Designated_Type = libghdl.vhdl__nodes__get_designated_type
 Set_Designated_Type = libghdl.vhdl__nodes__set_designated_type
 
-Get_Designated_Subtype_Indication = libghdl.vhdl__nodes__get_designated_subtype_indication
-Set_Designated_Subtype_Indication = libghdl.vhdl__nodes__set_designated_subtype_indication
+Get_Designated_Subtype_Indication = (
+    libghdl.vhdl__nodes__get_designated_subtype_indication
+)
+Set_Designated_Subtype_Indication = (
+    libghdl.vhdl__nodes__set_designated_subtype_indication
+)
 
 Get_Index_List = libghdl.vhdl__nodes__get_index_list
 Set_Index_List = libghdl.vhdl__nodes__set_index_list
@@ -2457,8 +2481,12 @@ Set_Configuration_Specification = libghdl.vhdl__nodes__set_configuration_specifi
 Get_Default_Binding_Indication = libghdl.vhdl__nodes__get_default_binding_indication
 Set_Default_Binding_Indication = libghdl.vhdl__nodes__set_default_binding_indication
 
-Get_Default_Configuration_Declaration = libghdl.vhdl__nodes__get_default_configuration_declaration
-Set_Default_Configuration_Declaration = libghdl.vhdl__nodes__set_default_configuration_declaration
+Get_Default_Configuration_Declaration = (
+    libghdl.vhdl__nodes__get_default_configuration_declaration
+)
+Set_Default_Configuration_Declaration = (
+    libghdl.vhdl__nodes__set_default_configuration_declaration
+)
 
 Get_Expression = libghdl.vhdl__nodes__get_expression
 Set_Expression = libghdl.vhdl__nodes__set_expression
@@ -2682,8 +2710,12 @@ Set_Aggregate_Expand_Flag = libghdl.vhdl__nodes__set_aggregate_expand_flag
 Get_Association_Choices_Chain = libghdl.vhdl__nodes__get_association_choices_chain
 Set_Association_Choices_Chain = libghdl.vhdl__nodes__set_association_choices_chain
 
-Get_Case_Statement_Alternative_Chain = libghdl.vhdl__nodes__get_case_statement_alternative_chain
-Set_Case_Statement_Alternative_Chain = libghdl.vhdl__nodes__set_case_statement_alternative_chain
+Get_Case_Statement_Alternative_Chain = (
+    libghdl.vhdl__nodes__get_case_statement_alternative_chain
+)
+Set_Case_Statement_Alternative_Chain = (
+    libghdl.vhdl__nodes__set_case_statement_alternative_chain
+)
 
 Get_Choice_Staticness = libghdl.vhdl__nodes__get_choice_staticness
 Set_Choice_Staticness = libghdl.vhdl__nodes__set_choice_staticness
@@ -2849,4 +2881,3 @@ Set_Clock_Expression = libghdl.vhdl__nodes__set_clock_expression
 
 Get_Default_Clock = libghdl.vhdl__nodes__get_default_clock
 Set_Default_Clock = libghdl.vhdl__nodes__set_default_clock
-

--- a/pyGHDL/libghdl/vhdl/nodes_meta.py
+++ b/pyGHDL/libghdl/vhdl/nodes_meta.py
@@ -509,1112 +509,802 @@ Get_Token_Type = libghdl.vhdl__nodes_meta__get_token_type
 Get_Tri_State_Type = libghdl.vhdl__nodes_meta__get_tri_state_type
 
 
-Has_First_Design_Unit =\
-    libghdl.vhdl__nodes_meta__has_first_design_unit
+Has_First_Design_Unit = libghdl.vhdl__nodes_meta__has_first_design_unit
 
-Has_Last_Design_Unit =\
-    libghdl.vhdl__nodes_meta__has_last_design_unit
+Has_Last_Design_Unit = libghdl.vhdl__nodes_meta__has_last_design_unit
 
-Has_Library_Declaration =\
-    libghdl.vhdl__nodes_meta__has_library_declaration
+Has_Library_Declaration = libghdl.vhdl__nodes_meta__has_library_declaration
 
-Has_File_Checksum =\
-    libghdl.vhdl__nodes_meta__has_file_checksum
+Has_File_Checksum = libghdl.vhdl__nodes_meta__has_file_checksum
 
-Has_Analysis_Time_Stamp =\
-    libghdl.vhdl__nodes_meta__has_analysis_time_stamp
+Has_Analysis_Time_Stamp = libghdl.vhdl__nodes_meta__has_analysis_time_stamp
 
-Has_Design_File_Source =\
-    libghdl.vhdl__nodes_meta__has_design_file_source
+Has_Design_File_Source = libghdl.vhdl__nodes_meta__has_design_file_source
 
-Has_Library =\
-    libghdl.vhdl__nodes_meta__has_library
+Has_Library = libghdl.vhdl__nodes_meta__has_library
 
-Has_File_Dependence_List =\
-    libghdl.vhdl__nodes_meta__has_file_dependence_list
+Has_File_Dependence_List = libghdl.vhdl__nodes_meta__has_file_dependence_list
 
-Has_Design_File_Filename =\
-    libghdl.vhdl__nodes_meta__has_design_file_filename
+Has_Design_File_Filename = libghdl.vhdl__nodes_meta__has_design_file_filename
 
-Has_Design_File_Directory =\
-    libghdl.vhdl__nodes_meta__has_design_file_directory
+Has_Design_File_Directory = libghdl.vhdl__nodes_meta__has_design_file_directory
 
-Has_Design_File =\
-    libghdl.vhdl__nodes_meta__has_design_file
+Has_Design_File = libghdl.vhdl__nodes_meta__has_design_file
 
-Has_Design_File_Chain =\
-    libghdl.vhdl__nodes_meta__has_design_file_chain
+Has_Design_File_Chain = libghdl.vhdl__nodes_meta__has_design_file_chain
 
-Has_Library_Directory =\
-    libghdl.vhdl__nodes_meta__has_library_directory
+Has_Library_Directory = libghdl.vhdl__nodes_meta__has_library_directory
 
-Has_Date =\
-    libghdl.vhdl__nodes_meta__has_date
+Has_Date = libghdl.vhdl__nodes_meta__has_date
 
-Has_Context_Items =\
-    libghdl.vhdl__nodes_meta__has_context_items
+Has_Context_Items = libghdl.vhdl__nodes_meta__has_context_items
 
-Has_Dependence_List =\
-    libghdl.vhdl__nodes_meta__has_dependence_list
+Has_Dependence_List = libghdl.vhdl__nodes_meta__has_dependence_list
 
-Has_Analysis_Checks_List =\
-    libghdl.vhdl__nodes_meta__has_analysis_checks_list
+Has_Analysis_Checks_List = libghdl.vhdl__nodes_meta__has_analysis_checks_list
 
-Has_Date_State =\
-    libghdl.vhdl__nodes_meta__has_date_state
+Has_Date_State = libghdl.vhdl__nodes_meta__has_date_state
 
-Has_Guarded_Target_State =\
-    libghdl.vhdl__nodes_meta__has_guarded_target_state
+Has_Guarded_Target_State = libghdl.vhdl__nodes_meta__has_guarded_target_state
 
-Has_Library_Unit =\
-    libghdl.vhdl__nodes_meta__has_library_unit
+Has_Library_Unit = libghdl.vhdl__nodes_meta__has_library_unit
 
-Has_Hash_Chain =\
-    libghdl.vhdl__nodes_meta__has_hash_chain
+Has_Hash_Chain = libghdl.vhdl__nodes_meta__has_hash_chain
 
-Has_Design_Unit_Source_Pos =\
-    libghdl.vhdl__nodes_meta__has_design_unit_source_pos
+Has_Design_Unit_Source_Pos = libghdl.vhdl__nodes_meta__has_design_unit_source_pos
 
-Has_Design_Unit_Source_Line =\
-    libghdl.vhdl__nodes_meta__has_design_unit_source_line
+Has_Design_Unit_Source_Line = libghdl.vhdl__nodes_meta__has_design_unit_source_line
 
-Has_Design_Unit_Source_Col =\
-    libghdl.vhdl__nodes_meta__has_design_unit_source_col
+Has_Design_Unit_Source_Col = libghdl.vhdl__nodes_meta__has_design_unit_source_col
 
-Has_Value =\
-    libghdl.vhdl__nodes_meta__has_value
+Has_Value = libghdl.vhdl__nodes_meta__has_value
 
-Has_Enum_Pos =\
-    libghdl.vhdl__nodes_meta__has_enum_pos
+Has_Enum_Pos = libghdl.vhdl__nodes_meta__has_enum_pos
 
-Has_Physical_Literal =\
-    libghdl.vhdl__nodes_meta__has_physical_literal
+Has_Physical_Literal = libghdl.vhdl__nodes_meta__has_physical_literal
 
-Has_Fp_Value =\
-    libghdl.vhdl__nodes_meta__has_fp_value
+Has_Fp_Value = libghdl.vhdl__nodes_meta__has_fp_value
 
-Has_Simple_Aggregate_List =\
-    libghdl.vhdl__nodes_meta__has_simple_aggregate_list
+Has_Simple_Aggregate_List = libghdl.vhdl__nodes_meta__has_simple_aggregate_list
 
-Has_String8_Id =\
-    libghdl.vhdl__nodes_meta__has_string8_id
+Has_String8_Id = libghdl.vhdl__nodes_meta__has_string8_id
 
-Has_String_Length =\
-    libghdl.vhdl__nodes_meta__has_string_length
+Has_String_Length = libghdl.vhdl__nodes_meta__has_string_length
 
-Has_Bit_String_Base =\
-    libghdl.vhdl__nodes_meta__has_bit_string_base
+Has_Bit_String_Base = libghdl.vhdl__nodes_meta__has_bit_string_base
 
-Has_Has_Signed =\
-    libghdl.vhdl__nodes_meta__has_has_signed
+Has_Has_Signed = libghdl.vhdl__nodes_meta__has_has_signed
 
-Has_Has_Sign =\
-    libghdl.vhdl__nodes_meta__has_has_sign
+Has_Has_Sign = libghdl.vhdl__nodes_meta__has_has_sign
 
-Has_Has_Length =\
-    libghdl.vhdl__nodes_meta__has_has_length
+Has_Has_Length = libghdl.vhdl__nodes_meta__has_has_length
 
-Has_Literal_Length =\
-    libghdl.vhdl__nodes_meta__has_literal_length
+Has_Literal_Length = libghdl.vhdl__nodes_meta__has_literal_length
 
-Has_Literal_Origin =\
-    libghdl.vhdl__nodes_meta__has_literal_origin
+Has_Literal_Origin = libghdl.vhdl__nodes_meta__has_literal_origin
 
-Has_Range_Origin =\
-    libghdl.vhdl__nodes_meta__has_range_origin
+Has_Range_Origin = libghdl.vhdl__nodes_meta__has_range_origin
 
-Has_Literal_Subtype =\
-    libghdl.vhdl__nodes_meta__has_literal_subtype
+Has_Literal_Subtype = libghdl.vhdl__nodes_meta__has_literal_subtype
 
-Has_Allocator_Subtype =\
-    libghdl.vhdl__nodes_meta__has_allocator_subtype
+Has_Allocator_Subtype = libghdl.vhdl__nodes_meta__has_allocator_subtype
 
-Has_Entity_Class =\
-    libghdl.vhdl__nodes_meta__has_entity_class
+Has_Entity_Class = libghdl.vhdl__nodes_meta__has_entity_class
 
-Has_Entity_Name_List =\
-    libghdl.vhdl__nodes_meta__has_entity_name_list
+Has_Entity_Name_List = libghdl.vhdl__nodes_meta__has_entity_name_list
 
-Has_Attribute_Designator =\
-    libghdl.vhdl__nodes_meta__has_attribute_designator
+Has_Attribute_Designator = libghdl.vhdl__nodes_meta__has_attribute_designator
 
-Has_Attribute_Specification_Chain =\
+Has_Attribute_Specification_Chain = (
     libghdl.vhdl__nodes_meta__has_attribute_specification_chain
+)
 
-Has_Attribute_Specification =\
-    libghdl.vhdl__nodes_meta__has_attribute_specification
+Has_Attribute_Specification = libghdl.vhdl__nodes_meta__has_attribute_specification
 
-Has_Static_Attribute_Flag =\
-    libghdl.vhdl__nodes_meta__has_static_attribute_flag
+Has_Static_Attribute_Flag = libghdl.vhdl__nodes_meta__has_static_attribute_flag
 
-Has_Signal_List =\
-    libghdl.vhdl__nodes_meta__has_signal_list
+Has_Signal_List = libghdl.vhdl__nodes_meta__has_signal_list
 
-Has_Quantity_List =\
-    libghdl.vhdl__nodes_meta__has_quantity_list
+Has_Quantity_List = libghdl.vhdl__nodes_meta__has_quantity_list
 
-Has_Designated_Entity =\
-    libghdl.vhdl__nodes_meta__has_designated_entity
+Has_Designated_Entity = libghdl.vhdl__nodes_meta__has_designated_entity
 
-Has_Formal =\
-    libghdl.vhdl__nodes_meta__has_formal
+Has_Formal = libghdl.vhdl__nodes_meta__has_formal
 
-Has_Actual =\
-    libghdl.vhdl__nodes_meta__has_actual
+Has_Actual = libghdl.vhdl__nodes_meta__has_actual
 
-Has_Actual_Conversion =\
-    libghdl.vhdl__nodes_meta__has_actual_conversion
+Has_Actual_Conversion = libghdl.vhdl__nodes_meta__has_actual_conversion
 
-Has_Formal_Conversion =\
-    libghdl.vhdl__nodes_meta__has_formal_conversion
+Has_Formal_Conversion = libghdl.vhdl__nodes_meta__has_formal_conversion
 
-Has_Whole_Association_Flag =\
-    libghdl.vhdl__nodes_meta__has_whole_association_flag
+Has_Whole_Association_Flag = libghdl.vhdl__nodes_meta__has_whole_association_flag
 
-Has_Collapse_Signal_Flag =\
-    libghdl.vhdl__nodes_meta__has_collapse_signal_flag
+Has_Collapse_Signal_Flag = libghdl.vhdl__nodes_meta__has_collapse_signal_flag
 
-Has_Artificial_Flag =\
-    libghdl.vhdl__nodes_meta__has_artificial_flag
+Has_Artificial_Flag = libghdl.vhdl__nodes_meta__has_artificial_flag
 
-Has_Open_Flag =\
-    libghdl.vhdl__nodes_meta__has_open_flag
+Has_Open_Flag = libghdl.vhdl__nodes_meta__has_open_flag
 
-Has_After_Drivers_Flag =\
-    libghdl.vhdl__nodes_meta__has_after_drivers_flag
+Has_After_Drivers_Flag = libghdl.vhdl__nodes_meta__has_after_drivers_flag
 
-Has_We_Value =\
-    libghdl.vhdl__nodes_meta__has_we_value
+Has_We_Value = libghdl.vhdl__nodes_meta__has_we_value
 
-Has_Time =\
-    libghdl.vhdl__nodes_meta__has_time
+Has_Time = libghdl.vhdl__nodes_meta__has_time
 
-Has_Associated_Expr =\
-    libghdl.vhdl__nodes_meta__has_associated_expr
+Has_Associated_Expr = libghdl.vhdl__nodes_meta__has_associated_expr
 
-Has_Associated_Block =\
-    libghdl.vhdl__nodes_meta__has_associated_block
+Has_Associated_Block = libghdl.vhdl__nodes_meta__has_associated_block
 
-Has_Associated_Chain =\
-    libghdl.vhdl__nodes_meta__has_associated_chain
+Has_Associated_Chain = libghdl.vhdl__nodes_meta__has_associated_chain
 
-Has_Choice_Name =\
-    libghdl.vhdl__nodes_meta__has_choice_name
+Has_Choice_Name = libghdl.vhdl__nodes_meta__has_choice_name
 
-Has_Choice_Expression =\
-    libghdl.vhdl__nodes_meta__has_choice_expression
+Has_Choice_Expression = libghdl.vhdl__nodes_meta__has_choice_expression
 
-Has_Choice_Range =\
-    libghdl.vhdl__nodes_meta__has_choice_range
+Has_Choice_Range = libghdl.vhdl__nodes_meta__has_choice_range
 
-Has_Same_Alternative_Flag =\
-    libghdl.vhdl__nodes_meta__has_same_alternative_flag
+Has_Same_Alternative_Flag = libghdl.vhdl__nodes_meta__has_same_alternative_flag
 
-Has_Element_Type_Flag =\
-    libghdl.vhdl__nodes_meta__has_element_type_flag
+Has_Element_Type_Flag = libghdl.vhdl__nodes_meta__has_element_type_flag
 
-Has_Architecture =\
-    libghdl.vhdl__nodes_meta__has_architecture
+Has_Architecture = libghdl.vhdl__nodes_meta__has_architecture
 
-Has_Block_Specification =\
-    libghdl.vhdl__nodes_meta__has_block_specification
+Has_Block_Specification = libghdl.vhdl__nodes_meta__has_block_specification
 
-Has_Prev_Block_Configuration =\
-    libghdl.vhdl__nodes_meta__has_prev_block_configuration
+Has_Prev_Block_Configuration = libghdl.vhdl__nodes_meta__has_prev_block_configuration
 
-Has_Configuration_Item_Chain =\
-    libghdl.vhdl__nodes_meta__has_configuration_item_chain
+Has_Configuration_Item_Chain = libghdl.vhdl__nodes_meta__has_configuration_item_chain
 
-Has_Attribute_Value_Chain =\
-    libghdl.vhdl__nodes_meta__has_attribute_value_chain
+Has_Attribute_Value_Chain = libghdl.vhdl__nodes_meta__has_attribute_value_chain
 
-Has_Spec_Chain =\
-    libghdl.vhdl__nodes_meta__has_spec_chain
+Has_Spec_Chain = libghdl.vhdl__nodes_meta__has_spec_chain
 
-Has_Value_Chain =\
-    libghdl.vhdl__nodes_meta__has_value_chain
+Has_Value_Chain = libghdl.vhdl__nodes_meta__has_value_chain
 
-Has_Attribute_Value_Spec_Chain =\
+Has_Attribute_Value_Spec_Chain = (
     libghdl.vhdl__nodes_meta__has_attribute_value_spec_chain
+)
 
-Has_Entity_Name =\
-    libghdl.vhdl__nodes_meta__has_entity_name
+Has_Entity_Name = libghdl.vhdl__nodes_meta__has_entity_name
 
-Has_Package =\
-    libghdl.vhdl__nodes_meta__has_package
+Has_Package = libghdl.vhdl__nodes_meta__has_package
 
-Has_Package_Body =\
-    libghdl.vhdl__nodes_meta__has_package_body
+Has_Package_Body = libghdl.vhdl__nodes_meta__has_package_body
 
-Has_Instance_Package_Body =\
-    libghdl.vhdl__nodes_meta__has_instance_package_body
+Has_Instance_Package_Body = libghdl.vhdl__nodes_meta__has_instance_package_body
 
-Has_Need_Body =\
-    libghdl.vhdl__nodes_meta__has_need_body
+Has_Need_Body = libghdl.vhdl__nodes_meta__has_need_body
 
-Has_Macro_Expanded_Flag =\
-    libghdl.vhdl__nodes_meta__has_macro_expanded_flag
+Has_Macro_Expanded_Flag = libghdl.vhdl__nodes_meta__has_macro_expanded_flag
 
-Has_Need_Instance_Bodies =\
-    libghdl.vhdl__nodes_meta__has_need_instance_bodies
+Has_Need_Instance_Bodies = libghdl.vhdl__nodes_meta__has_need_instance_bodies
 
-Has_Hierarchical_Name =\
-    libghdl.vhdl__nodes_meta__has_hierarchical_name
+Has_Hierarchical_Name = libghdl.vhdl__nodes_meta__has_hierarchical_name
 
-Has_Inherit_Spec_Chain =\
-    libghdl.vhdl__nodes_meta__has_inherit_spec_chain
+Has_Inherit_Spec_Chain = libghdl.vhdl__nodes_meta__has_inherit_spec_chain
 
-Has_Vunit_Item_Chain =\
-    libghdl.vhdl__nodes_meta__has_vunit_item_chain
+Has_Vunit_Item_Chain = libghdl.vhdl__nodes_meta__has_vunit_item_chain
 
-Has_Bound_Vunit_Chain =\
-    libghdl.vhdl__nodes_meta__has_bound_vunit_chain
+Has_Bound_Vunit_Chain = libghdl.vhdl__nodes_meta__has_bound_vunit_chain
 
-Has_Verification_Block_Configuration =\
+Has_Verification_Block_Configuration = (
     libghdl.vhdl__nodes_meta__has_verification_block_configuration
+)
 
-Has_Block_Configuration =\
-    libghdl.vhdl__nodes_meta__has_block_configuration
+Has_Block_Configuration = libghdl.vhdl__nodes_meta__has_block_configuration
 
-Has_Concurrent_Statement_Chain =\
+Has_Concurrent_Statement_Chain = (
     libghdl.vhdl__nodes_meta__has_concurrent_statement_chain
+)
 
-Has_Chain =\
-    libghdl.vhdl__nodes_meta__has_chain
+Has_Chain = libghdl.vhdl__nodes_meta__has_chain
 
-Has_Port_Chain =\
-    libghdl.vhdl__nodes_meta__has_port_chain
+Has_Port_Chain = libghdl.vhdl__nodes_meta__has_port_chain
 
-Has_Generic_Chain =\
-    libghdl.vhdl__nodes_meta__has_generic_chain
+Has_Generic_Chain = libghdl.vhdl__nodes_meta__has_generic_chain
 
-Has_Type =\
-    libghdl.vhdl__nodes_meta__has_type
+Has_Type = libghdl.vhdl__nodes_meta__has_type
 
-Has_Subtype_Indication =\
-    libghdl.vhdl__nodes_meta__has_subtype_indication
+Has_Subtype_Indication = libghdl.vhdl__nodes_meta__has_subtype_indication
 
-Has_Discrete_Range =\
-    libghdl.vhdl__nodes_meta__has_discrete_range
+Has_Discrete_Range = libghdl.vhdl__nodes_meta__has_discrete_range
 
-Has_Type_Definition =\
-    libghdl.vhdl__nodes_meta__has_type_definition
+Has_Type_Definition = libghdl.vhdl__nodes_meta__has_type_definition
 
-Has_Subtype_Definition =\
-    libghdl.vhdl__nodes_meta__has_subtype_definition
+Has_Subtype_Definition = libghdl.vhdl__nodes_meta__has_subtype_definition
 
-Has_Incomplete_Type_Declaration =\
+Has_Incomplete_Type_Declaration = (
     libghdl.vhdl__nodes_meta__has_incomplete_type_declaration
+)
 
-Has_Interface_Type_Subprograms =\
+Has_Interface_Type_Subprograms = (
     libghdl.vhdl__nodes_meta__has_interface_type_subprograms
+)
 
-Has_Nature_Definition =\
-    libghdl.vhdl__nodes_meta__has_nature_definition
+Has_Nature_Definition = libghdl.vhdl__nodes_meta__has_nature_definition
 
-Has_Nature =\
-    libghdl.vhdl__nodes_meta__has_nature
+Has_Nature = libghdl.vhdl__nodes_meta__has_nature
 
-Has_Subnature_Indication =\
-    libghdl.vhdl__nodes_meta__has_subnature_indication
+Has_Subnature_Indication = libghdl.vhdl__nodes_meta__has_subnature_indication
 
-Has_Mode =\
-    libghdl.vhdl__nodes_meta__has_mode
+Has_Mode = libghdl.vhdl__nodes_meta__has_mode
 
-Has_Guarded_Signal_Flag =\
-    libghdl.vhdl__nodes_meta__has_guarded_signal_flag
+Has_Guarded_Signal_Flag = libghdl.vhdl__nodes_meta__has_guarded_signal_flag
 
-Has_Signal_Kind =\
-    libghdl.vhdl__nodes_meta__has_signal_kind
+Has_Signal_Kind = libghdl.vhdl__nodes_meta__has_signal_kind
 
-Has_Base_Name =\
-    libghdl.vhdl__nodes_meta__has_base_name
+Has_Base_Name = libghdl.vhdl__nodes_meta__has_base_name
 
-Has_Interface_Declaration_Chain =\
+Has_Interface_Declaration_Chain = (
     libghdl.vhdl__nodes_meta__has_interface_declaration_chain
+)
 
-Has_Subprogram_Specification =\
-    libghdl.vhdl__nodes_meta__has_subprogram_specification
+Has_Subprogram_Specification = libghdl.vhdl__nodes_meta__has_subprogram_specification
 
-Has_Sequential_Statement_Chain =\
+Has_Sequential_Statement_Chain = (
     libghdl.vhdl__nodes_meta__has_sequential_statement_chain
+)
 
-Has_Simultaneous_Statement_Chain =\
+Has_Simultaneous_Statement_Chain = (
     libghdl.vhdl__nodes_meta__has_simultaneous_statement_chain
+)
 
-Has_Subprogram_Body =\
-    libghdl.vhdl__nodes_meta__has_subprogram_body
+Has_Subprogram_Body = libghdl.vhdl__nodes_meta__has_subprogram_body
 
-Has_Overload_Number =\
-    libghdl.vhdl__nodes_meta__has_overload_number
+Has_Overload_Number = libghdl.vhdl__nodes_meta__has_overload_number
 
-Has_Subprogram_Depth =\
-    libghdl.vhdl__nodes_meta__has_subprogram_depth
+Has_Subprogram_Depth = libghdl.vhdl__nodes_meta__has_subprogram_depth
 
-Has_Subprogram_Hash =\
-    libghdl.vhdl__nodes_meta__has_subprogram_hash
+Has_Subprogram_Hash = libghdl.vhdl__nodes_meta__has_subprogram_hash
 
-Has_Impure_Depth =\
-    libghdl.vhdl__nodes_meta__has_impure_depth
+Has_Impure_Depth = libghdl.vhdl__nodes_meta__has_impure_depth
 
-Has_Return_Type =\
-    libghdl.vhdl__nodes_meta__has_return_type
+Has_Return_Type = libghdl.vhdl__nodes_meta__has_return_type
 
-Has_Implicit_Definition =\
-    libghdl.vhdl__nodes_meta__has_implicit_definition
+Has_Implicit_Definition = libghdl.vhdl__nodes_meta__has_implicit_definition
 
-Has_Uninstantiated_Subprogram_Name =\
+Has_Uninstantiated_Subprogram_Name = (
     libghdl.vhdl__nodes_meta__has_uninstantiated_subprogram_name
+)
 
-Has_Default_Value =\
-    libghdl.vhdl__nodes_meta__has_default_value
+Has_Default_Value = libghdl.vhdl__nodes_meta__has_default_value
 
-Has_Deferred_Declaration =\
-    libghdl.vhdl__nodes_meta__has_deferred_declaration
+Has_Deferred_Declaration = libghdl.vhdl__nodes_meta__has_deferred_declaration
 
-Has_Deferred_Declaration_Flag =\
-    libghdl.vhdl__nodes_meta__has_deferred_declaration_flag
+Has_Deferred_Declaration_Flag = libghdl.vhdl__nodes_meta__has_deferred_declaration_flag
 
-Has_Shared_Flag =\
-    libghdl.vhdl__nodes_meta__has_shared_flag
+Has_Shared_Flag = libghdl.vhdl__nodes_meta__has_shared_flag
 
-Has_Design_Unit =\
-    libghdl.vhdl__nodes_meta__has_design_unit
+Has_Design_Unit = libghdl.vhdl__nodes_meta__has_design_unit
 
-Has_Block_Statement =\
-    libghdl.vhdl__nodes_meta__has_block_statement
+Has_Block_Statement = libghdl.vhdl__nodes_meta__has_block_statement
 
-Has_Signal_Driver =\
-    libghdl.vhdl__nodes_meta__has_signal_driver
+Has_Signal_Driver = libghdl.vhdl__nodes_meta__has_signal_driver
 
-Has_Declaration_Chain =\
-    libghdl.vhdl__nodes_meta__has_declaration_chain
+Has_Declaration_Chain = libghdl.vhdl__nodes_meta__has_declaration_chain
 
-Has_File_Logical_Name =\
-    libghdl.vhdl__nodes_meta__has_file_logical_name
+Has_File_Logical_Name = libghdl.vhdl__nodes_meta__has_file_logical_name
 
-Has_File_Open_Kind =\
-    libghdl.vhdl__nodes_meta__has_file_open_kind
+Has_File_Open_Kind = libghdl.vhdl__nodes_meta__has_file_open_kind
 
-Has_Element_Position =\
-    libghdl.vhdl__nodes_meta__has_element_position
+Has_Element_Position = libghdl.vhdl__nodes_meta__has_element_position
 
-Has_Use_Clause_Chain =\
-    libghdl.vhdl__nodes_meta__has_use_clause_chain
+Has_Use_Clause_Chain = libghdl.vhdl__nodes_meta__has_use_clause_chain
 
-Has_Context_Reference_Chain =\
-    libghdl.vhdl__nodes_meta__has_context_reference_chain
+Has_Context_Reference_Chain = libghdl.vhdl__nodes_meta__has_context_reference_chain
 
-Has_Selected_Name =\
-    libghdl.vhdl__nodes_meta__has_selected_name
+Has_Selected_Name = libghdl.vhdl__nodes_meta__has_selected_name
 
-Has_Type_Declarator =\
-    libghdl.vhdl__nodes_meta__has_type_declarator
+Has_Type_Declarator = libghdl.vhdl__nodes_meta__has_type_declarator
 
-Has_Complete_Type_Definition =\
-    libghdl.vhdl__nodes_meta__has_complete_type_definition
+Has_Complete_Type_Definition = libghdl.vhdl__nodes_meta__has_complete_type_definition
 
-Has_Incomplete_Type_Ref_Chain =\
-    libghdl.vhdl__nodes_meta__has_incomplete_type_ref_chain
+Has_Incomplete_Type_Ref_Chain = libghdl.vhdl__nodes_meta__has_incomplete_type_ref_chain
 
-Has_Associated_Type =\
-    libghdl.vhdl__nodes_meta__has_associated_type
+Has_Associated_Type = libghdl.vhdl__nodes_meta__has_associated_type
 
-Has_Enumeration_Literal_List =\
-    libghdl.vhdl__nodes_meta__has_enumeration_literal_list
+Has_Enumeration_Literal_List = libghdl.vhdl__nodes_meta__has_enumeration_literal_list
 
-Has_Entity_Class_Entry_Chain =\
-    libghdl.vhdl__nodes_meta__has_entity_class_entry_chain
+Has_Entity_Class_Entry_Chain = libghdl.vhdl__nodes_meta__has_entity_class_entry_chain
 
-Has_Group_Constituent_List =\
-    libghdl.vhdl__nodes_meta__has_group_constituent_list
+Has_Group_Constituent_List = libghdl.vhdl__nodes_meta__has_group_constituent_list
 
-Has_Unit_Chain =\
-    libghdl.vhdl__nodes_meta__has_unit_chain
+Has_Unit_Chain = libghdl.vhdl__nodes_meta__has_unit_chain
 
-Has_Primary_Unit =\
-    libghdl.vhdl__nodes_meta__has_primary_unit
+Has_Primary_Unit = libghdl.vhdl__nodes_meta__has_primary_unit
 
-Has_Identifier =\
-    libghdl.vhdl__nodes_meta__has_identifier
+Has_Identifier = libghdl.vhdl__nodes_meta__has_identifier
 
-Has_Label =\
-    libghdl.vhdl__nodes_meta__has_label
+Has_Label = libghdl.vhdl__nodes_meta__has_label
 
-Has_Visible_Flag =\
-    libghdl.vhdl__nodes_meta__has_visible_flag
+Has_Visible_Flag = libghdl.vhdl__nodes_meta__has_visible_flag
 
-Has_Range_Constraint =\
-    libghdl.vhdl__nodes_meta__has_range_constraint
+Has_Range_Constraint = libghdl.vhdl__nodes_meta__has_range_constraint
 
-Has_Direction =\
-    libghdl.vhdl__nodes_meta__has_direction
+Has_Direction = libghdl.vhdl__nodes_meta__has_direction
 
-Has_Left_Limit =\
-    libghdl.vhdl__nodes_meta__has_left_limit
+Has_Left_Limit = libghdl.vhdl__nodes_meta__has_left_limit
 
-Has_Right_Limit =\
-    libghdl.vhdl__nodes_meta__has_right_limit
+Has_Right_Limit = libghdl.vhdl__nodes_meta__has_right_limit
 
-Has_Left_Limit_Expr =\
-    libghdl.vhdl__nodes_meta__has_left_limit_expr
+Has_Left_Limit_Expr = libghdl.vhdl__nodes_meta__has_left_limit_expr
 
-Has_Right_Limit_Expr =\
-    libghdl.vhdl__nodes_meta__has_right_limit_expr
+Has_Right_Limit_Expr = libghdl.vhdl__nodes_meta__has_right_limit_expr
 
-Has_Parent_Type =\
-    libghdl.vhdl__nodes_meta__has_parent_type
+Has_Parent_Type = libghdl.vhdl__nodes_meta__has_parent_type
 
-Has_Simple_Nature =\
-    libghdl.vhdl__nodes_meta__has_simple_nature
+Has_Simple_Nature = libghdl.vhdl__nodes_meta__has_simple_nature
 
-Has_Base_Nature =\
-    libghdl.vhdl__nodes_meta__has_base_nature
+Has_Base_Nature = libghdl.vhdl__nodes_meta__has_base_nature
 
-Has_Resolution_Indication =\
-    libghdl.vhdl__nodes_meta__has_resolution_indication
+Has_Resolution_Indication = libghdl.vhdl__nodes_meta__has_resolution_indication
 
-Has_Record_Element_Resolution_Chain =\
+Has_Record_Element_Resolution_Chain = (
     libghdl.vhdl__nodes_meta__has_record_element_resolution_chain
+)
 
-Has_Tolerance =\
-    libghdl.vhdl__nodes_meta__has_tolerance
+Has_Tolerance = libghdl.vhdl__nodes_meta__has_tolerance
 
-Has_Plus_Terminal_Name =\
-    libghdl.vhdl__nodes_meta__has_plus_terminal_name
+Has_Plus_Terminal_Name = libghdl.vhdl__nodes_meta__has_plus_terminal_name
 
-Has_Minus_Terminal_Name =\
-    libghdl.vhdl__nodes_meta__has_minus_terminal_name
+Has_Minus_Terminal_Name = libghdl.vhdl__nodes_meta__has_minus_terminal_name
 
-Has_Plus_Terminal =\
-    libghdl.vhdl__nodes_meta__has_plus_terminal
+Has_Plus_Terminal = libghdl.vhdl__nodes_meta__has_plus_terminal
 
-Has_Minus_Terminal =\
-    libghdl.vhdl__nodes_meta__has_minus_terminal
+Has_Minus_Terminal = libghdl.vhdl__nodes_meta__has_minus_terminal
 
-Has_Magnitude_Expression =\
-    libghdl.vhdl__nodes_meta__has_magnitude_expression
+Has_Magnitude_Expression = libghdl.vhdl__nodes_meta__has_magnitude_expression
 
-Has_Phase_Expression =\
-    libghdl.vhdl__nodes_meta__has_phase_expression
+Has_Phase_Expression = libghdl.vhdl__nodes_meta__has_phase_expression
 
-Has_Power_Expression =\
-    libghdl.vhdl__nodes_meta__has_power_expression
+Has_Power_Expression = libghdl.vhdl__nodes_meta__has_power_expression
 
-Has_Simultaneous_Left =\
-    libghdl.vhdl__nodes_meta__has_simultaneous_left
+Has_Simultaneous_Left = libghdl.vhdl__nodes_meta__has_simultaneous_left
 
-Has_Simultaneous_Right =\
-    libghdl.vhdl__nodes_meta__has_simultaneous_right
+Has_Simultaneous_Right = libghdl.vhdl__nodes_meta__has_simultaneous_right
 
-Has_Text_File_Flag =\
-    libghdl.vhdl__nodes_meta__has_text_file_flag
+Has_Text_File_Flag = libghdl.vhdl__nodes_meta__has_text_file_flag
 
-Has_Only_Characters_Flag =\
-    libghdl.vhdl__nodes_meta__has_only_characters_flag
+Has_Only_Characters_Flag = libghdl.vhdl__nodes_meta__has_only_characters_flag
 
-Has_Is_Character_Type =\
-    libghdl.vhdl__nodes_meta__has_is_character_type
+Has_Is_Character_Type = libghdl.vhdl__nodes_meta__has_is_character_type
 
-Has_Nature_Staticness =\
-    libghdl.vhdl__nodes_meta__has_nature_staticness
+Has_Nature_Staticness = libghdl.vhdl__nodes_meta__has_nature_staticness
 
-Has_Type_Staticness =\
-    libghdl.vhdl__nodes_meta__has_type_staticness
+Has_Type_Staticness = libghdl.vhdl__nodes_meta__has_type_staticness
 
-Has_Constraint_State =\
-    libghdl.vhdl__nodes_meta__has_constraint_state
+Has_Constraint_State = libghdl.vhdl__nodes_meta__has_constraint_state
 
-Has_Index_Subtype_List =\
-    libghdl.vhdl__nodes_meta__has_index_subtype_list
+Has_Index_Subtype_List = libghdl.vhdl__nodes_meta__has_index_subtype_list
 
-Has_Index_Subtype_Definition_List =\
+Has_Index_Subtype_Definition_List = (
     libghdl.vhdl__nodes_meta__has_index_subtype_definition_list
+)
 
-Has_Element_Subtype_Indication =\
+Has_Element_Subtype_Indication = (
     libghdl.vhdl__nodes_meta__has_element_subtype_indication
+)
 
-Has_Element_Subtype =\
-    libghdl.vhdl__nodes_meta__has_element_subtype
+Has_Element_Subtype = libghdl.vhdl__nodes_meta__has_element_subtype
 
-Has_Element_Subnature_Indication =\
+Has_Element_Subnature_Indication = (
     libghdl.vhdl__nodes_meta__has_element_subnature_indication
+)
 
-Has_Element_Subnature =\
-    libghdl.vhdl__nodes_meta__has_element_subnature
+Has_Element_Subnature = libghdl.vhdl__nodes_meta__has_element_subnature
 
-Has_Index_Constraint_List =\
-    libghdl.vhdl__nodes_meta__has_index_constraint_list
+Has_Index_Constraint_List = libghdl.vhdl__nodes_meta__has_index_constraint_list
 
-Has_Array_Element_Constraint =\
-    libghdl.vhdl__nodes_meta__has_array_element_constraint
+Has_Array_Element_Constraint = libghdl.vhdl__nodes_meta__has_array_element_constraint
 
-Has_Has_Array_Constraint_Flag =\
-    libghdl.vhdl__nodes_meta__has_has_array_constraint_flag
+Has_Has_Array_Constraint_Flag = libghdl.vhdl__nodes_meta__has_has_array_constraint_flag
 
-Has_Has_Element_Constraint_Flag =\
+Has_Has_Element_Constraint_Flag = (
     libghdl.vhdl__nodes_meta__has_has_element_constraint_flag
+)
 
-Has_Elements_Declaration_List =\
-    libghdl.vhdl__nodes_meta__has_elements_declaration_list
+Has_Elements_Declaration_List = libghdl.vhdl__nodes_meta__has_elements_declaration_list
 
-Has_Owned_Elements_Chain =\
-    libghdl.vhdl__nodes_meta__has_owned_elements_chain
+Has_Owned_Elements_Chain = libghdl.vhdl__nodes_meta__has_owned_elements_chain
 
-Has_Designated_Type =\
-    libghdl.vhdl__nodes_meta__has_designated_type
+Has_Designated_Type = libghdl.vhdl__nodes_meta__has_designated_type
 
-Has_Designated_Subtype_Indication =\
+Has_Designated_Subtype_Indication = (
     libghdl.vhdl__nodes_meta__has_designated_subtype_indication
+)
 
-Has_Index_List =\
-    libghdl.vhdl__nodes_meta__has_index_list
+Has_Index_List = libghdl.vhdl__nodes_meta__has_index_list
 
-Has_Reference =\
-    libghdl.vhdl__nodes_meta__has_reference
+Has_Reference = libghdl.vhdl__nodes_meta__has_reference
 
-Has_Nature_Declarator =\
-    libghdl.vhdl__nodes_meta__has_nature_declarator
+Has_Nature_Declarator = libghdl.vhdl__nodes_meta__has_nature_declarator
 
-Has_Across_Type_Mark =\
-    libghdl.vhdl__nodes_meta__has_across_type_mark
+Has_Across_Type_Mark = libghdl.vhdl__nodes_meta__has_across_type_mark
 
-Has_Through_Type_Mark =\
-    libghdl.vhdl__nodes_meta__has_through_type_mark
+Has_Through_Type_Mark = libghdl.vhdl__nodes_meta__has_through_type_mark
 
-Has_Across_Type_Definition =\
-    libghdl.vhdl__nodes_meta__has_across_type_definition
+Has_Across_Type_Definition = libghdl.vhdl__nodes_meta__has_across_type_definition
 
-Has_Through_Type_Definition =\
-    libghdl.vhdl__nodes_meta__has_through_type_definition
+Has_Through_Type_Definition = libghdl.vhdl__nodes_meta__has_through_type_definition
 
-Has_Across_Type =\
-    libghdl.vhdl__nodes_meta__has_across_type
+Has_Across_Type = libghdl.vhdl__nodes_meta__has_across_type
 
-Has_Through_Type =\
-    libghdl.vhdl__nodes_meta__has_through_type
+Has_Through_Type = libghdl.vhdl__nodes_meta__has_through_type
 
-Has_Target =\
-    libghdl.vhdl__nodes_meta__has_target
+Has_Target = libghdl.vhdl__nodes_meta__has_target
 
-Has_Waveform_Chain =\
-    libghdl.vhdl__nodes_meta__has_waveform_chain
+Has_Waveform_Chain = libghdl.vhdl__nodes_meta__has_waveform_chain
 
-Has_Guard =\
-    libghdl.vhdl__nodes_meta__has_guard
+Has_Guard = libghdl.vhdl__nodes_meta__has_guard
 
-Has_Delay_Mechanism =\
-    libghdl.vhdl__nodes_meta__has_delay_mechanism
+Has_Delay_Mechanism = libghdl.vhdl__nodes_meta__has_delay_mechanism
 
-Has_Reject_Time_Expression =\
-    libghdl.vhdl__nodes_meta__has_reject_time_expression
+Has_Reject_Time_Expression = libghdl.vhdl__nodes_meta__has_reject_time_expression
 
-Has_Force_Mode =\
-    libghdl.vhdl__nodes_meta__has_force_mode
+Has_Force_Mode = libghdl.vhdl__nodes_meta__has_force_mode
 
-Has_Has_Force_Mode =\
-    libghdl.vhdl__nodes_meta__has_has_force_mode
+Has_Has_Force_Mode = libghdl.vhdl__nodes_meta__has_has_force_mode
 
-Has_Sensitivity_List =\
-    libghdl.vhdl__nodes_meta__has_sensitivity_list
+Has_Sensitivity_List = libghdl.vhdl__nodes_meta__has_sensitivity_list
 
-Has_Process_Origin =\
-    libghdl.vhdl__nodes_meta__has_process_origin
+Has_Process_Origin = libghdl.vhdl__nodes_meta__has_process_origin
 
-Has_Package_Origin =\
-    libghdl.vhdl__nodes_meta__has_package_origin
+Has_Package_Origin = libghdl.vhdl__nodes_meta__has_package_origin
 
-Has_Condition_Clause =\
-    libghdl.vhdl__nodes_meta__has_condition_clause
+Has_Condition_Clause = libghdl.vhdl__nodes_meta__has_condition_clause
 
-Has_Break_Element =\
-    libghdl.vhdl__nodes_meta__has_break_element
+Has_Break_Element = libghdl.vhdl__nodes_meta__has_break_element
 
-Has_Selector_Quantity =\
-    libghdl.vhdl__nodes_meta__has_selector_quantity
+Has_Selector_Quantity = libghdl.vhdl__nodes_meta__has_selector_quantity
 
-Has_Break_Quantity =\
-    libghdl.vhdl__nodes_meta__has_break_quantity
+Has_Break_Quantity = libghdl.vhdl__nodes_meta__has_break_quantity
 
-Has_Timeout_Clause =\
-    libghdl.vhdl__nodes_meta__has_timeout_clause
+Has_Timeout_Clause = libghdl.vhdl__nodes_meta__has_timeout_clause
 
-Has_Postponed_Flag =\
-    libghdl.vhdl__nodes_meta__has_postponed_flag
+Has_Postponed_Flag = libghdl.vhdl__nodes_meta__has_postponed_flag
 
-Has_Callees_List =\
-    libghdl.vhdl__nodes_meta__has_callees_list
+Has_Callees_List = libghdl.vhdl__nodes_meta__has_callees_list
 
-Has_Passive_Flag =\
-    libghdl.vhdl__nodes_meta__has_passive_flag
+Has_Passive_Flag = libghdl.vhdl__nodes_meta__has_passive_flag
 
-Has_Resolution_Function_Flag =\
-    libghdl.vhdl__nodes_meta__has_resolution_function_flag
+Has_Resolution_Function_Flag = libghdl.vhdl__nodes_meta__has_resolution_function_flag
 
-Has_Wait_State =\
-    libghdl.vhdl__nodes_meta__has_wait_state
+Has_Wait_State = libghdl.vhdl__nodes_meta__has_wait_state
 
-Has_All_Sensitized_State =\
-    libghdl.vhdl__nodes_meta__has_all_sensitized_state
+Has_All_Sensitized_State = libghdl.vhdl__nodes_meta__has_all_sensitized_state
 
-Has_Seen_Flag =\
-    libghdl.vhdl__nodes_meta__has_seen_flag
+Has_Seen_Flag = libghdl.vhdl__nodes_meta__has_seen_flag
 
-Has_Pure_Flag =\
-    libghdl.vhdl__nodes_meta__has_pure_flag
+Has_Pure_Flag = libghdl.vhdl__nodes_meta__has_pure_flag
 
-Has_Foreign_Flag =\
-    libghdl.vhdl__nodes_meta__has_foreign_flag
+Has_Foreign_Flag = libghdl.vhdl__nodes_meta__has_foreign_flag
 
-Has_Resolved_Flag =\
-    libghdl.vhdl__nodes_meta__has_resolved_flag
+Has_Resolved_Flag = libghdl.vhdl__nodes_meta__has_resolved_flag
 
-Has_Signal_Type_Flag =\
-    libghdl.vhdl__nodes_meta__has_signal_type_flag
+Has_Signal_Type_Flag = libghdl.vhdl__nodes_meta__has_signal_type_flag
 
-Has_Has_Signal_Flag =\
-    libghdl.vhdl__nodes_meta__has_has_signal_flag
+Has_Has_Signal_Flag = libghdl.vhdl__nodes_meta__has_has_signal_flag
 
-Has_Purity_State =\
-    libghdl.vhdl__nodes_meta__has_purity_state
+Has_Purity_State = libghdl.vhdl__nodes_meta__has_purity_state
 
-Has_Elab_Flag =\
-    libghdl.vhdl__nodes_meta__has_elab_flag
+Has_Elab_Flag = libghdl.vhdl__nodes_meta__has_elab_flag
 
-Has_Vendor_Library_Flag =\
-    libghdl.vhdl__nodes_meta__has_vendor_library_flag
+Has_Vendor_Library_Flag = libghdl.vhdl__nodes_meta__has_vendor_library_flag
 
-Has_Configuration_Mark_Flag =\
-    libghdl.vhdl__nodes_meta__has_configuration_mark_flag
+Has_Configuration_Mark_Flag = libghdl.vhdl__nodes_meta__has_configuration_mark_flag
 
-Has_Configuration_Done_Flag =\
-    libghdl.vhdl__nodes_meta__has_configuration_done_flag
+Has_Configuration_Done_Flag = libghdl.vhdl__nodes_meta__has_configuration_done_flag
 
-Has_Index_Constraint_Flag =\
-    libghdl.vhdl__nodes_meta__has_index_constraint_flag
+Has_Index_Constraint_Flag = libghdl.vhdl__nodes_meta__has_index_constraint_flag
 
-Has_Hide_Implicit_Flag =\
-    libghdl.vhdl__nodes_meta__has_hide_implicit_flag
+Has_Hide_Implicit_Flag = libghdl.vhdl__nodes_meta__has_hide_implicit_flag
 
-Has_Assertion_Condition =\
-    libghdl.vhdl__nodes_meta__has_assertion_condition
+Has_Assertion_Condition = libghdl.vhdl__nodes_meta__has_assertion_condition
 
-Has_Report_Expression =\
-    libghdl.vhdl__nodes_meta__has_report_expression
+Has_Report_Expression = libghdl.vhdl__nodes_meta__has_report_expression
 
-Has_Severity_Expression =\
-    libghdl.vhdl__nodes_meta__has_severity_expression
+Has_Severity_Expression = libghdl.vhdl__nodes_meta__has_severity_expression
 
-Has_Instantiated_Unit =\
-    libghdl.vhdl__nodes_meta__has_instantiated_unit
+Has_Instantiated_Unit = libghdl.vhdl__nodes_meta__has_instantiated_unit
 
-Has_Generic_Map_Aspect_Chain =\
-    libghdl.vhdl__nodes_meta__has_generic_map_aspect_chain
+Has_Generic_Map_Aspect_Chain = libghdl.vhdl__nodes_meta__has_generic_map_aspect_chain
 
-Has_Port_Map_Aspect_Chain =\
-    libghdl.vhdl__nodes_meta__has_port_map_aspect_chain
+Has_Port_Map_Aspect_Chain = libghdl.vhdl__nodes_meta__has_port_map_aspect_chain
 
-Has_Configuration_Name =\
-    libghdl.vhdl__nodes_meta__has_configuration_name
+Has_Configuration_Name = libghdl.vhdl__nodes_meta__has_configuration_name
 
-Has_Component_Configuration =\
-    libghdl.vhdl__nodes_meta__has_component_configuration
+Has_Component_Configuration = libghdl.vhdl__nodes_meta__has_component_configuration
 
-Has_Configuration_Specification =\
+Has_Configuration_Specification = (
     libghdl.vhdl__nodes_meta__has_configuration_specification
+)
 
-Has_Default_Binding_Indication =\
+Has_Default_Binding_Indication = (
     libghdl.vhdl__nodes_meta__has_default_binding_indication
+)
 
-Has_Default_Configuration_Declaration =\
+Has_Default_Configuration_Declaration = (
     libghdl.vhdl__nodes_meta__has_default_configuration_declaration
+)
 
-Has_Expression =\
-    libghdl.vhdl__nodes_meta__has_expression
+Has_Expression = libghdl.vhdl__nodes_meta__has_expression
 
-Has_Conditional_Expression_Chain =\
+Has_Conditional_Expression_Chain = (
     libghdl.vhdl__nodes_meta__has_conditional_expression_chain
+)
 
-Has_Allocator_Designated_Type =\
-    libghdl.vhdl__nodes_meta__has_allocator_designated_type
+Has_Allocator_Designated_Type = libghdl.vhdl__nodes_meta__has_allocator_designated_type
 
-Has_Selected_Waveform_Chain =\
-    libghdl.vhdl__nodes_meta__has_selected_waveform_chain
+Has_Selected_Waveform_Chain = libghdl.vhdl__nodes_meta__has_selected_waveform_chain
 
-Has_Conditional_Waveform_Chain =\
+Has_Conditional_Waveform_Chain = (
     libghdl.vhdl__nodes_meta__has_conditional_waveform_chain
+)
 
-Has_Guard_Expression =\
-    libghdl.vhdl__nodes_meta__has_guard_expression
+Has_Guard_Expression = libghdl.vhdl__nodes_meta__has_guard_expression
 
-Has_Guard_Decl =\
-    libghdl.vhdl__nodes_meta__has_guard_decl
+Has_Guard_Decl = libghdl.vhdl__nodes_meta__has_guard_decl
 
-Has_Guard_Sensitivity_List =\
-    libghdl.vhdl__nodes_meta__has_guard_sensitivity_list
+Has_Guard_Sensitivity_List = libghdl.vhdl__nodes_meta__has_guard_sensitivity_list
 
-Has_Signal_Attribute_Chain =\
-    libghdl.vhdl__nodes_meta__has_signal_attribute_chain
+Has_Signal_Attribute_Chain = libghdl.vhdl__nodes_meta__has_signal_attribute_chain
 
-Has_Block_Block_Configuration =\
-    libghdl.vhdl__nodes_meta__has_block_block_configuration
+Has_Block_Block_Configuration = libghdl.vhdl__nodes_meta__has_block_block_configuration
 
-Has_Package_Header =\
-    libghdl.vhdl__nodes_meta__has_package_header
+Has_Package_Header = libghdl.vhdl__nodes_meta__has_package_header
 
-Has_Block_Header =\
-    libghdl.vhdl__nodes_meta__has_block_header
+Has_Block_Header = libghdl.vhdl__nodes_meta__has_block_header
 
-Has_Uninstantiated_Package_Name =\
+Has_Uninstantiated_Package_Name = (
     libghdl.vhdl__nodes_meta__has_uninstantiated_package_name
+)
 
-Has_Uninstantiated_Package_Decl =\
+Has_Uninstantiated_Package_Decl = (
     libghdl.vhdl__nodes_meta__has_uninstantiated_package_decl
+)
 
-Has_Instance_Source_File =\
-    libghdl.vhdl__nodes_meta__has_instance_source_file
+Has_Instance_Source_File = libghdl.vhdl__nodes_meta__has_instance_source_file
 
-Has_Generate_Block_Configuration =\
+Has_Generate_Block_Configuration = (
     libghdl.vhdl__nodes_meta__has_generate_block_configuration
+)
 
-Has_Generate_Statement_Body =\
-    libghdl.vhdl__nodes_meta__has_generate_statement_body
+Has_Generate_Statement_Body = libghdl.vhdl__nodes_meta__has_generate_statement_body
 
-Has_Alternative_Label =\
-    libghdl.vhdl__nodes_meta__has_alternative_label
+Has_Alternative_Label = libghdl.vhdl__nodes_meta__has_alternative_label
 
-Has_Generate_Else_Clause =\
-    libghdl.vhdl__nodes_meta__has_generate_else_clause
+Has_Generate_Else_Clause = libghdl.vhdl__nodes_meta__has_generate_else_clause
 
-Has_Condition =\
-    libghdl.vhdl__nodes_meta__has_condition
+Has_Condition = libghdl.vhdl__nodes_meta__has_condition
 
-Has_Else_Clause =\
-    libghdl.vhdl__nodes_meta__has_else_clause
+Has_Else_Clause = libghdl.vhdl__nodes_meta__has_else_clause
 
-Has_Parameter_Specification =\
-    libghdl.vhdl__nodes_meta__has_parameter_specification
+Has_Parameter_Specification = libghdl.vhdl__nodes_meta__has_parameter_specification
 
-Has_Parent =\
-    libghdl.vhdl__nodes_meta__has_parent
+Has_Parent = libghdl.vhdl__nodes_meta__has_parent
 
-Has_Loop_Label =\
-    libghdl.vhdl__nodes_meta__has_loop_label
+Has_Loop_Label = libghdl.vhdl__nodes_meta__has_loop_label
 
-Has_Exit_Flag =\
-    libghdl.vhdl__nodes_meta__has_exit_flag
+Has_Exit_Flag = libghdl.vhdl__nodes_meta__has_exit_flag
 
-Has_Next_Flag =\
-    libghdl.vhdl__nodes_meta__has_next_flag
+Has_Next_Flag = libghdl.vhdl__nodes_meta__has_next_flag
 
-Has_Component_Name =\
-    libghdl.vhdl__nodes_meta__has_component_name
+Has_Component_Name = libghdl.vhdl__nodes_meta__has_component_name
 
-Has_Instantiation_List =\
-    libghdl.vhdl__nodes_meta__has_instantiation_list
+Has_Instantiation_List = libghdl.vhdl__nodes_meta__has_instantiation_list
 
-Has_Entity_Aspect =\
-    libghdl.vhdl__nodes_meta__has_entity_aspect
+Has_Entity_Aspect = libghdl.vhdl__nodes_meta__has_entity_aspect
 
-Has_Default_Entity_Aspect =\
-    libghdl.vhdl__nodes_meta__has_default_entity_aspect
+Has_Default_Entity_Aspect = libghdl.vhdl__nodes_meta__has_default_entity_aspect
 
-Has_Binding_Indication =\
-    libghdl.vhdl__nodes_meta__has_binding_indication
+Has_Binding_Indication = libghdl.vhdl__nodes_meta__has_binding_indication
 
-Has_Named_Entity =\
-    libghdl.vhdl__nodes_meta__has_named_entity
+Has_Named_Entity = libghdl.vhdl__nodes_meta__has_named_entity
 
-Has_Alias_Declaration =\
-    libghdl.vhdl__nodes_meta__has_alias_declaration
+Has_Alias_Declaration = libghdl.vhdl__nodes_meta__has_alias_declaration
 
-Has_Referenced_Name =\
-    libghdl.vhdl__nodes_meta__has_referenced_name
+Has_Referenced_Name = libghdl.vhdl__nodes_meta__has_referenced_name
 
-Has_Expr_Staticness =\
-    libghdl.vhdl__nodes_meta__has_expr_staticness
+Has_Expr_Staticness = libghdl.vhdl__nodes_meta__has_expr_staticness
 
-Has_Scalar_Size =\
-    libghdl.vhdl__nodes_meta__has_scalar_size
+Has_Scalar_Size = libghdl.vhdl__nodes_meta__has_scalar_size
 
-Has_Error_Origin =\
-    libghdl.vhdl__nodes_meta__has_error_origin
+Has_Error_Origin = libghdl.vhdl__nodes_meta__has_error_origin
 
-Has_Operand =\
-    libghdl.vhdl__nodes_meta__has_operand
+Has_Operand = libghdl.vhdl__nodes_meta__has_operand
 
-Has_Left =\
-    libghdl.vhdl__nodes_meta__has_left
+Has_Left = libghdl.vhdl__nodes_meta__has_left
 
-Has_Right =\
-    libghdl.vhdl__nodes_meta__has_right
+Has_Right = libghdl.vhdl__nodes_meta__has_right
 
-Has_Unit_Name =\
-    libghdl.vhdl__nodes_meta__has_unit_name
+Has_Unit_Name = libghdl.vhdl__nodes_meta__has_unit_name
 
-Has_Name =\
-    libghdl.vhdl__nodes_meta__has_name
+Has_Name = libghdl.vhdl__nodes_meta__has_name
 
-Has_Group_Template_Name =\
-    libghdl.vhdl__nodes_meta__has_group_template_name
+Has_Group_Template_Name = libghdl.vhdl__nodes_meta__has_group_template_name
 
-Has_Name_Staticness =\
-    libghdl.vhdl__nodes_meta__has_name_staticness
+Has_Name_Staticness = libghdl.vhdl__nodes_meta__has_name_staticness
 
-Has_Prefix =\
-    libghdl.vhdl__nodes_meta__has_prefix
+Has_Prefix = libghdl.vhdl__nodes_meta__has_prefix
 
-Has_Signature_Prefix =\
-    libghdl.vhdl__nodes_meta__has_signature_prefix
+Has_Signature_Prefix = libghdl.vhdl__nodes_meta__has_signature_prefix
 
-Has_External_Pathname =\
-    libghdl.vhdl__nodes_meta__has_external_pathname
+Has_External_Pathname = libghdl.vhdl__nodes_meta__has_external_pathname
 
-Has_Pathname_Suffix =\
-    libghdl.vhdl__nodes_meta__has_pathname_suffix
+Has_Pathname_Suffix = libghdl.vhdl__nodes_meta__has_pathname_suffix
 
-Has_Pathname_Expression =\
-    libghdl.vhdl__nodes_meta__has_pathname_expression
+Has_Pathname_Expression = libghdl.vhdl__nodes_meta__has_pathname_expression
 
-Has_In_Formal_Flag =\
-    libghdl.vhdl__nodes_meta__has_in_formal_flag
+Has_In_Formal_Flag = libghdl.vhdl__nodes_meta__has_in_formal_flag
 
-Has_Slice_Subtype =\
-    libghdl.vhdl__nodes_meta__has_slice_subtype
+Has_Slice_Subtype = libghdl.vhdl__nodes_meta__has_slice_subtype
 
-Has_Suffix =\
-    libghdl.vhdl__nodes_meta__has_suffix
+Has_Suffix = libghdl.vhdl__nodes_meta__has_suffix
 
-Has_Index_Subtype =\
-    libghdl.vhdl__nodes_meta__has_index_subtype
+Has_Index_Subtype = libghdl.vhdl__nodes_meta__has_index_subtype
 
-Has_Parameter =\
-    libghdl.vhdl__nodes_meta__has_parameter
+Has_Parameter = libghdl.vhdl__nodes_meta__has_parameter
 
-Has_Parameter_2 =\
-    libghdl.vhdl__nodes_meta__has_parameter_2
+Has_Parameter_2 = libghdl.vhdl__nodes_meta__has_parameter_2
 
-Has_Parameter_3 =\
-    libghdl.vhdl__nodes_meta__has_parameter_3
+Has_Parameter_3 = libghdl.vhdl__nodes_meta__has_parameter_3
 
-Has_Parameter_4 =\
-    libghdl.vhdl__nodes_meta__has_parameter_4
+Has_Parameter_4 = libghdl.vhdl__nodes_meta__has_parameter_4
 
-Has_Attr_Chain =\
-    libghdl.vhdl__nodes_meta__has_attr_chain
+Has_Attr_Chain = libghdl.vhdl__nodes_meta__has_attr_chain
 
-Has_Signal_Attribute_Declaration =\
+Has_Signal_Attribute_Declaration = (
     libghdl.vhdl__nodes_meta__has_signal_attribute_declaration
+)
 
-Has_Actual_Type =\
-    libghdl.vhdl__nodes_meta__has_actual_type
+Has_Actual_Type = libghdl.vhdl__nodes_meta__has_actual_type
 
-Has_Actual_Type_Definition =\
-    libghdl.vhdl__nodes_meta__has_actual_type_definition
+Has_Actual_Type_Definition = libghdl.vhdl__nodes_meta__has_actual_type_definition
 
-Has_Association_Chain =\
-    libghdl.vhdl__nodes_meta__has_association_chain
+Has_Association_Chain = libghdl.vhdl__nodes_meta__has_association_chain
 
-Has_Individual_Association_Chain =\
+Has_Individual_Association_Chain = (
     libghdl.vhdl__nodes_meta__has_individual_association_chain
+)
 
-Has_Subprogram_Association_Chain =\
+Has_Subprogram_Association_Chain = (
     libghdl.vhdl__nodes_meta__has_subprogram_association_chain
+)
 
-Has_Aggregate_Info =\
-    libghdl.vhdl__nodes_meta__has_aggregate_info
+Has_Aggregate_Info = libghdl.vhdl__nodes_meta__has_aggregate_info
 
-Has_Sub_Aggregate_Info =\
-    libghdl.vhdl__nodes_meta__has_sub_aggregate_info
+Has_Sub_Aggregate_Info = libghdl.vhdl__nodes_meta__has_sub_aggregate_info
 
-Has_Aggr_Dynamic_Flag =\
-    libghdl.vhdl__nodes_meta__has_aggr_dynamic_flag
+Has_Aggr_Dynamic_Flag = libghdl.vhdl__nodes_meta__has_aggr_dynamic_flag
 
-Has_Aggr_Min_Length =\
-    libghdl.vhdl__nodes_meta__has_aggr_min_length
+Has_Aggr_Min_Length = libghdl.vhdl__nodes_meta__has_aggr_min_length
 
-Has_Aggr_Low_Limit =\
-    libghdl.vhdl__nodes_meta__has_aggr_low_limit
+Has_Aggr_Low_Limit = libghdl.vhdl__nodes_meta__has_aggr_low_limit
 
-Has_Aggr_High_Limit =\
-    libghdl.vhdl__nodes_meta__has_aggr_high_limit
+Has_Aggr_High_Limit = libghdl.vhdl__nodes_meta__has_aggr_high_limit
 
-Has_Aggr_Others_Flag =\
-    libghdl.vhdl__nodes_meta__has_aggr_others_flag
+Has_Aggr_Others_Flag = libghdl.vhdl__nodes_meta__has_aggr_others_flag
 
-Has_Aggr_Named_Flag =\
-    libghdl.vhdl__nodes_meta__has_aggr_named_flag
+Has_Aggr_Named_Flag = libghdl.vhdl__nodes_meta__has_aggr_named_flag
 
-Has_Aggregate_Expand_Flag =\
-    libghdl.vhdl__nodes_meta__has_aggregate_expand_flag
+Has_Aggregate_Expand_Flag = libghdl.vhdl__nodes_meta__has_aggregate_expand_flag
 
-Has_Association_Choices_Chain =\
-    libghdl.vhdl__nodes_meta__has_association_choices_chain
+Has_Association_Choices_Chain = libghdl.vhdl__nodes_meta__has_association_choices_chain
 
-Has_Case_Statement_Alternative_Chain =\
+Has_Case_Statement_Alternative_Chain = (
     libghdl.vhdl__nodes_meta__has_case_statement_alternative_chain
+)
 
-Has_Choice_Staticness =\
-    libghdl.vhdl__nodes_meta__has_choice_staticness
+Has_Choice_Staticness = libghdl.vhdl__nodes_meta__has_choice_staticness
 
-Has_Procedure_Call =\
-    libghdl.vhdl__nodes_meta__has_procedure_call
+Has_Procedure_Call = libghdl.vhdl__nodes_meta__has_procedure_call
 
-Has_Implementation =\
-    libghdl.vhdl__nodes_meta__has_implementation
+Has_Implementation = libghdl.vhdl__nodes_meta__has_implementation
 
-Has_Parameter_Association_Chain =\
+Has_Parameter_Association_Chain = (
     libghdl.vhdl__nodes_meta__has_parameter_association_chain
+)
 
-Has_Method_Object =\
-    libghdl.vhdl__nodes_meta__has_method_object
+Has_Method_Object = libghdl.vhdl__nodes_meta__has_method_object
 
-Has_Subtype_Type_Mark =\
-    libghdl.vhdl__nodes_meta__has_subtype_type_mark
+Has_Subtype_Type_Mark = libghdl.vhdl__nodes_meta__has_subtype_type_mark
 
-Has_Subnature_Nature_Mark =\
-    libghdl.vhdl__nodes_meta__has_subnature_nature_mark
+Has_Subnature_Nature_Mark = libghdl.vhdl__nodes_meta__has_subnature_nature_mark
 
-Has_Type_Conversion_Subtype =\
-    libghdl.vhdl__nodes_meta__has_type_conversion_subtype
+Has_Type_Conversion_Subtype = libghdl.vhdl__nodes_meta__has_type_conversion_subtype
 
-Has_Type_Mark =\
-    libghdl.vhdl__nodes_meta__has_type_mark
+Has_Type_Mark = libghdl.vhdl__nodes_meta__has_type_mark
 
-Has_File_Type_Mark =\
-    libghdl.vhdl__nodes_meta__has_file_type_mark
+Has_File_Type_Mark = libghdl.vhdl__nodes_meta__has_file_type_mark
 
-Has_Return_Type_Mark =\
-    libghdl.vhdl__nodes_meta__has_return_type_mark
+Has_Return_Type_Mark = libghdl.vhdl__nodes_meta__has_return_type_mark
 
-Has_Has_Disconnect_Flag =\
-    libghdl.vhdl__nodes_meta__has_has_disconnect_flag
+Has_Has_Disconnect_Flag = libghdl.vhdl__nodes_meta__has_has_disconnect_flag
 
-Has_Has_Active_Flag =\
-    libghdl.vhdl__nodes_meta__has_has_active_flag
+Has_Has_Active_Flag = libghdl.vhdl__nodes_meta__has_has_active_flag
 
-Has_Is_Within_Flag =\
-    libghdl.vhdl__nodes_meta__has_is_within_flag
+Has_Is_Within_Flag = libghdl.vhdl__nodes_meta__has_is_within_flag
 
-Has_Type_Marks_List =\
-    libghdl.vhdl__nodes_meta__has_type_marks_list
+Has_Type_Marks_List = libghdl.vhdl__nodes_meta__has_type_marks_list
 
-Has_Implicit_Alias_Flag =\
-    libghdl.vhdl__nodes_meta__has_implicit_alias_flag
+Has_Implicit_Alias_Flag = libghdl.vhdl__nodes_meta__has_implicit_alias_flag
 
-Has_Alias_Signature =\
-    libghdl.vhdl__nodes_meta__has_alias_signature
+Has_Alias_Signature = libghdl.vhdl__nodes_meta__has_alias_signature
 
-Has_Attribute_Signature =\
-    libghdl.vhdl__nodes_meta__has_attribute_signature
+Has_Attribute_Signature = libghdl.vhdl__nodes_meta__has_attribute_signature
 
-Has_Overload_List =\
-    libghdl.vhdl__nodes_meta__has_overload_list
+Has_Overload_List = libghdl.vhdl__nodes_meta__has_overload_list
 
-Has_Simple_Name_Identifier =\
-    libghdl.vhdl__nodes_meta__has_simple_name_identifier
+Has_Simple_Name_Identifier = libghdl.vhdl__nodes_meta__has_simple_name_identifier
 
-Has_Simple_Name_Subtype =\
-    libghdl.vhdl__nodes_meta__has_simple_name_subtype
+Has_Simple_Name_Subtype = libghdl.vhdl__nodes_meta__has_simple_name_subtype
 
-Has_Protected_Type_Body =\
-    libghdl.vhdl__nodes_meta__has_protected_type_body
+Has_Protected_Type_Body = libghdl.vhdl__nodes_meta__has_protected_type_body
 
-Has_Protected_Type_Declaration =\
+Has_Protected_Type_Declaration = (
     libghdl.vhdl__nodes_meta__has_protected_type_declaration
+)
 
-Has_Use_Flag =\
-    libghdl.vhdl__nodes_meta__has_use_flag
+Has_Use_Flag = libghdl.vhdl__nodes_meta__has_use_flag
 
-Has_End_Has_Reserved_Id =\
-    libghdl.vhdl__nodes_meta__has_end_has_reserved_id
+Has_End_Has_Reserved_Id = libghdl.vhdl__nodes_meta__has_end_has_reserved_id
 
-Has_End_Has_Identifier =\
-    libghdl.vhdl__nodes_meta__has_end_has_identifier
+Has_End_Has_Identifier = libghdl.vhdl__nodes_meta__has_end_has_identifier
 
-Has_End_Has_Postponed =\
-    libghdl.vhdl__nodes_meta__has_end_has_postponed
+Has_End_Has_Postponed = libghdl.vhdl__nodes_meta__has_end_has_postponed
 
-Has_Has_Label =\
-    libghdl.vhdl__nodes_meta__has_has_label
+Has_Has_Label = libghdl.vhdl__nodes_meta__has_has_label
 
-Has_Has_Begin =\
-    libghdl.vhdl__nodes_meta__has_has_begin
+Has_Has_Begin = libghdl.vhdl__nodes_meta__has_has_begin
 
-Has_Has_End =\
-    libghdl.vhdl__nodes_meta__has_has_end
+Has_Has_End = libghdl.vhdl__nodes_meta__has_has_end
 
-Has_Has_Is =\
-    libghdl.vhdl__nodes_meta__has_has_is
+Has_Has_Is = libghdl.vhdl__nodes_meta__has_has_is
 
-Has_Has_Pure =\
-    libghdl.vhdl__nodes_meta__has_has_pure
+Has_Has_Pure = libghdl.vhdl__nodes_meta__has_has_pure
 
-Has_Has_Body =\
-    libghdl.vhdl__nodes_meta__has_has_body
+Has_Has_Body = libghdl.vhdl__nodes_meta__has_has_body
 
-Has_Has_Parameter =\
-    libghdl.vhdl__nodes_meta__has_has_parameter
+Has_Has_Parameter = libghdl.vhdl__nodes_meta__has_has_parameter
 
-Has_Has_Component =\
-    libghdl.vhdl__nodes_meta__has_has_component
+Has_Has_Component = libghdl.vhdl__nodes_meta__has_has_component
 
-Has_Has_Identifier_List =\
-    libghdl.vhdl__nodes_meta__has_has_identifier_list
+Has_Has_Identifier_List = libghdl.vhdl__nodes_meta__has_has_identifier_list
 
-Has_Has_Mode =\
-    libghdl.vhdl__nodes_meta__has_has_mode
+Has_Has_Mode = libghdl.vhdl__nodes_meta__has_has_mode
 
-Has_Has_Class =\
-    libghdl.vhdl__nodes_meta__has_has_class
+Has_Has_Class = libghdl.vhdl__nodes_meta__has_has_class
 
-Has_Has_Delay_Mechanism =\
-    libghdl.vhdl__nodes_meta__has_has_delay_mechanism
+Has_Has_Delay_Mechanism = libghdl.vhdl__nodes_meta__has_has_delay_mechanism
 
-Has_Suspend_Flag =\
-    libghdl.vhdl__nodes_meta__has_suspend_flag
+Has_Suspend_Flag = libghdl.vhdl__nodes_meta__has_suspend_flag
 
-Has_Is_Ref =\
-    libghdl.vhdl__nodes_meta__has_is_ref
+Has_Is_Ref = libghdl.vhdl__nodes_meta__has_is_ref
 
-Has_Is_Forward_Ref =\
-    libghdl.vhdl__nodes_meta__has_is_forward_ref
+Has_Is_Forward_Ref = libghdl.vhdl__nodes_meta__has_is_forward_ref
 
-Has_Psl_Property =\
-    libghdl.vhdl__nodes_meta__has_psl_property
+Has_Psl_Property = libghdl.vhdl__nodes_meta__has_psl_property
 
-Has_Psl_Sequence =\
-    libghdl.vhdl__nodes_meta__has_psl_sequence
+Has_Psl_Sequence = libghdl.vhdl__nodes_meta__has_psl_sequence
 
-Has_Psl_Declaration =\
-    libghdl.vhdl__nodes_meta__has_psl_declaration
+Has_Psl_Declaration = libghdl.vhdl__nodes_meta__has_psl_declaration
 
-Has_Psl_Expression =\
-    libghdl.vhdl__nodes_meta__has_psl_expression
+Has_Psl_Expression = libghdl.vhdl__nodes_meta__has_psl_expression
 
-Has_Psl_Boolean =\
-    libghdl.vhdl__nodes_meta__has_psl_boolean
+Has_Psl_Boolean = libghdl.vhdl__nodes_meta__has_psl_boolean
 
-Has_PSL_Clock =\
-    libghdl.vhdl__nodes_meta__has_psl_clock
+Has_PSL_Clock = libghdl.vhdl__nodes_meta__has_psl_clock
 
-Has_PSL_NFA =\
-    libghdl.vhdl__nodes_meta__has_psl_nfa
+Has_PSL_NFA = libghdl.vhdl__nodes_meta__has_psl_nfa
 
-Has_PSL_Nbr_States =\
-    libghdl.vhdl__nodes_meta__has_psl_nbr_states
+Has_PSL_Nbr_States = libghdl.vhdl__nodes_meta__has_psl_nbr_states
 
-Has_PSL_Clock_Sensitivity =\
-    libghdl.vhdl__nodes_meta__has_psl_clock_sensitivity
+Has_PSL_Clock_Sensitivity = libghdl.vhdl__nodes_meta__has_psl_clock_sensitivity
 
-Has_PSL_EOS_Flag =\
-    libghdl.vhdl__nodes_meta__has_psl_eos_flag
+Has_PSL_EOS_Flag = libghdl.vhdl__nodes_meta__has_psl_eos_flag
 
-Has_Count_Expression =\
-    libghdl.vhdl__nodes_meta__has_count_expression
+Has_Count_Expression = libghdl.vhdl__nodes_meta__has_count_expression
 
-Has_Clock_Expression =\
-    libghdl.vhdl__nodes_meta__has_clock_expression
+Has_Clock_Expression = libghdl.vhdl__nodes_meta__has_clock_expression
 
-Has_Default_Clock =\
-    libghdl.vhdl__nodes_meta__has_default_clock
+Has_Default_Clock = libghdl.vhdl__nodes_meta__has_default_clock

--- a/pyGHDL/libghdl/vhdl/nodes_utils.py
+++ b/pyGHDL/libghdl/vhdl/nodes_utils.py
@@ -39,62 +39,62 @@ from pyGHDL.libghdl import libghdl, Iir
 
 @export
 def Strip_Denoting_Name(Name: Iir) -> Iir:
-	"""
-	If :obj:`Name` is a simple or an expanded name, return the denoted declaration.
-	Otherwise, return :obj:`Name`.
+    """
+    If :obj:`Name` is a simple or an expanded name, return the denoted declaration.
+    Otherwise, return :obj:`Name`.
 
-	:param Name: Simple or an expanded name.
-	:return:     Denoted declaration.
-	"""
-	return libghdl.vhdl__utils__strip_denoting_name(Name)
+    :param Name: Simple or an expanded name.
+    :return:     Denoted declaration.
+    """
+    return libghdl.vhdl__utils__strip_denoting_name(Name)
 
 
 @export
 def Get_Entity(Decl: Iir) -> Iir:
-	"""
-	This is a wrapper around ``Get_Entity_Name`` to return the entity declaration
-	of the entity name of :obj:`Decl`, or ``Null_Iir`` in case of error.
+    """
+    This is a wrapper around ``Get_Entity_Name`` to return the entity declaration
+    of the entity name of :obj:`Decl`, or ``Null_Iir`` in case of error.
 
-	:param Decl: Declaration
-	:return:     Entity
-	"""
-	return libghdl.vhdl__utils__get_entity(Decl)
+    :param Decl: Declaration
+    :return:     Entity
+    """
+    return libghdl.vhdl__utils__get_entity(Decl)
 
 
 @export
 def Is_Second_Subprogram_Specification(Spec: Iir) -> bool:
-	"""
-	Check if :obj:`Spec` is the subprogram specification of a subprogram body
-	which was previously declared. In that case, the only use of :obj:`Spec`
-	is to match the body with its declaration.
+    """
+    Check if :obj:`Spec` is the subprogram specification of a subprogram body
+    which was previously declared. In that case, the only use of :obj:`Spec`
+    is to match the body with its declaration.
 
-	:param Spec: Specification
-	:return:     ``True`` if subprogram specification and previously declared subprogram body match
-	"""
-	return libghdl.vhdl__utils__is_second_subprogram_specification(Spec)
+    :param Spec: Specification
+    :return:     ``True`` if subprogram specification and previously declared subprogram body match
+    """
+    return libghdl.vhdl__utils__is_second_subprogram_specification(Spec)
 
 
 @export
 def Get_Entity_From_Entity_Aspect(Aspect: Iir) -> Iir:
-	"""
-	Extract the entity from :obj:`Aspect`.
+    """
+    Extract the entity from :obj:`Aspect`.
 
-	If :obj:`Aspect` is a component declaration, return :obj:`Aspect`. If it's
-	open, return ``Null_Iir``
+    If :obj:`Aspect` is a component declaration, return :obj:`Aspect`. If it's
+    open, return ``Null_Iir``
 
-	:param Aspect: Aspect
-	:return:       Entity
-	"""
-	return libghdl.vhdl__utils__get_entity_from_entity_aspect(Aspect)
+    :param Aspect: Aspect
+    :return:       Entity
+    """
+    return libghdl.vhdl__utils__get_entity_from_entity_aspect(Aspect)
 
 
 @export
 def Get_Interface_Of_Formal(Formal: Iir) -> Iir:
-	"""
-	Get the interface corresponding to the formal name :obj:`Formal`. This is
-	always an interface, even if the formal is a name.
+    """
+    Get the interface corresponding to the formal name :obj:`Formal`. This is
+    always an interface, even if the formal is a name.
 
-	:param Formal: The formal.
-	:return:       The corresponding interface.
-	"""
-	return libghdl.vhdl__utils__get_interface_of_formal(Formal)
+    :param Formal: The formal.
+    :return:       The corresponding interface.
+    """
+    return libghdl.vhdl__utils__get_interface_of_formal(Formal)

--- a/pyGHDL/libghdl/vhdl/parse.py
+++ b/pyGHDL/libghdl/vhdl/parse.py
@@ -38,9 +38,7 @@ from pydecor import export
 
 from pyGHDL.libghdl import libghdl
 
-__all__ = [
-	'Flag_Parse_Parenthesis'
-]
+__all__ = ["Flag_Parse_Parenthesis"]
 
 
 Flag_Parse_Parenthesis = c_bool.in_dll(libghdl, "vhdl__parse__flag_parse_parenthesis")
@@ -48,11 +46,11 @@ Flag_Parse_Parenthesis = c_bool.in_dll(libghdl, "vhdl__parse__flag_parse_parenth
 
 @export
 def Parse_Design_File():
-	"""
-	Parse a file.
+    """
+    Parse a file.
 
-	..note:: The scanner must have been initialized as for parse_design_unit.
+    ..note:: The scanner must have been initialized as for parse_design_unit.
 
-	:return: Return :obj:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` in case of error. Type: ``Iir_Design_File``
-	"""
-	return libghdl.vhdl__parse__parse_design_file()
+    :return: Return :obj:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` in case of error. Type: ``Iir_Design_File``
+    """
+    return libghdl.vhdl__parse__parse_design_file()

--- a/pyGHDL/libghdl/vhdl/scanner.py
+++ b/pyGHDL/libghdl/vhdl/scanner.py
@@ -40,10 +40,7 @@ from pyGHDL.libghdl import libghdl
 from pyGHDL.libghdl._types import SourceFileEntry, NameId
 
 
-__all__ = [
-	'Current_Token',
-	'Flag_Comment'
-]
+__all__ = ["Current_Token", "Flag_Comment"]
 
 # This is a c_int, so you want to use its .value
 Current_Token = c_int.in_dll(libghdl, "vhdl__scanner__current_token")
@@ -52,76 +49,76 @@ Flag_Comment = c_bool.in_dll(libghdl, "vhdl__scanner__flag_comment")
 
 @export
 def Set_File(SourceFile: SourceFileEntry) -> None:
-	"""
-	Initialize the scanner with file :obj:`SourceFile`.
+    """
+    Initialize the scanner with file :obj:`SourceFile`.
 
-	:param SourceFile: File to scan.
-	"""
-	libghdl.vhdl__scanner__set_file(SourceFile)
+    :param SourceFile: File to scan.
+    """
+    libghdl.vhdl__scanner__set_file(SourceFile)
 
 
 @export
 def Close_File() -> None:
-	"""Finalize the scanner."""
-	libghdl.vhdl__scanner__close_file()
+    """Finalize the scanner."""
+    libghdl.vhdl__scanner__close_file()
 
 
 @export
 def Scan() -> None:
-	"""Get a new token."""
-	libghdl.vhdl__scanner__scan()
+    """Get a new token."""
+    libghdl.vhdl__scanner__scan()
 
 
 @export
 def Get_Current_Line() -> int:
-	"""
-	Get the current location, or the location of the current token.
+    """
+    Get the current location, or the location of the current token.
 
-	Since a token cannot spread over lines, file and line of the current token are
-	the same as those of the current position. The offset is the offset in the current line.
+    Since a token cannot spread over lines, file and line of the current token are
+    the same as those of the current position. The offset is the offset in the current line.
 
-	:return: Current token's line.
-	"""
-	return libghdl.vhdl__scanner__get_current_line()
+    :return: Current token's line.
+    """
+    return libghdl.vhdl__scanner__get_current_line()
 
 
 @export
 def Get_Token_Offset() -> int:
-	"""
-	Get the current token's offset in the current line.
+    """
+    Get the current token's offset in the current line.
 
-	:return: Current token's offset.
-	"""
-	return libghdl.vhdl__scanner__get_token_offset()
+    :return: Current token's offset.
+    """
+    return libghdl.vhdl__scanner__get_token_offset()
 
 
 @export
 def Get_Token_Position():
-	"""
-	Get the current token's position.
+    """
+    Get the current token's position.
 
-	:return: Current token's position. Type: ``Source_Ptr``
-	"""
-	return libghdl.vhdl__scanner__get_token_position()
+    :return: Current token's position. Type: ``Source_Ptr``
+    """
+    return libghdl.vhdl__scanner__get_token_position()
 
 
 @export
 def Get_Position():
-	"""
-	Get the current position.
+    """
+    Get the current position.
 
-	:return: Current position. Type: ``Source_Ptr``
-	"""
-	return libghdl.vhdl__scanner__get_position()
+    :return: Current position. Type: ``Source_Ptr``
+    """
+    return libghdl.vhdl__scanner__get_position()
 
 
 @export
 def Current_Identifier() -> NameId:
-	"""
-	When :attr:`~pyGHDL.libghdl.vhdl.scanner.Current_Token` is an
-	``tok_identifier``, ``tok_char`` or ``tok_string``, its name_id can be
-	retrieved via this function.
+    """
+    When :attr:`~pyGHDL.libghdl.vhdl.scanner.Current_Token` is an
+    ``tok_identifier``, ``tok_char`` or ``tok_string``, its name_id can be
+    retrieved via this function.
 
-	:return: NameId of the current token.
-	"""
-	return libghdl.vhdl__scanner__current_identifier()
+    :return: NameId of the current token.
+    """
+    return libghdl.vhdl__scanner__current_identifier()

--- a/pyGHDL/libghdl/vhdl/sem.py
+++ b/pyGHDL/libghdl/vhdl/sem.py
@@ -39,12 +39,12 @@ from pyGHDL.libghdl import libghdl
 
 @export
 def Semantic(DesignUnit) -> None:
-	"""
-	Do the semantic analysis of design unit :obj:`DesignUnit`.
+    """
+    Do the semantic analysis of design unit :obj:`DesignUnit`.
 
-	Also add a few node or change some nodes, when for example an identifier is
-	changed into an access to the type.
+    Also add a few node or change some nodes, when for example an identifier is
+    changed into an access to the type.
 
-	:param DesignUnit: Design unit to semantically analyze. Type: ``Iir_Design_Unit``
-	"""
-	libghdl.vhdl__sem__semantic(DesignUnit)
+    :param DesignUnit: Design unit to semantically analyze. Type: ``Iir_Design_Unit``
+    """
+    libghdl.vhdl__sem__semantic(DesignUnit)

--- a/pyGHDL/libghdl/vhdl/sem_lib.py
+++ b/pyGHDL/libghdl/vhdl/sem_lib.py
@@ -40,31 +40,31 @@ from pyGHDL.libghdl._types import SourceFileEntry
 
 @export
 def Load_File(File: SourceFileEntry):
-	"""
-	Start to analyse a file (i.e. load and parse it).
+    """
+    Start to analyse a file (i.e. load and parse it).
 
-	:param File: File to analyse.
-	:return:     Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` in case of parse error. Type: ``Iir_Design_File``
-	"""
-	return libghdl.vhdl__sem_lib__load_file(File)
+    :param File: File to analyse.
+    :return:     Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` in case of parse error. Type: ``Iir_Design_File``
+    """
+    return libghdl.vhdl__sem_lib__load_file(File)
 
 
 @export
 def Finish_Compilation(Unit, Main: bool = False) -> None:
-	"""
-	Analyze :obj:`Unit`.
+    """
+    Analyze :obj:`Unit`.
 
-	:param Unit: Design unit to analyze.
-	:param Main: Is main unit.
-	"""
-	libghdl.vhdl__sem_lib__finish_compilation(Unit, Main)
+    :param Unit: Design unit to analyze.
+    :param Main: Is main unit.
+    """
+    libghdl.vhdl__sem_lib__finish_compilation(Unit, Main)
 
 
 @export
 def Free_Dependence_List(Design) -> None:
-	"""
-	Free the dependence list of :obj:`Design`.
+    """
+    Free the dependence list of :obj:`Design`.
 
-	:param Design: Design unit to free dependencies for.
-	"""
-	libghdl.vhdl__sem_lib__free_dependence_list(Design)
+    :param Design: Design unit to free dependencies for.
+    """
+    libghdl.vhdl__sem_lib__free_dependence_list(Design)

--- a/pyGHDL/libghdl/vhdl/std_package.py
+++ b/pyGHDL/libghdl/vhdl/std_package.py
@@ -36,12 +36,14 @@ from ctypes import c_int32
 
 from pyGHDL.libghdl import libghdl
 
-__all__ = [
-	'Std_Location',
-	'Standard_Package',
-	'Character_Type_Definition'
-]
+__all__ = ["Std_Location", "Standard_Package", "Character_Type_Definition"]
 
-Std_Location = c_int32.in_dll(libghdl, "vhdl__std_package__std_location")         #: Virtual location for the ``std.standard`` package. Type ``Location_Type``. Use ``.value`` to access this variable inside libghdl.
-Standard_Package = c_int32.in_dll(libghdl, "vhdl__std_package__standard_package") #: Virtual package ``std.package``. Type ``Iir_Package_Declaration``. Use ``.value`` to access this variable inside libghdl.
-Character_Type_Definition = c_int32.in_dll(libghdl, "vhdl__std_package__character_type_definition") #: Predefined character. Type ``Iir_Enumeration_Type_Definition``. Use ``.value`` to access this variable inside libghdl.
+Std_Location = c_int32.in_dll(
+    libghdl, "vhdl__std_package__std_location"
+)  #: Virtual location for the ``std.standard`` package. Type ``Location_Type``. Use ``.value`` to access this variable inside libghdl.
+Standard_Package = c_int32.in_dll(
+    libghdl, "vhdl__std_package__standard_package"
+)  #: Virtual package ``std.package``. Type ``Iir_Package_Declaration``. Use ``.value`` to access this variable inside libghdl.
+Character_Type_Definition = c_int32.in_dll(
+    libghdl, "vhdl__std_package__character_type_definition"
+)  #: Predefined character. Type ``Iir_Enumeration_Type_Definition``. Use ``.value`` to access this variable inside libghdl.

--- a/pyGHDL/lsp/lsp.py
+++ b/pyGHDL/lsp/lsp.py
@@ -7,6 +7,7 @@ log = logging.getLogger("ghdl-ls")
 
 is_windows = os.name == "nt"
 
+
 class ProtocolError(Exception):
     pass
 

--- a/src/vhdl/Makefile
+++ b/src/vhdl/Makefile
@@ -79,31 +79,37 @@ vhdl-elocations_meta.adb: vhdl-elocations_meta.adb.in vhdl-elocations.ads $(DEPS
 ../../pyGHDL/libghdl/vhdl/nodes.py: $(DEPS) $(PNODESPY)
 	$(RM) $@
 	$(PNODESPY) $(NODES_FLAGS) libghdl-nodes > $@
+	python -m black $@
 	chmod -w $@
 
 ../../pyGHDL/libghdl/vhdl/nodes_meta.py: $(DEPS) $(PNODESPY)
 	$(RM) $@
 	$(PNODESPY) $(NODES_FLAGS) libghdl-meta > $@
+	python -m black $@
 	chmod -w $@
 
 ../../pyGHDL/libghdl/std_names.py: $(PNODESPY) ../std_names.ads
 	$(RM) $@
 	$(PNODESPY) $(NODES_FLAGS) libghdl-names > $@
+	python -m black $@
 	chmod -w $@
 
 ../../pyGHDL/libghdl/vhdl/tokens.py: $(PNODESPY) vhdl-tokens.ads
 	$(RM) $@
 	$(PNODESPY) $(NODES_FLAGS) libghdl-tokens > $@
+	python -m black $@
 	chmod -w $@
 
 ../../pyGHDL/libghdl/vhdl/elocations.py: $(PNODESPY) vhdl-elocations.ads
 	$(RM) $@
 	$(PNODESPY) $(ELOCATIONS_FLAGS) libghdl-elocs > $@
+	python -m black $@
 	chmod -w $@
 
 ../../pyGHDL/libghdl/errorout.py: $(PNODESPY) ../errorout.ads
 	$(RM) $@
 	$(PNODESPY) $(ELOCATIONS_FLAGS) libghdl-errorout > $@
+	python -m black $@
 	chmod -w $@
 
 clean:


### PR DESCRIPTION
**Description**

This was already introduced in #1439, but disabled again in #1558 for reasons not completely obvious to me. One issue that was brought up was the formatting of the generated bindings, but simply running black after generating the file should fix that.

cc @eine @umarcor @Paebbels