### PR TITLE
Makefile.in: pass ghwdump location to testsuite

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -291,7 +291,7 @@ install.gcc: install.grt
 uninstall.gcc: uninstall.grt
 
 test.gcc:
-	cd $(srcdir)/testsuite; GHDL=$(GHDL_GCC_BIN) ./testsuite.sh
+	cd $(srcdir)/testsuite; GHDL=$(GHDL_GCC_BIN) GHWDUMP=$(CURDIR)/ghwdump$(EXEEXT) ./testsuite.sh
 
 #################### For gcc backend - development only (local build) ####
 

--- a/testsuite/testsuite.sh
+++ b/testsuite/testsuite.sh
@@ -19,6 +19,11 @@ enable_color() {
 disable_color() { unset ENABLECOLOR ANSI_RED ANSI_GREEN ANSI_YELLOW ANSI_BLUE ANSI_MAGENTA ANSI_CYAN ANSI_DARKCYAN ANSI_NOCOLOR; }
 enable_color
 
+die() {
+  printf "${ANSI_RED}%s${ANSI_NOCOLOR}\n" "$@" >&2
+  exit 1
+}
+
 print_start() {
   COL="$ANSI_YELLOW"
   if [ "x$2" != "x" ]; then
@@ -78,8 +83,7 @@ if [ "x$GHDL" = "x" ]; then
   elif [ "x$(command -v which)" != "x" ]; then
     export GHDL="$(which ghdl)"
   else
-    printf "${ANSI_RED}error: GHDL environment variable is not defined${ANSI_NOCOLOR}\n"
-    exit 1
+    die "error: GHDL environment variable is not defined"
   fi
 fi
 
@@ -125,8 +129,8 @@ do_test() {
       _vests
     ;;
     *)
-      printf "${ANSI_RED}$0: test name '$1' is unknown${ANSI_NOCOLOR}\n"
-      exit 1;;
+      die "$0: test name '$1' is unknown"
+    ;;
   esac
 }
 

--- a/testsuite/testsuite.sh
+++ b/testsuite/testsuite.sh
@@ -87,6 +87,15 @@ if [ "x$GHDL" = "x" ]; then
   fi
 fi
 
+if [ "$GHWDUMP" = "" ]; then
+  case "$GHDL" in
+    */*) export GHWDUMP=${GHDL%/*}/ghwdump;;
+    *) export GHWDUMP=ghwdump;;
+  esac
+fi
+
+command -v "$GHWDUMP" >/dev/null || die "ghwdump executable not found: $GHWDUMP"
+
 cd $(dirname "$0")
 rm -f test_ok
 failures=""


### PR DESCRIPTION
**Description**
#1738 broke PKGBUILDs because tests are performed before GHDL is installed, so the `ghwdump` binary in the build directory must be used, however the `test` make targets don't set the `$GHWDUMP` variable.