### PR TITLE
pyGHDL: add ghdl-dom entrypoint

### DIFF
--- a/pyGHDL/cli/DOM.py
+++ b/pyGHDL/cli/DOM.py
@@ -40,7 +40,7 @@ class Application:
         print("\n".join(buffer))
 
 
-def main(items):
+def main(items=argv[1:]):
     _exitcode = 0
 
     if len(items) < 1:
@@ -63,4 +63,4 @@ def main(items):
 
 
 if __name__ == "__main__":
-    sysexit(main(argv[1:]))
+    sysexit(main())

--- a/pyGHDL/cli/DOM.py
+++ b/pyGHDL/cli/DOM.py
@@ -7,14 +7,14 @@ from pathlib import Path
 
 from pydecor import export
 
+from pyGHDL import GHDLBaseException
+from pyGHDL.libghdl import LibGHDLException
 from pyGHDL.dom import NonStandard
+from pyGHDL.dom.Common import DOMException
+from pyGHDL.dom.formatting.prettyprint import PrettyPrint, PrettyPrintException
 
 __all__ = []
 __api__ = __all__
-
-from pyGHDL.dom.Common import DOMException
-
-from pyGHDL.dom.formatting.prettyprint import PrettyPrint, PrettyPrintException
 
 
 @export
@@ -40,6 +40,26 @@ class Application:
         print("\n".join(buffer))
 
 
+def handleException(ex):
+    if isinstance(ex, PrettyPrintException):
+        print("PP:", ex)
+        return 5
+    elif isinstance(ex, DOMException):
+        print("DOM:", ex)
+        return 4
+    elif isinstance(ex, LibGHDLException):
+        print("LIB:", ex)
+        return 3
+    elif isinstance(ex, GHDLBaseException):
+        print("GHDL:", ex)
+        return 2
+    else:
+        print(
+            "Fatal: An unhandled exception has reached to the top-most exception handler."
+        )
+        return 1
+
+
 def main(items=argv[1:]):
     _exitcode = 0
 
@@ -53,11 +73,8 @@ def main(items=argv[1:]):
             app = Application()
             app.addFile(Path(item), "default_lib")
             app.prettyPrint()
-        except DOMException as ex:
-            print("DOM:", ex)
-        except PrettyPrintException as ex:
-            print("PP:", ex)
-            _exitcode = 1
+        except Exception as ex:
+            _exitcode = handleException(ex)
 
     return _exitcode
 

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,8 @@ setuptools_setup(
 	packages=setuptools_find_packages(exclude=("tests",)),
 	entry_points={
 		'console_scripts': [
-			"ghdl-ls = pyGHDL.cli.lsp:main"
+			"ghdl-ls = pyGHDL.cli.lsp:main",
+			"ghdl-dom = pyGHDL.cli.DOM:main"
 		]
 	},
 


### PR DESCRIPTION
Similarly to `ghdl-ls`, this PR adds a `ghdl-dom` entrypoint when pyGHDL is installed, so that user can analise their sources directly:

```sh
$ ghdl-dom path/to/a/file
# or
$ ghdl-dom path/to/a/file path/to/anothe/file ...
```

For instance:

```sh
# ghdl-dom libraries/ieee/math_real.vhdl libraries/ieee2008/numeric_bit-body.vhdl
Unknown expression kind 'String_Literal8'(11) in expression '1294'.
Unknown expression kind 'Aggregate'(185) in expression '1298'.
```