### PR TITLE
scripts/vendors: add missing workdir argument

### DIFF
--- a/scripts/vendors/shared.sh
+++ b/scripts/vendors/shared.sh
@@ -252,7 +252,7 @@ AnalyzeVHDL() {
 	fi
 
 	if [[ $FILTERING -eq 0 ]]; then
-		test $DEBUG -eq 1 && echo -e "    ${ANSI_DARK_GRAY}$GHDL -a ${Analyze_Parameters[*]} ${Parameters[*]} --work=$LibraryName \"$SourceFile\"${ANSI_NOCOLOR}"
+		test $DEBUG -eq 1 && echo -e "    ${ANSI_DARK_GRAY}$GHDL -a ${Analyze_Parameters[*]} ${Parameters[*]} --work=$LibraryName --workdir=$DestinationDirectory \"$SourceFile\"${ANSI_NOCOLOR}"
 		$GHDL -a "${Analyze_Parameters[@]}" "${Parameters[@]}" --work=$LibraryName --workdir=$DestinationDirectory "$SourceFile"
 		ExitCode=$?
 		if [[ $ExitCode -ne 0 ]]; then
@@ -260,9 +260,9 @@ AnalyzeVHDL() {
 			test $CONTINUE_ON_ERROR -eq 0 && exit 1
 		fi
 	 else
-		 test $DEBUG -eq 1 && echo -e "    ${ANSI_DARK_GRAY}$GHDL -a ${Analyze_Parameters[*]} ${Parameters[*]} --work=$LibraryName \"$SourceFile\" 2>&1 | \\\\${ANSI_NOCOLOR}"
+		 test $DEBUG -eq 1 && echo -e "    ${ANSI_DARK_GRAY}$GHDL -a ${Analyze_Parameters[*]} ${Parameters[*]} --work=$LibraryName --workdir=$DestinationDirectory \"$SourceFile\" 2>&1 | \\\\${ANSI_NOCOLOR}"
 		 test $DEBUG -eq 1 && echo -e "    ${ANSI_DARK_GRAY}$ScriptDir/$Analyze_Filter ${Filter_Parameters[*]} -i \"$Filter_Indent\"${ANSI_NOCOLOR}"
-		 $GHDL -a "${Analyze_Parameters[@]}" "${Parameters[@]}" --work=$LibraryName "$SourceFile" 2>&1 | $ScriptDir/$Analyze_Filter "${Filter_Parameters[@]}" -i "$Filter_Indent"
+		 $GHDL -a "${Analyze_Parameters[@]}" "${Parameters[@]}" --work=$LibraryName --workdir=$DestinationDirectory "$SourceFile" 2>&1 | $ScriptDir/$Analyze_Filter "${Filter_Parameters[@]}" -i "$Filter_Indent"
 		 local PiplineStatus=("${PIPESTATUS[@]}")
 		 if [[ ${PiplineStatus[0]}  -ne 0 ]]; then
 			 echo 1>&2 -e "$Filter_Indent${COLORED_ERROR} While analyzing '$File'. ExitCode: ${PiplineStatus[0]}${ANSI_NOCOLOR}"


### PR DESCRIPTION
ghdl invocation in scripts/vendors was missing the `workdir` argument, causing the output files to be in the wrong directory.
Tested with compile-xilinx-vivado.sh.