### PR TITLE
Grt optimize wave dump

### DIFF
--- a/src/grt/grt-avls.adb
+++ b/src/grt/grt-avls.adb
@@ -31,6 +31,7 @@ package body Grt.Avls is
          return Tree (N).Height;
       end if;
    end Get_Height;
+   pragma Inline (Get_Height);
 
    procedure Check_AVL (Tree : AVL_Tree; N : AVL_Nid)
    is
@@ -43,12 +44,11 @@ package body Grt.Avls is
       end if;
       L := Tree (N).Left;
       R := Tree (N).Right;
-      H := Get_Height (Tree, N);
+      H := Tree (N).Height;
       if L = AVL_Nil and R = AVL_Nil then
-         if Get_Height (Tree, N) /= 1 then
+         if H /= 1 then
             Internal_Error ("check_AVL(1)");
          end if;
-         return;
       elsif L = AVL_Nil then
          Check_AVL (Tree, R);
          if H /= Get_Height (Tree, R) + 1 or H > 2 then
@@ -215,7 +215,7 @@ package body Grt.Avls is
          Internal_Error ("avls.get_node");
       end if;
       Insert (Tree, Cmp, N, AVL_Root, Res);
-      Check_AVL (Tree, AVL_Root);
+      pragma Debug (Check_AVL (Tree, AVL_Root));
    end Get_Node;
 
    function Find_Node (Tree : AVL_Tree;

--- a/src/grt/grt-signals.adb
+++ b/src/grt/grt-signals.adb
@@ -252,6 +252,8 @@ package body Grt.Signals is
                               Nbr_Ports => 0,
                               Ports => null,
 
+                              Dump_Table_Idx => 0,
+
                               S => S);
 
       if Resolv /= null and then Resolv.Resolv_Ptr = System.Null_Address then
@@ -621,6 +623,8 @@ package body Grt.Signals is
 
                                      Nbr_Ports => 0,
                                      Ports => null,
+
+                                     Dump_Table_Idx => 0,
 
                                      S => (Mode_Sig => Mode_End));
 
@@ -3123,7 +3127,12 @@ package body Grt.Signals is
 
       Sig.Event := True;
       Sig.Last_Event := Current_Time;
-      Sig.Flags.RO_Event := True;
+      if not Sig.Flags.RO_Event then
+         Sig.Flags.RO_Event := True;
+         if Sig.Dump_Table_Idx /= 0 then
+            Changed_Sig_Table.Append(Sig);
+         end if;
+      end if;
 
       El := Sig.Event_List;
       while El /= null loop

--- a/src/grt/grt-signals.ads
+++ b/src/grt/grt-signals.ads
@@ -355,6 +355,8 @@ package Grt.Signals is
       Nbr_Ports : Ghdl_Index_Type;
       Ports : Signal_Arr_Ptr;
 
+      Dump_Table_Idx : Dump_Table_Index;
+
       --  Mode of the signal (in, out ...)
       --Mode_Signal : Mode_Signal_Type;
       S : Ghdl_Signal_Data;
@@ -365,6 +367,13 @@ package Grt.Signals is
      (Table_Component_Type => Ghdl_Signal_Ptr,
       Table_Index_Type => Sig_Table_Index,
       Table_Low_Bound => 0,
+      Table_Initial => 128);
+
+   -- Signals with RO_Event set. Cleared in Grt.Wave.Wave_Cycle.
+   package Changed_Sig_Table is new Grt.Table
+     (Table_Component_Type => Ghdl_Signal_Ptr,
+      Table_Index_Type => Natural,
+      Table_Low_Bound => 1,
       Table_Initial => 128);
 
    --  Read the value pointed by VALUE_PTR.  It cannot be simply deferred as

--- a/src/grt/grt-types.ads
+++ b/src/grt/grt-types.ads
@@ -180,6 +180,9 @@ package Grt.Types is
       First, Last : Sig_Table_Index;
    end record;
 
+   --  Signal index in Waves.Dump_Table.
+   type Dump_Table_Index is new Natural;
+
    --  Simple values, used for signals.
    type Mode_Type is
      (Mode_B1, Mode_E8, Mode_E32, Mode_I32, Mode_I64, Mode_F64);


### PR DESCRIPTION
**Description**
This PR pretty much duplicates [Wave-dump-optimize](https://github.com/ghdl/ghdl/pull/782), but it uses GRT sort
instead of Ada library sort for Wave table.

Branch was built with LLVM backend, and briefly tested (dumped waves seem to be the same as in GCC build before
the sort function modification)

**When contributing to the GHDL codebase...**

- [ ] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [ ] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
- [ ] CONSIDER adding a unit test if your PR resolves an issue.
- [ ] CONSIDER modifying the docs, if your contribution is relevant to any of the content.
- [ ] AVOID breaking the continuous integration build.
- [ ] AVOID breaking the testsuite.

**When contributing to the docs...**

- [ ] DO make sure that the build is successful.

**Further comments**

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
