### PR TITLE
revert "log stderr of make to a file and use tail to show last 1000 lines"

### DIFF
--- a/scripts/ci-run.sh
+++ b/scripts/ci-run.sh
@@ -308,10 +308,7 @@ build () {
   #--- make
 
   gstart "[GHDL - build] Make"
-  set +e
-  make LIB_CFLAGS="$LIB_CFLAGS" OPT_FLAGS="$OPT_FLAGS" -j`nproc` 2>make_err.log
-  tail -1000 make_err.log
-  set -e
+  make LIB_CFLAGS="$LIB_CFLAGS" OPT_FLAGS="$OPT_FLAGS" -j"$(nproc)"
   gend
 
   gstart "[GHDL - build] Install"


### PR DESCRIPTION
This reverts commit 30ee7a32b64c94f1ac0c8e3b5068894b6ea8b556 (#601), cc @eine .

This workaround masks the return value of `make`, causing runs to appear to fail during install, even though build failed already. Since travis is no longer used for CI, it's probably no longer necessary anyway.