### PR TITLE
src: Remove obsolete FIXME, file_open_information parsed. Default "IN…

### DIFF
--- a/src/vhdl/vhdl-parse.adb
+++ b/src/vhdl/vhdl-parse.adb
@@ -4141,7 +4141,6 @@ package body Vhdl.Parse is
    --  [ LRM93 4.3.1.2 ]
    --  signal_kind ::= REGISTER | BUS
    --
-   --  FIXME: file_open_information.
    function Parse_Object_Declaration (Parent : Iir) return Iir
    is
       --  First and last element of the chain to be returned.


### PR DESCRIPTION
**Description** Please explain the changes you made here.
It seems to me, that file_open_information production is parsed correctly and there is nothing left undone,
therefore removing FIXME.
File_Open_Information and Open_kind (of VHDL87) are IMHO combined together in elaboration code,
and giving correct default behavior (Read mode), if file_open_information is missing.
Also, file_open_information is correctly checking its value to be of "open_kind" type, therefore it seems
to me that this FIXME is a legacy.

Change in comment only, not in compilable code.
