### PR TITLE
update for LLVM 11.1

### DIFF
--- a/configure
+++ b/configure
@@ -275,6 +275,7 @@ if test $backend = llvm; then
        check_version  9.0 $llvm_version ||
        check_version 10.0 $llvm_version ||
        check_version 11.0 $llvm_version ||
+       check_version 11.1 $llvm_version ||
        false; then
     echo "Debugging is enabled with llvm $llvm_version"
   else

--- a/doc/development/building/LLVM.rst
+++ b/doc/development/building/LLVM.rst
@@ -7,7 +7,7 @@ LLVM backend
 
 * GCC (Gnu Compiler Collection)
 * GNAT (Ada compiler for GCC)
-* LLVM (Low-Level-Virtual Machine) and CLANG (Compiler front-end for LLVM): 3.5, 3.8, 3.9, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 or 11.0
+* LLVM (Low-Level-Virtual Machine) and CLANG (Compiler front-end for LLVM): 3.5, 3.8, 3.9, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0 or 11.1
 
 .. _BUILD:llvm:GNAT:
 


### PR DESCRIPTION
We need this in Fedora, because we already have the LLVM 11.1 release candidates available in the distro. A similar update for LLVM 12 will follow soon.