### PR TITLE
Python-C/Ada Bindings - Updated decorator

### DIFF
--- a/pyGHDL/cli/DOM.py
+++ b/pyGHDL/cli/DOM.py
@@ -28,13 +28,13 @@ class Application:
         self._design.Documents.append(document)
 
     def prettyPrint(self):
-        buffer = []
-
         PP = PrettyPrint()
 
-        for doc in self._design.Documents:
-            for line in PP.formatDocument(doc):
-                buffer.append(line)
+        buffer = []
+
+        buffer.append("Design:")
+        for line in PP.formatDesign(self._design, 1):
+            buffer.append(line)
 
         print("\n".join(buffer))
 

--- a/pyGHDL/dom/Aggregates.py
+++ b/pyGHDL/dom/Aggregates.py
@@ -41,6 +41,8 @@ This module contains all DOM classes for VHDL's design units (:class:`context <E
 """
 from pydecor import export
 
+from pyGHDL.dom.Range import Range
+from pyGHDL.dom.Symbol import EnumerationLiteralSymbol
 from pyVHDLModel.VHDLModel import (
     SimpleAggregateElement as VHDLModel_SimpleAggregateElement,
     IndexedAggregateElement as VHDLModel_IndexedAggregateElement,
@@ -63,19 +65,30 @@ class SimpleAggregateElement(VHDLModel_SimpleAggregateElement):
 
 @export
 class IndexedAggregateElement(VHDLModel_IndexedAggregateElement):
-	pass
+    def __init__(self, index: Expression, expression: Expression):
+        super().__init__()
+        self._index = index
+        self._expression = expression
 
 
 @export
 class RangedAggregateElement(VHDLModel_RangedAggregateElement):
-	pass
+    def __init__(self, r: Range, expression: Expression):
+        super().__init__()
+        self._range = r
+        self._expression = expression
 
 
 @export
 class NamedAggregateElement(VHDLModel_NamedAggregateElement):
-    pass
+    def __init__(self, name: EnumerationLiteralSymbol, expression: Expression):
+        super().__init__()
+        self._name = name
+        self._expression = expression
 
 
 @export
 class OthersAggregateElement(VHDLModel_OthersAggregateElement):
-	pass
+    def __init__(self, expression: Expression):
+        super().__init__()
+        self._expression = expression

--- a/pyGHDL/dom/Aggregates.py
+++ b/pyGHDL/dom/Aggregates.py
@@ -9,7 +9,7 @@
 # Authors:
 #   Patrick Lehmann
 #
-# Package module:   DOM: Interface items (e.g. generic or port)
+# Package module:   DOM: VHDL design units (e.g. context or package).
 #
 # License:
 # ============================================================================
@@ -30,54 +30,52 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+
+"""
+This module contains all DOM classes for VHDL's design units (:class:`context <Entity>`,
+:class:`architecture <Architecture>`, :class:`package <Package>`,
+:class:`package body <PackageBody>`, :class:`context <Context>` and
+:class:`configuration <Configuration>`.
+
+
+"""
 from pydecor import export
 
-from typing import List
-
-from pyGHDL.dom._Utils import NodeToName
 from pyVHDLModel.VHDLModel import (
-    SimpleSubTypeSymbol as VHDLModel_SimpleSubTypeSymbol,
-    ConstrainedSubTypeSymbol as VHDLModel_ConstrainedSubTypeSymbol,
-    EnumerationLiteralSymbol as VHDLModel_EnumerationLiteralSymbol,
-    SimpleObjectSymbol as VHDLModel_SimpleObjectSymbol,
-    Constraint,
+    SimpleAggregateElement as VHDLModel_SimpleAggregateElement,
+    IndexedAggregateElement as VHDLModel_IndexedAggregateElement,
+    RangedAggregateElement as VHDLModel_RangedAggregateElement,
+    NamedAggregateElement as VHDLModel_NamedAggregateElement,
+    OthersAggregateElement as VHDLModel_OthersAggregateElement, Expression
 )
+
 
 __all__ = []
 
 
-@export
-class EnumerationLiteralSymbol(VHDLModel_EnumerationLiteralSymbol):
-    def __init__(self, literalName: str):
-        super().__init__(symbolName=literalName)
-
 
 @export
-class SimpleSubTypeSymbol(VHDLModel_SimpleSubTypeSymbol):
-    def __init__(self, subTypeName: str):
-        super().__init__(subTypeName=subTypeName)
-
-    @classmethod
-    def parse(cls, node):
-        pass
+class SimpleAggregateElement(VHDLModel_SimpleAggregateElement):
+    def __init__(self, expression: Expression):
+        super().__init__()
+        self._expression = expression
 
 
 @export
-class ConstrainedSubTypeSymbol(VHDLModel_ConstrainedSubTypeSymbol):
-    def __init__(self, subTypeName: str, constraints: List[Constraint] = None):
-        super().__init__(subTypeName=subTypeName, constraints=constraints)
-
-    @classmethod
-    def parse(cls, node):
-        pass
+class IndexedAggregateElement(VHDLModel_IndexedAggregateElement):
+	pass
 
 
 @export
-class SimpleObjectSymbol(VHDLModel_SimpleObjectSymbol):
-    def __init__(self, symbolName: str):
-        super().__init__(symbolName)
+class RangedAggregateElement(VHDLModel_RangedAggregateElement):
+	pass
 
-    @classmethod
-    def parse(cls, node):
-        name = NodeToName(node)
-        return cls(name)
+
+@export
+class NamedAggregateElement(VHDLModel_NamedAggregateElement):
+    pass
+
+
+@export
+class OthersAggregateElement(VHDLModel_OthersAggregateElement):
+	pass

--- a/pyGHDL/dom/Aggregates.py
+++ b/pyGHDL/dom/Aggregates.py
@@ -48,12 +48,12 @@ from pyVHDLModel.VHDLModel import (
     IndexedAggregateElement as VHDLModel_IndexedAggregateElement,
     RangedAggregateElement as VHDLModel_RangedAggregateElement,
     NamedAggregateElement as VHDLModel_NamedAggregateElement,
-    OthersAggregateElement as VHDLModel_OthersAggregateElement, Expression
+    OthersAggregateElement as VHDLModel_OthersAggregateElement,
+    Expression,
 )
 
 
 __all__ = []
-
 
 
 @export

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -41,7 +41,8 @@ This module contains all DOM classes for VHDL's design units (:class:`context <E
 """
 from pydecor import export
 
-from pyVHDLModel.VHDLModel import Entity as VHDLModel_Entity
+from pyGHDL.dom.Symbol import EntitySymbol
+from pyVHDLModel.VHDLModel import Entity as VHDLModel_Entity, EntityOrSymbol
 from pyVHDLModel.VHDLModel import Architecture as VHDLModel_Architecture
 from pyVHDLModel.VHDLModel import Package as VHDLModel_Package
 from pyVHDLModel.VHDLModel import PackageBody as VHDLModel_PackageBody
@@ -87,17 +88,18 @@ class Entity(VHDLModel_Entity, GHDLMixin):
 
 @export
 class Architecture(VHDLModel_Architecture, GHDLMixin):
-    def __init__(self, name: str, entityName: str):
+    def __init__(self, name: str, entity: EntityOrSymbol):
         super().__init__(name)
 
-        self.__entityName = entityName
+        self._entity = entity
 
     @classmethod
     def parse(cls, libraryUnit):
         name = NodeToName(libraryUnit)
         entityName = NodeToName(nodes.Get_Entity_Name(libraryUnit))
+        entity = EntitySymbol(entityName)
 
-        architecture = cls(name, entityName)
+        architecture = cls(name, entity)
 
         for item in GetDeclaredItemsFromChainedNodes(
             nodes.Get_Declaration_Chain(libraryUnit), "architecture", name

--- a/pyGHDL/dom/Expression.py
+++ b/pyGHDL/dom/Expression.py
@@ -401,5 +401,5 @@ class Aggregate(VHDLModel_Aggregate):
                     )
                 )
 
-        return choices
+        return cls(choices)
 

--- a/pyGHDL/dom/Expression.py
+++ b/pyGHDL/dom/Expression.py
@@ -52,6 +52,7 @@ from pyVHDLModel.VHDLModel import (
     IdentityExpression as VHDLModel_IdentityExpression,
     NegationExpression as VHDLModel_NegationExpression,
     AbsoluteExpression as VHDLModel_AbsoluteExpression,
+    ParenthesisExpression as VHDLModel_ParenthesisExpression,
     TypeConversion as VHDLModel_TypeConversion,
     FunctionCall as VHDLModel_FunctionCall,
     QualifiedExpression as VHDLModel_QualifiedExpression,
@@ -133,6 +134,20 @@ class AbsoluteExpression(VHDLModel_AbsoluteExpression, _ParseUnaryExpression):
     def __init__(self, operand: Expression):
         super().__init__()
         self._operand = operand
+
+
+@export
+class ParenthesisExpression(VHDLModel_ParenthesisExpression, _ParseUnaryExpression):
+    def __init__(self, operand: Expression):
+        super().__init__()
+        self._operand = operand
+
+    @classmethod
+    def parse(cls, node):
+        from pyGHDL.dom._Translate import GetExpressionFromNode
+
+        operand = GetExpressionFromNode(nodes.Get_Expression(node))
+        return cls(operand)
 
 
 @export

--- a/pyGHDL/dom/Expression.py
+++ b/pyGHDL/dom/Expression.py
@@ -32,7 +32,13 @@
 # ============================================================================
 from typing import List
 
-from pyGHDL.dom.Aggregates import OthersAggregateElement, SimpleAggregateElement, RangedAggregateElement, IndexedAggregateElement, NamedAggregateElement
+from pyGHDL.dom.Aggregates import (
+    OthersAggregateElement,
+    SimpleAggregateElement,
+    RangedAggregateElement,
+    IndexedAggregateElement,
+    NamedAggregateElement,
+)
 from pyGHDL.dom.Symbol import EnumerationLiteralSymbol
 from pyGHDL.libghdl import utils
 
@@ -75,7 +81,8 @@ from pyVHDLModel.VHDLModel import (
     RotateRightExpression as VHDLModel_RotateRightExpression,
     RotateLeftExpression as VHDLModel_RotateLeftExpression,
     Aggregate as VHDLModel_Aggregate,
-    Expression, AggregateElement,
+    Expression,
+    AggregateElement,
 )
 
 __all__ = []
@@ -402,4 +409,3 @@ class Aggregate(VHDLModel_Aggregate):
                 )
 
         return cls(choices)
-

--- a/pyGHDL/dom/Literal.py
+++ b/pyGHDL/dom/Literal.py
@@ -57,7 +57,7 @@ class FloatingPointLiteral(VHDLModel_FloatingPointLiteral):
     @classmethod
     def parse(cls, node):
         value = nodes.Get_Fp_Value(node)
-        return cls(float(value))
+        return cls(value)
 
 
 @export

--- a/pyGHDL/dom/Misc.py
+++ b/pyGHDL/dom/Misc.py
@@ -52,7 +52,7 @@ from pyGHDL.libghdl import (
     LibGHDLException,
     utils,
 )
-from pyGHDL.libghdl.vhdl import nodes, sem_lib
+from pyGHDL.libghdl.vhdl import nodes, sem_lib, parse
 
 from pyGHDL.dom._Utils import GetIirKindOfNode
 from pyGHDL.dom.Common import DOMException, GHDLMixin
@@ -85,6 +85,8 @@ class Design(VHDLModel_Design):
         errorout_memory.Install_Handler()
 
         libghdl.set_option("--std=08")
+
+        parse.Flag_Parse_Parenthesis.value = True
 
         # Finish initialization. This will load the standard package.
         if libghdl.analyze_init_status() != 0:

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -36,6 +36,7 @@ from typing import List
 
 from pyGHDL.dom._Utils import NodeToName
 from pyVHDLModel.VHDLModel import (
+    EntitySymbol as VHDLModel_EntitySymbol,
     SimpleSubTypeSymbol as VHDLModel_SimpleSubTypeSymbol,
     ConstrainedSubTypeSymbol as VHDLModel_ConstrainedSubTypeSymbol,
     EnumerationLiteralSymbol as VHDLModel_EnumerationLiteralSymbol,
@@ -44,6 +45,12 @@ from pyVHDLModel.VHDLModel import (
 )
 
 __all__ = []
+
+
+@export
+class EntitySymbol(VHDLModel_EntitySymbol):
+    def __init__(self, entityName: str):
+        super().__init__(entityName)
 
 
 @export

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -81,9 +81,6 @@ class ConstrainedSubTypeSymbol(VHDLModel_ConstrainedSubTypeSymbol):
 
 @export
 class SimpleObjectSymbol(VHDLModel_SimpleObjectSymbol):
-    def __init__(self, symbolName: str):
-        super().__init__(symbolName)
-
     @classmethod
     def parse(cls, node):
         name = NodeToName(node)

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -56,6 +56,7 @@ from pyGHDL.dom.Expression import (
     ExponentiationExpression,
     Aggregate,
     NegationExpression,
+    ParenthesisExpression,
 )
 
 __all__ = []
@@ -134,6 +135,7 @@ __EXPRESSION_TRANSLATION = {
     nodes.Iir_Kind.Negation_Operator: NegationExpression,
     nodes.Iir_Kind.Addition_Operator: AdditionExpression,
     nodes.Iir_Kind.Not_Operator: InverseExpression,
+    nodes.Iir_Kind.Parenthesis_Expression: ParenthesisExpression,
     nodes.Iir_Kind.Substraction_Operator: SubtractionExpression,
     nodes.Iir_Kind.Multiplication_Operator: MultiplyExpression,
     nodes.Iir_Kind.Division_Operator: DivisionExpression,

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -53,7 +53,8 @@ from pyGHDL.dom.Expression import (
     MultiplyExpression,
     DivisionExpression,
     InverseExpression,
-    ExponentiationExpression, Aggregate,
+    ExponentiationExpression,
+    Aggregate,
 )
 
 __all__ = []

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -53,7 +53,7 @@ from pyGHDL.dom.Expression import (
     MultiplyExpression,
     DivisionExpression,
     InverseExpression,
-    ExponentiationExpression,
+    ExponentiationExpression, Aggregate,
 )
 
 __all__ = []
@@ -135,7 +135,7 @@ __EXPRESSION_TRANSLATION = {
     nodes.Iir_Kind.Multiplication_Operator: MultiplyExpression,
     nodes.Iir_Kind.Division_Operator: DivisionExpression,
     nodes.Iir_Kind.Exponentiation_Operator: ExponentiationExpression,
-    #    nodes.Iir_Kind.Aggregate: Aggregate
+    nodes.Iir_Kind.Aggregate: Aggregate,
 }
 
 

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -55,6 +55,7 @@ from pyGHDL.dom.Expression import (
     InverseExpression,
     ExponentiationExpression,
     Aggregate,
+    NegationExpression,
 )
 
 __all__ = []
@@ -130,8 +131,9 @@ __EXPRESSION_TRANSLATION = {
     nodes.Iir_Kind.Integer_Literal: IntegerLiteral,
     nodes.Iir_Kind.Floating_Point_Literal: FloatingPointLiteral,
     nodes.Iir_Kind.Character_Literal: CharacterLiteral,
-    nodes.Iir_Kind.Negation_Operator: InverseExpression,
+    nodes.Iir_Kind.Negation_Operator: NegationExpression,
     nodes.Iir_Kind.Addition_Operator: AdditionExpression,
+    nodes.Iir_Kind.Not_Operator: InverseExpression,
     nodes.Iir_Kind.Substraction_Operator: SubtractionExpression,
     nodes.Iir_Kind.Multiplication_Operator: MultiplyExpression,
     nodes.Iir_Kind.Division_Operator: DivisionExpression,

--- a/pyGHDL/dom/formatting/prettyprint.py
+++ b/pyGHDL/dom/formatting/prettyprint.py
@@ -2,7 +2,13 @@ from typing import List, Union
 
 from pydecor import export
 
-from pyGHDL.dom.Aggregates import SimpleAggregateElement, IndexedAggregateElement, RangedAggregateElement, NamedAggregateElement, OthersAggregateElement
+from pyGHDL.dom.Aggregates import (
+    SimpleAggregateElement,
+    IndexedAggregateElement,
+    RangedAggregateElement,
+    NamedAggregateElement,
+    OthersAggregateElement,
+)
 from pyGHDL.dom.Object import Constant, Signal
 from pyGHDL.dom.Range import Range
 from pyVHDLModel.VHDLModel import (
@@ -16,7 +22,7 @@ from pyVHDLModel.VHDLModel import (
     IdentityExpression,
     UnaryExpression,
     WithDefaultExpression,
-    AggregateElement
+    AggregateElement,
 )
 
 from pyGHDL import GHDLBaseException
@@ -48,7 +54,8 @@ from pyGHDL.dom.Expression import (
     InverseExpression,
     AbsoluteExpression,
     NegationExpression,
-    ExponentiationExpression, Aggregate,
+    ExponentiationExpression,
+    Aggregate,
 )
 
 StringBuffer = List[str]
@@ -323,7 +330,10 @@ class PrettyPrint:
             return "{type}".format(type=subTypeIndication.SymbolName)
         elif isinstance(subTypeIndication, ConstrainedSubTypeSymbol):
             constraints = ", ".join(
-                [self.formatRange(constraint.Range) for constraint in subTypeIndication.Constraints]
+                [
+                    self.formatRange(constraint.Range)
+                    for constraint in subTypeIndication.Constraints
+                ]
             )
 
             return "{type}({constraints})".format(
@@ -379,7 +389,14 @@ class PrettyPrint:
                 operator=operator,
             )
         elif isinstance(expression, Aggregate):
-            return "({choices})".format(choices=", ".join([self.formatAggregateElement(element) for element in expression.Elements]))
+            return "({choices})".format(
+                choices=", ".join(
+                    [
+                        self.formatAggregateElement(element)
+                        for element in expression.Elements
+                    ]
+                )
+            )
         else:
             raise PrettyPrintException("Unhandled expression kind.")
 
@@ -391,17 +408,17 @@ class PrettyPrint:
         elif isinstance(aggregateElement, IndexedAggregateElement):
             return "{index} => {value}".format(
                 index=self.formatExpression(aggregateElement.Index),
-                value=self.formatExpression(aggregateElement.Expression)
+                value=self.formatExpression(aggregateElement.Expression),
             )
         elif isinstance(aggregateElement, RangedAggregateElement):
             return "{range} => {value}".format(
                 range=self.formatRange(aggregateElement.Range),
-                value=self.formatExpression(aggregateElement.Expression)
+                value=self.formatExpression(aggregateElement.Expression),
             )
         elif isinstance(aggregateElement, NamedAggregateElement):
             return "{name} => {value}".format(
                 name=aggregateElement.Name,
-                value=self.formatExpression(aggregateElement.Expression)
+                value=self.formatExpression(aggregateElement.Expression),
             )
         elif isinstance(aggregateElement, OthersAggregateElement):
             return "other => {value}".format(

--- a/pyGHDL/dom/formatting/prettyprint.py
+++ b/pyGHDL/dom/formatting/prettyprint.py
@@ -45,7 +45,7 @@ from pyGHDL.dom.Expression import (
     InverseExpression,
     AbsoluteExpression,
     NegationExpression,
-    ExponentiationExpression,
+    ExponentiationExpression, Aggregate,
 )
 
 StringBuffer = List[str]
@@ -375,5 +375,7 @@ class PrettyPrint:
                 right=self.formatExpression(expression.RightOperand),
                 operator=operator,
             )
+        elif isinstance(expression, Aggregate):
+            print(Aggregate.Elements[0])
         else:
             raise PrettyPrintException("Unhandled expression kind.")

--- a/pyGHDL/dom/formatting/prettyprint.py
+++ b/pyGHDL/dom/formatting/prettyprint.py
@@ -4,11 +4,8 @@ from pydecor import export
 
 from pyVHDLModel.VHDLModel import (
     GenericInterfaceItem,
-    Direction,
-    Mode,
     NamedEntity,
     PortInterfaceItem,
-    IdentityExpression,
     WithDefaultExpression,
 )
 
@@ -23,7 +20,6 @@ from pyGHDL.dom.DesignUnit import (
     Context,
 )
 from pyGHDL.dom.Object import Constant, Signal
-from pyGHDL.dom.Range import Range
 from pyGHDL.dom.InterfaceItem import (
     GenericConstantInterfaceItem,
     PortSignalInterfaceItem,
@@ -32,17 +28,7 @@ from pyGHDL.dom.Symbol import (
     SimpleSubTypeSymbol,
     ConstrainedSubTypeSymbol,
 )
-from pyGHDL.dom.Expression import (
-    SubtractionExpression,
-    AdditionExpression,
-    MultiplyExpression,
-    DivisionExpression,
-    InverseExpression,
-    AbsoluteExpression,
-    NegationExpression,
-    ExponentiationExpression,
-    ParenthesisExpression,
-)
+
 
 StringBuffer = List[str]
 
@@ -291,7 +277,7 @@ class PrettyPrint:
                     subtype=self.formatSubtypeIndication(
                         item.SubType, "constant", item.Name
                     ),
-                    expr=self.formatExpression(item.DefaultExpression),
+                    expr=str(item.DefaultExpression),
                 )
             )
         elif isinstance(item, Signal):
@@ -302,9 +288,7 @@ class PrettyPrint:
                     subtype=self.formatSubtypeIndication(
                         item.SubType, "signal", item.Name
                     ),
-                    initValue=" := {expr}".format(
-                        expr=self.formatExpression(item.DefaultExpression)
-                    )
+                    initValue=" := {expr}".format(expr=str(item.DefaultExpression))
                     if item.DefaultExpression is not None
                     else "",
                 )
@@ -318,12 +302,8 @@ class PrettyPrint:
         if isinstance(subTypeIndication, SimpleSubTypeSymbol):
             return "{type}".format(type=subTypeIndication.SymbolName)
         elif isinstance(subTypeIndication, ConstrainedSubTypeSymbol):
-            constraints = ", ".join(
-                [
-                    self.formatRange(constraint.Range)
-                    for constraint in subTypeIndication.Constraints
-                ]
-            )
+            ranges = [str(c.Range) for c in subTypeIndication.Constraints]
+            constraints = ", ".join(ranges)
 
             return "{type}({constraints})".format(
                 type=subTypeIndication.SymbolName, constraints=constraints
@@ -340,6 +320,3 @@ class PrettyPrint:
             return ""
 
         return " := {expr!s}".format(expr=item.DefaultExpression)
-
-    def formatRange(self, r: Range):
-        return str(r)

--- a/pyGHDL/dom/formatting/prettyprint.py
+++ b/pyGHDL/dom/formatting/prettyprint.py
@@ -9,7 +9,7 @@ from pyVHDLModel.VHDLModel import (
     NamedEntity,
     PortInterfaceItem,
     IdentityExpression,
-    WithDefaultExpression
+    WithDefaultExpression,
 )
 
 from pyGHDL import GHDLBaseException

--- a/pyGHDL/dom/formatting/prettyprint.py
+++ b/pyGHDL/dom/formatting/prettyprint.py
@@ -4,6 +4,7 @@ from pydecor import export
 
 from pyGHDL.dom.Aggregates import SimpleAggregateElement, IndexedAggregateElement, RangedAggregateElement, NamedAggregateElement, OthersAggregateElement
 from pyGHDL.dom.Object import Constant, Signal
+from pyGHDL.dom.Range import Range
 from pyVHDLModel.VHDLModel import (
     GenericInterfaceItem,
     Expression,
@@ -322,14 +323,7 @@ class PrettyPrint:
             return "{type}".format(type=subTypeIndication.SymbolName)
         elif isinstance(subTypeIndication, ConstrainedSubTypeSymbol):
             constraints = ", ".join(
-                [
-                    "{left} {dir} {right}".format(
-                        left=self.formatExpression(constraint.Range.LeftBound),
-                        right=self.formatExpression(constraint.Range.RightBound),
-                        dir=DirectionTranslation[constraint.Range.Direction],
-                    )
-                    for constraint in subTypeIndication.Constraints
-                ]
+                [self.formatRange(constraint.Range) for constraint in subTypeIndication.Constraints]
             )
 
             return "{type}({constraints})".format(
@@ -347,6 +341,13 @@ class PrettyPrint:
             return ""
 
         return " := {expr}".format(expr=self.formatExpression(item.DefaultExpression))
+
+    def formatRange(self, r: Range) -> str:
+        return "{left} {dir} {right}".format(
+            left=self.formatExpression(r.LeftBound),
+            right=self.formatExpression(r.RightBound),
+            dir=DirectionTranslation[r.Direction],
+        )
 
     def formatExpression(self, expression: Expression) -> str:
         if isinstance(expression, SimpleObjectSymbol):

--- a/pyGHDL/dom/formatting/prettyprint.py
+++ b/pyGHDL/dom/formatting/prettyprint.py
@@ -2,6 +2,7 @@ from typing import List, Union
 
 from pydecor import export
 
+from pyGHDL.dom.Aggregates import SimpleAggregateElement, IndexedAggregateElement, RangedAggregateElement, NamedAggregateElement, OthersAggregateElement
 from pyGHDL.dom.Object import Constant, Signal
 from pyVHDLModel.VHDLModel import (
     GenericInterfaceItem,
@@ -14,6 +15,7 @@ from pyVHDLModel.VHDLModel import (
     IdentityExpression,
     UnaryExpression,
     WithDefaultExpression,
+    AggregateElement
 )
 
 from pyGHDL import GHDLBaseException
@@ -376,6 +378,31 @@ class PrettyPrint:
                 operator=operator,
             )
         elif isinstance(expression, Aggregate):
-            print(Aggregate.Elements[0])
+            return "({choices})".format(choices=", ".join([self.formatAggregateElement(element) for element in expression.Elements]))
         else:
             raise PrettyPrintException("Unhandled expression kind.")
+
+    def formatAggregateElement(self, aggregateElement: AggregateElement):
+        if isinstance(aggregateElement, SimpleAggregateElement):
+            return "{value}".format(
+                value=self.formatExpression(aggregateElement.Expression)
+            )
+        elif isinstance(aggregateElement, IndexedAggregateElement):
+            return "{index} => {value}".format(
+                index=self.formatExpression(aggregateElement.Index),
+                value=self.formatExpression(aggregateElement.Expression)
+            )
+        elif isinstance(aggregateElement, RangedAggregateElement):
+            return "{range} => {value}".format(
+                range=self.formatRange(aggregateElement.Range),
+                value=self.formatExpression(aggregateElement.Expression)
+            )
+        elif isinstance(aggregateElement, NamedAggregateElement):
+            return "{name} => {value}".format(
+                name=aggregateElement.Name,
+                value=self.formatExpression(aggregateElement.Expression)
+            )
+        elif isinstance(aggregateElement, OthersAggregateElement):
+            return "other => {value}".format(
+                value=self.formatExpression(aggregateElement.Expression)
+            )

--- a/pyGHDL/dom/formatting/prettyprint.py
+++ b/pyGHDL/dom/formatting/prettyprint.py
@@ -48,6 +48,7 @@ from pyGHDL.dom.Expression import (
     NegationExpression,
     ExponentiationExpression,
     Aggregate,
+    ParenthesisExpression,
 )
 from pyGHDL.dom.Aggregates import (
     SimpleAggregateElement,
@@ -70,18 +71,19 @@ ModeTranslation = {
 }
 
 UnaryExpressionTranslation = {
-    IdentityExpression: " +",
-    NegationExpression: " -",
-    InverseExpression: "not ",
-    AbsoluteExpression: "abs ",
+    IdentityExpression: (" +", ""),
+    NegationExpression: (" -", ""),
+    InverseExpression: ("not ", ""),
+    AbsoluteExpression: ("abs ", ""),
+    ParenthesisExpression: ("(", ")"),
 }
 
 BinaryExpressionTranslation = {
-    AdditionExpression: " + ",
-    SubtractionExpression: " - ",
-    MultiplyExpression: " * ",
-    DivisionExpression: " / ",
-    ExponentiationExpression: "**",
+    AdditionExpression: ("", " + ", ""),
+    SubtractionExpression: ("", " - ", ""),
+    MultiplyExpression: ("", " * ", ""),
+    DivisionExpression: ("", " / ", ""),
+    ExponentiationExpression: ("", "**", ""),
 }
 
 
@@ -401,8 +403,10 @@ class PrettyPrint:
             except KeyError:
                 raise PrettyPrintException("Unhandled operator for unary expression.")
 
-            return "{operator}{operand}".format(
-                operand=self.formatExpression(expression.Operand), operator=operator
+            return "{leftOp}{operand}{rightOp}".format(
+                leftOp=operator[0],
+                rightOp=operator[1],
+                operand=self.formatExpression(expression.Operand),
             )
         elif isinstance(expression, BinaryExpression):
             try:
@@ -410,10 +414,12 @@ class PrettyPrint:
             except KeyError:
                 raise PrettyPrintException("Unhandled operator for binary expression.")
 
-            return "{left}{operator}{right}".format(
-                left=self.formatExpression(expression.LeftOperand),
-                right=self.formatExpression(expression.RightOperand),
-                operator=operator,
+            return "{leftOp}{leftExpr}{middleOp}{rightExpr}{rightOp}".format(
+                leftOp=operator[0],
+                middleOp=operator[1],
+                rightOp=operator[2],
+                leftExpr=self.formatExpression(expression.LeftOperand),
+                rightExpr=self.formatExpression(expression.RightOperand),
             )
         elif isinstance(expression, Aggregate):
             return "({choices})".format(

--- a/pyGHDL/libghdl/_decorator.py
+++ b/pyGHDL/libghdl/_decorator.py
@@ -31,7 +31,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
-from ctypes import c_int32, c_uint32, c_char_p, c_bool, Structure, c_char
+from ctypes import c_int32, c_uint32, c_char_p, c_bool, c_double, Structure, c_char
 from functools import wraps
 from typing import Callable, List, Dict, Any, TypeVar
 
@@ -82,6 +82,8 @@ def BindToLibGHDL(subprogramName):
             return None
         elif typ is int:
             return c_int32
+        elif type is float:
+            return c_double
         elif typ is bool:
             return c_bool
         elif typ is bytes:
@@ -92,8 +94,9 @@ def BindToLibGHDL(subprogramName):
             # Humm, recurse ?
             if typ.__bound__ is int:
                 return c_int32
-            if typ.__bound__ in (c_uint32, c_int32):
+            if typ.__bound__ in (c_uint32, c_int32, c_double):
                 return typ.__bound__
+            raise TypeError("Unsupported typevar bound to {!s}".format(typ.__bound__))
         elif issubclass(typ, Structure):
             return typ
         raise TypeError

--- a/pyGHDL/libghdl/_types.py
+++ b/pyGHDL/libghdl/_types.py
@@ -65,7 +65,7 @@ Boolean = TypeVar("Boolean", bound=c_bool)
 
 Int32 = TypeVar("Int32", bound=c_int32)
 Int64 = TypeVar("Int64", bound=c_int64)
-Fp64 = TypeVar("Fp64", bound=c_double)
+Fp64 = TypeVar("Fp64", bound=float)
 
 ErrorIndex = TypeVar("ErrorIndex", bound=int)
 MessageIdWarnings = TypeVar("MessageIdWarnings", bound=int)

--- a/pyGHDL/libghdl/_types.py
+++ b/pyGHDL/libghdl/_types.py
@@ -65,11 +65,11 @@ Boolean = TypeVar("Boolean", bound=c_bool)
 
 Int32 = TypeVar("Int32", bound=c_int32)
 Int64 = TypeVar("Int64", bound=c_int64)
-Fp64 = TypeVar("Fp64", bound=float)
+Fp64 = TypeVar("Fp64", bound=c_double)
 
-ErrorIndex = TypeVar("ErrorIndex", bound=int)
-MessageIdWarnings = TypeVar("MessageIdWarnings", bound=int)
-NameId = TypeVar("NameId", bound=int)
+ErrorIndex = TypeVar("ErrorIndex", bound=c_int32)
+MessageIdWarnings = TypeVar("MessageIdWarnings", bound=c_int32)
+NameId = TypeVar("NameId", bound=c_int32)
 
 String8Id = TypeVar("String8Id", bound=c_uint32)
 FileChecksumId = TypeVar("FileChecksumId", bound=c_uint32)
@@ -79,14 +79,14 @@ SourceFileEntry = TypeVar("SourceFileEntry", bound=c_uint32)
 SourcePtr = TypeVar("SourcePtr", bound=c_int32)
 LocationType = TypeVar("LocationType", bound=c_uint32)
 
-Iir = TypeVar("Iir", bound=int)
+Iir = TypeVar("Iir", bound=c_int32)
 IirKind = TypeVar("IirKind", bound=c_int32)
 
 PSLNode = TypeVar("PSLNode", bound=c_int32)
 PSLNFA = TypeVar("PSLNFA", bound=c_int32)
 
-Iir_Design_File = TypeVar("Iir_Design_File", bound=int)
-Iir_Design_Unit = TypeVar("Iir_Design_Unit", bound=int)
+Iir_Design_File = TypeVar("Iir_Design_File", bound=c_int32)
+Iir_Design_Unit = TypeVar("Iir_Design_Unit", bound=c_int32)
 Iir_Library_Declaration = TypeVar("Iir_Library_Declaration", bound=c_int32)
 Iir_Package_Declaration = TypeVar("Iir_Package_Declaration", bound=c_int32)
 Iir_Enumeration_Type_Definition = TypeVar(

--- a/pyGHDL/libghdl/errorout.py
+++ b/pyGHDL/libghdl/errorout.py
@@ -3,14 +3,17 @@
 #
 from enum import IntEnum, unique
 from pydecor import export
+
+from pyGHDL.libghdl._decorator import BindToLibGHDL
 from enum import IntEnum, unique
 
 from pyGHDL.libghdl import libghdl
 
 
 @export
+@BindToLibGHDL("errorout__enable_warning")
 def Enable_Warning(Id: int, Enable: bool) -> None:
-    libghdl.errorout__enable_warning(Id, Enable)
+    """"""
 
 
 @export

--- a/pyGHDL/libghdl/std_names.py
+++ b/pyGHDL/libghdl/std_names.py
@@ -4,6 +4,8 @@
 from enum import IntEnum, unique
 from pydecor import export
 
+from pyGHDL.libghdl._decorator import BindToLibGHDL
+
 
 @export
 class Name:

--- a/pyGHDL/libghdl/vhdl/elocations.py
+++ b/pyGHDL/libghdl/vhdl/elocations.py
@@ -3,6 +3,8 @@
 #
 from enum import IntEnum, unique
 from pydecor import export
+
+from pyGHDL.libghdl._decorator import BindToLibGHDL
 from pyGHDL.libghdl import libghdl
 
 

--- a/pyGHDL/libghdl/vhdl/nodes.py
+++ b/pyGHDL/libghdl/vhdl/nodes.py
@@ -3,11 +3,14 @@
 #
 from enum import IntEnum, unique
 from pydecor import export
+
+from pyGHDL.libghdl._decorator import BindToLibGHDL
 from typing import TypeVar
 from ctypes import c_int32
 from pyGHDL.libghdl import libghdl
 from pyGHDL.libghdl._types import (
     Iir,
+    IirKind,
     LocationType,
     FileChecksumId,
     TimeStampId,
@@ -1796,3710 +1799,4452 @@ class Iir_Predefined(IntEnum):
 
 
 @export
-def Get_Kind(node: Iir) -> Iir_Kind:
-    return libghdl.vhdl__nodes__get_kind(node)
+@BindToLibGHDL("vhdl__nodes__get_kind")
+def Get_Kind(node: Iir) -> IirKind:
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_location")
 def Get_Location(node: Iir) -> LocationType:
-    return libghdl.vhdl__nodes__get_location(node)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_first_design_unit")
 def Get_First_Design_Unit(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_first_design_unit(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_first_design_unit")
 def Set_First_Design_Unit(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_first_design_unit(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_last_design_unit")
 def Get_Last_Design_Unit(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_last_design_unit(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_last_design_unit")
 def Set_Last_Design_Unit(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_last_design_unit(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_library_declaration")
 def Get_Library_Declaration(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_library_declaration(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_library_declaration")
 def Set_Library_Declaration(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_library_declaration(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_file_checksum")
 def Get_File_Checksum(obj: Iir) -> FileChecksumId:
-    return libghdl.vhdl__nodes__get_file_checksum(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_file_checksum")
 def Set_File_Checksum(obj: Iir, value: FileChecksumId) -> None:
-    libghdl.vhdl__nodes__set_file_checksum(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_analysis_time_stamp")
 def Get_Analysis_Time_Stamp(obj: Iir) -> TimeStampId:
-    return libghdl.vhdl__nodes__get_analysis_time_stamp(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_analysis_time_stamp")
 def Set_Analysis_Time_Stamp(obj: Iir, value: TimeStampId) -> None:
-    libghdl.vhdl__nodes__set_analysis_time_stamp(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_design_file_source")
 def Get_Design_File_Source(obj: Iir) -> SourceFileEntry:
-    return libghdl.vhdl__nodes__get_design_file_source(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_design_file_source")
 def Set_Design_File_Source(obj: Iir, value: SourceFileEntry) -> None:
-    libghdl.vhdl__nodes__set_design_file_source(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_library")
 def Get_Library(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_library(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_library")
 def Set_Library(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_library(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_file_dependence_list")
 def Get_File_Dependence_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_file_dependence_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_file_dependence_list")
 def Set_File_Dependence_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_file_dependence_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_design_file_filename")
 def Get_Design_File_Filename(obj: Iir) -> NameId:
-    return libghdl.vhdl__nodes__get_design_file_filename(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_design_file_filename")
 def Set_Design_File_Filename(obj: Iir, value: NameId) -> None:
-    libghdl.vhdl__nodes__set_design_file_filename(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_design_file_directory")
 def Get_Design_File_Directory(obj: Iir) -> NameId:
-    return libghdl.vhdl__nodes__get_design_file_directory(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_design_file_directory")
 def Set_Design_File_Directory(obj: Iir, value: NameId) -> None:
-    libghdl.vhdl__nodes__set_design_file_directory(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_design_file")
 def Get_Design_File(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_design_file(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_design_file")
 def Set_Design_File(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_design_file(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_design_file_chain")
 def Get_Design_File_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_design_file_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_design_file_chain")
 def Set_Design_File_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_design_file_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_library_directory")
 def Get_Library_Directory(obj: Iir) -> NameId:
-    return libghdl.vhdl__nodes__get_library_directory(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_library_directory")
 def Set_Library_Directory(obj: Iir, value: NameId) -> None:
-    libghdl.vhdl__nodes__set_library_directory(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_date")
 def Get_Date(obj: Iir) -> DateType:
-    return libghdl.vhdl__nodes__get_date(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_date")
 def Set_Date(obj: Iir, value: DateType) -> None:
-    libghdl.vhdl__nodes__set_date(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_context_items")
 def Get_Context_Items(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_context_items(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_context_items")
 def Set_Context_Items(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_context_items(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_dependence_list")
 def Get_Dependence_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_dependence_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_dependence_list")
 def Set_Dependence_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_dependence_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_analysis_checks_list")
 def Get_Analysis_Checks_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_analysis_checks_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_analysis_checks_list")
 def Set_Analysis_Checks_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_analysis_checks_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_date_state")
 def Get_Date_State(obj: Iir) -> DateStateType:
-    return libghdl.vhdl__nodes__get_date_state(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_date_state")
 def Set_Date_State(obj: Iir, value: DateStateType) -> None:
-    libghdl.vhdl__nodes__set_date_state(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_guarded_target_state")
 def Get_Guarded_Target_State(obj: Iir) -> TriStateType:
-    return libghdl.vhdl__nodes__get_guarded_target_state(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_guarded_target_state")
 def Set_Guarded_Target_State(obj: Iir, value: TriStateType) -> None:
-    libghdl.vhdl__nodes__set_guarded_target_state(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_library_unit")
 def Get_Library_Unit(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_library_unit(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_library_unit")
 def Set_Library_Unit(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_library_unit(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_hash_chain")
 def Get_Hash_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_hash_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_hash_chain")
 def Set_Hash_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_hash_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_design_unit_source_pos")
 def Get_Design_Unit_Source_Pos(obj: Iir) -> SourcePtr:
-    return libghdl.vhdl__nodes__get_design_unit_source_pos(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_design_unit_source_pos")
 def Set_Design_Unit_Source_Pos(obj: Iir, value: SourcePtr) -> None:
-    libghdl.vhdl__nodes__set_design_unit_source_pos(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_design_unit_source_line")
 def Get_Design_Unit_Source_Line(obj: Iir) -> Int32:
-    return libghdl.vhdl__nodes__get_design_unit_source_line(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_design_unit_source_line")
 def Set_Design_Unit_Source_Line(obj: Iir, value: Int32) -> None:
-    libghdl.vhdl__nodes__set_design_unit_source_line(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_design_unit_source_col")
 def Get_Design_Unit_Source_Col(obj: Iir) -> Int32:
-    return libghdl.vhdl__nodes__get_design_unit_source_col(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_design_unit_source_col")
 def Set_Design_Unit_Source_Col(obj: Iir, value: Int32) -> None:
-    libghdl.vhdl__nodes__set_design_unit_source_col(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_value")
 def Get_Value(obj: Iir) -> Int64:
-    return libghdl.vhdl__nodes__get_value(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_value")
 def Set_Value(obj: Iir, value: Int64) -> None:
-    libghdl.vhdl__nodes__set_value(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_enum_pos")
 def Get_Enum_Pos(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_enum_pos(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_enum_pos")
 def Set_Enum_Pos(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_enum_pos(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_physical_literal")
 def Get_Physical_Literal(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_physical_literal(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_physical_literal")
 def Set_Physical_Literal(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_physical_literal(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_fp_value")
 def Get_Fp_Value(obj: Iir) -> Fp64:
-    return libghdl.vhdl__nodes__get_fp_value(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_fp_value")
 def Set_Fp_Value(obj: Iir, value: Fp64) -> None:
-    libghdl.vhdl__nodes__set_fp_value(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_simple_aggregate_list")
 def Get_Simple_Aggregate_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_simple_aggregate_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_simple_aggregate_list")
 def Set_Simple_Aggregate_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_simple_aggregate_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_string8_id")
 def Get_String8_Id(obj: Iir) -> String8Id:
-    return libghdl.vhdl__nodes__get_string8_id(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_string8_id")
 def Set_String8_Id(obj: Iir, value: String8Id) -> None:
-    libghdl.vhdl__nodes__set_string8_id(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_string_length")
 def Get_String_Length(obj: Iir) -> Int32:
-    return libghdl.vhdl__nodes__get_string_length(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_string_length")
 def Set_String_Length(obj: Iir, value: Int32) -> None:
-    libghdl.vhdl__nodes__set_string_length(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_bit_string_base")
 def Get_Bit_String_Base(obj: Iir) -> NumberBaseType:
-    return libghdl.vhdl__nodes__get_bit_string_base(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_bit_string_base")
 def Set_Bit_String_Base(obj: Iir, value: NumberBaseType) -> None:
-    libghdl.vhdl__nodes__set_bit_string_base(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_signed")
 def Get_Has_Signed(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_signed(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_signed")
 def Set_Has_Signed(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_signed(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_sign")
 def Get_Has_Sign(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_sign(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_sign")
 def Set_Has_Sign(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_sign(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_length")
 def Get_Has_Length(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_length(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_length")
 def Set_Has_Length(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_length(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_literal_length")
 def Get_Literal_Length(obj: Iir) -> Int32:
-    return libghdl.vhdl__nodes__get_literal_length(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_literal_length")
 def Set_Literal_Length(obj: Iir, value: Int32) -> None:
-    libghdl.vhdl__nodes__set_literal_length(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_literal_origin")
 def Get_Literal_Origin(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_literal_origin(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_literal_origin")
 def Set_Literal_Origin(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_literal_origin(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_range_origin")
 def Get_Range_Origin(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_range_origin(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_range_origin")
 def Set_Range_Origin(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_range_origin(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_literal_subtype")
 def Get_Literal_Subtype(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_literal_subtype(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_literal_subtype")
 def Set_Literal_Subtype(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_literal_subtype(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_allocator_subtype")
 def Get_Allocator_Subtype(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_allocator_subtype(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_allocator_subtype")
 def Set_Allocator_Subtype(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_allocator_subtype(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_entity_class")
 def Get_Entity_Class(obj: Iir) -> Tok:
-    return libghdl.vhdl__nodes__get_entity_class(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_entity_class")
 def Set_Entity_Class(obj: Iir, value: Tok) -> None:
-    libghdl.vhdl__nodes__set_entity_class(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_entity_name_list")
 def Get_Entity_Name_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_entity_name_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_entity_name_list")
 def Set_Entity_Name_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_entity_name_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_attribute_designator")
 def Get_Attribute_Designator(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_attribute_designator(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_attribute_designator")
 def Set_Attribute_Designator(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_attribute_designator(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_attribute_specification_chain")
 def Get_Attribute_Specification_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_attribute_specification_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_attribute_specification_chain")
 def Set_Attribute_Specification_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_attribute_specification_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_attribute_specification")
 def Get_Attribute_Specification(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_attribute_specification(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_attribute_specification")
 def Set_Attribute_Specification(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_attribute_specification(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_static_attribute_flag")
 def Get_Static_Attribute_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_static_attribute_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_static_attribute_flag")
 def Set_Static_Attribute_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_static_attribute_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_signal_list")
 def Get_Signal_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_signal_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_signal_list")
 def Set_Signal_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_signal_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_quantity_list")
 def Get_Quantity_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_quantity_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_quantity_list")
 def Set_Quantity_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_quantity_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_designated_entity")
 def Get_Designated_Entity(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_designated_entity(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_designated_entity")
 def Set_Designated_Entity(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_designated_entity(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_formal")
 def Get_Formal(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_formal(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_formal")
 def Set_Formal(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_formal(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_actual")
 def Get_Actual(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_actual(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_actual")
 def Set_Actual(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_actual(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_actual_conversion")
 def Get_Actual_Conversion(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_actual_conversion(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_actual_conversion")
 def Set_Actual_Conversion(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_actual_conversion(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_formal_conversion")
 def Get_Formal_Conversion(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_formal_conversion(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_formal_conversion")
 def Set_Formal_Conversion(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_formal_conversion(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_whole_association_flag")
 def Get_Whole_Association_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_whole_association_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_whole_association_flag")
 def Set_Whole_Association_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_whole_association_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_collapse_signal_flag")
 def Get_Collapse_Signal_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_collapse_signal_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_collapse_signal_flag")
 def Set_Collapse_Signal_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_collapse_signal_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_artificial_flag")
 def Get_Artificial_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_artificial_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_artificial_flag")
 def Set_Artificial_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_artificial_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_open_flag")
 def Get_Open_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_open_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_open_flag")
 def Set_Open_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_open_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_after_drivers_flag")
 def Get_After_Drivers_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_after_drivers_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_after_drivers_flag")
 def Set_After_Drivers_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_after_drivers_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_we_value")
 def Get_We_Value(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_we_value(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_we_value")
 def Set_We_Value(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_we_value(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_time")
 def Get_Time(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_time(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_time")
 def Set_Time(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_time(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_associated_expr")
 def Get_Associated_Expr(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_associated_expr(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_associated_expr")
 def Set_Associated_Expr(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_associated_expr(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_associated_block")
 def Get_Associated_Block(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_associated_block(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_associated_block")
 def Set_Associated_Block(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_associated_block(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_associated_chain")
 def Get_Associated_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_associated_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_associated_chain")
 def Set_Associated_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_associated_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_choice_name")
 def Get_Choice_Name(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_choice_name(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_choice_name")
 def Set_Choice_Name(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_choice_name(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_choice_expression")
 def Get_Choice_Expression(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_choice_expression(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_choice_expression")
 def Set_Choice_Expression(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_choice_expression(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_choice_range")
 def Get_Choice_Range(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_choice_range(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_choice_range")
 def Set_Choice_Range(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_choice_range(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_same_alternative_flag")
 def Get_Same_Alternative_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_same_alternative_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_same_alternative_flag")
 def Set_Same_Alternative_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_same_alternative_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_element_type_flag")
 def Get_Element_Type_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_element_type_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_element_type_flag")
 def Set_Element_Type_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_element_type_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_architecture")
 def Get_Architecture(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_architecture(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_architecture")
 def Set_Architecture(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_architecture(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_block_specification")
 def Get_Block_Specification(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_block_specification(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_block_specification")
 def Set_Block_Specification(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_block_specification(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_prev_block_configuration")
 def Get_Prev_Block_Configuration(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_prev_block_configuration(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_prev_block_configuration")
 def Set_Prev_Block_Configuration(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_prev_block_configuration(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_configuration_item_chain")
 def Get_Configuration_Item_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_configuration_item_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_configuration_item_chain")
 def Set_Configuration_Item_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_configuration_item_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_attribute_value_chain")
 def Get_Attribute_Value_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_attribute_value_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_attribute_value_chain")
 def Set_Attribute_Value_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_attribute_value_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_spec_chain")
 def Get_Spec_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_spec_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_spec_chain")
 def Set_Spec_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_spec_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_value_chain")
 def Get_Value_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_value_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_value_chain")
 def Set_Value_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_value_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_attribute_value_spec_chain")
 def Get_Attribute_Value_Spec_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_attribute_value_spec_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_attribute_value_spec_chain")
 def Set_Attribute_Value_Spec_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_attribute_value_spec_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_entity_name")
 def Get_Entity_Name(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_entity_name(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_entity_name")
 def Set_Entity_Name(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_entity_name(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_package")
 def Get_Package(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_package(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_package")
 def Set_Package(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_package(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_package_body")
 def Get_Package_Body(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_package_body(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_package_body")
 def Set_Package_Body(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_package_body(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_instance_package_body")
 def Get_Instance_Package_Body(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_instance_package_body(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_instance_package_body")
 def Set_Instance_Package_Body(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_instance_package_body(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_need_body")
 def Get_Need_Body(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_need_body(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_need_body")
 def Set_Need_Body(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_need_body(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_macro_expanded_flag")
 def Get_Macro_Expanded_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_macro_expanded_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_macro_expanded_flag")
 def Set_Macro_Expanded_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_macro_expanded_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_need_instance_bodies")
 def Get_Need_Instance_Bodies(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_need_instance_bodies(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_need_instance_bodies")
 def Set_Need_Instance_Bodies(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_need_instance_bodies(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_hierarchical_name")
 def Get_Hierarchical_Name(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_hierarchical_name(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_hierarchical_name")
 def Set_Hierarchical_Name(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_hierarchical_name(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_inherit_spec_chain")
 def Get_Inherit_Spec_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_inherit_spec_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_inherit_spec_chain")
 def Set_Inherit_Spec_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_inherit_spec_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_vunit_item_chain")
 def Get_Vunit_Item_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_vunit_item_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_vunit_item_chain")
 def Set_Vunit_Item_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_vunit_item_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_bound_vunit_chain")
 def Get_Bound_Vunit_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_bound_vunit_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_bound_vunit_chain")
 def Set_Bound_Vunit_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_bound_vunit_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_verification_block_configuration")
 def Get_Verification_Block_Configuration(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_verification_block_configuration(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_verification_block_configuration")
 def Set_Verification_Block_Configuration(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_verification_block_configuration(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_block_configuration")
 def Get_Block_Configuration(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_block_configuration(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_block_configuration")
 def Set_Block_Configuration(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_block_configuration(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_concurrent_statement_chain")
 def Get_Concurrent_Statement_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_concurrent_statement_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_concurrent_statement_chain")
 def Set_Concurrent_Statement_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_concurrent_statement_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_chain")
 def Get_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_chain")
 def Set_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_port_chain")
 def Get_Port_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_port_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_port_chain")
 def Set_Port_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_port_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_generic_chain")
 def Get_Generic_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_generic_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_generic_chain")
 def Set_Generic_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_generic_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_type")
 def Get_Type(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_type(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_type")
 def Set_Type(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_type(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_subtype_indication")
 def Get_Subtype_Indication(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_subtype_indication(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_subtype_indication")
 def Set_Subtype_Indication(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_subtype_indication(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_discrete_range")
 def Get_Discrete_Range(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_discrete_range(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_discrete_range")
 def Set_Discrete_Range(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_discrete_range(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_type_definition")
 def Get_Type_Definition(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_type_definition(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_type_definition")
 def Set_Type_Definition(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_type_definition(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_subtype_definition")
 def Get_Subtype_Definition(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_subtype_definition(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_subtype_definition")
 def Set_Subtype_Definition(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_subtype_definition(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_incomplete_type_declaration")
 def Get_Incomplete_Type_Declaration(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_incomplete_type_declaration(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_incomplete_type_declaration")
 def Set_Incomplete_Type_Declaration(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_incomplete_type_declaration(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_interface_type_subprograms")
 def Get_Interface_Type_Subprograms(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_interface_type_subprograms(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_interface_type_subprograms")
 def Set_Interface_Type_Subprograms(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_interface_type_subprograms(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_nature_definition")
 def Get_Nature_Definition(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_nature_definition(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_nature_definition")
 def Set_Nature_Definition(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_nature_definition(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_nature")
 def Get_Nature(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_nature(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_nature")
 def Set_Nature(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_nature(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_subnature_indication")
 def Get_Subnature_Indication(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_subnature_indication(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_subnature_indication")
 def Set_Subnature_Indication(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_subnature_indication(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_mode")
 def Get_Mode(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_mode(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_mode")
 def Set_Mode(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_mode(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_guarded_signal_flag")
 def Get_Guarded_Signal_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_guarded_signal_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_guarded_signal_flag")
 def Set_Guarded_Signal_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_guarded_signal_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_signal_kind")
 def Get_Signal_Kind(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_signal_kind(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_signal_kind")
 def Set_Signal_Kind(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_signal_kind(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_base_name")
 def Get_Base_Name(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_base_name(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_base_name")
 def Set_Base_Name(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_base_name(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_interface_declaration_chain")
 def Get_Interface_Declaration_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_interface_declaration_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_interface_declaration_chain")
 def Set_Interface_Declaration_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_interface_declaration_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_subprogram_specification")
 def Get_Subprogram_Specification(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_subprogram_specification(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_subprogram_specification")
 def Set_Subprogram_Specification(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_subprogram_specification(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_sequential_statement_chain")
 def Get_Sequential_Statement_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_sequential_statement_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_sequential_statement_chain")
 def Set_Sequential_Statement_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_sequential_statement_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_simultaneous_statement_chain")
 def Get_Simultaneous_Statement_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_simultaneous_statement_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_simultaneous_statement_chain")
 def Set_Simultaneous_Statement_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_simultaneous_statement_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_subprogram_body")
 def Get_Subprogram_Body(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_subprogram_body(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_subprogram_body")
 def Set_Subprogram_Body(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_subprogram_body(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_overload_number")
 def Get_Overload_Number(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_overload_number(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_overload_number")
 def Set_Overload_Number(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_overload_number(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_subprogram_depth")
 def Get_Subprogram_Depth(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_subprogram_depth(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_subprogram_depth")
 def Set_Subprogram_Depth(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_subprogram_depth(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_subprogram_hash")
 def Get_Subprogram_Hash(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_subprogram_hash(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_subprogram_hash")
 def Set_Subprogram_Hash(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_subprogram_hash(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_impure_depth")
 def Get_Impure_Depth(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_impure_depth(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_impure_depth")
 def Set_Impure_Depth(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_impure_depth(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_return_type")
 def Get_Return_Type(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_return_type(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_return_type")
 def Set_Return_Type(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_return_type(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_implicit_definition")
 def Get_Implicit_Definition(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_implicit_definition(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_implicit_definition")
 def Set_Implicit_Definition(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_implicit_definition(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_uninstantiated_subprogram_name")
 def Get_Uninstantiated_Subprogram_Name(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_uninstantiated_subprogram_name(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_uninstantiated_subprogram_name")
 def Set_Uninstantiated_Subprogram_Name(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_uninstantiated_subprogram_name(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_default_value")
 def Get_Default_Value(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_default_value(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_default_value")
 def Set_Default_Value(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_default_value(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_deferred_declaration")
 def Get_Deferred_Declaration(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_deferred_declaration(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_deferred_declaration")
 def Set_Deferred_Declaration(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_deferred_declaration(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_deferred_declaration_flag")
 def Get_Deferred_Declaration_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_deferred_declaration_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_deferred_declaration_flag")
 def Set_Deferred_Declaration_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_deferred_declaration_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_shared_flag")
 def Get_Shared_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_shared_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_shared_flag")
 def Set_Shared_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_shared_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_design_unit")
 def Get_Design_Unit(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_design_unit(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_design_unit")
 def Set_Design_Unit(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_design_unit(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_block_statement")
 def Get_Block_Statement(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_block_statement(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_block_statement")
 def Set_Block_Statement(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_block_statement(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_signal_driver")
 def Get_Signal_Driver(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_signal_driver(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_signal_driver")
 def Set_Signal_Driver(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_signal_driver(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_declaration_chain")
 def Get_Declaration_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_declaration_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_declaration_chain")
 def Set_Declaration_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_declaration_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_file_logical_name")
 def Get_File_Logical_Name(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_file_logical_name(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_file_logical_name")
 def Set_File_Logical_Name(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_file_logical_name(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_file_open_kind")
 def Get_File_Open_Kind(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_file_open_kind(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_file_open_kind")
 def Set_File_Open_Kind(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_file_open_kind(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_element_position")
 def Get_Element_Position(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_element_position(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_element_position")
 def Set_Element_Position(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_element_position(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_use_clause_chain")
 def Get_Use_Clause_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_use_clause_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_use_clause_chain")
 def Set_Use_Clause_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_use_clause_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_context_reference_chain")
 def Get_Context_Reference_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_context_reference_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_context_reference_chain")
 def Set_Context_Reference_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_context_reference_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_selected_name")
 def Get_Selected_Name(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_selected_name(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_selected_name")
 def Set_Selected_Name(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_selected_name(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_type_declarator")
 def Get_Type_Declarator(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_type_declarator(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_type_declarator")
 def Set_Type_Declarator(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_type_declarator(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_complete_type_definition")
 def Get_Complete_Type_Definition(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_complete_type_definition(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_complete_type_definition")
 def Set_Complete_Type_Definition(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_complete_type_definition(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_incomplete_type_ref_chain")
 def Get_Incomplete_Type_Ref_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_incomplete_type_ref_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_incomplete_type_ref_chain")
 def Set_Incomplete_Type_Ref_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_incomplete_type_ref_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_associated_type")
 def Get_Associated_Type(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_associated_type(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_associated_type")
 def Set_Associated_Type(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_associated_type(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_enumeration_literal_list")
 def Get_Enumeration_Literal_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_enumeration_literal_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_enumeration_literal_list")
 def Set_Enumeration_Literal_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_enumeration_literal_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_entity_class_entry_chain")
 def Get_Entity_Class_Entry_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_entity_class_entry_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_entity_class_entry_chain")
 def Set_Entity_Class_Entry_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_entity_class_entry_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_group_constituent_list")
 def Get_Group_Constituent_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_group_constituent_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_group_constituent_list")
 def Set_Group_Constituent_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_group_constituent_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_unit_chain")
 def Get_Unit_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_unit_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_unit_chain")
 def Set_Unit_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_unit_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_primary_unit")
 def Get_Primary_Unit(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_primary_unit(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_primary_unit")
 def Set_Primary_Unit(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_primary_unit(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_identifier")
 def Get_Identifier(obj: Iir) -> NameId:
-    return libghdl.vhdl__nodes__get_identifier(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_identifier")
 def Set_Identifier(obj: Iir, value: NameId) -> None:
-    libghdl.vhdl__nodes__set_identifier(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_label")
 def Get_Label(obj: Iir) -> NameId:
-    return libghdl.vhdl__nodes__get_label(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_label")
 def Set_Label(obj: Iir, value: NameId) -> None:
-    libghdl.vhdl__nodes__set_label(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_visible_flag")
 def Get_Visible_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_visible_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_visible_flag")
 def Set_Visible_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_visible_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_range_constraint")
 def Get_Range_Constraint(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_range_constraint(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_range_constraint")
 def Set_Range_Constraint(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_range_constraint(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_direction")
 def Get_Direction(obj: Iir) -> DirectionType:
-    return libghdl.vhdl__nodes__get_direction(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_direction")
 def Set_Direction(obj: Iir, value: DirectionType) -> None:
-    libghdl.vhdl__nodes__set_direction(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_left_limit")
 def Get_Left_Limit(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_left_limit(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_left_limit")
 def Set_Left_Limit(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_left_limit(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_right_limit")
 def Get_Right_Limit(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_right_limit(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_right_limit")
 def Set_Right_Limit(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_right_limit(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_left_limit_expr")
 def Get_Left_Limit_Expr(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_left_limit_expr(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_left_limit_expr")
 def Set_Left_Limit_Expr(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_left_limit_expr(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_right_limit_expr")
 def Get_Right_Limit_Expr(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_right_limit_expr(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_right_limit_expr")
 def Set_Right_Limit_Expr(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_right_limit_expr(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_parent_type")
 def Get_Parent_Type(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_parent_type(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_parent_type")
 def Set_Parent_Type(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_parent_type(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_simple_nature")
 def Get_Simple_Nature(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_simple_nature(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_simple_nature")
 def Set_Simple_Nature(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_simple_nature(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_base_nature")
 def Get_Base_Nature(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_base_nature(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_base_nature")
 def Set_Base_Nature(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_base_nature(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_resolution_indication")
 def Get_Resolution_Indication(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_resolution_indication(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_resolution_indication")
 def Set_Resolution_Indication(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_resolution_indication(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_record_element_resolution_chain")
 def Get_Record_Element_Resolution_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_record_element_resolution_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_record_element_resolution_chain")
 def Set_Record_Element_Resolution_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_record_element_resolution_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_tolerance")
 def Get_Tolerance(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_tolerance(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_tolerance")
 def Set_Tolerance(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_tolerance(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_plus_terminal_name")
 def Get_Plus_Terminal_Name(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_plus_terminal_name(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_plus_terminal_name")
 def Set_Plus_Terminal_Name(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_plus_terminal_name(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_minus_terminal_name")
 def Get_Minus_Terminal_Name(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_minus_terminal_name(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_minus_terminal_name")
 def Set_Minus_Terminal_Name(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_minus_terminal_name(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_plus_terminal")
 def Get_Plus_Terminal(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_plus_terminal(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_plus_terminal")
 def Set_Plus_Terminal(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_plus_terminal(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_minus_terminal")
 def Get_Minus_Terminal(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_minus_terminal(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_minus_terminal")
 def Set_Minus_Terminal(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_minus_terminal(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_magnitude_expression")
 def Get_Magnitude_Expression(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_magnitude_expression(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_magnitude_expression")
 def Set_Magnitude_Expression(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_magnitude_expression(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_phase_expression")
 def Get_Phase_Expression(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_phase_expression(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_phase_expression")
 def Set_Phase_Expression(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_phase_expression(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_power_expression")
 def Get_Power_Expression(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_power_expression(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_power_expression")
 def Set_Power_Expression(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_power_expression(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_simultaneous_left")
 def Get_Simultaneous_Left(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_simultaneous_left(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_simultaneous_left")
 def Set_Simultaneous_Left(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_simultaneous_left(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_simultaneous_right")
 def Get_Simultaneous_Right(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_simultaneous_right(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_simultaneous_right")
 def Set_Simultaneous_Right(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_simultaneous_right(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_text_file_flag")
 def Get_Text_File_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_text_file_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_text_file_flag")
 def Set_Text_File_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_text_file_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_only_characters_flag")
 def Get_Only_Characters_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_only_characters_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_only_characters_flag")
 def Set_Only_Characters_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_only_characters_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_is_character_type")
 def Get_Is_Character_Type(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_is_character_type(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_is_character_type")
 def Set_Is_Character_Type(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_is_character_type(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_nature_staticness")
 def Get_Nature_Staticness(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_nature_staticness(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_nature_staticness")
 def Set_Nature_Staticness(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_nature_staticness(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_type_staticness")
 def Get_Type_Staticness(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_type_staticness(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_type_staticness")
 def Set_Type_Staticness(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_type_staticness(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_constraint_state")
 def Get_Constraint_State(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_constraint_state(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_constraint_state")
 def Set_Constraint_State(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_constraint_state(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_index_subtype_list")
 def Get_Index_Subtype_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_index_subtype_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_index_subtype_list")
 def Set_Index_Subtype_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_index_subtype_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_index_subtype_definition_list")
 def Get_Index_Subtype_Definition_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_index_subtype_definition_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_index_subtype_definition_list")
 def Set_Index_Subtype_Definition_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_index_subtype_definition_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_element_subtype_indication")
 def Get_Element_Subtype_Indication(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_element_subtype_indication(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_element_subtype_indication")
 def Set_Element_Subtype_Indication(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_element_subtype_indication(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_element_subtype")
 def Get_Element_Subtype(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_element_subtype(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_element_subtype")
 def Set_Element_Subtype(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_element_subtype(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_element_subnature_indication")
 def Get_Element_Subnature_Indication(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_element_subnature_indication(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_element_subnature_indication")
 def Set_Element_Subnature_Indication(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_element_subnature_indication(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_element_subnature")
 def Get_Element_Subnature(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_element_subnature(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_element_subnature")
 def Set_Element_Subnature(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_element_subnature(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_index_constraint_list")
 def Get_Index_Constraint_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_index_constraint_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_index_constraint_list")
 def Set_Index_Constraint_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_index_constraint_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_array_element_constraint")
 def Get_Array_Element_Constraint(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_array_element_constraint(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_array_element_constraint")
 def Set_Array_Element_Constraint(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_array_element_constraint(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_array_constraint_flag")
 def Get_Has_Array_Constraint_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_array_constraint_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_array_constraint_flag")
 def Set_Has_Array_Constraint_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_array_constraint_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_element_constraint_flag")
 def Get_Has_Element_Constraint_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_element_constraint_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_element_constraint_flag")
 def Set_Has_Element_Constraint_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_element_constraint_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_elements_declaration_list")
 def Get_Elements_Declaration_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_elements_declaration_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_elements_declaration_list")
 def Set_Elements_Declaration_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_elements_declaration_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_owned_elements_chain")
 def Get_Owned_Elements_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_owned_elements_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_owned_elements_chain")
 def Set_Owned_Elements_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_owned_elements_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_designated_type")
 def Get_Designated_Type(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_designated_type(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_designated_type")
 def Set_Designated_Type(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_designated_type(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_designated_subtype_indication")
 def Get_Designated_Subtype_Indication(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_designated_subtype_indication(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_designated_subtype_indication")
 def Set_Designated_Subtype_Indication(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_designated_subtype_indication(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_index_list")
 def Get_Index_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_index_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_index_list")
 def Set_Index_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_index_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_reference")
 def Get_Reference(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_reference(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_reference")
 def Set_Reference(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_reference(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_nature_declarator")
 def Get_Nature_Declarator(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_nature_declarator(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_nature_declarator")
 def Set_Nature_Declarator(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_nature_declarator(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_across_type_mark")
 def Get_Across_Type_Mark(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_across_type_mark(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_across_type_mark")
 def Set_Across_Type_Mark(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_across_type_mark(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_through_type_mark")
 def Get_Through_Type_Mark(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_through_type_mark(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_through_type_mark")
 def Set_Through_Type_Mark(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_through_type_mark(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_across_type_definition")
 def Get_Across_Type_Definition(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_across_type_definition(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_across_type_definition")
 def Set_Across_Type_Definition(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_across_type_definition(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_through_type_definition")
 def Get_Through_Type_Definition(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_through_type_definition(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_through_type_definition")
 def Set_Through_Type_Definition(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_through_type_definition(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_across_type")
 def Get_Across_Type(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_across_type(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_across_type")
 def Set_Across_Type(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_across_type(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_through_type")
 def Get_Through_Type(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_through_type(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_through_type")
 def Set_Through_Type(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_through_type(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_target")
 def Get_Target(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_target(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_target")
 def Set_Target(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_target(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_waveform_chain")
 def Get_Waveform_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_waveform_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_waveform_chain")
 def Set_Waveform_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_waveform_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_guard")
 def Get_Guard(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_guard(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_guard")
 def Set_Guard(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_guard(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_delay_mechanism")
 def Get_Delay_Mechanism(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_delay_mechanism(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_delay_mechanism")
 def Set_Delay_Mechanism(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_delay_mechanism(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_reject_time_expression")
 def Get_Reject_Time_Expression(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_reject_time_expression(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_reject_time_expression")
 def Set_Reject_Time_Expression(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_reject_time_expression(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_force_mode")
 def Get_Force_Mode(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_force_mode(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_force_mode")
 def Set_Force_Mode(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_force_mode(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_force_mode")
 def Get_Has_Force_Mode(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_force_mode(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_force_mode")
 def Set_Has_Force_Mode(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_force_mode(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_sensitivity_list")
 def Get_Sensitivity_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_sensitivity_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_sensitivity_list")
 def Set_Sensitivity_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_sensitivity_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_process_origin")
 def Get_Process_Origin(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_process_origin(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_process_origin")
 def Set_Process_Origin(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_process_origin(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_package_origin")
 def Get_Package_Origin(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_package_origin(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_package_origin")
 def Set_Package_Origin(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_package_origin(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_condition_clause")
 def Get_Condition_Clause(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_condition_clause(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_condition_clause")
 def Set_Condition_Clause(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_condition_clause(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_break_element")
 def Get_Break_Element(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_break_element(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_break_element")
 def Set_Break_Element(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_break_element(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_selector_quantity")
 def Get_Selector_Quantity(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_selector_quantity(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_selector_quantity")
 def Set_Selector_Quantity(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_selector_quantity(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_break_quantity")
 def Get_Break_Quantity(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_break_quantity(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_break_quantity")
 def Set_Break_Quantity(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_break_quantity(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_timeout_clause")
 def Get_Timeout_Clause(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_timeout_clause(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_timeout_clause")
 def Set_Timeout_Clause(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_timeout_clause(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_postponed_flag")
 def Get_Postponed_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_postponed_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_postponed_flag")
 def Set_Postponed_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_postponed_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_callees_list")
 def Get_Callees_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_callees_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_callees_list")
 def Set_Callees_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_callees_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_passive_flag")
 def Get_Passive_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_passive_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_passive_flag")
 def Set_Passive_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_passive_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_resolution_function_flag")
 def Get_Resolution_Function_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_resolution_function_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_resolution_function_flag")
 def Set_Resolution_Function_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_resolution_function_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_wait_state")
 def Get_Wait_State(obj: Iir) -> TriStateType:
-    return libghdl.vhdl__nodes__get_wait_state(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_wait_state")
 def Set_Wait_State(obj: Iir, value: TriStateType) -> None:
-    libghdl.vhdl__nodes__set_wait_state(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_all_sensitized_state")
 def Get_All_Sensitized_State(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_all_sensitized_state(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_all_sensitized_state")
 def Set_All_Sensitized_State(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_all_sensitized_state(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_seen_flag")
 def Get_Seen_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_seen_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_seen_flag")
 def Set_Seen_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_seen_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_pure_flag")
 def Get_Pure_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_pure_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_pure_flag")
 def Set_Pure_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_pure_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_foreign_flag")
 def Get_Foreign_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_foreign_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_foreign_flag")
 def Set_Foreign_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_foreign_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_resolved_flag")
 def Get_Resolved_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_resolved_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_resolved_flag")
 def Set_Resolved_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_resolved_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_signal_type_flag")
 def Get_Signal_Type_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_signal_type_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_signal_type_flag")
 def Set_Signal_Type_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_signal_type_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_signal_flag")
 def Get_Has_Signal_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_signal_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_signal_flag")
 def Set_Has_Signal_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_signal_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_purity_state")
 def Get_Purity_State(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_purity_state(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_purity_state")
 def Set_Purity_State(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_purity_state(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_elab_flag")
 def Get_Elab_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_elab_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_elab_flag")
 def Set_Elab_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_elab_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_vendor_library_flag")
 def Get_Vendor_Library_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_vendor_library_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_vendor_library_flag")
 def Set_Vendor_Library_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_vendor_library_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_configuration_mark_flag")
 def Get_Configuration_Mark_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_configuration_mark_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_configuration_mark_flag")
 def Set_Configuration_Mark_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_configuration_mark_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_configuration_done_flag")
 def Get_Configuration_Done_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_configuration_done_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_configuration_done_flag")
 def Set_Configuration_Done_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_configuration_done_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_index_constraint_flag")
 def Get_Index_Constraint_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_index_constraint_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_index_constraint_flag")
 def Set_Index_Constraint_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_index_constraint_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_hide_implicit_flag")
 def Get_Hide_Implicit_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_hide_implicit_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_hide_implicit_flag")
 def Set_Hide_Implicit_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_hide_implicit_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_assertion_condition")
 def Get_Assertion_Condition(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_assertion_condition(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_assertion_condition")
 def Set_Assertion_Condition(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_assertion_condition(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_report_expression")
 def Get_Report_Expression(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_report_expression(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_report_expression")
 def Set_Report_Expression(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_report_expression(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_severity_expression")
 def Get_Severity_Expression(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_severity_expression(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_severity_expression")
 def Set_Severity_Expression(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_severity_expression(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_instantiated_unit")
 def Get_Instantiated_Unit(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_instantiated_unit(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_instantiated_unit")
 def Set_Instantiated_Unit(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_instantiated_unit(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_generic_map_aspect_chain")
 def Get_Generic_Map_Aspect_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_generic_map_aspect_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_generic_map_aspect_chain")
 def Set_Generic_Map_Aspect_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_generic_map_aspect_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_port_map_aspect_chain")
 def Get_Port_Map_Aspect_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_port_map_aspect_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_port_map_aspect_chain")
 def Set_Port_Map_Aspect_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_port_map_aspect_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_configuration_name")
 def Get_Configuration_Name(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_configuration_name(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_configuration_name")
 def Set_Configuration_Name(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_configuration_name(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_component_configuration")
 def Get_Component_Configuration(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_component_configuration(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_component_configuration")
 def Set_Component_Configuration(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_component_configuration(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_configuration_specification")
 def Get_Configuration_Specification(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_configuration_specification(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_configuration_specification")
 def Set_Configuration_Specification(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_configuration_specification(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_default_binding_indication")
 def Get_Default_Binding_Indication(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_default_binding_indication(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_default_binding_indication")
 def Set_Default_Binding_Indication(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_default_binding_indication(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_default_configuration_declaration")
 def Get_Default_Configuration_Declaration(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_default_configuration_declaration(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_default_configuration_declaration")
 def Set_Default_Configuration_Declaration(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_default_configuration_declaration(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_expression")
 def Get_Expression(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_expression(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_expression")
 def Set_Expression(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_expression(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_conditional_expression_chain")
 def Get_Conditional_Expression_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_conditional_expression_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_conditional_expression_chain")
 def Set_Conditional_Expression_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_conditional_expression_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_allocator_designated_type")
 def Get_Allocator_Designated_Type(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_allocator_designated_type(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_allocator_designated_type")
 def Set_Allocator_Designated_Type(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_allocator_designated_type(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_selected_waveform_chain")
 def Get_Selected_Waveform_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_selected_waveform_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_selected_waveform_chain")
 def Set_Selected_Waveform_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_selected_waveform_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_conditional_waveform_chain")
 def Get_Conditional_Waveform_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_conditional_waveform_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_conditional_waveform_chain")
 def Set_Conditional_Waveform_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_conditional_waveform_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_guard_expression")
 def Get_Guard_Expression(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_guard_expression(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_guard_expression")
 def Set_Guard_Expression(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_guard_expression(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_guard_decl")
 def Get_Guard_Decl(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_guard_decl(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_guard_decl")
 def Set_Guard_Decl(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_guard_decl(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_guard_sensitivity_list")
 def Get_Guard_Sensitivity_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_guard_sensitivity_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_guard_sensitivity_list")
 def Set_Guard_Sensitivity_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_guard_sensitivity_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_signal_attribute_chain")
 def Get_Signal_Attribute_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_signal_attribute_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_signal_attribute_chain")
 def Set_Signal_Attribute_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_signal_attribute_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_block_block_configuration")
 def Get_Block_Block_Configuration(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_block_block_configuration(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_block_block_configuration")
 def Set_Block_Block_Configuration(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_block_block_configuration(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_package_header")
 def Get_Package_Header(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_package_header(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_package_header")
 def Set_Package_Header(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_package_header(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_block_header")
 def Get_Block_Header(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_block_header(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_block_header")
 def Set_Block_Header(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_block_header(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_uninstantiated_package_name")
 def Get_Uninstantiated_Package_Name(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_uninstantiated_package_name(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_uninstantiated_package_name")
 def Set_Uninstantiated_Package_Name(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_uninstantiated_package_name(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_uninstantiated_package_decl")
 def Get_Uninstantiated_Package_Decl(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_uninstantiated_package_decl(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_uninstantiated_package_decl")
 def Set_Uninstantiated_Package_Decl(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_uninstantiated_package_decl(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_instance_source_file")
 def Get_Instance_Source_File(obj: Iir) -> SourceFileEntry:
-    return libghdl.vhdl__nodes__get_instance_source_file(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_instance_source_file")
 def Set_Instance_Source_File(obj: Iir, value: SourceFileEntry) -> None:
-    libghdl.vhdl__nodes__set_instance_source_file(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_generate_block_configuration")
 def Get_Generate_Block_Configuration(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_generate_block_configuration(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_generate_block_configuration")
 def Set_Generate_Block_Configuration(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_generate_block_configuration(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_generate_statement_body")
 def Get_Generate_Statement_Body(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_generate_statement_body(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_generate_statement_body")
 def Set_Generate_Statement_Body(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_generate_statement_body(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_alternative_label")
 def Get_Alternative_Label(obj: Iir) -> NameId:
-    return libghdl.vhdl__nodes__get_alternative_label(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_alternative_label")
 def Set_Alternative_Label(obj: Iir, value: NameId) -> None:
-    libghdl.vhdl__nodes__set_alternative_label(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_generate_else_clause")
 def Get_Generate_Else_Clause(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_generate_else_clause(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_generate_else_clause")
 def Set_Generate_Else_Clause(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_generate_else_clause(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_condition")
 def Get_Condition(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_condition(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_condition")
 def Set_Condition(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_condition(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_else_clause")
 def Get_Else_Clause(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_else_clause(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_else_clause")
 def Set_Else_Clause(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_else_clause(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_parameter_specification")
 def Get_Parameter_Specification(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_parameter_specification(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_parameter_specification")
 def Set_Parameter_Specification(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_parameter_specification(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_parent")
 def Get_Parent(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_parent(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_parent")
 def Set_Parent(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_parent(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_loop_label")
 def Get_Loop_Label(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_loop_label(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_loop_label")
 def Set_Loop_Label(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_loop_label(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_exit_flag")
 def Get_Exit_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_exit_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_exit_flag")
 def Set_Exit_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_exit_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_next_flag")
 def Get_Next_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_next_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_next_flag")
 def Set_Next_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_next_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_component_name")
 def Get_Component_Name(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_component_name(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_component_name")
 def Set_Component_Name(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_component_name(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_instantiation_list")
 def Get_Instantiation_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_instantiation_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_instantiation_list")
 def Set_Instantiation_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_instantiation_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_entity_aspect")
 def Get_Entity_Aspect(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_entity_aspect(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_entity_aspect")
 def Set_Entity_Aspect(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_entity_aspect(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_default_entity_aspect")
 def Get_Default_Entity_Aspect(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_default_entity_aspect(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_default_entity_aspect")
 def Set_Default_Entity_Aspect(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_default_entity_aspect(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_binding_indication")
 def Get_Binding_Indication(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_binding_indication(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_binding_indication")
 def Set_Binding_Indication(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_binding_indication(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_named_entity")
 def Get_Named_Entity(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_named_entity(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_named_entity")
 def Set_Named_Entity(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_named_entity(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_referenced_name")
 def Get_Referenced_Name(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_referenced_name(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_referenced_name")
 def Set_Referenced_Name(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_referenced_name(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_expr_staticness")
 def Get_Expr_Staticness(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_expr_staticness(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_expr_staticness")
 def Set_Expr_Staticness(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_expr_staticness(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_scalar_size")
 def Get_Scalar_Size(obj: Iir) -> ScalarSize:
-    return libghdl.vhdl__nodes__get_scalar_size(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_scalar_size")
 def Set_Scalar_Size(obj: Iir, value: ScalarSize) -> None:
-    libghdl.vhdl__nodes__set_scalar_size(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_error_origin")
 def Get_Error_Origin(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_error_origin(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_error_origin")
 def Set_Error_Origin(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_error_origin(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_operand")
 def Get_Operand(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_operand(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_operand")
 def Set_Operand(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_operand(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_left")
 def Get_Left(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_left(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_left")
 def Set_Left(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_left(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_right")
 def Get_Right(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_right(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_right")
 def Set_Right(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_right(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_unit_name")
 def Get_Unit_Name(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_unit_name(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_unit_name")
 def Set_Unit_Name(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_unit_name(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_name")
 def Get_Name(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_name(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_name")
 def Set_Name(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_name(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_group_template_name")
 def Get_Group_Template_Name(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_group_template_name(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_group_template_name")
 def Set_Group_Template_Name(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_group_template_name(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_name_staticness")
 def Get_Name_Staticness(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_name_staticness(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_name_staticness")
 def Set_Name_Staticness(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_name_staticness(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_prefix")
 def Get_Prefix(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_prefix(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_prefix")
 def Set_Prefix(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_prefix(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_signature_prefix")
 def Get_Signature_Prefix(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_signature_prefix(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_signature_prefix")
 def Set_Signature_Prefix(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_signature_prefix(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_external_pathname")
 def Get_External_Pathname(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_external_pathname(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_external_pathname")
 def Set_External_Pathname(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_external_pathname(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_pathname_suffix")
 def Get_Pathname_Suffix(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_pathname_suffix(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_pathname_suffix")
 def Set_Pathname_Suffix(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_pathname_suffix(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_pathname_expression")
 def Get_Pathname_Expression(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_pathname_expression(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_pathname_expression")
 def Set_Pathname_Expression(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_pathname_expression(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_in_formal_flag")
 def Get_In_Formal_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_in_formal_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_in_formal_flag")
 def Set_In_Formal_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_in_formal_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_slice_subtype")
 def Get_Slice_Subtype(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_slice_subtype(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_slice_subtype")
 def Set_Slice_Subtype(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_slice_subtype(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_suffix")
 def Get_Suffix(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_suffix(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_suffix")
 def Set_Suffix(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_suffix(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_index_subtype")
 def Get_Index_Subtype(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_index_subtype(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_index_subtype")
 def Set_Index_Subtype(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_index_subtype(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_parameter")
 def Get_Parameter(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_parameter(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_parameter")
 def Set_Parameter(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_parameter(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_parameter_2")
 def Get_Parameter_2(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_parameter_2(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_parameter_2")
 def Set_Parameter_2(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_parameter_2(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_parameter_3")
 def Get_Parameter_3(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_parameter_3(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_parameter_3")
 def Set_Parameter_3(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_parameter_3(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_parameter_4")
 def Get_Parameter_4(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_parameter_4(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_parameter_4")
 def Set_Parameter_4(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_parameter_4(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_attr_chain")
 def Get_Attr_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_attr_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_attr_chain")
 def Set_Attr_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_attr_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_signal_attribute_declaration")
 def Get_Signal_Attribute_Declaration(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_signal_attribute_declaration(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_signal_attribute_declaration")
 def Set_Signal_Attribute_Declaration(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_signal_attribute_declaration(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_actual_type")
 def Get_Actual_Type(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_actual_type(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_actual_type")
 def Set_Actual_Type(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_actual_type(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_actual_type_definition")
 def Get_Actual_Type_Definition(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_actual_type_definition(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_actual_type_definition")
 def Set_Actual_Type_Definition(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_actual_type_definition(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_association_chain")
 def Get_Association_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_association_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_association_chain")
 def Set_Association_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_association_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_individual_association_chain")
 def Get_Individual_Association_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_individual_association_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_individual_association_chain")
 def Set_Individual_Association_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_individual_association_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_subprogram_association_chain")
 def Get_Subprogram_Association_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_subprogram_association_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_subprogram_association_chain")
 def Set_Subprogram_Association_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_subprogram_association_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_aggregate_info")
 def Get_Aggregate_Info(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_aggregate_info(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_aggregate_info")
 def Set_Aggregate_Info(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_aggregate_info(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_sub_aggregate_info")
 def Get_Sub_Aggregate_Info(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_sub_aggregate_info(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_sub_aggregate_info")
 def Set_Sub_Aggregate_Info(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_sub_aggregate_info(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_aggr_dynamic_flag")
 def Get_Aggr_Dynamic_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_aggr_dynamic_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_aggr_dynamic_flag")
 def Set_Aggr_Dynamic_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_aggr_dynamic_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_aggr_min_length")
 def Get_Aggr_Min_Length(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_aggr_min_length(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_aggr_min_length")
 def Set_Aggr_Min_Length(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_aggr_min_length(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_aggr_low_limit")
 def Get_Aggr_Low_Limit(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_aggr_low_limit(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_aggr_low_limit")
 def Set_Aggr_Low_Limit(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_aggr_low_limit(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_aggr_high_limit")
 def Get_Aggr_High_Limit(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_aggr_high_limit(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_aggr_high_limit")
 def Set_Aggr_High_Limit(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_aggr_high_limit(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_aggr_others_flag")
 def Get_Aggr_Others_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_aggr_others_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_aggr_others_flag")
 def Set_Aggr_Others_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_aggr_others_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_aggr_named_flag")
 def Get_Aggr_Named_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_aggr_named_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_aggr_named_flag")
 def Set_Aggr_Named_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_aggr_named_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_aggregate_expand_flag")
 def Get_Aggregate_Expand_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_aggregate_expand_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_aggregate_expand_flag")
 def Set_Aggregate_Expand_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_aggregate_expand_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_association_choices_chain")
 def Get_Association_Choices_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_association_choices_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_association_choices_chain")
 def Set_Association_Choices_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_association_choices_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_case_statement_alternative_chain")
 def Get_Case_Statement_Alternative_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_case_statement_alternative_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_case_statement_alternative_chain")
 def Set_Case_Statement_Alternative_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_case_statement_alternative_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_choice_staticness")
 def Get_Choice_Staticness(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_choice_staticness(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_choice_staticness")
 def Set_Choice_Staticness(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_choice_staticness(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_procedure_call")
 def Get_Procedure_Call(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_procedure_call(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_procedure_call")
 def Set_Procedure_Call(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_procedure_call(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_implementation")
 def Get_Implementation(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_implementation(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_implementation")
 def Set_Implementation(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_implementation(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_parameter_association_chain")
 def Get_Parameter_Association_Chain(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_parameter_association_chain(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_parameter_association_chain")
 def Set_Parameter_Association_Chain(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_parameter_association_chain(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_method_object")
 def Get_Method_Object(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_method_object(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_method_object")
 def Set_Method_Object(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_method_object(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_subtype_type_mark")
 def Get_Subtype_Type_Mark(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_subtype_type_mark(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_subtype_type_mark")
 def Set_Subtype_Type_Mark(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_subtype_type_mark(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_subnature_nature_mark")
 def Get_Subnature_Nature_Mark(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_subnature_nature_mark(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_subnature_nature_mark")
 def Set_Subnature_Nature_Mark(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_subnature_nature_mark(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_type_conversion_subtype")
 def Get_Type_Conversion_Subtype(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_type_conversion_subtype(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_type_conversion_subtype")
 def Set_Type_Conversion_Subtype(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_type_conversion_subtype(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_type_mark")
 def Get_Type_Mark(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_type_mark(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_type_mark")
 def Set_Type_Mark(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_type_mark(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_file_type_mark")
 def Get_File_Type_Mark(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_file_type_mark(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_file_type_mark")
 def Set_File_Type_Mark(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_file_type_mark(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_return_type_mark")
 def Get_Return_Type_Mark(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_return_type_mark(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_return_type_mark")
 def Set_Return_Type_Mark(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_return_type_mark(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_disconnect_flag")
 def Get_Has_Disconnect_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_disconnect_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_disconnect_flag")
 def Set_Has_Disconnect_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_disconnect_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_active_flag")
 def Get_Has_Active_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_active_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_active_flag")
 def Set_Has_Active_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_active_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_is_within_flag")
 def Get_Is_Within_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_is_within_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_is_within_flag")
 def Set_Is_Within_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_is_within_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_type_marks_list")
 def Get_Type_Marks_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_type_marks_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_type_marks_list")
 def Set_Type_Marks_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_type_marks_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_implicit_alias_flag")
 def Get_Implicit_Alias_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_implicit_alias_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_implicit_alias_flag")
 def Set_Implicit_Alias_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_implicit_alias_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_alias_signature")
 def Get_Alias_Signature(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_alias_signature(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_alias_signature")
 def Set_Alias_Signature(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_alias_signature(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_attribute_signature")
 def Get_Attribute_Signature(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_attribute_signature(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_attribute_signature")
 def Set_Attribute_Signature(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_attribute_signature(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_overload_list")
 def Get_Overload_List(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_overload_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_overload_list")
 def Set_Overload_List(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_overload_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_simple_name_identifier")
 def Get_Simple_Name_Identifier(obj: Iir) -> NameId:
-    return libghdl.vhdl__nodes__get_simple_name_identifier(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_simple_name_identifier")
 def Set_Simple_Name_Identifier(obj: Iir, value: NameId) -> None:
-    libghdl.vhdl__nodes__set_simple_name_identifier(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_simple_name_subtype")
 def Get_Simple_Name_Subtype(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_simple_name_subtype(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_simple_name_subtype")
 def Set_Simple_Name_Subtype(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_simple_name_subtype(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_protected_type_body")
 def Get_Protected_Type_Body(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_protected_type_body(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_protected_type_body")
 def Set_Protected_Type_Body(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_protected_type_body(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_protected_type_declaration")
 def Get_Protected_Type_Declaration(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_protected_type_declaration(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_protected_type_declaration")
 def Set_Protected_Type_Declaration(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_protected_type_declaration(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_use_flag")
 def Get_Use_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_use_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_use_flag")
 def Set_Use_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_use_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_end_has_reserved_id")
 def Get_End_Has_Reserved_Id(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_end_has_reserved_id(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_end_has_reserved_id")
 def Set_End_Has_Reserved_Id(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_end_has_reserved_id(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_end_has_identifier")
 def Get_End_Has_Identifier(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_end_has_identifier(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_end_has_identifier")
 def Set_End_Has_Identifier(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_end_has_identifier(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_end_has_postponed")
 def Get_End_Has_Postponed(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_end_has_postponed(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_end_has_postponed")
 def Set_End_Has_Postponed(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_end_has_postponed(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_label")
 def Get_Has_Label(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_label(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_label")
 def Set_Has_Label(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_label(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_begin")
 def Get_Has_Begin(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_begin(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_begin")
 def Set_Has_Begin(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_begin(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_end")
 def Get_Has_End(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_end(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_end")
 def Set_Has_End(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_end(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_is")
 def Get_Has_Is(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_is(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_is")
 def Set_Has_Is(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_is(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_pure")
 def Get_Has_Pure(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_pure(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_pure")
 def Set_Has_Pure(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_pure(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_body")
 def Get_Has_Body(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_body(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_body")
 def Set_Has_Body(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_body(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_parameter")
 def Get_Has_Parameter(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_parameter(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_parameter")
 def Set_Has_Parameter(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_parameter(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_component")
 def Get_Has_Component(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_component(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_component")
 def Set_Has_Component(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_component(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_identifier_list")
 def Get_Has_Identifier_List(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_identifier_list(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_identifier_list")
 def Set_Has_Identifier_List(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_identifier_list(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_mode")
 def Get_Has_Mode(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_mode(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_mode")
 def Set_Has_Mode(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_mode(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_class")
 def Get_Has_Class(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_class(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_class")
 def Set_Has_Class(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_class(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_has_delay_mechanism")
 def Get_Has_Delay_Mechanism(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_has_delay_mechanism(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_has_delay_mechanism")
 def Set_Has_Delay_Mechanism(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_has_delay_mechanism(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_suspend_flag")
 def Get_Suspend_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_suspend_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_suspend_flag")
 def Set_Suspend_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_suspend_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_is_ref")
 def Get_Is_Ref(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_is_ref(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_is_ref")
 def Set_Is_Ref(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_is_ref(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_is_forward_ref")
 def Get_Is_Forward_Ref(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_is_forward_ref(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_is_forward_ref")
 def Set_Is_Forward_Ref(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_is_forward_ref(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_psl_property")
 def Get_Psl_Property(obj: Iir) -> PSLNode:
-    return libghdl.vhdl__nodes__get_psl_property(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_psl_property")
 def Set_Psl_Property(obj: Iir, value: PSLNode) -> None:
-    libghdl.vhdl__nodes__set_psl_property(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_psl_sequence")
 def Get_Psl_Sequence(obj: Iir) -> PSLNode:
-    return libghdl.vhdl__nodes__get_psl_sequence(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_psl_sequence")
 def Set_Psl_Sequence(obj: Iir, value: PSLNode) -> None:
-    libghdl.vhdl__nodes__set_psl_sequence(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_psl_declaration")
 def Get_Psl_Declaration(obj: Iir) -> PSLNode:
-    return libghdl.vhdl__nodes__get_psl_declaration(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_psl_declaration")
 def Set_Psl_Declaration(obj: Iir, value: PSLNode) -> None:
-    libghdl.vhdl__nodes__set_psl_declaration(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_psl_expression")
 def Get_Psl_Expression(obj: Iir) -> PSLNode:
-    return libghdl.vhdl__nodes__get_psl_expression(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_psl_expression")
 def Set_Psl_Expression(obj: Iir, value: PSLNode) -> None:
-    libghdl.vhdl__nodes__set_psl_expression(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_psl_boolean")
 def Get_Psl_Boolean(obj: Iir) -> PSLNode:
-    return libghdl.vhdl__nodes__get_psl_boolean(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_psl_boolean")
 def Set_Psl_Boolean(obj: Iir, value: PSLNode) -> None:
-    libghdl.vhdl__nodes__set_psl_boolean(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_psl_clock")
 def Get_PSL_Clock(obj: Iir) -> PSLNode:
-    return libghdl.vhdl__nodes__get_psl_clock(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_psl_clock")
 def Set_PSL_Clock(obj: Iir, value: PSLNode) -> None:
-    libghdl.vhdl__nodes__set_psl_clock(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_psl_nfa")
 def Get_PSL_NFA(obj: Iir) -> PSLNFA:
-    return libghdl.vhdl__nodes__get_psl_nfa(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_psl_nfa")
 def Set_PSL_NFA(obj: Iir, value: PSLNFA) -> None:
-    libghdl.vhdl__nodes__set_psl_nfa(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_psl_nbr_states")
 def Get_PSL_Nbr_States(obj: Iir) -> Int32:
-    return libghdl.vhdl__nodes__get_psl_nbr_states(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_psl_nbr_states")
 def Set_PSL_Nbr_States(obj: Iir, value: Int32) -> None:
-    libghdl.vhdl__nodes__set_psl_nbr_states(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_psl_clock_sensitivity")
 def Get_PSL_Clock_Sensitivity(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_psl_clock_sensitivity(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_psl_clock_sensitivity")
 def Set_PSL_Clock_Sensitivity(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_psl_clock_sensitivity(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_psl_eos_flag")
 def Get_PSL_EOS_Flag(obj: Iir) -> Boolean:
-    return libghdl.vhdl__nodes__get_psl_eos_flag(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_psl_eos_flag")
 def Set_PSL_EOS_Flag(obj: Iir, value: Boolean) -> None:
-    libghdl.vhdl__nodes__set_psl_eos_flag(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_count_expression")
 def Get_Count_Expression(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_count_expression(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_count_expression")
 def Set_Count_Expression(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_count_expression(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_clock_expression")
 def Get_Clock_Expression(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_clock_expression(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_clock_expression")
 def Set_Clock_Expression(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_clock_expression(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_default_clock")
 def Get_Default_Clock(obj: Iir) -> Iir:
-    return libghdl.vhdl__nodes__get_default_clock(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_default_clock")
 def Set_Default_Clock(obj: Iir, value: Iir) -> None:
-    libghdl.vhdl__nodes__set_default_clock(obj, value)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__get_foreign_node")
 def Get_Foreign_Node(obj: Iir) -> Int32:
-    return libghdl.vhdl__nodes__get_foreign_node(obj)
+    """"""
 
 
 @export
+@BindToLibGHDL("vhdl__nodes__set_foreign_node")
 def Set_Foreign_Node(obj: Iir, value: Int32) -> None:
-    libghdl.vhdl__nodes__set_foreign_node(obj, value)
+    """"""

--- a/pyGHDL/libghdl/vhdl/nodes_meta.py
+++ b/pyGHDL/libghdl/vhdl/nodes_meta.py
@@ -3,12 +3,15 @@
 #
 from enum import IntEnum, unique
 from pydecor import export
+
+from pyGHDL.libghdl._decorator import BindToLibGHDL
 from pyGHDL.libghdl import libghdl
 from pyGHDL.libghdl._types import IirKind
 
 
 # From nodes_meta
 @export
+@BindToLibGHDL("vhdl__nodes_meta__get_fields_first")
 def get_fields_first(K: IirKind) -> int:
     """
     Return the list of fields for node :obj:`K`.
@@ -21,10 +24,10 @@ def get_fields_first(K: IirKind) -> int:
 
     :param K: Node to get first array index from.
     """
-    return libghdl.vhdl__nodes_meta__get_fields_first(K)
 
 
 @export
+@BindToLibGHDL("vhdl__nodes_meta__get_fields_last")
 def get_fields_last(K: IirKind) -> int:
     """
     Return the list of fields for node :obj:`K`.
@@ -37,12 +40,12 @@ def get_fields_last(K: IirKind) -> int:
 
     :param K: Node to get last array index from.
     """
-    return libghdl.vhdl__nodes_meta__get_fields_last(K)
 
 
 @export
+@BindToLibGHDL("vhdl__nodes_meta__get_field_by_index")
 def get_field_by_index(K: IirKind) -> int:
-    return libghdl.vhdl__nodes_meta__get_field_by_index(K)
+    """"""
 
 
 @export
@@ -614,1481 +617,2221 @@ def Get_Tri_State_Type(node, field):
     return libghdl.vhdl__nodes_meta__get_tri_state_type(node, field)
 
 
-def Has_First_Design_Unit(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_first_design_unit(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_first_design_unit")
+def Has_First_Design_Unit(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Last_Design_Unit(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_last_design_unit(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_last_design_unit")
+def Has_Last_Design_Unit(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Library_Declaration(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_library_declaration(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_library_declaration")
+def Has_Library_Declaration(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_File_Checksum(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_file_checksum(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_file_checksum")
+def Has_File_Checksum(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Analysis_Time_Stamp(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_analysis_time_stamp(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_analysis_time_stamp")
+def Has_Analysis_Time_Stamp(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Design_File_Source(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_design_file_source(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_design_file_source")
+def Has_Design_File_Source(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Library(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_library(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_library")
+def Has_Library(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_File_Dependence_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_file_dependence_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_file_dependence_list")
+def Has_File_Dependence_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Design_File_Filename(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_design_file_filename(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_design_file_filename")
+def Has_Design_File_Filename(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Design_File_Directory(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_design_file_directory(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_design_file_directory")
+def Has_Design_File_Directory(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Design_File(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_design_file(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_design_file")
+def Has_Design_File(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Design_File_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_design_file_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_design_file_chain")
+def Has_Design_File_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Library_Directory(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_library_directory(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_library_directory")
+def Has_Library_Directory(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Date(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_date(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_date")
+def Has_Date(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Context_Items(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_context_items(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_context_items")
+def Has_Context_Items(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Dependence_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_dependence_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_dependence_list")
+def Has_Dependence_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Analysis_Checks_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_analysis_checks_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_analysis_checks_list")
+def Has_Analysis_Checks_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Date_State(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_date_state(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_date_state")
+def Has_Date_State(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Guarded_Target_State(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_guarded_target_state(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_guarded_target_state")
+def Has_Guarded_Target_State(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Library_Unit(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_library_unit(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_library_unit")
+def Has_Library_Unit(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Hash_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_hash_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_hash_chain")
+def Has_Hash_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Design_Unit_Source_Pos(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_design_unit_source_pos(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_design_unit_source_pos")
+def Has_Design_Unit_Source_Pos(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Design_Unit_Source_Line(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_design_unit_source_line(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_design_unit_source_line")
+def Has_Design_Unit_Source_Line(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Design_Unit_Source_Col(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_design_unit_source_col(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_design_unit_source_col")
+def Has_Design_Unit_Source_Col(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Value(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_value(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_value")
+def Has_Value(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Enum_Pos(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_enum_pos(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_enum_pos")
+def Has_Enum_Pos(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Physical_Literal(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_physical_literal(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_physical_literal")
+def Has_Physical_Literal(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Fp_Value(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_fp_value(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_fp_value")
+def Has_Fp_Value(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Simple_Aggregate_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_simple_aggregate_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_simple_aggregate_list")
+def Has_Simple_Aggregate_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_String8_Id(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_string8_id(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_string8_id")
+def Has_String8_Id(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_String_Length(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_string_length(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_string_length")
+def Has_String_Length(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Bit_String_Base(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_bit_string_base(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_bit_string_base")
+def Has_Bit_String_Base(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Signed(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_signed(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_signed")
+def Has_Has_Signed(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Sign(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_sign(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_sign")
+def Has_Has_Sign(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Length(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_length(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_length")
+def Has_Has_Length(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Literal_Length(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_literal_length(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_literal_length")
+def Has_Literal_Length(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Literal_Origin(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_literal_origin(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_literal_origin")
+def Has_Literal_Origin(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Range_Origin(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_range_origin(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_range_origin")
+def Has_Range_Origin(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Literal_Subtype(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_literal_subtype(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_literal_subtype")
+def Has_Literal_Subtype(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Allocator_Subtype(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_allocator_subtype(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_allocator_subtype")
+def Has_Allocator_Subtype(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Entity_Class(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_entity_class(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_entity_class")
+def Has_Entity_Class(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Entity_Name_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_entity_name_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_entity_name_list")
+def Has_Entity_Name_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Attribute_Designator(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_attribute_designator(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_attribute_designator")
+def Has_Attribute_Designator(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Attribute_Specification_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_attribute_specification_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_attribute_specification_chain")
+def Has_Attribute_Specification_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Attribute_Specification(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_attribute_specification(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_attribute_specification")
+def Has_Attribute_Specification(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Static_Attribute_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_static_attribute_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_static_attribute_flag")
+def Has_Static_Attribute_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Signal_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_signal_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_signal_list")
+def Has_Signal_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Quantity_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_quantity_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_quantity_list")
+def Has_Quantity_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Designated_Entity(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_designated_entity(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_designated_entity")
+def Has_Designated_Entity(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Formal(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_formal(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_formal")
+def Has_Formal(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Actual(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_actual(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_actual")
+def Has_Actual(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Actual_Conversion(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_actual_conversion(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_actual_conversion")
+def Has_Actual_Conversion(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Formal_Conversion(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_formal_conversion(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_formal_conversion")
+def Has_Formal_Conversion(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Whole_Association_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_whole_association_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_whole_association_flag")
+def Has_Whole_Association_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Collapse_Signal_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_collapse_signal_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_collapse_signal_flag")
+def Has_Collapse_Signal_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Artificial_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_artificial_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_artificial_flag")
+def Has_Artificial_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Open_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_open_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_open_flag")
+def Has_Open_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_After_Drivers_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_after_drivers_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_after_drivers_flag")
+def Has_After_Drivers_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_We_Value(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_we_value(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_we_value")
+def Has_We_Value(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Time(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_time(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_time")
+def Has_Time(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Associated_Expr(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_associated_expr(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_associated_expr")
+def Has_Associated_Expr(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Associated_Block(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_associated_block(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_associated_block")
+def Has_Associated_Block(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Associated_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_associated_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_associated_chain")
+def Has_Associated_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Choice_Name(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_choice_name(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_choice_name")
+def Has_Choice_Name(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Choice_Expression(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_choice_expression(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_choice_expression")
+def Has_Choice_Expression(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Choice_Range(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_choice_range(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_choice_range")
+def Has_Choice_Range(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Same_Alternative_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_same_alternative_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_same_alternative_flag")
+def Has_Same_Alternative_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Element_Type_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_element_type_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_element_type_flag")
+def Has_Element_Type_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Architecture(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_architecture(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_architecture")
+def Has_Architecture(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Block_Specification(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_block_specification(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_block_specification")
+def Has_Block_Specification(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Prev_Block_Configuration(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_prev_block_configuration(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_prev_block_configuration")
+def Has_Prev_Block_Configuration(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Configuration_Item_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_configuration_item_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_configuration_item_chain")
+def Has_Configuration_Item_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Attribute_Value_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_attribute_value_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_attribute_value_chain")
+def Has_Attribute_Value_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Spec_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_spec_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_spec_chain")
+def Has_Spec_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Value_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_value_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_value_chain")
+def Has_Value_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Attribute_Value_Spec_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_attribute_value_spec_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_attribute_value_spec_chain")
+def Has_Attribute_Value_Spec_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Entity_Name(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_entity_name(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_entity_name")
+def Has_Entity_Name(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Package(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_package(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_package")
+def Has_Package(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Package_Body(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_package_body(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_package_body")
+def Has_Package_Body(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Instance_Package_Body(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_instance_package_body(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_instance_package_body")
+def Has_Instance_Package_Body(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Need_Body(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_need_body(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_need_body")
+def Has_Need_Body(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Macro_Expanded_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_macro_expanded_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_macro_expanded_flag")
+def Has_Macro_Expanded_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Need_Instance_Bodies(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_need_instance_bodies(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_need_instance_bodies")
+def Has_Need_Instance_Bodies(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Hierarchical_Name(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_hierarchical_name(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_hierarchical_name")
+def Has_Hierarchical_Name(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Inherit_Spec_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_inherit_spec_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_inherit_spec_chain")
+def Has_Inherit_Spec_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Vunit_Item_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_vunit_item_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_vunit_item_chain")
+def Has_Vunit_Item_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Bound_Vunit_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_bound_vunit_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_bound_vunit_chain")
+def Has_Bound_Vunit_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Verification_Block_Configuration(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_verification_block_configuration(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_verification_block_configuration")
+def Has_Verification_Block_Configuration(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Block_Configuration(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_block_configuration(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_block_configuration")
+def Has_Block_Configuration(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Concurrent_Statement_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_concurrent_statement_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_concurrent_statement_chain")
+def Has_Concurrent_Statement_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_chain")
+def Has_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Port_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_port_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_port_chain")
+def Has_Port_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Generic_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_generic_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_generic_chain")
+def Has_Generic_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Type(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_type(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_type")
+def Has_Type(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Subtype_Indication(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_subtype_indication(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_subtype_indication")
+def Has_Subtype_Indication(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Discrete_Range(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_discrete_range(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_discrete_range")
+def Has_Discrete_Range(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Type_Definition(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_type_definition(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_type_definition")
+def Has_Type_Definition(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Subtype_Definition(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_subtype_definition(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_subtype_definition")
+def Has_Subtype_Definition(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Incomplete_Type_Declaration(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_incomplete_type_declaration(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_incomplete_type_declaration")
+def Has_Incomplete_Type_Declaration(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Interface_Type_Subprograms(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_interface_type_subprograms(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_interface_type_subprograms")
+def Has_Interface_Type_Subprograms(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Nature_Definition(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_nature_definition(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_nature_definition")
+def Has_Nature_Definition(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Nature(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_nature(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_nature")
+def Has_Nature(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Subnature_Indication(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_subnature_indication(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_subnature_indication")
+def Has_Subnature_Indication(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Mode(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_mode(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_mode")
+def Has_Mode(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Guarded_Signal_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_guarded_signal_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_guarded_signal_flag")
+def Has_Guarded_Signal_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Signal_Kind(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_signal_kind(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_signal_kind")
+def Has_Signal_Kind(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Base_Name(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_base_name(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_base_name")
+def Has_Base_Name(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Interface_Declaration_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_interface_declaration_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_interface_declaration_chain")
+def Has_Interface_Declaration_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Subprogram_Specification(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_subprogram_specification(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_subprogram_specification")
+def Has_Subprogram_Specification(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Sequential_Statement_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_sequential_statement_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_sequential_statement_chain")
+def Has_Sequential_Statement_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Simultaneous_Statement_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_simultaneous_statement_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_simultaneous_statement_chain")
+def Has_Simultaneous_Statement_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Subprogram_Body(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_subprogram_body(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_subprogram_body")
+def Has_Subprogram_Body(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Overload_Number(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_overload_number(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_overload_number")
+def Has_Overload_Number(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Subprogram_Depth(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_subprogram_depth(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_subprogram_depth")
+def Has_Subprogram_Depth(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Subprogram_Hash(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_subprogram_hash(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_subprogram_hash")
+def Has_Subprogram_Hash(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Impure_Depth(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_impure_depth(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_impure_depth")
+def Has_Impure_Depth(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Return_Type(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_return_type(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_return_type")
+def Has_Return_Type(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Implicit_Definition(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_implicit_definition(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_implicit_definition")
+def Has_Implicit_Definition(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Uninstantiated_Subprogram_Name(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_uninstantiated_subprogram_name(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_uninstantiated_subprogram_name")
+def Has_Uninstantiated_Subprogram_Name(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Default_Value(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_default_value(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_default_value")
+def Has_Default_Value(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Deferred_Declaration(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_deferred_declaration(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_deferred_declaration")
+def Has_Deferred_Declaration(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Deferred_Declaration_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_deferred_declaration_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_deferred_declaration_flag")
+def Has_Deferred_Declaration_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Shared_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_shared_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_shared_flag")
+def Has_Shared_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Design_Unit(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_design_unit(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_design_unit")
+def Has_Design_Unit(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Block_Statement(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_block_statement(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_block_statement")
+def Has_Block_Statement(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Signal_Driver(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_signal_driver(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_signal_driver")
+def Has_Signal_Driver(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Declaration_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_declaration_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_declaration_chain")
+def Has_Declaration_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_File_Logical_Name(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_file_logical_name(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_file_logical_name")
+def Has_File_Logical_Name(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_File_Open_Kind(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_file_open_kind(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_file_open_kind")
+def Has_File_Open_Kind(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Element_Position(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_element_position(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_element_position")
+def Has_Element_Position(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Use_Clause_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_use_clause_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_use_clause_chain")
+def Has_Use_Clause_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Context_Reference_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_context_reference_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_context_reference_chain")
+def Has_Context_Reference_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Selected_Name(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_selected_name(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_selected_name")
+def Has_Selected_Name(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Type_Declarator(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_type_declarator(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_type_declarator")
+def Has_Type_Declarator(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Complete_Type_Definition(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_complete_type_definition(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_complete_type_definition")
+def Has_Complete_Type_Definition(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Incomplete_Type_Ref_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_incomplete_type_ref_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_incomplete_type_ref_chain")
+def Has_Incomplete_Type_Ref_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Associated_Type(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_associated_type(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_associated_type")
+def Has_Associated_Type(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Enumeration_Literal_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_enumeration_literal_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_enumeration_literal_list")
+def Has_Enumeration_Literal_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Entity_Class_Entry_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_entity_class_entry_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_entity_class_entry_chain")
+def Has_Entity_Class_Entry_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Group_Constituent_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_group_constituent_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_group_constituent_list")
+def Has_Group_Constituent_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Unit_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_unit_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_unit_chain")
+def Has_Unit_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Primary_Unit(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_primary_unit(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_primary_unit")
+def Has_Primary_Unit(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Identifier(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_identifier(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_identifier")
+def Has_Identifier(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Label(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_label(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_label")
+def Has_Label(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Visible_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_visible_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_visible_flag")
+def Has_Visible_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Range_Constraint(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_range_constraint(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_range_constraint")
+def Has_Range_Constraint(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Direction(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_direction(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_direction")
+def Has_Direction(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Left_Limit(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_left_limit(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_left_limit")
+def Has_Left_Limit(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Right_Limit(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_right_limit(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_right_limit")
+def Has_Right_Limit(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Left_Limit_Expr(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_left_limit_expr(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_left_limit_expr")
+def Has_Left_Limit_Expr(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Right_Limit_Expr(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_right_limit_expr(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_right_limit_expr")
+def Has_Right_Limit_Expr(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Parent_Type(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_parent_type(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_parent_type")
+def Has_Parent_Type(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Simple_Nature(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_simple_nature(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_simple_nature")
+def Has_Simple_Nature(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Base_Nature(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_base_nature(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_base_nature")
+def Has_Base_Nature(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Resolution_Indication(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_resolution_indication(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_resolution_indication")
+def Has_Resolution_Indication(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Record_Element_Resolution_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_record_element_resolution_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_record_element_resolution_chain")
+def Has_Record_Element_Resolution_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Tolerance(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_tolerance(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_tolerance")
+def Has_Tolerance(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Plus_Terminal_Name(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_plus_terminal_name(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_plus_terminal_name")
+def Has_Plus_Terminal_Name(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Minus_Terminal_Name(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_minus_terminal_name(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_minus_terminal_name")
+def Has_Minus_Terminal_Name(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Plus_Terminal(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_plus_terminal(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_plus_terminal")
+def Has_Plus_Terminal(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Minus_Terminal(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_minus_terminal(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_minus_terminal")
+def Has_Minus_Terminal(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Magnitude_Expression(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_magnitude_expression(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_magnitude_expression")
+def Has_Magnitude_Expression(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Phase_Expression(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_phase_expression(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_phase_expression")
+def Has_Phase_Expression(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Power_Expression(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_power_expression(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_power_expression")
+def Has_Power_Expression(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Simultaneous_Left(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_simultaneous_left(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_simultaneous_left")
+def Has_Simultaneous_Left(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Simultaneous_Right(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_simultaneous_right(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_simultaneous_right")
+def Has_Simultaneous_Right(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Text_File_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_text_file_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_text_file_flag")
+def Has_Text_File_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Only_Characters_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_only_characters_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_only_characters_flag")
+def Has_Only_Characters_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Is_Character_Type(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_is_character_type(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_is_character_type")
+def Has_Is_Character_Type(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Nature_Staticness(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_nature_staticness(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_nature_staticness")
+def Has_Nature_Staticness(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Type_Staticness(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_type_staticness(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_type_staticness")
+def Has_Type_Staticness(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Constraint_State(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_constraint_state(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_constraint_state")
+def Has_Constraint_State(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Index_Subtype_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_index_subtype_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_index_subtype_list")
+def Has_Index_Subtype_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Index_Subtype_Definition_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_index_subtype_definition_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_index_subtype_definition_list")
+def Has_Index_Subtype_Definition_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Element_Subtype_Indication(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_element_subtype_indication(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_element_subtype_indication")
+def Has_Element_Subtype_Indication(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Element_Subtype(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_element_subtype(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_element_subtype")
+def Has_Element_Subtype(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Element_Subnature_Indication(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_element_subnature_indication(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_element_subnature_indication")
+def Has_Element_Subnature_Indication(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Element_Subnature(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_element_subnature(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_element_subnature")
+def Has_Element_Subnature(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Index_Constraint_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_index_constraint_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_index_constraint_list")
+def Has_Index_Constraint_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Array_Element_Constraint(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_array_element_constraint(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_array_element_constraint")
+def Has_Array_Element_Constraint(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Array_Constraint_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_array_constraint_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_array_constraint_flag")
+def Has_Has_Array_Constraint_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Element_Constraint_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_element_constraint_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_element_constraint_flag")
+def Has_Has_Element_Constraint_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Elements_Declaration_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_elements_declaration_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_elements_declaration_list")
+def Has_Elements_Declaration_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Owned_Elements_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_owned_elements_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_owned_elements_chain")
+def Has_Owned_Elements_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Designated_Type(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_designated_type(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_designated_type")
+def Has_Designated_Type(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Designated_Subtype_Indication(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_designated_subtype_indication(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_designated_subtype_indication")
+def Has_Designated_Subtype_Indication(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Index_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_index_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_index_list")
+def Has_Index_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Reference(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_reference(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_reference")
+def Has_Reference(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Nature_Declarator(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_nature_declarator(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_nature_declarator")
+def Has_Nature_Declarator(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Across_Type_Mark(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_across_type_mark(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_across_type_mark")
+def Has_Across_Type_Mark(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Through_Type_Mark(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_through_type_mark(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_through_type_mark")
+def Has_Through_Type_Mark(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Across_Type_Definition(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_across_type_definition(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_across_type_definition")
+def Has_Across_Type_Definition(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Through_Type_Definition(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_through_type_definition(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_through_type_definition")
+def Has_Through_Type_Definition(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Across_Type(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_across_type(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_across_type")
+def Has_Across_Type(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Through_Type(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_through_type(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_through_type")
+def Has_Through_Type(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Target(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_target(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_target")
+def Has_Target(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Waveform_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_waveform_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_waveform_chain")
+def Has_Waveform_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Guard(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_guard(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_guard")
+def Has_Guard(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Delay_Mechanism(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_delay_mechanism(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_delay_mechanism")
+def Has_Delay_Mechanism(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Reject_Time_Expression(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_reject_time_expression(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_reject_time_expression")
+def Has_Reject_Time_Expression(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Force_Mode(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_force_mode(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_force_mode")
+def Has_Force_Mode(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Force_Mode(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_force_mode(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_force_mode")
+def Has_Has_Force_Mode(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Sensitivity_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_sensitivity_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_sensitivity_list")
+def Has_Sensitivity_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Process_Origin(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_process_origin(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_process_origin")
+def Has_Process_Origin(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Package_Origin(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_package_origin(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_package_origin")
+def Has_Package_Origin(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Condition_Clause(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_condition_clause(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_condition_clause")
+def Has_Condition_Clause(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Break_Element(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_break_element(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_break_element")
+def Has_Break_Element(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Selector_Quantity(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_selector_quantity(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_selector_quantity")
+def Has_Selector_Quantity(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Break_Quantity(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_break_quantity(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_break_quantity")
+def Has_Break_Quantity(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Timeout_Clause(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_timeout_clause(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_timeout_clause")
+def Has_Timeout_Clause(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Postponed_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_postponed_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_postponed_flag")
+def Has_Postponed_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Callees_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_callees_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_callees_list")
+def Has_Callees_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Passive_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_passive_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_passive_flag")
+def Has_Passive_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Resolution_Function_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_resolution_function_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_resolution_function_flag")
+def Has_Resolution_Function_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Wait_State(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_wait_state(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_wait_state")
+def Has_Wait_State(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_All_Sensitized_State(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_all_sensitized_state(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_all_sensitized_state")
+def Has_All_Sensitized_State(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Seen_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_seen_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_seen_flag")
+def Has_Seen_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Pure_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_pure_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_pure_flag")
+def Has_Pure_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Foreign_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_foreign_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_foreign_flag")
+def Has_Foreign_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Resolved_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_resolved_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_resolved_flag")
+def Has_Resolved_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Signal_Type_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_signal_type_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_signal_type_flag")
+def Has_Signal_Type_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Signal_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_signal_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_signal_flag")
+def Has_Has_Signal_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Purity_State(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_purity_state(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_purity_state")
+def Has_Purity_State(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Elab_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_elab_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_elab_flag")
+def Has_Elab_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Vendor_Library_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_vendor_library_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_vendor_library_flag")
+def Has_Vendor_Library_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Configuration_Mark_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_configuration_mark_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_configuration_mark_flag")
+def Has_Configuration_Mark_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Configuration_Done_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_configuration_done_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_configuration_done_flag")
+def Has_Configuration_Done_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Index_Constraint_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_index_constraint_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_index_constraint_flag")
+def Has_Index_Constraint_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Hide_Implicit_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_hide_implicit_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_hide_implicit_flag")
+def Has_Hide_Implicit_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Assertion_Condition(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_assertion_condition(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_assertion_condition")
+def Has_Assertion_Condition(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Report_Expression(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_report_expression(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_report_expression")
+def Has_Report_Expression(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Severity_Expression(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_severity_expression(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_severity_expression")
+def Has_Severity_Expression(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Instantiated_Unit(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_instantiated_unit(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_instantiated_unit")
+def Has_Instantiated_Unit(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Generic_Map_Aspect_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_generic_map_aspect_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_generic_map_aspect_chain")
+def Has_Generic_Map_Aspect_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Port_Map_Aspect_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_port_map_aspect_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_port_map_aspect_chain")
+def Has_Port_Map_Aspect_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Configuration_Name(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_configuration_name(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_configuration_name")
+def Has_Configuration_Name(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Component_Configuration(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_component_configuration(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_component_configuration")
+def Has_Component_Configuration(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Configuration_Specification(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_configuration_specification(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_configuration_specification")
+def Has_Configuration_Specification(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Default_Binding_Indication(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_default_binding_indication(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_default_binding_indication")
+def Has_Default_Binding_Indication(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Default_Configuration_Declaration(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_default_configuration_declaration(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_default_configuration_declaration")
+def Has_Default_Configuration_Declaration(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Expression(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_expression(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_expression")
+def Has_Expression(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Conditional_Expression_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_conditional_expression_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_conditional_expression_chain")
+def Has_Conditional_Expression_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Allocator_Designated_Type(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_allocator_designated_type(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_allocator_designated_type")
+def Has_Allocator_Designated_Type(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Selected_Waveform_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_selected_waveform_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_selected_waveform_chain")
+def Has_Selected_Waveform_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Conditional_Waveform_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_conditional_waveform_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_conditional_waveform_chain")
+def Has_Conditional_Waveform_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Guard_Expression(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_guard_expression(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_guard_expression")
+def Has_Guard_Expression(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Guard_Decl(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_guard_decl(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_guard_decl")
+def Has_Guard_Decl(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Guard_Sensitivity_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_guard_sensitivity_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_guard_sensitivity_list")
+def Has_Guard_Sensitivity_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Signal_Attribute_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_signal_attribute_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_signal_attribute_chain")
+def Has_Signal_Attribute_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Block_Block_Configuration(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_block_block_configuration(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_block_block_configuration")
+def Has_Block_Block_Configuration(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Package_Header(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_package_header(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_package_header")
+def Has_Package_Header(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Block_Header(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_block_header(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_block_header")
+def Has_Block_Header(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Uninstantiated_Package_Name(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_uninstantiated_package_name(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_uninstantiated_package_name")
+def Has_Uninstantiated_Package_Name(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Uninstantiated_Package_Decl(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_uninstantiated_package_decl(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_uninstantiated_package_decl")
+def Has_Uninstantiated_Package_Decl(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Instance_Source_File(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_instance_source_file(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_instance_source_file")
+def Has_Instance_Source_File(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Generate_Block_Configuration(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_generate_block_configuration(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_generate_block_configuration")
+def Has_Generate_Block_Configuration(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Generate_Statement_Body(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_generate_statement_body(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_generate_statement_body")
+def Has_Generate_Statement_Body(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Alternative_Label(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_alternative_label(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_alternative_label")
+def Has_Alternative_Label(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Generate_Else_Clause(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_generate_else_clause(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_generate_else_clause")
+def Has_Generate_Else_Clause(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Condition(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_condition(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_condition")
+def Has_Condition(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Else_Clause(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_else_clause(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_else_clause")
+def Has_Else_Clause(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Parameter_Specification(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_parameter_specification(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_parameter_specification")
+def Has_Parameter_Specification(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Parent(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_parent(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_parent")
+def Has_Parent(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Loop_Label(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_loop_label(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_loop_label")
+def Has_Loop_Label(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Exit_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_exit_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_exit_flag")
+def Has_Exit_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Next_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_next_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_next_flag")
+def Has_Next_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Component_Name(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_component_name(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_component_name")
+def Has_Component_Name(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Instantiation_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_instantiation_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_instantiation_list")
+def Has_Instantiation_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Entity_Aspect(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_entity_aspect(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_entity_aspect")
+def Has_Entity_Aspect(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Default_Entity_Aspect(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_default_entity_aspect(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_default_entity_aspect")
+def Has_Default_Entity_Aspect(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Binding_Indication(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_binding_indication(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_binding_indication")
+def Has_Binding_Indication(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Named_Entity(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_named_entity(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_named_entity")
+def Has_Named_Entity(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Referenced_Name(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_referenced_name(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_referenced_name")
+def Has_Referenced_Name(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Expr_Staticness(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_expr_staticness(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_expr_staticness")
+def Has_Expr_Staticness(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Scalar_Size(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_scalar_size(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_scalar_size")
+def Has_Scalar_Size(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Error_Origin(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_error_origin(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_error_origin")
+def Has_Error_Origin(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Operand(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_operand(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_operand")
+def Has_Operand(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Left(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_left(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_left")
+def Has_Left(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Right(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_right(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_right")
+def Has_Right(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Unit_Name(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_unit_name(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_unit_name")
+def Has_Unit_Name(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Name(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_name(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_name")
+def Has_Name(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Group_Template_Name(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_group_template_name(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_group_template_name")
+def Has_Group_Template_Name(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Name_Staticness(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_name_staticness(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_name_staticness")
+def Has_Name_Staticness(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Prefix(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_prefix(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_prefix")
+def Has_Prefix(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Signature_Prefix(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_signature_prefix(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_signature_prefix")
+def Has_Signature_Prefix(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_External_Pathname(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_external_pathname(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_external_pathname")
+def Has_External_Pathname(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Pathname_Suffix(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_pathname_suffix(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_pathname_suffix")
+def Has_Pathname_Suffix(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Pathname_Expression(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_pathname_expression(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_pathname_expression")
+def Has_Pathname_Expression(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_In_Formal_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_in_formal_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_in_formal_flag")
+def Has_In_Formal_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Slice_Subtype(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_slice_subtype(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_slice_subtype")
+def Has_Slice_Subtype(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Suffix(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_suffix(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_suffix")
+def Has_Suffix(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Index_Subtype(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_index_subtype(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_index_subtype")
+def Has_Index_Subtype(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Parameter(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_parameter(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_parameter")
+def Has_Parameter(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Parameter_2(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_parameter_2(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_parameter_2")
+def Has_Parameter_2(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Parameter_3(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_parameter_3(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_parameter_3")
+def Has_Parameter_3(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Parameter_4(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_parameter_4(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_parameter_4")
+def Has_Parameter_4(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Attr_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_attr_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_attr_chain")
+def Has_Attr_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Signal_Attribute_Declaration(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_signal_attribute_declaration(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_signal_attribute_declaration")
+def Has_Signal_Attribute_Declaration(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Actual_Type(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_actual_type(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_actual_type")
+def Has_Actual_Type(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Actual_Type_Definition(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_actual_type_definition(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_actual_type_definition")
+def Has_Actual_Type_Definition(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Association_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_association_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_association_chain")
+def Has_Association_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Individual_Association_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_individual_association_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_individual_association_chain")
+def Has_Individual_Association_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Subprogram_Association_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_subprogram_association_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_subprogram_association_chain")
+def Has_Subprogram_Association_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Aggregate_Info(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_aggregate_info(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_aggregate_info")
+def Has_Aggregate_Info(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Sub_Aggregate_Info(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_sub_aggregate_info(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_sub_aggregate_info")
+def Has_Sub_Aggregate_Info(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Aggr_Dynamic_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_aggr_dynamic_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_aggr_dynamic_flag")
+def Has_Aggr_Dynamic_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Aggr_Min_Length(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_aggr_min_length(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_aggr_min_length")
+def Has_Aggr_Min_Length(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Aggr_Low_Limit(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_aggr_low_limit(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_aggr_low_limit")
+def Has_Aggr_Low_Limit(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Aggr_High_Limit(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_aggr_high_limit(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_aggr_high_limit")
+def Has_Aggr_High_Limit(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Aggr_Others_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_aggr_others_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_aggr_others_flag")
+def Has_Aggr_Others_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Aggr_Named_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_aggr_named_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_aggr_named_flag")
+def Has_Aggr_Named_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Aggregate_Expand_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_aggregate_expand_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_aggregate_expand_flag")
+def Has_Aggregate_Expand_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Association_Choices_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_association_choices_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_association_choices_chain")
+def Has_Association_Choices_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Case_Statement_Alternative_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_case_statement_alternative_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_case_statement_alternative_chain")
+def Has_Case_Statement_Alternative_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Choice_Staticness(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_choice_staticness(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_choice_staticness")
+def Has_Choice_Staticness(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Procedure_Call(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_procedure_call(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_procedure_call")
+def Has_Procedure_Call(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Implementation(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_implementation(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_implementation")
+def Has_Implementation(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Parameter_Association_Chain(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_parameter_association_chain(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_parameter_association_chain")
+def Has_Parameter_Association_Chain(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Method_Object(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_method_object(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_method_object")
+def Has_Method_Object(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Subtype_Type_Mark(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_subtype_type_mark(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_subtype_type_mark")
+def Has_Subtype_Type_Mark(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Subnature_Nature_Mark(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_subnature_nature_mark(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_subnature_nature_mark")
+def Has_Subnature_Nature_Mark(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Type_Conversion_Subtype(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_type_conversion_subtype(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_type_conversion_subtype")
+def Has_Type_Conversion_Subtype(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Type_Mark(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_type_mark(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_type_mark")
+def Has_Type_Mark(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_File_Type_Mark(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_file_type_mark(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_file_type_mark")
+def Has_File_Type_Mark(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Return_Type_Mark(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_return_type_mark(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_return_type_mark")
+def Has_Return_Type_Mark(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Disconnect_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_disconnect_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_disconnect_flag")
+def Has_Has_Disconnect_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Active_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_active_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_active_flag")
+def Has_Has_Active_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Is_Within_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_is_within_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_is_within_flag")
+def Has_Is_Within_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Type_Marks_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_type_marks_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_type_marks_list")
+def Has_Type_Marks_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Implicit_Alias_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_implicit_alias_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_implicit_alias_flag")
+def Has_Implicit_Alias_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Alias_Signature(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_alias_signature(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_alias_signature")
+def Has_Alias_Signature(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Attribute_Signature(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_attribute_signature(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_attribute_signature")
+def Has_Attribute_Signature(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Overload_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_overload_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_overload_list")
+def Has_Overload_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Simple_Name_Identifier(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_simple_name_identifier(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_simple_name_identifier")
+def Has_Simple_Name_Identifier(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Simple_Name_Subtype(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_simple_name_subtype(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_simple_name_subtype")
+def Has_Simple_Name_Subtype(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Protected_Type_Body(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_protected_type_body(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_protected_type_body")
+def Has_Protected_Type_Body(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Protected_Type_Declaration(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_protected_type_declaration(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_protected_type_declaration")
+def Has_Protected_Type_Declaration(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Use_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_use_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_use_flag")
+def Has_Use_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_End_Has_Reserved_Id(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_end_has_reserved_id(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_end_has_reserved_id")
+def Has_End_Has_Reserved_Id(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_End_Has_Identifier(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_end_has_identifier(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_end_has_identifier")
+def Has_End_Has_Identifier(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_End_Has_Postponed(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_end_has_postponed(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_end_has_postponed")
+def Has_End_Has_Postponed(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Label(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_label(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_label")
+def Has_Has_Label(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Begin(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_begin(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_begin")
+def Has_Has_Begin(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_End(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_end(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_end")
+def Has_Has_End(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Is(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_is(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_is")
+def Has_Has_Is(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Pure(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_pure(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_pure")
+def Has_Has_Pure(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Body(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_body(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_body")
+def Has_Has_Body(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Parameter(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_parameter(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_parameter")
+def Has_Has_Parameter(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Component(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_component(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_component")
+def Has_Has_Component(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Identifier_List(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_identifier_list(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_identifier_list")
+def Has_Has_Identifier_List(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Mode(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_mode(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_mode")
+def Has_Has_Mode(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Class(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_class(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_class")
+def Has_Has_Class(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Has_Delay_Mechanism(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_has_delay_mechanism(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_has_delay_mechanism")
+def Has_Has_Delay_Mechanism(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Suspend_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_suspend_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_suspend_flag")
+def Has_Suspend_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Is_Ref(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_is_ref(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_is_ref")
+def Has_Is_Ref(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Is_Forward_Ref(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_is_forward_ref(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_is_forward_ref")
+def Has_Is_Forward_Ref(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Psl_Property(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_psl_property(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_psl_property")
+def Has_Psl_Property(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Psl_Sequence(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_psl_sequence(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_psl_sequence")
+def Has_Psl_Sequence(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Psl_Declaration(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_psl_declaration(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_psl_declaration")
+def Has_Psl_Declaration(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Psl_Expression(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_psl_expression(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_psl_expression")
+def Has_Psl_Expression(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Psl_Boolean(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_psl_boolean(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_psl_boolean")
+def Has_Psl_Boolean(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_PSL_Clock(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_psl_clock(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_psl_clock")
+def Has_PSL_Clock(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_PSL_NFA(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_psl_nfa(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_psl_nfa")
+def Has_PSL_NFA(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_PSL_Nbr_States(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_psl_nbr_states(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_psl_nbr_states")
+def Has_PSL_Nbr_States(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_PSL_Clock_Sensitivity(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_psl_clock_sensitivity(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_psl_clock_sensitivity")
+def Has_PSL_Clock_Sensitivity(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_PSL_EOS_Flag(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_psl_eos_flag(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_psl_eos_flag")
+def Has_PSL_EOS_Flag(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Count_Expression(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_count_expression(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_count_expression")
+def Has_Count_Expression(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Clock_Expression(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_clock_expression(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_clock_expression")
+def Has_Clock_Expression(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Default_Clock(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_default_clock(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_default_clock")
+def Has_Default_Clock(kind: IirKind) -> bool:
+    """"""
 
 
-def Has_Foreign_Node(kind) -> bool:
-    return libghdl.vhdl__nodes_meta__has_foreign_node(kind)
+@export
+@BindToLibGHDL("vhdl__nodes_meta__has_foreign_node")
+def Has_Foreign_Node(kind: IirKind) -> bool:
+    """"""

--- a/pyGHDL/libghdl/vhdl/tokens.py
+++ b/pyGHDL/libghdl/vhdl/tokens.py
@@ -4,6 +4,8 @@
 from enum import IntEnum, unique
 from pydecor import export
 
+from pyGHDL.libghdl._decorator import BindToLibGHDL
+
 
 @export
 @unique

--- a/pyGHDL/requirements.txt
+++ b/pyGHDL/requirements.txt
@@ -1,2 +1,2 @@
 pydecor>=2.0.1
-pyVHDLModel>=0.10.0
+pyVHDLModel>=0.10.1

--- a/scripts/pnodespy.py
+++ b/scripts/pnodespy.py
@@ -37,6 +37,8 @@ def print_file_header():
             #
             from enum import IntEnum, unique
             from pydecor import export
+
+            from pyGHDL.libghdl._decorator import BindToLibGHDL
         """), end=''
     )
 
@@ -62,12 +64,14 @@ def do_iirs_subprg():
     print(dedent("""
 
         @export
-        def Get_Kind(node: Iir) -> Iir_Kind:
-            return {libname}.{classname}__get_kind(node)
+        @BindToLibGHDL("{classname}__get_kind")
+        def Get_Kind(node: Iir) -> IirKind:
+            \"\"\"\"\"\"
 
         @export
+        @BindToLibGHDL("{classname}__get_location")
         def Get_Location(node: Iir) -> LocationType:
-            return {libname}.{classname}__get_location(node)
+            \"\"\"\"\"\"
         """).format(libname=libname, classname=classname)
     )
     for k in pnodes.funcs:
@@ -79,13 +83,15 @@ def do_iirs_subprg():
 
         print(dedent("""
             @export
+            @BindToLibGHDL("{classname}__get_{kname_lower}")
             def Get_{kname}(obj: Iir) -> {rtype}:
-                return {libname}.{classname}__get_{kname_lower}(obj)
+                \"\"\"{gettercomment}\"\"\"
             @export
+            @BindToLibGHDL("{classname}__set_{kname_lower}")
             def Set_{kname}(obj: Iir, value: {rtype}) -> None:
-                {libname}.{classname}__set_{kname_lower}(obj, value)
+                \"\"\"{settercomment}\"\"\"
             """).format(kname=k.name, kname_lower=k.name.lower(), rtype=rtype,
-                         libname=libname, classname=classname)
+                         libname=libname, classname=classname, gettercomment="", settercomment="")
         )
 
 
@@ -124,8 +130,10 @@ def do_has_subprg():
     print()
     for f in pnodes.funcs:
         print(dedent("""
-            def Has_{fname}(kind) -> bool:
-                return {libname}.vhdl__nodes_meta__has_{fname_lower}(kind)
+            @export
+            @BindToLibGHDL("vhdl__nodes_meta__has_{fname_lower}")
+            def Has_{fname}(kind: IirKind) -> bool:
+                \"\"\"\"\"\"
             """).format(fname=f.name, libname=libname, fname_lower=f.name.lower())
         )
 
@@ -187,6 +195,7 @@ def do_libghdl_nodes():
         from pyGHDL.libghdl import libghdl
         from pyGHDL.libghdl._types import (
             Iir,
+            IirKind,
             LocationType,
             FileChecksumId,
             TimeStampId,
@@ -239,8 +248,9 @@ def do_libghdl_meta():
 
         # From nodes_meta
         @export
+        @BindToLibGHDL("vhdl__nodes_meta__get_fields_first")
         def get_fields_first(K: IirKind) -> int:
-            '''
+            \"\"\"
             Return the list of fields for node :obj:`K`.
 
             In Ada ``Vhdl.Nodes_Meta.Get_Fields`` returns a ``Fields_Array``. To emulate
@@ -250,12 +260,13 @@ def do_libghdl_meta():
             nodes/lists that aren't reference, and then the reference.
 
             :param K: Node to get first array index from.
-            '''
-            return libghdl.vhdl__nodes_meta__get_fields_first(K)
+            \"\"\"
+
 
         @export
+        @BindToLibGHDL("vhdl__nodes_meta__get_fields_last")
         def get_fields_last(K: IirKind) -> int:
-            '''
+            \"\"\"
             Return the list of fields for node :obj:`K`.
 
             In Ada ``Vhdl.Nodes_Meta.Get_Fields`` returns a ``Fields_Array``. To emulate
@@ -265,12 +276,12 @@ def do_libghdl_meta():
             nodes/lists that aren't reference, and then the reference.
 
             :param K: Node to get last array index from.
-            '''
-            return libghdl.vhdl__nodes_meta__get_fields_last(K)
+            \"\"\"
 
         @export
+        @BindToLibGHDL("vhdl__nodes_meta__get_field_by_index")
         def get_field_by_index(K: IirKind) -> int:
-            return libghdl.vhdl__nodes_meta__get_field_by_index(K)
+            \"\"\"\"\"\"
 
         @export
         def get_field_type(*args):
@@ -352,8 +363,9 @@ def do_libghdl_errorout():
         from pyGHDL.libghdl import libghdl
 
         @export
+        @BindToLibGHDL("errorout__enable_warning")
         def Enable_Warning(Id: int, Enable: bool) -> None:
-            libghdl.errorout__enable_warning(Id, Enable)
+            \"\"\"\"\"\"
         """), end=''
     )
 

--- a/testsuite/pyunit/Current.vhdl
+++ b/testsuite/pyunit/Current.vhdl
@@ -1,0 +1,53 @@
+library ieee;
+use     ieee.std_logic_1164.all;
+use     ieee.numeric_std.all;
+
+entity entity_1 is
+	generic (
+		FREQ : real     := 100.0;
+		BITS : positive := 8
+	);
+	port (
+	  Clock: in  std_logic;
+	  Reset: in  std_logic := '0';
+	  Q:     out std_logic_vector(BITS - 1 downto 0)
+	);
+
+	constant fire : boolean := True;
+begin
+	wood <= fire;
+end entity entity_1;
+
+architecture behav of entity_1 is
+	constant MAX : positive := -25;
+	signal rst : std_logic := 'U';
+
+	type newInt is range -4 to 3;
+	subtype uint8 is integer range 0 to 255;
+
+	function foo(a : integer; b : boolean) return bit is
+	begin
+
+	end function;
+
+	alias bar is boolean;
+begin
+	process(Clock)
+	begin
+		if rising_edge(Clock) then
+			if Reset = '1' then
+				Q <= (others => '0');
+			else
+				Q <= std_logic_vector(unsigned(Q) + 1);
+			end if;
+		end if;
+	end process;
+end architecture behav;
+
+package package_1 is
+	constant ghdl : float := (3, 5, 0 => 5, 3 => 4, name => 10); -- 2.3;
+end package;
+
+package body package_1 is
+	constant ghdl : float := (1); -- => 2, 4 => 5, others => 10); -- .5;
+end package body;

--- a/testsuite/pyunit/SimpleEntity.vhdl
+++ b/testsuite/pyunit/SimpleEntity.vhdl
@@ -4,7 +4,7 @@ use     ieee.numeric_std.all;
 
 entity entity_1 is
 	generic (
-		FREQ : real     := 100.0;
+		FREQ : real     := (100.0 * 1024.0 * 1024.0);
 		BITS : positive := 8
 	);
 	port (
@@ -17,7 +17,7 @@ end entity entity_1;
 architecture behav of entity_1 is
 	signal Reset_n : std_logic;
 begin
-	Reset_n <= not Reset;
+	Reset_n <= (not Reset);
 
 	process(Clock)
 	begin

--- a/testsuite/pyunit/SimpleEntity.vhdl
+++ b/testsuite/pyunit/SimpleEntity.vhdl
@@ -27,3 +27,11 @@ begin
 		end if;
 	end process;
 end architecture behav;
+
+package package_1 is
+	constant ghdl : float := (3, 5); -- 2.3;
+end package;
+
+package body package_1 is
+	constant ghdl : float := (1); -- => 2, 4 => 5, others => 10); -- .5;
+end package body;

--- a/testsuite/pyunit/SimpleEntity.vhdl
+++ b/testsuite/pyunit/SimpleEntity.vhdl
@@ -15,11 +15,14 @@ entity entity_1 is
 end entity entity_1;
 
 architecture behav of entity_1 is
+	signal Reset_n : std_logic;
 begin
+	Reset_n <= not Reset;
+
 	process(Clock)
 	begin
 		if rising_edge(Clock) then
-			if Reset = '1' then
+			if Reset_n = '0' then
 				Q <= (others => '0');
 			else
 				Q <= std_logic_vector(unsigned(Q) + 1);
@@ -27,11 +30,3 @@ begin
 		end if;
 	end process;
 end architecture behav;
-
-package package_1 is
-	constant ghdl : float := (3, 5, 0 => 5, 3 => 4, name => 10); -- 2.3;
-end package;
-
-package body package_1 is
-	constant ghdl : float := (1); -- => 2, 4 => 5, others => 10); -- .5;
-end package body;

--- a/testsuite/pyunit/SimpleEntity.vhdl
+++ b/testsuite/pyunit/SimpleEntity.vhdl
@@ -4,7 +4,7 @@ use     ieee.numeric_std.all;
 
 entity entity_1 is
 	generic (
-		FREQ : real     := -25.7;
+		FREQ : real     := 100.0;
 		BITS : positive := 8
 	);
 	port (

--- a/testsuite/pyunit/SimpleEntity.vhdl
+++ b/testsuite/pyunit/SimpleEntity.vhdl
@@ -29,7 +29,7 @@ begin
 end architecture behav;
 
 package package_1 is
-	constant ghdl : float := (3, 5); -- 2.3;
+	constant ghdl : float := (3, 5, 0 => 5, 3 => 4, name => 10); -- 2.3;
 end package;
 
 package body package_1 is

--- a/testsuite/pyunit/SimpleEntity.vhdl
+++ b/testsuite/pyunit/SimpleEntity.vhdl
@@ -4,7 +4,7 @@ use     ieee.numeric_std.all;
 
 entity entity_1 is
 	generic (
-		FREQ : real     := 100.0;
+		FREQ : real     := -25.7;
 		BITS : positive := 8
 	);
 	port (

--- a/testsuite/pyunit/dom/Expressions.py
+++ b/testsuite/pyunit/dom/Expressions.py
@@ -2,10 +2,11 @@ from pathlib  import Path
 from textwrap import dedent
 from unittest import TestCase
 
+from pyGHDL.dom import Expression
 from pyGHDL.dom.Misc       import Design, Document
+from pyGHDL.dom.Symbol import SimpleObjectSymbol
 from pyGHDL.dom.Object import Constant
-from pyGHDL.dom.Literal import IntegerLiteral
-
+from pyGHDL.dom.Expression import InverseExpression
 
 if __name__ == "__main__":
     print("ERROR: you called a testcase declaration file as an executable module.")
@@ -13,21 +14,17 @@ if __name__ == "__main__":
     exit(1)
 
 
-class Literals(TestCase):
+class Expressions(TestCase):
     _root = Path(__file__).resolve().parent.parent
 
-    def test_IntegerLiteral(self):
+    def test_NotExpression(self):
         self._filename: Path = self._root / "{className}.vhdl".format(className=self.__class__.__name__)
 
         sourceCode = dedent("""\
             package package_1 is
-              constant c0 : integer := 0;
-              constant c1 : integer := 1;
-              constant c2 : integer := 1024;
-              constant c3 : integer := 1048576;
+              constant c0 : boolean := not true;
             end package;
             """)
-        expected = (0, 1, 1024, 1048576)
 
         with self._filename.open(mode="w", encoding="utf-8") as file:
             file.write(sourceCode)
@@ -39,11 +36,14 @@ class Literals(TestCase):
         self.assertEqual(len(design.Documents[0].Packages), 1)
         package = design.Documents[0].Packages[0]
         self.assertTrue(package.Name == "package_1")
-        self.assertEqual(len(package.DeclaredItems), len(expected))
-        for i in range(len(expected)):
-            item: Constant = package.DeclaredItems[i]
-            self.assertTrue(isinstance(item, Constant))
-            self.assertTrue(item.Name == "c{}".format(i))
-            self.assertTrue(item.SubType.SymbolName == "integer")
-            self.assertTrue(isinstance(item.DefaultExpression, IntegerLiteral))
-            self.assertTrue(item.DefaultExpression.Value == expected[i])
+        self.assertEqual(len(package.DeclaredItems), 1)
+
+        item: Constant = package.DeclaredItems[0]
+        self.assertTrue(isinstance(item, Constant))
+        self.assertTrue(item.Name == "c0")
+        self.assertTrue(item.SubType.SymbolName == "boolean")
+
+        default: Expression = item.DefaultExpression
+        self.assertTrue(isinstance(default, InverseExpression))
+        self.assertTrue(isinstance(default.Operand, SimpleObjectSymbol))
+        self.assertTrue(default.Operand.SymbolName == "true")

--- a/testsuite/pyunit/dom/Expressions.py
+++ b/testsuite/pyunit/dom/Expressions.py
@@ -2,6 +2,8 @@ from pathlib  import Path
 from textwrap import dedent
 from unittest import TestCase
 
+from pyGHDL.dom.DesignUnit import Package
+
 from pyGHDL.dom import Expression
 from pyGHDL.dom.Misc       import Design, Document
 from pyGHDL.dom.Symbol import SimpleObjectSymbol
@@ -33,17 +35,36 @@ class Expressions(TestCase):
         document = Document(self._filename)
         design.Documents.append(document)
 
-        self.assertEqual(len(design.Documents[0].Packages), 1)
-        package = design.Documents[0].Packages[0]
-        self.assertTrue(package.Name == "package_1")
-        self.assertEqual(len(package.DeclaredItems), 1)
-
+        package: Package = design.Documents[0].Packages[0]
         item: Constant = package.DeclaredItems[0]
-        self.assertTrue(isinstance(item, Constant))
-        self.assertTrue(item.Name == "c0")
-        self.assertTrue(item.SubType.SymbolName == "boolean")
-
         default: Expression = item.DefaultExpression
         self.assertTrue(isinstance(default, InverseExpression))
         self.assertTrue(isinstance(default.Operand, SimpleObjectSymbol))
         self.assertTrue(default.Operand.SymbolName == "true")
+
+    # def test_Aggregare(self):
+    #     self._filename: Path = self._root / "{className}.vhdl".format(className=self.__class__.__name__)
+    #
+    #     sourceCode = dedent("""\
+    #         package package_1 is
+    #           constant c0 : integer_vector := (0, 1, 2); 0 =>);
+    #           constant c1 : integer_vector := (0 => 0, 1 => 1, 2 => 2);
+    #           constant c3 : integer_vector := (a => 0, b => 1, c => 2);
+    #           constant c3 : integer_vector := (0 to 2 => 3, 3 to 4 => 2);
+    #           constant c2 : integer_vector := (others => 0);
+    #         end package;
+    #         """)
+    #
+    #     with self._filename.open(mode="w", encoding="utf-8") as file:
+    #         file.write(sourceCode)
+    #
+    #     design = Design()
+    #     document = Document(self._filename)
+    #     design.Documents.append(document)
+    #
+    #     package: Package = design.Documents[0].Packages[0]
+    #     item: Constant = package.DeclaredItems[0]
+    #     default: Expression = item.DefaultExpression
+    #     self.assertTrue(isinstance(default, InverseExpression))
+    #     self.assertTrue(isinstance(default.Operand, SimpleObjectSymbol))
+    #     self.assertTrue(default.Operand.SymbolName == "true")

--- a/testsuite/pyunit/dom/Literals.py
+++ b/testsuite/pyunit/dom/Literals.py
@@ -1,0 +1,48 @@
+from pyGHDL.dom.Literal import IntegerLiteral
+from pyGHDL.dom.Object import Constant
+from pathlib  import Path
+from textwrap import dedent
+from unittest import TestCase
+
+from pyGHDL.dom.Misc       import Design, Document
+
+if __name__ == "__main__":
+    print("ERROR: you called a testcase declaration file as an executable module.")
+    print("Use: 'python -m unitest <testcase module>'")
+    exit(1)
+
+
+class Literals(TestCase):
+    _root = Path(__file__).resolve().parent.parent
+
+    def test_IntegerLiteral(self):
+        self._filename: Path = self._root / "{className}.vhdl".format(className=self.__class__.__name__)
+
+        sourceCode = dedent("""\
+            package package_1 is
+              constant c0 : integer := 0;
+              constant c1 : integer := 1;
+              constant c2 : integer := 1024;
+              constant c3 : integer := 1048576;
+            end package;
+            """)
+        expected = (0, 1, 1024, 1048576)
+
+        with self._filename.open(mode="w", encoding="utf-8") as file:
+            file.write(sourceCode)
+
+        design = Design()
+        document = Document(self._filename)
+        design.Documents.append(document)
+
+        self.assertEqual(len(design.Documents[0].Packages), 1)
+        package = design.Documents[0].Packages[0]
+        self.assertTrue(package.Name == "package_1")
+        self.assertEqual(len(package.DeclaredItems), len(expected))
+        for i in range(len(expected)):
+            item: Constant = package.DeclaredItems[i]
+            self.assertTrue(isinstance(item, Constant))
+            self.assertTrue(item.Name == "c{}".format(i))
+            self.assertTrue(item.SubType.SymbolName == "integer")
+            self.assertTrue(isinstance(item.DefaultExpression, IntegerLiteral))
+            self.assertTrue(item.DefaultExpression.Value == expected[i])


### PR DESCRIPTION
**Description**
* Added new types (c_int64, c_double) to the decorator.
* Fixed typo `Iir_Kind` &rarr; `IirKind` in `pnodes.py`
* If a return type is an enum derived from `IntEnum`, it is automatically converted from `c_int32/int` to the enum.  
   As to functions are used in the decorator, there is no `if...then...else` runtime overhead.
* Add decorator usage everywhere in auto generated API.
* Changed all TypeVars to use more specific CDLL types.

----------------
**TODOs:**
* [x] Review changes  
  &rArr; **new PR**
* [ ] Split type translation function for directions PY->C and C->PY into 2 functions  
  &rArr; **new PR**
* [x] Review / discuss if TypeVars should be bound to Python types (done by @Paebbels) or to CDLL types (done by @tgingold).  
  &rArr; **done**
* [ ] `Has_` functions had no type for parameter `kind`.  
  I used `IirKind`. Is this correct?