### PR TITLE
Vhdl parse cleanups

### DIFF
--- a/src/errorout-console.adb
+++ b/src/errorout-console.adb
@@ -247,6 +247,11 @@ package body Errorout.Console is
       end if;
    end Console_Message_End;
 
+   procedure Console_Message_New_Line is
+   begin
+      Put_Line;
+   end Console_Message_New_Line;
+
    procedure Console_Message_Group (Start : Boolean) is
    begin
       Current_Line := 0;
@@ -260,6 +265,7 @@ package body Errorout.Console is
 
       Set_Report_Handler ((Console_Error_Start'Access,
                            Console_Message'Access,
+                           Console_Message_New_Line'Access,
                            Console_Message_End'Access,
                            Console_Message_Group'Access));
    end Install_Handler;

--- a/src/errorout-memory.adb
+++ b/src/errorout-memory.adb
@@ -99,6 +99,12 @@ package body Errorout.Memory is
       end loop;
    end Memory_Message;
 
+   procedure Memory_Message_New_Line is
+   begin
+      Messages.Append (ASCII.CR);
+      Messages.Append (ASCII.LF);
+   end Memory_Message_New_Line;
+
    procedure Memory_Message_End is
    begin
       Messages.Append (ASCII.NUL);
@@ -130,6 +136,7 @@ package body Errorout.Memory is
    begin
       Set_Report_Handler ((Memory_Error_Start'Access,
                            Memory_Message'Access,
+                           Memory_Message_New_Line'Access,
                            Memory_Message_End'Access,
                            Memory_Message_Group'Access));
       Group := Msg_Single;

--- a/src/errorout.adb
+++ b/src/errorout.adb
@@ -241,6 +241,27 @@ package body Errorout is
       Lang_Handlers (Kind) := Handler;
    end Register_Earg_Handler;
 
+   -- Prints source line with indication of position
+   -- Indented to show where error/warning occured.
+   procedure Print_Source_Line(Loc : Source_Coord_Type) is
+      Line_Text : constant String :=
+         Extract_Expanded_Line(Loc.File, Loc.Line);
+      Marker_Col : Natural;
+   begin
+      -- Print line itself
+      Report_Handler.Message (Line_Text);
+      Report_Handler.Message_New_Line.all;
+
+      -- Marker to Loc
+      Marker_Col := Coord_To_Col(Loc.File, Loc.Line_Pos, Loc.Offset);
+      for i in 1 .. Marker_Col loop
+         Report_Handler.Message(" ");
+      end loop;
+      Report_Handler.Message("^");
+      Report_Handler.Message_New_Line.all;
+
+   end Print_Source_Line;
+
    procedure Report_Msg (Id : Msgid_Type;
                          Origin : Report_Origin;
                          Loc : Source_Coord_Type;
@@ -367,8 +388,13 @@ package body Errorout is
          --  Are all arguments displayed ?
          pragma Assert (Argn > Args'Last);
       end;
-
       Report_Handler.Message_End.all;
+
+      -- Visualize line and spot at which the error occured
+      if (Loc /= No_Source_Coord) then
+         Print_Source_Line(Loc);
+      end if;
+
    end Report_Msg;
 
    procedure Report_Start_Group is

--- a/src/errorout.ads
+++ b/src/errorout.ads
@@ -238,11 +238,13 @@ package Errorout is
    type Error_Start_Handler is access procedure (Err : Error_Record);
    type Message_Str_Handler is access procedure (Str : String);
    type Message_End_Handler is access procedure;
+   type Message_New_Line_Handler is access procedure;
    type Message_Group_Handler is access procedure (Start : Boolean);
 
    type Report_Msg_Handler is record
       Error_Start : Error_Start_Handler;
       Message : Message_Str_Handler;
+      Message_New_Line : Message_New_Line_Handler;
       Message_End : Message_End_Handler;
       Message_Group : Message_Group_Handler;
    end record;

--- a/src/vhdl/vhdl-parse.adb
+++ b/src/vhdl/vhdl-parse.adb
@@ -85,6 +85,10 @@ package body Vhdl.Parse is
    --  Current number of open parenthesis (in expressions).
    Parenthesis_Depth : Natural := 0;
 
+   -- Missing parenthesis has been reported already. Flag used to
+   -- remember only first report
+   Parenthesis_Reported : Boolean := False;
+
    -- Copy the current location into an iir.
    procedure Set_Location (Node : Iir) is
    begin
@@ -505,6 +509,25 @@ package body Vhdl.Parse is
          Error_Msg_Parse (Prefix & Common & "here");
       end case;
    end Error_Variable_Location;
+
+   procedure Error_Missing_Parenthesis(Loc : Location_Type) is
+   begin
+      if not Parenthesis_Reported then
+         if (Parenthesis_Depth > 1) then
+            Error_Msg_Parse
+            ("missing ')' for opening parenthesis at %l. " &
+               "Total missing parenthesis: " &
+               Integer'Image(Parenthesis_Depth), +Loc);
+            Parenthesis_Reported := True;
+         else
+            Error_Msg_Parse
+            ("missing ')' for opening parenthesis at %l. " , +Loc);
+         end if;
+      end if;
+      if (Parenthesis_Depth = 1) then
+         Parenthesis_Reported := False;
+      end if;
+   end Error_Missing_Parenthesis;
 
    --  Expect and scan ';' emit an error message using MSG if not present.
    procedure Scan_Semi_Colon (Msg : String) is
@@ -5798,12 +5821,8 @@ package body Vhdl.Parse is
                | Tok_Generate
                | Tok_Loop =>
                --  Surely a missing parenthesis.
-               --  FIXME: in case of multiple missing parenthesises, several
-               --    messages will be displayed
-               Error_Msg_Parse
-                 ("missing ')' for opening parenthesis at %l", +Loc);
+               Error_Missing_Parenthesis(Loc);
                return Expr;
-
             when others =>
                --  Surely a parse error...
                null;

--- a/src/vhdl/vhdl-parse.adb
+++ b/src/vhdl/vhdl-parse.adb
@@ -4416,8 +4416,12 @@ package body Vhdl.Parse is
          Set_Subtype_Indication (Res, Parse_Subtype_Indication);
       end if;
 
-      --  FIXME: nice message if token is ':=' ?
-      Expect_Scan (Tok_Is);
+      if (Current_Token = Tok_Assign) then
+         Error_Msg_Parse ("alias shall be defined with 'is', not ':='");
+         Scan;
+      else
+         Expect_Scan (Tok_Is);
+      end if;
       Set_Name (Res, Parse_Signature_Name);
 
       if Flag_Elocations then

--- a/src/vhdl/vhdl-parse.adb
+++ b/src/vhdl/vhdl-parse.adb
@@ -449,6 +449,21 @@ package body Vhdl.Parse is
       end loop;
    end Resync_To_End_Of_Interface;
 
+   -- Search for next colon (likely before subtype_indication) or
+   -- semicolon, likely at end of line, if we are totally lost.
+   procedure Resync_To_End_Of_External_Name is
+   begin
+      loop
+         case Current_Token is
+            when Tok_Colon
+               | Tok_Semi_Colon =>
+               exit;
+            when others =>
+               Scan;
+         end case;
+      end loop;
+   end Resync_To_End_Of_External_Name;
+
    procedure Error_Missing_Semi_Colon (Msg : String) is
    begin
       Error_Msg_Parse (Get_Prev_Location, "missing "";"" at end of " & Msg);
@@ -1285,7 +1300,7 @@ package body Vhdl.Parse is
       loop
          if Current_Token /= Tok_Identifier then
             Error_Msg_Parse ("pathname element expected");
-            --  FIXME: resync.
+            Resync_To_End_Of_External_Name;
             return Res;
          end if;
 

--- a/src/vhdl/vhdl-parse.adb
+++ b/src/vhdl/vhdl-parse.adb
@@ -4059,7 +4059,6 @@ package body Vhdl.Parse is
    --  [ LRM93 4.3.1.2 ]
    --  signal_kind ::= REGISTER | BUS
    --
-   --  FIXME: file_open_information.
    function Parse_Object_Declaration (Parent : Iir) return Iir
    is
       --  First and last element of the chain to be returned.

--- a/src/vhdl/vhdl-parse.adb
+++ b/src/vhdl/vhdl-parse.adb
@@ -469,6 +469,43 @@ package body Vhdl.Parse is
       Error_Msg_Parse (Get_Prev_Location, "missing "";"" at end of " & Msg);
    end Error_Missing_Semi_Colon;
 
+   procedure Error_Variable_Location (Kind : Iir_Kind) is
+      Prefix : constant String := "non-";
+      Common : constant String := "shared variable declaration not allowed ";
+   begin
+      case Kind is
+
+      -- Shared variables
+      when Iir_Kind_Entity_Declaration =>
+         Error_Msg_Parse (Prefix & Common & "in entity declaration");
+      when Iir_Kind_Architecture_Body =>
+         Error_Msg_Parse (Prefix & Common & "in architecture body");
+      when Iir_Kind_Block_Statement =>
+         Error_Msg_Parse (Prefix & Common & "in block statement");
+      when Iir_Kind_Generate_Statement_Body =>
+         Error_Msg_Parse (Prefix & Common & "in generate statement body");
+      when Iir_Kind_Package_Declaration =>
+         Error_Msg_Parse (Prefix & Common & "in package declaration");
+      when Iir_Kind_Package_Body =>
+         Error_Msg_Parse (Prefix & Common & "in entity body");
+      when Iir_Kind_Protected_Type_Declaration =>
+         Error_Msg_Parse (Prefix & Common & "in protected type declaration");
+
+      -- Non-shared variables
+      when Iir_Kind_Function_Body =>
+         Error_Msg_Parse (Common & "in function body");
+      when Iir_Kinds_Process_Statement =>
+         Error_Msg_Parse (Common & "in process statement");
+      when Iir_Kind_Protected_Type_Body =>
+         Error_Msg_Parse (Common & "in protected type body");
+      when Iir_Kind_Simultaneous_Procedural_Statement =>
+         Error_Msg_Parse (Common & "in procedural statement");
+
+      when others =>
+         Error_Msg_Parse (Prefix & Common & "here");
+      end case;
+   end Error_Variable_Location;
+
    --  Expect and scan ';' emit an error message using MSG if not present.
    procedure Scan_Semi_Colon (Msg : String) is
    begin
@@ -5281,16 +5318,13 @@ package body Vhdl.Parse is
             --  shared data.
             case Get_Kind (Package_Parent) is
                when Iir_Kind_Entity_Declaration
-                 | Iir_Kind_Architecture_Body
-                 | Iir_Kind_Block_Statement
-                 | Iir_Kind_Generate_Statement_Body
-                 | Iir_Kind_Package_Declaration
-                 | Iir_Kind_Package_Body
-                 | Iir_Kind_Protected_Type_Declaration =>
-                  --  FIXME: replace HERE with the kind of declaration
-                  --  ie: "not allowed in a package" rather than "here".
-                  Error_Msg_Parse
-                    ("non-shared variable declaration not allowed here");
+                  | Iir_Kind_Architecture_Body
+                  | Iir_Kind_Block_Statement
+                  | Iir_Kind_Generate_Statement_Body
+                  | Iir_Kind_Package_Declaration
+                  | Iir_Kind_Package_Body
+                  | Iir_Kind_Protected_Type_Declaration =>
+                  Error_Variable_Location(Get_Kind(Package_Parent));
                when Iir_Kind_Function_Body
                  | Iir_Kind_Procedure_Body
                  | Iir_Kinds_Process_Statement
@@ -5340,8 +5374,7 @@ package body Vhdl.Parse is
                  | Iir_Kinds_Process_Statement
                  | Iir_Kind_Protected_Type_Body
                  | Iir_Kind_Simultaneous_Procedural_Statement =>
-                  Error_Msg_Parse
-                    ("shared variable declaration not allowed here");
+                  Error_Variable_Location(Get_Kind(Package_Parent));
                when others =>
                   Error_Kind ("parse_declarative_part(3)", Package_Parent);
             end case;

--- a/testsuite/gna/bug0101/repro1.ref
+++ b/testsuite/gna/bug0101/repro1.ref
@@ -1,1 +1,3 @@
 repro1.vhdl:7:16: no declaration for "sig1"
+  g : for i in sig1'range generate
+                ^

--- a/testsuite/gna/bug063/dff.expected
+++ b/testsuite/gna/bug063/dff.expected
@@ -1,4 +1,12 @@
 dff.vhdl:10:25: invalid use of UTF8 character for '
+           if (CLEAR = ‘1’) then
+                         ^
 dff.vhdl:11:23: invalid use of UTF8 character for '
+                Q <= ‘0’;
+                       ^
 dff.vhdl:12:23: invalid use of UTF8 character for '
+           elsif (CLK’event and CLK = ‘1’) then
+                       ^
 dff.vhdl:12:42: invalid use of UTF8 character for '
+           elsif (CLK’event and CLK = ‘1’) then
+                                          ^

--- a/testsuite/gna/issue719/tb.ref
+++ b/testsuite/gna/issue719/tb.ref
@@ -1,2 +1,6 @@
 tb.vhdl:23:14:warning: declaration of "din" hides signal "din" [-Whide]
+    variable din : in std_logic;
+              ^
 tb.vhdl:24:14:warning: declaration of "dout" hides port "dout" [-Whide]
+    variable dout : out std_logic
+              ^


### PR DESCRIPTION
**Description** Please explain the changes you made here.
Improve error/warning logging. Following is done (mostly in VHDL parser and Errorout):
 - If available, print also source code line + location marker where error/warning occured (mimic other compilers)
 - Missing parenthesis are reported only once. If multiple are missing, total missing count is reported. (Resolves FIXME)
 - Improve Invalid shared/non-shared variable error report in cases if variable is declared where it should not be. (Resolves FIXME)
 - give hint if ':=' is used for alias instead of 'is' (resolves FIXME)
 - add resynchronization to end of external name (resolves FIXME)
 - remove FIXME for parsing of file_open_information. AFAIK combination of file_open_kind and file_mode are handled
   correctly, and no FIX is needed. If no file_open_information is present READ_MODE is assumed.

:rotating_light: Before submitting your PR, please read [contribute](http://ghdl.readthedocs.io/en/latest/contribute.html#fork-modify-and-pull-request) in the [Docs](http://ghdl.readthedocs.io/en/latest/index.html), and review the following checklist:

- [x] No issue closed. Feature added was not in any open issue. FIXMEs were searched through the code.

**When contributing to the GHDL codebase...**

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
- [ ] CONSIDER adding a unit test if your PR resolves an issue. **AFAIK , No issue resolved by this PR**.
- [x] CONSIDER modifying the docs, at least in the TODO, if your contribution is relevant to any of the content.
- [x] AVOID breaking the continuous integration build.
- [x] AVOID breaking the testsuite. **All tests which relied on exact error output format has been adjusted.**

**When contributing to the docs...**

Not contributing to the docs.

**Further comments**

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

**For FIXMEs:** It is a good way how to get to know the codebase, therefore I started with FIXMEs.
**For detailed logging:** Inspired by other compilers (LLVM, Slang), IMHO it makes easier to debug. First thing a user
  will do after error, is anyway search line and column in source code at which the error occured.
TBD: At the moment this behavior is default (each reported message, note, warning, error). It is possible
         we could disable it by default, and enable with -v flag? Or is it reasonable to keep it default??

