### PR TITLE
Add missing llvm version check in configure

### DIFF
--- a/configure
+++ b/configure
@@ -276,6 +276,7 @@ if test $backend = llvm; then
        check_version 10.0 $llvm_version ||
        check_version 11.0 $llvm_version ||
        check_version 11.1 $llvm_version ||
+       check_version 12.0 $llvm_version ||
        false; then
     echo "Debugging is enabled with llvm $llvm_version"
   else

--- a/src/ortho/llvm6/llvm-cbindings.cpp
+++ b/src/ortho/llvm6/llvm-cbindings.cpp
@@ -1254,7 +1254,7 @@ new_var_decl(ODnode *Res, OIdent Ident, OStorage Storage, OTnode Atype)
          DebugCurrentLine, Atype->Dbg, true);
       DBuilder->insertDeclare
         (unwrap(Decl), D, DBuilder->createExpression(),
-         DebugLoc::get(DebugCurrentLine, 0, DebugCurrentScope),
+         DILocation::get(DebugCurrentScope->getContext(), DebugCurrentLine, 0, DebugCurrentScope),
          unwrap(LLVMGetInsertBlock(DeclBuilder)));
     }
 #endif
@@ -1597,7 +1597,7 @@ start_subprogram_body(ODnodeSubprg *Func)
     DebugCurrentScope = DebugCurrentSubprg;
 
     unwrap(Builder)->SetCurrentDebugLocation
-      (DebugLoc::get(DebugCurrentLine, 0, DebugCurrentScope));
+      (DILocation::get(DebugCurrentScope->getContext(), DebugCurrentLine, 0, DebugCurrentScope));
   }
 
   if (FlagDebug) {
@@ -1612,7 +1612,7 @@ start_subprogram_body(ODnodeSubprg *Func)
          DebugCurrentFile, DebugCurrentLine, Inter->Dtype->Dbg, true);
       DBuilder->insertDeclare
         (unwrap(Var), D, DBuilder->createExpression(),
-         DebugLoc::get(DebugCurrentLine, 0, DebugCurrentSubprg),
+         DILocation::get(DebugCurrentSubprg->getContext(), DebugCurrentLine, 0, DebugCurrentSubprg),
          unwrap(LLVMGetInsertBlock(DeclBuilder)));
       LLVMBuildStore(DeclBuilder, Inter->Ref, Var);
       Inter->Ref = Var;
@@ -2759,7 +2759,7 @@ new_debug_line_stmt (unsigned Line)
   if (FlagDebugLines && Line != DebugCurrentLine) {
     DebugCurrentLine = Line;
     unwrap(Builder)->SetCurrentDebugLocation
-      (DebugLoc::get(DebugCurrentLine, 0, DebugCurrentScope));
+      (DILocation::get(DebugCurrentScope->getContext(), DebugCurrentLine, 0, DebugCurrentScope));
   }
 #endif
 }


### PR DESCRIPTION
I tested the earlier DILocation patch in original ghdl master. In order to submit it, I forked ghdl and applied the patch there. However I forgot to specify --with-lvm-config in configure (which was still effective in the original ghdl master). I now added the necessary check to pass.