### PR TITLE
scripts/vendors: fix typo in deprecated script param

### DIFF
--- a/scripts/vendors/compile-xilinx-ise.sh
+++ b/scripts/vendors/compile-xilinx-ise.sh
@@ -121,11 +121,11 @@ while [[ $# -gt 0 ]]; do
 			GHDL="$2"				# overwrite a potentially existing GHDL environment variable
 			shift						# skip argument
 			;;
-		-src|--source)
+		--src|--source)
 			SrcDir="$2"
 			shift						# skip argument
 			;;
-		-out|--output)
+		--out|--output)
 			DestDir="$2"
 			shift						# skip argument
 			;;


### PR DESCRIPTION
**Description**
Pull request #1653 reintroduced deprecated script params, but with a
typo in one of the vendor scripts.
This PR fixes that mistake.

Sorry for this mess!

