### PR TITLE
Add handling of resize(uns, uns) for synthesis

### DIFF
--- a/src/synth/synth-vhdl_oper.adb
+++ b/src/synth/synth-vhdl_oper.adb
@@ -1944,6 +1944,7 @@ package body Synth.Vhdl_Oper is
               (Synth_Sresize (Ctxt, L, Res_Typ.W, Expr), Res_Typ);
 
          when Iir_Predefined_Ieee_Numeric_Std_Resize_Uns_Nat
+            | Iir_Predefined_Ieee_Numeric_Std_Resize_Uns_Uns
             | Iir_Predefined_Ieee_Std_Logic_Arith_Conv_Vector_Uns
             | Iir_Predefined_Ieee_Std_Logic_Arith_Conv_Unsigned_Uns
             | Iir_Predefined_Ieee_Std_Logic_Arith_Conv_Unsigned_Log

--- a/testsuite/synth/resizeunsuns01/axis_conv1d9x1.vhdl
+++ b/testsuite/synth/resizeunsuns01/axis_conv1d9x1.vhdl
@@ -1,0 +1,115 @@
+library ieee;
+context ieee.ieee_std_context;
+
+entity axis_conv1d9x1 is
+  generic (
+    fifo_depth : integer := 0 -- ceiling of the log base 2 of the desired FIFO length
+  );
+  port (
+    s_axis_clk   : in  std_logic;
+    s_axis_rstn  : in  std_logic;
+    s_axis_rdy   : out std_logic;
+    s_axis_data  : in  std_logic_vector(31 downto 0);
+    s_axis_valid : in  std_logic;
+    s_axis_strb  : in  std_logic_vector(3 downto 0);
+    s_axis_last  : in  std_logic;
+
+    m_axis_clk   : in  std_logic;
+    m_axis_rstn  : in  std_logic;
+    m_axis_valid : out std_logic;
+    m_axis_data  : out std_logic_vector(31 downto 0);
+    m_axis_rdy   : in  std_logic;
+    m_axis_strb  : out std_logic_vector(3 downto 0);
+    m_axis_last  : out std_logic
+  );
+end axis_conv1d9x1;
+
+architecture arch of axis_conv1d9x1 is
+
+  constant data_width : integer := 32;
+
+  signal r, e, f, wr, rd, valid : std_logic;
+  signal d, q : std_logic_vector(31 downto 0);
+
+  signal acca, accb, acca_n, accb_n : unsigned(31 downto 0);
+  signal rlast : std_logic;
+
+begin
+
+  r <= (s_axis_rstn nand m_axis_rstn);
+
+  fifo: entity work.fifo
+    generic map (
+      fifo_depth => fifo_depth,
+      data_width => 32
+    )
+    port map (
+      CLKW => s_axis_clk,
+      CLKR => m_axis_clk,
+      RST => r,
+      WR => wr,
+      RD => rd,
+      E => e,
+      F => f,
+      D => d,
+      Q => q
+    );
+
+  process(s_axis_clk) begin
+    if rising_edge(s_axis_clk) then
+      if not s_axis_rstn then
+        acca <= (others=>'0');
+        accb <= (others=>'0');
+      elsif s_axis_valid and s_axis_rdy then
+        acca <= acca_n;
+        accb <= accb_n;
+      end if;
+    end if;
+  end process;
+
+  acca_n <=
+    acca + unsigned(s_axis_data(15 downto 0)) when rlast='0' else
+    resize(unsigned(s_axis_data(15 downto 0)), acca) when ??(s_axis_valid and s_axis_rdy) else
+    (others=>'0');
+  accb_n <=
+    accb + unsigned(s_axis_data(31 downto 16)) when rlast='0' else
+    resize(unsigned(s_axis_data(31 downto 16)), acca) when ??(s_axis_valid and s_axis_rdy) else
+    (others=>'0');
+
+  process(s_axis_clk) begin
+    if rising_edge(s_axis_clk) then
+      if not s_axis_rstn then
+        rlast <= '0';
+      else
+        rlast <= s_axis_last and (s_axis_valid and s_axis_rdy);
+      end if;
+    end if;
+  end process;
+
+  wr <= rlast;
+  d <= std_logic_vector(accb(18 downto 3)) & std_logic_vector(acca(18 downto 3));
+
+-- AXI4 Stream Slave logic
+
+  s_axis_rdy <= not f;
+
+-- AXI4 Stream Master logic
+
+  rd <= (not e) and (valid nand (not m_axis_rdy));
+
+  process(m_axis_clk) begin
+    if rising_edge(m_axis_clk) then
+      if ((not m_axis_rstn) or ((valid and E) and m_axis_rdy))='1' then
+        valid <= '0';
+      elsif rd then
+        valid <= '1';
+      end if;
+    end if;
+  end process;
+
+  m_axis_valid <= valid;
+  m_axis_last <= q(d'left);
+  m_axis_strb <= (others=>'1');
+  m_axis_data <= q(data_width-1 downto 0);
+
+end architecture;

--- a/testsuite/synth/resizeunsuns01/fifo.vhdl
+++ b/testsuite/synth/resizeunsuns01/fifo.vhdl
@@ -1,0 +1,99 @@
+library ieee;
+context ieee.ieee_std_context;
+
+entity fifo is
+  generic (
+    data_width : positive := 8;
+    fifo_depth : positive := 8
+  );
+  port (
+    clkw : in std_logic;
+    clkr : in std_logic;
+    rst  : in std_logic;
+    wr   : in std_logic;
+    rd   : in std_logic;
+    d    : in std_logic_vector(data_width-1 downto 0);
+    e    : out std_logic;
+    f    : out std_logic;
+    q    : out std_logic_vector(data_width-1 downto 0)
+  );
+end fifo;
+
+architecture arch of fifo is
+
+  type fifo_t is array (0 to 2**fifo_depth-1)
+    of std_logic_vector(data_width-1 downto 0);
+  signal mem : fifo_t;
+
+  signal rdp, wrp : unsigned(fifo_depth downto 0);
+
+begin
+
+-- Assertions
+  process(clkw, clkr)
+    constant dx : std_logic_vector(d'left downto 0) := (others => 'X');
+    constant du : std_logic_vector(d'left downto 0) := (others => 'U');
+  begin
+    if rising_edge(clkw) then
+      if ( wr and ( d?=dx or d?=du ) ) then
+        assert false report "wrote X|U to fIfO" severity failure;
+      end if;
+      if (f and wr) then
+        assert false report "wrote to fIfO while full" severity failure;
+      end if;
+    end if;
+    if rising_edge(clkr) then
+      if (e and rd) then
+        assert false report "Read from fIfO while empty" severity failure;
+      end if;
+    end if;
+  end process;
+
+--
+
+  process(clkw) begin
+    if rising_edge(clkw) then
+      if wr then
+        mem(to_integer(wrp(fifo_depth-1 downto 0))) <= d;
+      end if;
+    end if;
+  end process;
+
+  process(clkw) begin
+    if rising_edge(clkw) then
+      if rst then
+        wrp <= (others => '0');
+      else
+        if wr then
+          wrp <= wrp+1;
+        end if;
+      end if;
+    end if;
+  end process;
+
+  f <= rdp(fifo_depth-1 downto 0)?=wrp(fifo_depth-1 downto 0)
+       and (rdp(fifo_depth) xor wrp(fifo_depth));
+  e <= rdp ?= wrp;
+
+  process(clkr) begin
+    if rising_edge(clkr) then
+      if rst then
+        q <= (others => '0');
+      elsif rd then
+        q <= mem(to_integer(rdp(fifo_depth-1 downto 0)));
+      end if;
+    end if;
+  end process;
+
+  process(clkr) begin
+    if rising_edge(clkr) then
+      if rst then
+        rdp <= (others => '0');
+      else
+        if rd then rdp <= rdp+1; end if;
+      end if;
+    end if;
+  end process;
+
+end arch;
+

--- a/testsuite/synth/resizeunsuns01/testsuite.sh
+++ b/testsuite/synth/resizeunsuns01/testsuite.sh
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+synth_failure --std=08 -gfifo_depth=3 fifo.vhdl axis_conv1d9x1.vhdl -e
+
+echo "Test successful"


### PR DESCRIPTION
This PR adds handling of `resize(uns, uns)` for synthesis. A simple test is included, similar to the one of #1731.