### PR TITLE
OpenBSD port

### DIFF
--- a/configure
+++ b/configure
@@ -228,6 +228,7 @@ if test $backend = mcode; then
   case "$build" in
     i[3-6]86*) mcode64="" ;;
     x86_64*) mcode64="64" ;;
+    amd64*)  mcode64="64" ;;
     *)
       mcode64=""
       echo "WARNING: GHDL for mcode is supported only on x86"
@@ -376,6 +377,7 @@ if test $backend = mcode; then
     *darwin*) ortho_flags="Flags_Macosx${mcode64}" ;;
     *mingw32*) ortho_flags="Flags_Windows${mcode64}" ;;
     *linux*) ortho_flags="Flags_Linux${mcode64}" ;;
+    *openbsd*) ortho_flags="Flags_Openbsd${mcode64}" ;;
     *) echo "Unsupported $build build for mcode"; exit 1;;
   esac
   echo "Generate ortho_code-x86-flags.ads"

--- a/include/ghdl/libghw.h
+++ b/include/ghdl/libghw.h
@@ -1,0 +1,1 @@
+../../ghw/libghw.h

--- a/include/ghdl/synth.h
+++ b/include/ghdl/synth.h
@@ -1,0 +1,1 @@
+../../src/synth/include/synth.h

--- a/include/ghdl/synth_gates.h
+++ b/include/ghdl/synth_gates.h
@@ -1,0 +1,1 @@
+../.././src/synth/include/synth_gates.h

--- a/include/ghdl/vhpi_user.h
+++ b/include/ghdl/vhpi_user.h
@@ -1,0 +1,1 @@
+../../src/grt/vhpi_user.h

--- a/include/ghdl/vpi_user.h
+++ b/include/ghdl/vpi_user.h
@@ -1,0 +1,1 @@
+../../src/grt/vpi_user.h

--- a/src/ortho/mcode/memsegs_c.c
+++ b/src/ortho/mcode/memsegs_c.c
@@ -26,7 +26,7 @@
    set rights.
 */
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 #define MAP_ANONYMOUS MAP_ANON
 #else
 #define HAVE_MREMAP

--- a/src/ortho/mcode/ortho_code-x86-flags_openbsd.ads
+++ b/src/ortho/mcode/ortho_code-x86-flags_openbsd.ads
@@ -1,0 +1,35 @@
+--  X86 ABI flags.
+--  Copyright (C) 2006 Tristan Gingold
+--
+--  This program is free software: you can redistribute it and/or modify
+--  it under the terms of the GNU General Public License as published by
+--  the Free Software Foundation, either version 2 of the License, or
+--  (at your option) any later version.
+--
+--  This program is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--  GNU General Public License for more details.
+--
+--  You should have received a copy of the GNU General Public License
+--  along with this program.  If not, see <gnu.org/licenses>.
+with Interfaces; use Interfaces;
+
+package Ortho_Code.X86.Flags_Openbsd is
+   --  If true, OE_Alloca calls __chkstk (Windows), otherwise OE_Alloc
+   --  modifies ESP directly.
+   Flag_Alloca_Call : constant Boolean := False;
+
+   --  Prefered stack alignment.
+   --  Must be a power of 2.
+   Stack_Boundary : constant Unsigned_32 := 2 ** 4;
+
+   --  Alignment for double (64 bit float).
+   Mode_F64_Align : constant Natural := 2;
+
+   --  32 bits.
+   M64 : constant Boolean := False;
+
+   --  Not Windows x64 calling convention.
+   Win64 : constant Boolean := False;
+end Ortho_Code.X86.Flags_Openbsd;

--- a/src/ortho/mcode/ortho_code-x86-flags_openbsd64.ads
+++ b/src/ortho/mcode/ortho_code-x86-flags_openbsd64.ads
@@ -1,0 +1,35 @@
+--  X86 ABI flags.
+--  Copyright (C) 2006 Tristan Gingold
+--
+--  This program is free software: you can redistribute it and/or modify
+--  it under the terms of the GNU General Public License as published by
+--  the Free Software Foundation, either version 2 of the License, or
+--  (at your option) any later version.
+--
+--  This program is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--  GNU General Public License for more details.
+--
+--  You should have received a copy of the GNU General Public License
+--  along with this program.  If not, see <gnu.org/licenses>.
+with Interfaces; use Interfaces;
+
+package Ortho_Code.X86.Flags_Openbsd64 is
+   --  If true, OE_Alloca calls __chkstk (Windows), otherwise OE_Alloc
+   --  modifies ESP directly.
+   Flag_Alloca_Call : constant Boolean := False;
+
+   --  Prefered stack alignment.
+   --  Must be a power of 2.
+   Stack_Boundary : constant Unsigned_32 := 2 ** 4;
+
+   --  Alignment for double (64 bit float).
+   Mode_F64_Align : constant Natural := 3;
+
+   --  64 bits.
+   M64 : constant Boolean := True;
+
+   --  Not Windows x64 calling convention.
+   Win64 : constant Boolean := False;
+end Ortho_Code.X86.Flags_Openbsd64;

--- a/testsuite/gna/bug0101/testsuite.sh
+++ b/testsuite/gna/bug0101/testsuite.sh
@@ -4,7 +4,7 @@
 
 # Expect only one error.
 analyze_failure repro1.vhdl 2> repro1.err
-if ! diff repro1.err repro1.ref; then
+if ! ghdl_diff_stcr repro1.err repro1.ref; then
   echo "unexpected output"
   exit 1;
 fi

--- a/testsuite/gna/bug0101/testsuite.sh
+++ b/testsuite/gna/bug0101/testsuite.sh
@@ -4,7 +4,7 @@
 
 # Expect only one error.
 analyze_failure repro1.vhdl 2> repro1.err
-if ! diff --strip-trailing-cr repro1.err repro1.ref; then
+if ! diff repro1.err repro1.ref; then
   echo "unexpected output"
   exit 1;
 fi

--- a/testsuite/gna/bug0120/testsuite.sh
+++ b/testsuite/gna/bug0120/testsuite.sh
@@ -3,9 +3,9 @@
 . ../../testenv.sh
 
 $GHDL fmt --std=08 --level=space print1.vhdl > print1.out
-diff --strip-trailing-cr print1.ref print1.out
+diff print1.ref print1.out
 
 $GHDL fmt --std=08 --range=10:10 print1.vhdl > print2.out
-diff --strip-trailing-cr print2.ref print2.out
+diff print2.ref print2.out
 
 echo "Test successful"

--- a/testsuite/gna/bug0120/testsuite.sh
+++ b/testsuite/gna/bug0120/testsuite.sh
@@ -3,9 +3,9 @@
 . ../../testenv.sh
 
 $GHDL fmt --std=08 --level=space print1.vhdl > print1.out
-diff print1.ref print1.out
+ghdl_diff_stcr print1.ref print1.out
 
 $GHDL fmt --std=08 --range=10:10 print1.vhdl > print2.out
-diff print2.ref print2.out
+ghdl_diff_stcr print2.ref print2.out
 
 echo "Test successful"

--- a/testsuite/gna/bug0122/testsuite.sh
+++ b/testsuite/gna/bug0122/testsuite.sh
@@ -3,6 +3,6 @@
 . ../../testenv.sh
 
 analyze_failure tab1.vhdl 2> tab1.err
-diff tab1.ref tab1.err
+ghdl_diff_stcr tab1.ref tab1.err
 
 echo "Test successful"

--- a/testsuite/gna/bug0122/testsuite.sh
+++ b/testsuite/gna/bug0122/testsuite.sh
@@ -3,6 +3,6 @@
 . ../../testenv.sh
 
 analyze_failure tab1.vhdl 2> tab1.err
-diff --strip-trailing-cr tab1.ref tab1.err
+diff tab1.ref tab1.err
 
 echo "Test successful"

--- a/testsuite/gna/bug063/testsuite.sh
+++ b/testsuite/gna/bug063/testsuite.sh
@@ -3,7 +3,7 @@
 . ../../testenv.sh
 
 analyze_failure dff.vhdl 2> dff.out
-diff --strip-trailing-cr dff.out dff.expected
+diff dff.out dff.expected
 
 rm -f dff.out
 clean

--- a/testsuite/gna/bug063/testsuite.sh
+++ b/testsuite/gna/bug063/testsuite.sh
@@ -3,7 +3,7 @@
 . ../../testenv.sh
 
 analyze_failure dff.vhdl 2> dff.out
-diff dff.out dff.expected
+ghdl_diff_stcr dff.out dff.expected
 
 rm -f dff.out
 clean

--- a/testsuite/gna/issue1256/testsuite.sh
+++ b/testsuite/gna/issue1256/testsuite.sh
@@ -12,7 +12,7 @@ if c_compiler_is_available && ghdl_has_feature enum_test vpi; then
   $GHDL --vpi-link -v gcc -o vpi_plugin.vpi vpi_plugin.o
 
   simulate enum_test --vpi=./vpi_plugin.vpi > enum_test.out
-  diff enum_test.ref enum_test.out
+  ghdl_diff_stcr enum_test.ref enum_test.out
 
   rm -f vpi_plugin.vpi vpi_plugin.o
 fi

--- a/testsuite/gna/issue1256/testsuite.sh
+++ b/testsuite/gna/issue1256/testsuite.sh
@@ -12,7 +12,7 @@ if c_compiler_is_available && ghdl_has_feature enum_test vpi; then
   $GHDL --vpi-link -v gcc -o vpi_plugin.vpi vpi_plugin.o
 
   simulate enum_test --vpi=./vpi_plugin.vpi > enum_test.out
-  diff --strip-trailing-cr enum_test.ref enum_test.out
+  diff enum_test.ref enum_test.out
 
   rm -f vpi_plugin.vpi vpi_plugin.o
 fi

--- a/testsuite/gna/issue1771/testsuite.sh
+++ b/testsuite/gna/issue1771/testsuite.sh
@@ -8,7 +8,7 @@ elab_simulate tf
 
 analyze add_carry_ghdl_testbench.vhdl
 elab_simulate add_carry_ghdl_testbench > add_carry_testbench.out
-diff --strip-trailing-cr add_carry_testbench.ref add_carry_testbench.out
+diff add_carry_testbench.ref add_carry_testbench.out
 
 clean
 

--- a/testsuite/gna/issue1771/testsuite.sh
+++ b/testsuite/gna/issue1771/testsuite.sh
@@ -8,7 +8,7 @@ elab_simulate tf
 
 analyze add_carry_ghdl_testbench.vhdl
 elab_simulate add_carry_ghdl_testbench > add_carry_testbench.out
-diff add_carry_testbench.ref add_carry_testbench.out
+ghdl_diff_stcr add_carry_testbench.ref add_carry_testbench.out
 
 clean
 

--- a/testsuite/gna/issue394/testsuite.sh
+++ b/testsuite/gna/issue394/testsuite.sh
@@ -4,7 +4,7 @@
 
 analyze bug.vhdl
 elab_simulate bug > out.txt 2> err.txt
-diff --strip-trailing-cr -q out.txt out.ref
+diff -q out.txt out.ref
 
 rm -f out.txt err.txt
 clean

--- a/testsuite/gna/issue394/testsuite.sh
+++ b/testsuite/gna/issue394/testsuite.sh
@@ -4,7 +4,7 @@
 
 analyze bug.vhdl
 elab_simulate bug > out.txt 2> err.txt
-diff -q out.txt out.ref
+ghdl_diff_stcr -q out.txt out.ref
 
 rm -f out.txt err.txt
 clean

--- a/testsuite/gna/issue450/testsuite.sh
+++ b/testsuite/gna/issue450/testsuite.sh
@@ -12,7 +12,7 @@ if c_compiler_is_available && ghdl_has_feature disptree vpi; then
   $GHDL --vpi-link -v gcc -o vpi2.vpi vpi2.o
 
   simulate disptree --vpi=./vpi2.vpi | tee disptree.out
-  diff --strip-trailing-cr -q disptree.ref disptree.out
+  diff -q disptree.ref disptree.out
 
   rm -f vpi2.o vpi2.vpi disptree.out
 fi

--- a/testsuite/gna/issue672/testsuite.sh
+++ b/testsuite/gna/issue672/testsuite.sh
@@ -10,7 +10,7 @@ if ! simulate --time-resolution=fs sqrtb --stop-time=1us; then
     echo "skip --time-resolution tests"
 else
     simulate --time-resolution=ns sqrtb --stop-time=1us --disp-time | sed -e 's/.*info/info/' > sqrtb.out
-    diff --strip-trailing-cr sqrtb.ref sqrtb.out
+    diff sqrtb.ref sqrtb.out
 fi
 
 rm -f sqrtb.out

--- a/testsuite/gna/issue672/testsuite.sh
+++ b/testsuite/gna/issue672/testsuite.sh
@@ -10,7 +10,7 @@ if ! simulate --time-resolution=fs sqrtb --stop-time=1us; then
     echo "skip --time-resolution tests"
 else
     simulate --time-resolution=ns sqrtb --stop-time=1us --disp-time | sed -e 's/.*info/info/' > sqrtb.out
-    diff sqrtb.ref sqrtb.out
+    ghdl_diff_stcr sqrtb.ref sqrtb.out
 fi
 
 rm -f sqrtb.out

--- a/testsuite/gna/issue685/testsuite.sh
+++ b/testsuite/gna/issue685/testsuite.sh
@@ -9,7 +9,7 @@ elab wb_demux_tb
 if ghdl_has_feature wb_demux_tb ghw; then
   simulate wb_demux_tb --trace-signals | 
     grep wb_demux_tb | cut -d ' ' -f 1,3- > tb.out
-  diff tb.out tb.ref
+  ghdl_diff_stcr tb.out tb.ref
 fi
 
 rm -f tb.out

--- a/testsuite/gna/issue685/testsuite.sh
+++ b/testsuite/gna/issue685/testsuite.sh
@@ -9,7 +9,7 @@ elab wb_demux_tb
 if ghdl_has_feature wb_demux_tb ghw; then
   simulate wb_demux_tb --trace-signals | 
     grep wb_demux_tb | cut -d ' ' -f 1,3- > tb.out
-  diff --strip-trailing-cr tb.out tb.ref
+  diff tb.out tb.ref
 fi
 
 rm -f tb.out

--- a/testsuite/gna/issue719/testsuite.sh
+++ b/testsuite/gna/issue719/testsuite.sh
@@ -3,7 +3,7 @@
 . ../../testenv.sh
 
 analyze tb.vhdl 2> tb.out
-diff -q tb.ref tb.out
+ghdl_diff_stcr -q tb.ref tb.out
 
 rm -f tb.out
 clean

--- a/testsuite/gna/issue719/testsuite.sh
+++ b/testsuite/gna/issue719/testsuite.sh
@@ -3,7 +3,7 @@
 . ../../testenv.sh
 
 analyze tb.vhdl 2> tb.out
-diff --strip-trailing-cr -q tb.ref tb.out
+diff -q tb.ref tb.out
 
 rm -f tb.out
 clean

--- a/testsuite/gna/issue880/testsuite.sh
+++ b/testsuite/gna/issue880/testsuite.sh
@@ -8,7 +8,7 @@ elab psl
 if ghdl_has_feature psl psl; then
   simulate psl --psl-report=psl.out
 
-  if ! diff --strip-trailing-cr psl.out psl.ref > /dev/null; then
+  if ! diff psl.out psl.ref > /dev/null; then
       echo "report mismatch"
       exit 1
   fi
@@ -24,7 +24,7 @@ elab -fpsl psl
 if ghdl_has_feature psl psl; then
   simulate psl --psl-report=psl.out
 
-  diff --strip-trailing-cr -q psl.out psl.ref
+  diff -q psl.out psl.ref
 
   rm -f psl.out
 fi

--- a/testsuite/gna/issue880/testsuite.sh
+++ b/testsuite/gna/issue880/testsuite.sh
@@ -8,7 +8,7 @@ elab psl
 if ghdl_has_feature psl psl; then
   simulate psl --psl-report=psl.out
 
-  if ! diff psl.out psl.ref > /dev/null; then
+  if ! ghdl_diff_stcr psl.out psl.ref > /dev/null; then
       echo "report mismatch"
       exit 1
   fi
@@ -24,7 +24,7 @@ elab -fpsl psl
 if ghdl_has_feature psl psl; then
   simulate psl --psl-report=psl.out
 
-  diff -q psl.out psl.ref
+  ghdl_diff_stcr -q psl.out psl.ref
 
   rm -f psl.out
 fi

--- a/testsuite/gna/ticket24/testsuite.sh
+++ b/testsuite/gna/ticket24/testsuite.sh
@@ -8,7 +8,7 @@ elab psl
 if ghdl_has_feature psl psl; then
   simulate psl --psl-report=psl.out
 
-  if ! diff --strip-trailing-cr psl.out psl.ref > /dev/null; then
+  if ! diff psl.out psl.ref > /dev/null; then
       echo "report mismatch"
       exit 1
   fi
@@ -24,7 +24,7 @@ elab -fpsl psl
 if ghdl_has_feature psl psl; then
   simulate psl --psl-report=psl.out
 
-  diff --strip-trailing-cr -q psl.out psl.ref
+  diff -q psl.out psl.ref
 
   rm -f psl.out
 fi

--- a/testsuite/gna/ticket24/testsuite.sh
+++ b/testsuite/gna/ticket24/testsuite.sh
@@ -8,7 +8,7 @@ elab psl
 if ghdl_has_feature psl psl; then
   simulate psl --psl-report=psl.out
 
-  if ! diff psl.out psl.ref > /dev/null; then
+  if ! ghdl_diff_stcr psl.out psl.ref > /dev/null; then
       echo "report mismatch"
       exit 1
   fi
@@ -24,7 +24,7 @@ elab -fpsl psl
 if ghdl_has_feature psl psl; then
   simulate psl --psl-report=psl.out
 
-  diff -q psl.out psl.ref
+  ghdl_diff_stcr -q psl.out psl.ref
 
   rm -f psl.out
 fi

--- a/testsuite/synth/issue1428/testsuite.sh
+++ b/testsuite/synth/issue1428/testsuite.sh
@@ -5,7 +5,7 @@
 for t in rec1 rec2 rec3 repro1 repro2 repro3 repro4b repro4 repro5b repro5 repro6
 do
     synth --expect-failure $t.vhdl -e 2>&1 | grep $t.vhdl: > $t.out
-    diff --strip-trailing-cr $t.out $t.ref
+    diff $t.out $t.ref
 done
 
 echo "Test successful"

--- a/testsuite/synth/issue1428/testsuite.sh
+++ b/testsuite/synth/issue1428/testsuite.sh
@@ -5,7 +5,7 @@
 for t in rec1 rec2 rec3 repro1 repro2 repro3 repro4b repro4 repro5b repro5 repro6
 do
     synth --expect-failure $t.vhdl -e 2>&1 | grep $t.vhdl: > $t.out
-    diff $t.out $t.ref
+    ghdl_diff_stcr $t.out $t.ref
 done
 
 echo "Test successful"

--- a/testsuite/synth/sns01/testsuite.sh
+++ b/testsuite/synth/sns01/testsuite.sh
@@ -14,7 +14,7 @@ for f in adds subs unaries muls cmplt cmple cmpgt cmpge cmpeq cmpne shrs exts; d
     analyze tb_$f.vhdl
     elab_simulate tb_$f > $f.out
 
-    diff $f.out $f.ref
+    ghdl_diff_stcr $f.out $f.ref
 done
 
 for t in sns01; do

--- a/testsuite/synth/sns01/testsuite.sh
+++ b/testsuite/synth/sns01/testsuite.sh
@@ -14,7 +14,7 @@ for f in adds subs unaries muls cmplt cmple cmpgt cmpge cmpeq cmpne shrs exts; d
     analyze tb_$f.vhdl
     elab_simulate tb_$f > $f.out
 
-    diff --strip-trailing-cr $f.out $f.ref
+    diff $f.out $f.ref
 done
 
 for t in sns01; do

--- a/testsuite/synth/snsuns01/testsuite.sh
+++ b/testsuite/synth/snsuns01/testsuite.sh
@@ -15,7 +15,7 @@ for s in u s; do
         analyze tb_$f.vhdl
         elab_simulate tb_$f > $s$f.out
 
-        diff $s$f.out $s$f.ref
+        ghdl_diff_stcr $s$f.out $s$f.ref
     done
 
   clean

--- a/testsuite/synth/snsuns01/testsuite.sh
+++ b/testsuite/synth/snsuns01/testsuite.sh
@@ -15,7 +15,7 @@ for s in u s; do
         analyze tb_$f.vhdl
         elab_simulate tb_$f > $s$f.out
 
-        diff --strip-trailing-cr $s$f.out $s$f.ref
+        diff $s$f.out $s$f.ref
     done
 
   clean

--- a/testsuite/testenv.sh
+++ b/testsuite/testenv.sh
@@ -124,7 +124,7 @@ ghw_dump ()
 ghw_diff ()
 {
   ghw_dump "$1"
-  if diff --strip-trailing-cr "$1".txt golden_"$1".txt; then
+  if diff "$1".txt golden_"$1".txt; then
     echo "The ghw dump matches."
   else
     echo "The ghw dump does not match what is expected."

--- a/testsuite/testenv.sh
+++ b/testsuite/testenv.sh
@@ -243,3 +243,16 @@ clean ()
     esac
   fi
 }
+
+
+# Try to call diff with --strip-trailing-cr; if the option is not
+# available resort to ignore the switch.  This is for handling UNIX
+# and DOS EOL.
+ghdl_diff_stcr ()
+{
+    if diff --strip-trailing-cr -q /dev/null /dev/null; then
+	diff --strip-trailing-cr $@
+    else
+	diff $@
+    fi
+}

--- a/testsuite/testsuite.sh
+++ b/testsuite/testsuite.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # Stop in case of error
 set -e

--- a/testsuite/vpi/vpi001/vpi1.c
+++ b/testsuite/vpi/vpi001/vpi1.c
@@ -31,8 +31,9 @@ vpi_proc (void)
      //"myentity.genstring", -- Not supported
      //"myentity.conststring" -- Not supported
     };
+  int name_index;
                        
-  for (int name_index=0; name_index<N_NAMES; name_index+=1) {
+  for (name_index=0; name_index<N_NAMES; name_index+=1) {
     printf ("Trying to find name %s\n", names[name_index]);
     net = vpi_handle_by_name (names[name_index], NULL);
     if (net == NULL)

--- a/testsuite/vpi/vpi002/vpi1.c
+++ b/testsuite/vpi/vpi002/vpi1.c
@@ -46,8 +46,9 @@ vpi_proc (void)
      //"myentity.sigarray5[0]", // Not supported
      //"myentity.portarray5[0]" // Not supported
     };
+  int name_index;
                        
-  for (int name_index=0; name_index<N_NAMES; name_index+=1) {
+  for (name_index=0; name_index<N_NAMES; name_index+=1) {
     printf ("Trying to find name %s\n", names[name_index]);
     net = vpi_handle_by_name (names[name_index], NULL);
     if (net == NULL)

--- a/testsuite/vpi/vpi003/vpi1.c
+++ b/testsuite/vpi/vpi003/vpi1.c
@@ -21,8 +21,9 @@ vpi_proc (void)
      //"myentity.genarray1",
      //"myentity.constarray1"
     };
+  int name_index;
                        
-  for (int name_index=0; name_index<N_NAMES; name_index+=1) {
+  for (name_index=0; name_index<N_NAMES; name_index+=1) {
     printf ("Trying to find name %s\n", names[name_index]);
     net = vpi_handle_by_name (names[name_index], NULL);
     if (net == NULL)

--- a/testsuite/vpi/vpi004/vpi1.c
+++ b/testsuite/vpi/vpi004/vpi1.c
@@ -6,6 +6,7 @@ void
 vpi_proc (void)
 {
   s_vpi_vlog_info info;
+  int i;
   printf ("Trying to get vlog_info\n");
   int ret = vpi_get_vlog_info(&info);
   if (ret != 1) {
@@ -19,7 +20,7 @@ vpi_proc (void)
   }
   printf ("Argc: %d\n", info.argc);
 
-  for (int i = 0; i < info.argc; i++) {
+  for (i = 0; i < info.argc; i++) {
    printf ("Argv[%d]: %s\n", i, info.argv[i]);
   }
 


### PR DESCRIPTION
**Description**
Quick port to OpenBSD (6.9, AMD64) to use the mcode backend.  Test suite passes.

There are some egregious fixes here to make the test suite work on OpenBSD, like removing `--strip-trailing-cr` to diff, fixing some C99 specific things (OpenBSD defaults to C90) and other misc. changes.

The changes specifically to get GHDL working on OpenBSD are: 76fb1cf9d3a6d59fab5127b47f22ab08f2eaa801, 236ef20f39a7f519079e7ad6316b00a747980602  and 51d78ee6ffdcf308f2ee74f3d6f285eae595f02c.

Log files:

[configure.txt](https://github.com/ghdl/ghdl/files/6630447/configure.txt)
[testsuite.txt](https://github.com/ghdl/ghdl/files/6630445/testsuite.txt)
[compile.txt](https://github.com/ghdl/ghdl/files/6630446/compile.txt)


