### PR TITLE
VPI: support loading multiple libraries

### DIFF
--- a/doc/using/Simulation.rst
+++ b/doc/using/Simulation.rst
@@ -146,15 +146,20 @@ Here is the list of the most useful options. For further info, see :ref:`DEV:Deb
 
 .. option:: --vpi=<FILENAME>
 
-  Load VPI module.
+  Load VPI library. This option can be used multiple times to load different libraries.
 
-  .. HINT::
-    Currently, although multiple ``--vpi=`` options can be passed, only the last one is kept/used. However, handling
-    more than one shouldn't be a difficult change.
+  Any registration functions in the ``vlog_startup_routines`` array in the library will be called:
 
-.. option:: --vpi-trace=<FILE>
+  .. code-block:: c
 
-  Trace vpi calls to FILE.
+    void (*vlog_startup_routines[]) () = {
+      my_handle_register,
+      0
+    };
+
+.. option:: --vpi-trace[=<FILENAME>]
+
+  Trace vpi calls. Trace is printed to :file:`FILENAME` if provided, otherwise to stdout.
 
 .. option:: --help
 

--- a/testsuite/vpi/vpi005/mydesign.vhdl
+++ b/testsuite/vpi/vpi005/mydesign.vhdl
@@ -1,0 +1,9 @@
+library ieee ;
+use ieee.std_logic_1164.all;
+
+entity myentity is
+end myentity;
+
+architecture arch of myentity is
+begin
+end arch; 

--- a/testsuite/vpi/vpi005/testsuite.sh
+++ b/testsuite/vpi/vpi005/testsuite.sh
@@ -1,0 +1,35 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+analyze mydesign.vhdl
+elab myentity
+
+if c_compiler_is_available && ghdl_has_feature myentity vpi; then
+  $GHDL --vpi-compile -v gcc -c vpi1.c
+  $GHDL --vpi-link -v gcc -o vpi1.vpi vpi1.o
+
+  $GHDL --vpi-compile -v gcc -c vpi2.c
+  $GHDL --vpi-link -v gcc -o vpi2.vpi vpi2.o
+
+  add_vpi_path
+
+  simulate myentity --vpi=./vpi1.vpi --vpi=./vpi2.vpi | tee myentity.out
+    if grep -q error myentity.out; then
+      echo "error in output"
+      exit 1;
+  fi
+  if ! grep -q "VPI lib 1" myentity.out; then
+      echo "VPI Library 1 not loaded"
+      exit 1;
+  fi
+  if ! grep -q "VPI lib 2" myentity.out; then
+      echo "VPI Library 2 not loaded"
+      exit 1;
+  fi
+
+  rm -f vpi1.vpi vpi1.o vpi2.vpi vpi2.o myentity.out
+fi
+clean
+
+echo "Test successful"

--- a/testsuite/vpi/vpi005/vpi1.c
+++ b/testsuite/vpi/vpi005/vpi1.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <vpi_user.h>
+
+void my_startup()
+{
+  printf ("VPI lib 1\n");
+}
+
+void (*vlog_startup_routines[]) () =
+{
+  my_startup,
+  0
+};

--- a/testsuite/vpi/vpi005/vpi2.c
+++ b/testsuite/vpi/vpi005/vpi2.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <vpi_user.h>
+
+void my_startup()
+{
+  printf ("VPI lib 2\n");
+}
+
+void (*vlog_startup_routines[]) () =
+{
+  my_startup,
+  0
+};


### PR DESCRIPTION
**Description**
Store library information for all `--vpi=` options and load each in the order they are passed in.
Library file names are stored in a simple singly-linked list.
