### PR TITLE
pyGHDL/cli/DOM: support passing target files as CLI arguments

### DIFF
--- a/pyGHDL/cli/DOM.py
+++ b/pyGHDL/cli/DOM.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+
+from sys import argv
+
 from pathlib import Path
 
 from pydecor import export
@@ -35,13 +39,21 @@ class Application:
 
 
 def main():
-    try:
-        app = Application()
-        app.addFile(Path("testsuite/pyunit/SimpleEntity.vhdl"), "default_lib")
-    except GHDLBaseException as ex:
-        print(ex)
+    items = argv[1:]
+    if len(items) < 1:
+        print("Please, provide the files to be analyzed as CLI arguments.")
+        print("Using <testsuite/pyunit/SimpleEntity.vhdl> for demo purposes.\n")
+        items = ["testsuite/pyunit/SimpleEntity.vhdl"]
 
-    app.prettyPrint()
+    for item in items:
+        print("·", item)
+        try:
+            app = Application()
+            app.addFile(Path(item), "default_lib")
+        except GHDLBaseException as ex:
+            print(ex)
+
+        app.prettyPrint()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a minor update to the DOM cli example, which allows passing the files to be analysed through CLI arguments, instead of hardcoding it. As a result, this script can be used for testing how are the VHDL sources in this repo supported by the VHDLModel implementation:

```sh
# find ./ -type f -name "*.vhdl" | xargs ./pyGHDL/cli/DOM.py 
· ./doc/quick_start/simulation/adder/adder.vhdl

raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : vhdl-nodes.adb:861
· ./testsuite/gna/bug084/func_test3.vhdl
Unknown declared item kind 'Type_Declaration'(91) in architecture 'fum'.

· ./testsuite/gna/bug084/mod5.vhdl
Unknown declared item kind 'Type_Declaration'(91) in architecture 'foo'.

· ./testsuite/gna/bug084/mod5x.vhdl

raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : vhdl-nodes.adb:861
· ./testsuite/gna/issue652/ent.vhdl

raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : vhdl-nodes.adb:861
· ./testsuite/synth/issue1107/unconnected.vhdl

raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : vhdl-nodes.adb:861
· ./testsuite/synth/synth60/leds_wrapper_arch_comp_inst.vhdl
Unknown declared item kind 'Component_Declaration'(99) in architecture 'rtl_comp_inst'.

· ./testsuite/synth/synth60/leds_wrapper_arch_entity_inst.vhdl
Document 'testsuite/synth/synth60/leds_wrapper_arch_entity_inst.vhdl':
  Entities:
  Architectures:
  - rtl_comp_inst
    Declared:
  Packages:
  PackageBodies:
  Configurations:
  Contexts:
· ./testsuite/synth/synth60/spin1.vhdl

raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : vhdl-nodes.adb:861
```

Or, for working around the assertion failures:

```sh
# find ./ -type f -name "*.vhdl" | xargs -L 1 ./pyGHDL/cli/DOM.py 
```