### PR TITLE
ci: generate Windows installers

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -267,7 +267,7 @@ jobs:
     - name: '📤 Upload artifact: installer'
       uses: actions/upload-artifact@v2
       with:
-        path: scripts/msys2-${{ matrix.pkg }}/pkg/mingw-w64-${{ matrix.arch }}-ghdl-${{ matrix.pkg }}/installer-${{ matrix.arch }}-${{ matrix.pkg }}.exe
+        path: scripts/msys2-${{ matrix.pkg }}/pkg/mingw-w64-${{ matrix.arch }}-ghdl-${{ matrix.pkg }}/ghdl-installer-${{ matrix.arch }}-${{ matrix.pkg }}.exe
 
 #
 # Windows Test

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -242,6 +242,15 @@ jobs:
         cd scripts/msys2-${{ matrix.pkg }}
         makepkg-mingw --noconfirm --noprogressbar -sCLf
 
+    - name: 'Prepare NSIS build'
+      run: |
+        cp scripts/installer-${{ matrix.installs }}-${{ matrix.pkg }}.nsi scripts/msys2-${{ matrix.pkg }}/pkg/mingw-w64-${{ matrix.arch }}-ghdl-${{ matrix.pkg }}
+
+    - name: 'Create NSIS installer'
+      uses: joncloud/makensis-action@v3.3
+      with:
+        script-file: scripts/msys2-${{ matrix.pkg }}/pkg/mingw-w64-${{ matrix.arch }}-ghdl-${{ matrix.pkg }}/installer-${{ matrix.installs }}-${{ matrix.pkg }}.nsi
+
     - name: '📤 Upload artifact: builddir'
       uses: actions/upload-artifact@v2
       with:
@@ -254,6 +263,11 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         path: scripts/msys2-${{ matrix.pkg }}/mingw-*ghdl*.pkg.tar.zst
+
+    - name: '📤 Upload artifact: installer'
+      uses: actions/upload-artifact@v2
+      with:
+        path: scripts/msys2-${{ matrix.pkg }}/pkg/mingw-w64-${{ matrix.arch }}-ghdl-${{ matrix.pkg }}/installer-${{ matrix.arch }}-${{ matrix.pkg }}.exe
 
 #
 # Windows Test

--- a/scripts/installer-MINGW32-mcode.nsi
+++ b/scripts/installer-MINGW32-mcode.nsi
@@ -1,0 +1,254 @@
+!define APPNAME "GHDL"
+!define COMPANYNAME "GHDL"
+!define DESCRIPTION " VHDL 2008/93/87 simulator"
+
+;kind dependent section
+!define ARCH "mingw32"
+!define BACKEND "mcode"
+!define ARCH2 "i686"
+InstallDir "$PROGRAMFILES\${APPNAME}"
+;end kind dependent section
+
+!define VERSIONMAJOR 1
+!define VERSIONMINOR 0
+!define VERSIONBUILD 0
+
+OutFile "ghdl-installer-${ARCH2}-${BACKEND}.exe"
+
+Name "${APPNAME}"
+
+!include LogicLib.nsh
+
+Page directory
+Page instfiles
+
+!macro VerifyUserIsAdmin
+UserInfo::GetAccountType
+Pop $0
+${If} $0 != "admin"
+        MessageBox mb_iconstop "Administrator rights required!"
+        SetErrorLevel 740
+        Quit
+${EndIf}
+!macroend
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;https://www.smartmontools.org/browser/trunk/smartmontools/os_win32/installer.nsi;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+!include "WinMessages.nsh"
+!define Environ 'HKCU "Environment"'
+
+; AddToPath - Appends dir to PATH
+;   (does not work on Win9x/ME)
+;
+; Usage:
+;   Push "dir"
+;   Call AddToPath
+
+Function AddToPath
+  Exch $0
+  Push $1
+  Push $2
+  Push $3
+  Push $4
+
+  ; NSIS ReadRegStr returns empty string on string overflow
+  ; Native calls are used here to check actual length of PATH
+
+  ; $4 = RegOpenKey(HKEY_CURRENT_USER, "Environment", &$3)
+  System::Call "advapi32::RegOpenKey(i 0x80000001, t'Environment', *i.r3) i.r4"
+  IntCmp $4 0 0 done done
+  ; $4 = RegQueryValueEx($3, "PATH", (DWORD*)0, (DWORD*)0, &$1, ($2=NSIS_MAX_STRLEN, &$2))
+  ; RegCloseKey($3)
+  System::Call "advapi32::RegQueryValueEx(i $3, t'PATH', i 0, i 0, t.r1, *i ${NSIS_MAX_STRLEN} r2) i.r4"
+  System::Call "advapi32::RegCloseKey(i $3)"
+
+  ${If} $4 = 234 ; ERROR_MORE_DATA
+    DetailPrint "AddToPath: original length $2 > ${NSIS_MAX_STRLEN}"
+    MessageBox MB_OK "PATH not updated, original length $2 > ${NSIS_MAX_STRLEN}" /SD IDOK
+    Goto done
+  ${EndIf}
+
+  ${If} $4 <> 0 ; NO_ERROR
+    ${If} $4 <> 2 ; ERROR_FILE_NOT_FOUND
+      DetailPrint "AddToPath: unexpected error code $4"
+      Goto done
+    ${EndIf}
+    StrCpy $1 ""
+  ${EndIf}
+
+  ; Check if already in PATH
+  Push "$1;"
+  Push "$0;"
+  Call StrStr
+  Pop $2
+  StrCmp $2 "" 0 done
+  Push "$1;"
+  Push "$0\;"
+  Call StrStr
+  Pop $2
+  StrCmp $2 "" 0 done
+
+  ; Prevent NSIS string overflow
+  StrLen $2 $0
+  StrLen $3 $1
+  IntOp $2 $2 + $3
+  IntOp $2 $2 + 2 ; $2 = strlen(dir) + strlen(PATH) + sizeof(";")
+  ${If} $2 > ${NSIS_MAX_STRLEN}
+    DetailPrint "AddToPath: new length $2 > ${NSIS_MAX_STRLEN}"
+    MessageBox MB_OK "PATH not updated, new length $2 > ${NSIS_MAX_STRLEN}." /SD IDOK
+    Goto done
+  ${EndIf}
+
+  ; Append dir to PATH
+  DetailPrint "Add to PATH: $0"
+  StrCpy $2 $1 1 -1
+  ${If} $2 == ";"
+    StrCpy $1 $1 -1 ; remove trailing ';'
+  ${EndIf}
+  ${If} $1 != "" ; no leading ';'
+    StrCpy $0 "$1;$0"
+  ${EndIf}
+  WriteRegExpandStr ${Environ} "PATH" $0
+  SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+
+done:
+  Pop $4
+  Pop $3
+  Pop $2
+  Pop $1
+  Pop $0
+FunctionEnd
+
+
+; RemoveFromPath - Removes dir from PATH
+;
+; Usage:
+;   Push "dir"
+;   Call RemoveFromPath
+
+Function un.RemoveFromPath
+  Exch $0
+  Push $1
+  Push $2
+  Push $3
+  Push $4
+  Push $5
+  Push $6
+
+  ReadRegStr $1 ${Environ} "PATH"
+  StrCpy $5 $1 1 -1
+  ${If} $5 != ";"
+    StrCpy $1 "$1;" ; ensure trailing ';'
+  ${EndIf}
+  Push $1
+  Push "$0;"
+  Call un.StrStr
+  Pop $2 ; pos of our dir
+  StrCmp $2 "" done
+
+  DetailPrint "Remove from PATH: $0"
+  StrLen $3 "$0;"
+  StrLen $4 $2
+  StrCpy $5 $1 -$4 ; $5 is now the part before the path to remove
+  StrCpy $6 $2 "" $3 ; $6 is now the part after the path to remove
+  StrCpy $3 "$5$6"
+  StrCpy $5 $3 1 -1
+  ${If} $5 == ";"
+    StrCpy $3 $3 -1 ; remove trailing ';'
+  ${EndIf}
+  WriteRegExpandStr ${Environ} "PATH" $3
+  SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+
+done:
+  Pop $6
+  Pop $5
+  Pop $4
+  Pop $3
+  Pop $2
+  Pop $1
+  Pop $0
+FunctionEnd
+
+
+; StrStr - find substring in a string
+;
+; Usage:
+;   Push "this is some string"
+;   Push "some"
+;   Call StrStr
+;   Pop $0 ; "some string"
+
+!macro StrStr un
+Function ${un}StrStr
+  Exch $R1 ; $R1=substring, stack=[old$R1,string,...]
+  Exch     ;                stack=[string,old$R1,...]
+  Exch $R2 ; $R2=string,    stack=[old$R2,old$R1,...]
+  Push $R3
+  Push $R4
+  Push $R5
+  StrLen $R3 $R1
+  StrCpy $R4 0
+  ; $R1=substring, $R2=string, $R3=strlen(substring)
+  ; $R4=count, $R5=tmp
+  ${Do}
+    StrCpy $R5 $R2 $R3 $R4
+    ${IfThen} $R5 == $R1 ${|} ${ExitDo} ${|}
+    ${IfThen} $R5 == ""  ${|} ${ExitDo} ${|}
+    IntOp $R4 $R4 + 1
+  ${Loop}
+  StrCpy $R1 $R2 "" $R4
+  Pop $R5
+  Pop $R4
+  Pop $R3
+  Pop $R2
+  Exch $R1 ; $R1=old$R1, stack=[result,...]
+FunctionEnd
+!macroend
+!insertmacro StrStr ""
+!insertmacro StrStr "un."
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;end https://www.smartmontools.org/browser/trunk/smartmontools/os_win32/installer.nsi;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+Function .onInit
+	SetShellVarContext all
+	!insertmacro VerifyUserIsAdmin
+FunctionEnd
+
+Function un.onInit
+	SetShellVarContext all
+
+	MessageBox MB_OKCANCEL "Permanantly remove ${APPNAME}? This will delete the whole directory where ${APPNAME} was installed." IDOK next
+		Abort
+	next:
+	!insertmacro VerifyUserIsAdmin
+FunctionEnd
+
+Section "install"
+	SetOutPath $INSTDIR
+	File /r "${ARCH}\*"
+
+	WriteUninstaller "$INSTDIR\uninstall.exe"
+
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayName" "${APPNAME} - ${DESCRIPTION}"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "QuietUninstallString" "$\"$INSTDIR\uninstall.exe$\" /S"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "InstallLocation" "$\"$INSTDIR$\""
+
+	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "NoModify" 1
+	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "NoRepair" 1
+	Push "$INSTDIR\bin"
+	Call AddToPath
+SectionEnd
+
+Section "uninstall"
+	Push "$INSTDIR\bin"
+	Call un.RemoveFromPath
+
+	RMDir /r $INSTDIR
+
+	DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
+SectionEnd

--- a/scripts/installer-MINGW64-llvm.nsi
+++ b/scripts/installer-MINGW64-llvm.nsi
@@ -1,0 +1,254 @@
+!define APPNAME "GHDL"
+!define COMPANYNAME "GHDL"
+!define DESCRIPTION " VHDL 2008/93/87 simulator"
+
+;kind dependent section
+!define ARCH "mingw64"
+!define BACKEND "llvm"
+!define ARCH2 "x86_64"
+InstallDir "$PROGRAMFILES64\${APPNAME}"
+;end kind dependent section
+
+!define VERSIONMAJOR 1
+!define VERSIONMINOR 0
+!define VERSIONBUILD 0
+
+OutFile "ghdl-installer-${ARCH2}-${BACKEND}.exe"
+
+Name "${APPNAME}"
+
+!include LogicLib.nsh
+
+Page directory
+Page instfiles
+
+!macro VerifyUserIsAdmin
+UserInfo::GetAccountType
+Pop $0
+${If} $0 != "admin"
+        MessageBox mb_iconstop "Administrator rights required!"
+        SetErrorLevel 740
+        Quit
+${EndIf}
+!macroend
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;https://www.smartmontools.org/browser/trunk/smartmontools/os_win32/installer.nsi;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+!include "WinMessages.nsh"
+!define Environ 'HKCU "Environment"'
+
+; AddToPath - Appends dir to PATH
+;   (does not work on Win9x/ME)
+;
+; Usage:
+;   Push "dir"
+;   Call AddToPath
+
+Function AddToPath
+  Exch $0
+  Push $1
+  Push $2
+  Push $3
+  Push $4
+
+  ; NSIS ReadRegStr returns empty string on string overflow
+  ; Native calls are used here to check actual length of PATH
+
+  ; $4 = RegOpenKey(HKEY_CURRENT_USER, "Environment", &$3)
+  System::Call "advapi32::RegOpenKey(i 0x80000001, t'Environment', *i.r3) i.r4"
+  IntCmp $4 0 0 done done
+  ; $4 = RegQueryValueEx($3, "PATH", (DWORD*)0, (DWORD*)0, &$1, ($2=NSIS_MAX_STRLEN, &$2))
+  ; RegCloseKey($3)
+  System::Call "advapi32::RegQueryValueEx(i $3, t'PATH', i 0, i 0, t.r1, *i ${NSIS_MAX_STRLEN} r2) i.r4"
+  System::Call "advapi32::RegCloseKey(i $3)"
+
+  ${If} $4 = 234 ; ERROR_MORE_DATA
+    DetailPrint "AddToPath: original length $2 > ${NSIS_MAX_STRLEN}"
+    MessageBox MB_OK "PATH not updated, original length $2 > ${NSIS_MAX_STRLEN}" /SD IDOK
+    Goto done
+  ${EndIf}
+
+  ${If} $4 <> 0 ; NO_ERROR
+    ${If} $4 <> 2 ; ERROR_FILE_NOT_FOUND
+      DetailPrint "AddToPath: unexpected error code $4"
+      Goto done
+    ${EndIf}
+    StrCpy $1 ""
+  ${EndIf}
+
+  ; Check if already in PATH
+  Push "$1;"
+  Push "$0;"
+  Call StrStr
+  Pop $2
+  StrCmp $2 "" 0 done
+  Push "$1;"
+  Push "$0\;"
+  Call StrStr
+  Pop $2
+  StrCmp $2 "" 0 done
+
+  ; Prevent NSIS string overflow
+  StrLen $2 $0
+  StrLen $3 $1
+  IntOp $2 $2 + $3
+  IntOp $2 $2 + 2 ; $2 = strlen(dir) + strlen(PATH) + sizeof(";")
+  ${If} $2 > ${NSIS_MAX_STRLEN}
+    DetailPrint "AddToPath: new length $2 > ${NSIS_MAX_STRLEN}"
+    MessageBox MB_OK "PATH not updated, new length $2 > ${NSIS_MAX_STRLEN}." /SD IDOK
+    Goto done
+  ${EndIf}
+
+  ; Append dir to PATH
+  DetailPrint "Add to PATH: $0"
+  StrCpy $2 $1 1 -1
+  ${If} $2 == ";"
+    StrCpy $1 $1 -1 ; remove trailing ';'
+  ${EndIf}
+  ${If} $1 != "" ; no leading ';'
+    StrCpy $0 "$1;$0"
+  ${EndIf}
+  WriteRegExpandStr ${Environ} "PATH" $0
+  SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+
+done:
+  Pop $4
+  Pop $3
+  Pop $2
+  Pop $1
+  Pop $0
+FunctionEnd
+
+
+; RemoveFromPath - Removes dir from PATH
+;
+; Usage:
+;   Push "dir"
+;   Call RemoveFromPath
+
+Function un.RemoveFromPath
+  Exch $0
+  Push $1
+  Push $2
+  Push $3
+  Push $4
+  Push $5
+  Push $6
+
+  ReadRegStr $1 ${Environ} "PATH"
+  StrCpy $5 $1 1 -1
+  ${If} $5 != ";"
+    StrCpy $1 "$1;" ; ensure trailing ';'
+  ${EndIf}
+  Push $1
+  Push "$0;"
+  Call un.StrStr
+  Pop $2 ; pos of our dir
+  StrCmp $2 "" done
+
+  DetailPrint "Remove from PATH: $0"
+  StrLen $3 "$0;"
+  StrLen $4 $2
+  StrCpy $5 $1 -$4 ; $5 is now the part before the path to remove
+  StrCpy $6 $2 "" $3 ; $6 is now the part after the path to remove
+  StrCpy $3 "$5$6"
+  StrCpy $5 $3 1 -1
+  ${If} $5 == ";"
+    StrCpy $3 $3 -1 ; remove trailing ';'
+  ${EndIf}
+  WriteRegExpandStr ${Environ} "PATH" $3
+  SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+
+done:
+  Pop $6
+  Pop $5
+  Pop $4
+  Pop $3
+  Pop $2
+  Pop $1
+  Pop $0
+FunctionEnd
+
+
+; StrStr - find substring in a string
+;
+; Usage:
+;   Push "this is some string"
+;   Push "some"
+;   Call StrStr
+;   Pop $0 ; "some string"
+
+!macro StrStr un
+Function ${un}StrStr
+  Exch $R1 ; $R1=substring, stack=[old$R1,string,...]
+  Exch     ;                stack=[string,old$R1,...]
+  Exch $R2 ; $R2=string,    stack=[old$R2,old$R1,...]
+  Push $R3
+  Push $R4
+  Push $R5
+  StrLen $R3 $R1
+  StrCpy $R4 0
+  ; $R1=substring, $R2=string, $R3=strlen(substring)
+  ; $R4=count, $R5=tmp
+  ${Do}
+    StrCpy $R5 $R2 $R3 $R4
+    ${IfThen} $R5 == $R1 ${|} ${ExitDo} ${|}
+    ${IfThen} $R5 == ""  ${|} ${ExitDo} ${|}
+    IntOp $R4 $R4 + 1
+  ${Loop}
+  StrCpy $R1 $R2 "" $R4
+  Pop $R5
+  Pop $R4
+  Pop $R3
+  Pop $R2
+  Exch $R1 ; $R1=old$R1, stack=[result,...]
+FunctionEnd
+!macroend
+!insertmacro StrStr ""
+!insertmacro StrStr "un."
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;end https://www.smartmontools.org/browser/trunk/smartmontools/os_win32/installer.nsi;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+Function .onInit
+	SetShellVarContext all
+	!insertmacro VerifyUserIsAdmin
+FunctionEnd
+
+Function un.onInit
+	SetShellVarContext all
+
+	MessageBox MB_OKCANCEL "Permanantly remove ${APPNAME}? This will delete the whole directory where ${APPNAME} was installed." IDOK next
+		Abort
+	next:
+	!insertmacro VerifyUserIsAdmin
+FunctionEnd
+
+Section "install"
+	SetOutPath $INSTDIR
+	File /r "${ARCH}\*"
+
+	WriteUninstaller "$INSTDIR\uninstall.exe"
+
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayName" "${APPNAME} - ${DESCRIPTION}"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "QuietUninstallString" "$\"$INSTDIR\uninstall.exe$\" /S"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "InstallLocation" "$\"$INSTDIR$\""
+
+	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "NoModify" 1
+	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "NoRepair" 1
+	Push "$INSTDIR\bin"
+	Call AddToPath
+SectionEnd
+
+Section "uninstall"
+	Push "$INSTDIR\bin"
+	Call un.RemoveFromPath
+
+	RMDir /r $INSTDIR
+
+	DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
+SectionEnd


### PR DESCRIPTION
**Description** 
Added a CI job steps to generate windows NSIS installers from the built windows binaries. This serves mainly as a way to decrease entry barrier for learning to write VHDL on windows, but should be generally useful for everyone running windows.

:rotating_light: This has *not* been thoroughly tested, as I don't have any windows machine currently on hand, and don't have enough free disk space for a 64-bit windows virtual machine. I did however at least test that the 32-bit installer installs and uninstalls correctly, and that the `ghdl` binary can be launched from `cmd` after installation, and there *should* not be anything too different in the 64 bit version to cause breakage.

**Further comments**
This is a fairly simple and primitive installer, currently serving as a proof of concept for me for another ghdl-related project, but should be mergeable nevertheless. If that other thing comes through and this gets merged, I will probably create another PR trying to simplify the `.nsi` scripts to reduce code duplication, and probably to include option to somehow also install `gtkWave` alongside `ghdl` as optional component.
