### PR TITLE
CI: print diff of necessary python formatting

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -99,7 +99,7 @@ jobs:
         git diff --exit-code
 
     - name: Check if python follows code formatting standards
-      run: python -m black --check pyGHDL
+      run: python -m black --check --diff pyGHDL
 
 #
 # GPL


### PR DESCRIPTION
While looking at the CI output of 58c808dd, I noticed that black only complains about formatting being necessary, but doesn't show the necessary changes - the `--diff` option does just that.