### PR TITLE
Fix xilinx vendorlib compilation

### DIFF
--- a/scripts/vendors/compile-altera.ps1
+++ b/scripts/vendors/compile-altera.ps1
@@ -151,6 +151,7 @@ $VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables $VHDL93 $VHDL2008
 
 # define global GHDL Options
 $Analyze_Parameters = @(
+	"--std=$VHDLStandard",
 	"-fexplicit",
 	"-frelaxed-rules",
 	"--mb-comments",
@@ -171,7 +172,6 @@ if (-not ($EnableVerbose -or $EnableDebug))
 $Analyze_Parameters += @(
 	"--ieee=$VHDLFlavor",
 	"--no-vital-checks",
-	"--std=$VHDLStandard",
 	"-P$DestinationDirectory"
 )
 

--- a/scripts/vendors/compile-intel.ps1
+++ b/scripts/vendors/compile-intel.ps1
@@ -151,6 +151,7 @@ $VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables $VHDL93 $VHDL2008
 
 # define global GHDL Options
 $Analyze_Parameters = @(
+	"--std=$VHDLStandard",
 	"-fexplicit",
 	"-frelaxed-rules",
 	"--mb-comments",
@@ -171,7 +172,6 @@ if (-not ($EnableVerbose -or $EnableDebug))
 $Analyze_Parameters += @(
 	"--ieee=$VHDLFlavor",
 	"--no-vital-checks",
-	"--std=$VHDLStandard",
 	"-P$DestinationDirectory"
 )
 

--- a/scripts/vendors/compile-lattice.ps1
+++ b/scripts/vendors/compile-lattice.ps1
@@ -178,6 +178,7 @@ $VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables $VHDL93 $VHDL2008
 
 # define global GHDL Options
 $Analyze_Parameters = @(
+	"--std=$VHDLStandard",
 	"-fexplicit",
 	"-frelaxed-rules",
 	"--mb-comments",
@@ -198,7 +199,6 @@ if (-not ($EnableVerbose -or $EnableDebug))
 $Analyze_Parameters += @(
 	"--ieee=$VHDLFlavor",
 	"--no-vital-checks",
-	"--std=$VHDLStandard",
 	"-P$DestinationDirectory"
 )
 

--- a/scripts/vendors/compile-osvvm.ps1
+++ b/scripts/vendors/compile-osvvm.ps1
@@ -116,10 +116,11 @@ $VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables -VHDL2008
 
 # define global GHDL Options
 $Analyze_Parameters = @(
+	"--std=$VHDLStandard",
 	"-fexplicit",
 	"-frelaxed-rules",
 	"--mb-comments",
-  "-Wbinding"
+	"-Wbinding"
 )
 if (-not $EnableDebug)
 {	$Analyze_Parameters += @(
@@ -135,7 +136,6 @@ if (-not ($EnableVerbose -or $EnableDebug))
 $Analyze_Parameters += @(
 	"--ieee=$VHDLFlavor",
 	"--no-vital-checks",
-	"--std=$VHDLStandard",
 	"-P$DestinationDirectory"
 )
 

--- a/scripts/vendors/compile-uvvm.ps1
+++ b/scripts/vendors/compile-uvvm.ps1
@@ -168,9 +168,11 @@ $VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables
 
 # define global GHDL Options
 $Analyze_Parameters = @(
+	"--std=$VHDLStandard",
+	"-fexplicit",
+	"-frelaxed-rules",
 	"--mb-comments",
 	"-Wbinding",
-	"-fexplicit",
 	"-Wno-shared"          # UVVM specific
 )
 if (-not $EnableDebug)
@@ -187,8 +189,6 @@ if (-not ($EnableVerbose -or $EnableDebug))
 $Analyze_Parameters += @(
 	"--ieee=$VHDLFlavor",
 	"--no-vital-checks",
-	"--std=$VHDLStandard",
-	"-frelaxed",
 	"-P$DestinationDirectory"
 )
 

--- a/scripts/vendors/compile-xilinx-ise.ps1
+++ b/scripts/vendors/compile-xilinx-ise.ps1
@@ -144,6 +144,7 @@ $VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables $VHDL93 $VHDL2008
 
 # define global GHDL Options
 $Analyze_Parameters = @(
+	"--std=$VHDLStandard",
 	"-fexplicit",
 	"-frelaxed-rules",
 	"--mb-comments",
@@ -164,7 +165,6 @@ if (-not ($EnableVerbose -or $EnableDebug))
 $Analyze_Parameters += @(
 	"--ieee=$VHDLFlavor",
 	"--no-vital-checks",
-	"--std=$VHDLStandard",
 	"-P$DestinationDirectory"
 )
 

--- a/scripts/vendors/compile-xilinx-vivado.ps1
+++ b/scripts/vendors/compile-xilinx-vivado.ps1
@@ -135,6 +135,7 @@ $VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables $VHDL93 $VHDL2008
 
 # define global GHDL Options
 $Analyze_Parameters = @(
+	"--std=$VHDLStandard",
 	"-fexplicit",
 	"-frelaxed-rules",
 	"--mb-comments",
@@ -155,7 +156,6 @@ if (-not ($EnableVerbose -or $EnableDebug))
 $Analyze_Parameters += @(
 	"--ieee=$VHDLFlavor",
 	"--no-vital-checks",
-	"--std=$VHDLStandard",
 	"-P$DestinationDirectory"
 )
 

--- a/scripts/vendors/shared.psm1
+++ b/scripts/vendors/shared.psm1
@@ -188,8 +188,8 @@ function Get-VHDLVariables
 	#>
 	[CmdletBinding()]
 	param(
-		[switch]$VHDL93 =   $false,
-		[switch]$VHDL2008 = $true
+		[bool]$VHDL93 =   $false,
+		[bool]$VHDL2008 = $true
 	)
 
 	if ($VHDL93)


### PR DESCRIPTION
**Description**
Compilation of Xilinx Vivado 2019.2 vendor libraries on Windows fails with current version of the PS scripts. This PR includes all changes I needed to make to the compile-xilinx-vivado.ps1 script to run on my machine with ghdl-1.0.0. For release 0.37 compilation is successful without swapping --std=08 and -frelaxed-rules.


**When contributing to the GHDL codebase...**

- [X] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [ ] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
- [ ] CONSIDER adding a unit test if your PR resolves an issue.
- [ ] CONSIDER modifying the docs, if your contribution is relevant to any of the content.
- [ ] AVOID breaking the continuous integration build.
- [ ] AVOID breaking the testsuite.


**Further comments**

I have no build environment for GHDL under Windows, so it would be great if someone else could have a closer look to the changes to make sure they are complete and don't break anything.

