### PR TITLE
Increase stack size for msys2-mcode binary (fix #1742)

### DIFF
--- a/scripts/msys2-mcode/PKGBUILD
+++ b/scripts/msys2-mcode/PKGBUILD
@@ -18,7 +18,7 @@ build() {
   cd "${srcdir}/builddir"
   ../../../../configure \
     --prefix=${MINGW_PREFIX} \
-    LDFLAGS=-static \
+    LDFLAGS="-static -Wl,--stack=8388608" \
     --enable-libghdl \
     --enable-synth
   make GNATMAKE="gnatmake -j$(nproc)"


### PR DESCRIPTION
This fixes the stack overflow error when using UVVM axistream_vvc for msys2-mcode.