### PR TITLE
ci: generate standalone zipfiles and add CPython jobs

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -68,7 +68,7 @@ jobs:
         path: doc/_build/man/ghdl.1
 
 #
-# pyGHDL
+# pyGHDL Bindings and Formatting
 #
 
   fmt:
@@ -194,7 +194,7 @@ jobs:
         path: ghdl-macos*${{ matrix.backend }}.tgz
 
 #
-# Windows Build
+# Windows MSYS2 Build
 #
 
   win-build:
@@ -256,7 +256,7 @@ jobs:
         path: scripts/msys2-${{ matrix.pkg }}/mingw-*ghdl*.pkg.tar.zst
 
 #
-# Windows Test
+# Windows MSYS2 Test
 #
 
   win-test:
@@ -314,7 +314,7 @@ jobs:
       run: GHDL=ghdl ./testsuite/testsuite.sh ${{ matrix.suite }}
 
 #
-# Windows pyGHDL
+# Windows pyGHDL pip installation
 #
 
   win-pip:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -201,12 +201,12 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 3
       matrix:
         include: [
           {icon: '🟦', installs: 'MINGW32', arch: i686,   pkg: 'mcode' },
           #{icon: '🟦', installs: "MINGW32", arch: i686,   pkg: "llvm"  }, ! Not yet functional
-          #{icon: '🟪', installs: "MINGW64", arch: x86_64, pkg: "mcode" }, ! mcode is not yet supported on win64
+          {icon: '🟪', installs: "MINGW64", arch: x86_64, pkg: "mcode" }, #! simulation with mcode is not yet supported on win64
           {icon: '🟪', installs: 'MINGW64', arch: x86_64, pkg: 'llvm'  },
         ]
     name: '${{ matrix.icon }} Build · ${{ matrix.installs }} · ${{ matrix.pkg }}'
@@ -269,7 +269,7 @@ jobs:
         sys: [
           {icon: '🟦', installs: 'MINGW32', arch: i686,   pkg: 'mcode' },
           #{icon: '🟦', installs: "MINGW32", arch: i686,   pkg: "llvm"  }, ! Not yet functional
-          #{icon: '🟪', installs: "MINGW64", arch: x86_64, pkg: "mcode" }, ! mcode is not yet supported on win64
+          #{icon: '🟪', installs: "MINGW64", arch: x86_64, pkg: "mcode" }, ! simulation with mcode is not yet supported on win64
           {icon: '🟪', installs: 'MINGW64', arch: x86_64, pkg: 'llvm'  },
         ]
         suite: [
@@ -322,12 +322,12 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 3
       matrix:
         sys: [
           {icon: '🟦', installs: 'MINGW32', arch: i686,   pkg: 'mcode' },
           #{icon: '🟦', installs: "MINGW32", arch: i686,   pkg: "llvm"  }, ! Not yet functional
-          #{icon: '🟪', installs: "MINGW64", arch: x86_64, pkg: "mcode" }, ! mcode is not yet supported on win64
+          {icon: '🟪', installs: "MINGW64", arch: x86_64, pkg: "mcode" }, #! simulation with mcode is not yet supported on win64
           {icon: '🟪', installs: 'MINGW64', arch: x86_64, pkg: 'llvm'  },
         ]
     name: '${{ matrix.sys.icon }} pyGHDL · ${{ matrix.sys.installs }} · ${{ matrix.sys.pkg }}'

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -366,12 +366,74 @@ jobs:
         ghdl-ls --help
 
 #
+# Windows Generate Standalone ZipFile
+#
+
+  win-generate-standalone-zip:
+    needs: win-build
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        include: [
+          {icon: '🟪', installs: 'MINGW32', arch: i686   },
+          {icon: '🟦', installs: "MINGW64", arch: x86_64 }, #! simulation with mcode is not yet supported on win64
+        ]
+    name: '${{ matrix.icon }} Deps · ${{ matrix.installs }} · mcode'
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+
+    - name: '${{ matrix.icon }} Setup MSYS2'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.installs }}
+        update: true
+        install: >-
+          tree
+          zstd
+          zip
+          tar
+
+    - name: '⚙️ git config'
+      run: git config --global core.autocrlf input
+      shell: bash
+
+    - name: '🧰 Checkout'
+      uses: actions/checkout@v2
+
+    - name: '📥 Download artifact: package'
+      uses: actions/download-artifact@v2
+
+    - name: '🚧 Install package'
+      run: pacman --noconfirm -U artifact/mingw-w64-${{ matrix.arch }}-ghdl-mcode-*.zst
+
+    - name: '🥡 Generate standalone zipfile'
+      run: |
+        _zipdir="${{ matrix.installs }}-mcode-standalone"
+        mkdir -p "${_zipdir}"-extract
+        tar xf artifact/mingw-w64-${{ matrix.arch }}-ghdl-mcode-*.zst -C "${_zipdir}"-extract
+        cd "${_zipdir}-extract/${{ matrix.installs }}"/bin
+        ../../../scripts/msys2-mcode/GetStandaloneDeps.sh
+        cd ../../..
+        mv "${_zipdir}"-extract/mingw${{ matrix.bits }} "${_zipdir}"
+        tree "${_zipdir}"
+        zip "${_zipdir}".zip -r "${_zipdir}"
+
+    - name: '📤 Upload artifact: zipfile'
+      uses: actions/upload-artifact@v2
+      with:
+        path: ${{ matrix.installs }}-mcode-standalone.zip
+
+#
 # Release
 #
 
   Release:
     if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/'))
-    needs: [ doc, lin, osx, win-test, win-pip ]
+    needs: [ doc, lin, osx, win-test, win-pip, win-generate-standalone-zip ]
     runs-on: ubuntu-latest
     name: '📦 Release'
     steps:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -317,7 +317,7 @@ jobs:
 # Windows pyGHDL
 #
 
-  win-pyGHDL:
+  win-pip:
     needs: win-build
     runs-on: windows-latest
     strategy:
@@ -371,7 +371,7 @@ jobs:
 
   Release:
     if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/'))
-    needs: [ doc, lin, osx, win-test, win-pyGHDL ]
+    needs: [ doc, lin, osx, win-test, win-pip ]
     runs-on: ubuntu-latest
     name: '📦 Release'
     steps:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -489,7 +489,7 @@ jobs:
         include:
         #- { pkg: '32-llvm', pyarch: x86 } ! not yet functional
         #- { pkg: '64-llvm', pyarch: x64 }
-        - { pkg: '32-mcode', pyarch: x86 }
+        #- { pkg: '32-mcode', pyarch: x86 } #! the tarball generation on MINGW32 needs to be fixed
         - { pkg: '64-mcode', pyarch: x64 } #! simulation with mcode is not yet supported on win64
     name: '🚦🐍🥡 ${{ matrix.pkg }}'
     defaults:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -122,7 +122,6 @@ jobs:
   lin:
     strategy:
       fail-fast: false
-      max-parallel: 4
       matrix:
         include: [
           { os: 18, backend: mcode },
@@ -156,7 +155,6 @@ jobs:
   osx:
     strategy:
       fail-fast: false
-      max-parallel: 2
       matrix:
         backend:
         - mcode
@@ -201,7 +199,6 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
-      max-parallel: 3
       matrix:
         include: [
           {icon: '🟪', installs: 'MINGW32', arch: i686,   pkg: 'mcode' },
@@ -264,7 +261,6 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
-      max-parallel: 8
       matrix:
         sys: [
           {icon: '🟪', installs: 'MINGW32', arch: i686,   pkg: 'mcode' },
@@ -322,7 +318,6 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
-      max-parallel: 3
       matrix:
         sys: [
           {icon: '🟪', installs: 'MINGW32', arch: i686,   pkg: 'mcode' },
@@ -374,7 +369,6 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
-      max-parallel: 2
       matrix:
         include: [
           {icon: '🟪', installs: 'MINGW32', arch: i686   },
@@ -436,7 +430,6 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
-      max-parallel: 2
       matrix:
         include: [
           {icon: '🟪', installs: 'MINGW32', arch: i686,   pkg: 'mcode',  pyarch: x86  },

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -204,10 +204,10 @@ jobs:
       max-parallel: 3
       matrix:
         include: [
-          {icon: '🟦', installs: 'MINGW32', arch: i686,   pkg: 'mcode' },
-          #{icon: '🟦', installs: "MINGW32", arch: i686,   pkg: "llvm"  }, ! Not yet functional
-          {icon: '🟪', installs: "MINGW64", arch: x86_64, pkg: "mcode" }, #! simulation with mcode is not yet supported on win64
-          {icon: '🟪', installs: 'MINGW64', arch: x86_64, pkg: 'llvm'  },
+          {icon: '🟪', installs: 'MINGW32', arch: i686,   pkg: 'mcode' },
+          #{icon: '🟪', installs: "MINGW32", arch: i686,   pkg: "llvm"  }, ! Not yet functional
+          {icon: '🟦', installs: "MINGW64", arch: x86_64, pkg: "mcode" }, #! simulation with mcode is not yet supported on win64
+          {icon: '🟦', installs: 'MINGW64', arch: x86_64, pkg: 'llvm'  },
         ]
     name: '${{ matrix.icon }} Build · ${{ matrix.installs }} · ${{ matrix.pkg }}'
     env:
@@ -267,10 +267,10 @@ jobs:
       max-parallel: 8
       matrix:
         sys: [
-          {icon: '🟦', installs: 'MINGW32', arch: i686,   pkg: 'mcode' },
-          #{icon: '🟦', installs: "MINGW32", arch: i686,   pkg: "llvm"  }, ! Not yet functional
-          #{icon: '🟪', installs: "MINGW64", arch: x86_64, pkg: "mcode" }, ! simulation with mcode is not yet supported on win64
-          {icon: '🟪', installs: 'MINGW64', arch: x86_64, pkg: 'llvm'  },
+          {icon: '🟪', installs: 'MINGW32', arch: i686,   pkg: 'mcode' },
+          #{icon: '🟪', installs: "MINGW32", arch: i686,   pkg: "llvm"  }, ! Not yet functional
+          #{icon: '🟦', installs: "MINGW64", arch: x86_64, pkg: "mcode" }, ! simulation with mcode is not yet supported on win64
+          {icon: '🟦', installs: 'MINGW64', arch: x86_64, pkg: 'llvm'  },
         ]
         suite: [
           'sanity pyunit vpi vhpi',
@@ -325,10 +325,10 @@ jobs:
       max-parallel: 3
       matrix:
         sys: [
-          {icon: '🟦', installs: 'MINGW32', arch: i686,   pkg: 'mcode' },
-          #{icon: '🟦', installs: "MINGW32", arch: i686,   pkg: "llvm"  }, ! Not yet functional
-          {icon: '🟪', installs: "MINGW64", arch: x86_64, pkg: "mcode" }, #! simulation with mcode is not yet supported on win64
-          {icon: '🟪', installs: 'MINGW64', arch: x86_64, pkg: 'llvm'  },
+          {icon: '🟪', installs: 'MINGW32', arch: i686,   pkg: 'mcode' },
+          #{icon: '🟪', installs: "MINGW32", arch: i686,   pkg: "llvm"  }, ! Not yet functional
+          {icon: '🟦', installs: "MINGW64", arch: x86_64, pkg: "mcode" }, #! simulation with mcode is not yet supported on win64
+          {icon: '🟦', installs: 'MINGW64', arch: x86_64, pkg: 'llvm'  },
         ]
     name: '${{ matrix.sys.icon }} pyGHDL · ${{ matrix.sys.installs }} · ${{ matrix.sys.pkg }}'
     defaults:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -314,7 +314,7 @@ jobs:
       run: GHDL=ghdl ./testsuite/testsuite.sh ${{ matrix.suite }}
 
 #
-# Windows pyGHDL pip installation
+# Windows MSYS2 pyGHDL pip installation
 #
 
   win-pip:
@@ -426,6 +426,68 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         path: ${{ matrix.installs }}-mcode-standalone.zip
+
+#
+# Windows CPython pyGHDL Test with MSYS2 installation
+#
+
+  win-cpython-msys2:
+    needs: win-build
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        include: [
+          {icon: '🟪', installs: 'MINGW32', arch: i686,   pkg: 'mcode',  pyarch: x86  },
+          #{icon: '🟪', installs: "MINGW32", arch: i686,   pkg: "llvm",  pyarch: x86  }, ! Not yet functional
+          {icon: '🟦', installs: "MINGW64", arch: x86_64, pkg: "mcode", pyarch: x64 }, #! simulation with mcode is not yet supported on win64
+          {icon: '🟦', installs: 'MINGW64', arch: x86_64, pkg: 'llvm',  pyarch: x64 },
+        ]
+    name: '${{ matrix.icon }} CPython · ${{ matrix.installs }} · ${{ matrix.pkg }}'
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+
+    - name: '${{ matrix.icon }} Setup MSYS2'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.installs }}
+        update: true
+
+    - name: '⚙️ git config'
+      run: git config --global core.autocrlf input
+
+    - name: '🧰 Checkout'
+      uses: actions/checkout@v2
+
+    - name: '📥 Download artifact: package'
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ matrix.installs }}-${{ matrix.pkg }}
+
+    - name: '⚙️ Install package'
+      shell: msys2 {0}
+      run: |
+        pacman --noconfirm -U artifact/mingw-w64-${{ matrix.arch }}-ghdl-${{ matrix.pkg }}-*.zst
+
+    - name: '🐍 Setup Python'
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+        architecture: ${{ matrix.pyarch }}
+
+    - name: '🐍 Install Python dependencies'
+      run: |
+        pip3 install -r testsuite/requirements.txt
+
+    - name: '🚧 Test package'
+      run: |
+        $env:GHDL_PREFIX = (& msys2 -c 'cygpath -w /') + '${{ matrix.installs }}\lib\ghdl\'
+        $env:PYTHONPATH = (pwd).Path
+        cd testsuite
+        python3 -m pytest -vsrA pyunit
 
 #
 # Release

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -498,6 +498,62 @@ jobs:
         python3 -m pytest -vsrA pyunit
 
 #
+# Windows CPython pyGHDL Test with standalone zipfile
+#
+
+  win-cpython-standalone:
+    needs: win-standalone
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: [
+          {icon: '🟪', pkg: 'MINGW32-mcode', pyarch: x86 },
+          #{icon: '🟪', pkg: 'MINGW32-llvm',  pyarch: x86 }, ! Not yet functional
+          {icon: '🟦', pkg: 'MINGW64-mcode', pyarch: x64 }, #! simulation with mcode is not yet supported on win64
+          #{icon: '🟦', pkg: 'MINGW64-llvm',  pyarch: x64  },
+        ]
+    name: '${{ matrix.icon }} CPython Test · ${{ matrix.pkg }}'
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+
+    - name: '⚙️ git config'
+      run: git config --global core.autocrlf input
+
+    - name: '🧰 Checkout'
+      uses: actions/checkout@v2
+
+    - name: '📥 Download artifact: package'
+      uses: actions/download-artifact@v2
+      with:
+        path: artifact
+        name: ${{ matrix.pkg }}-standalone
+
+    - name: '⚙️ Extract package'
+      run: |
+        unzip artifact\${{ matrix.pkg }}-standalone.zip
+        mv '${{ matrix.pkg }}-standalone\' GHDL-standalone
+
+    - name: '🐍 Setup Python'
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+        architecture: ${{ matrix.pyarch }}
+
+    - name: '🐍 Install Python dependencies'
+      run: |
+        pip3 install -r testsuite/requirements.txt
+
+    - name: '🚧 Test package'
+      run: |
+        $env:GHDL_PREFIX = (pwd).Path + '\GHDL-standalone\lib\ghdl'
+        $env:PYTHONPATH = (pwd).Path
+        cd testsuite
+        python3 -m pytest -vsrA pyunit
+
+#
 # Release
 #
 

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -65,6 +65,7 @@ jobs:
       if: github.event_name != 'pull_request'
       uses: actions/upload-artifact@v2
       with:
+        name: man
         path: doc/_build/man/ghdl.1
 
 #
@@ -146,6 +147,7 @@ jobs:
     - name: '📤 Upload artifact: package'
       uses: actions/upload-artifact@v2
       with:
+        name: ubuntu${{ matrix.os }}-${{ matrix.backend }}
         path: ghdl-gha-ubuntu-*.tgz
 
 #
@@ -189,6 +191,7 @@ jobs:
     - name: '📤 Upload artifact: package'
       uses: actions/upload-artifact@v2
       with:
+        name: macos10.15-${{ matrix.backend }}
         path: ghdl-macos*${{ matrix.backend }}.tgz
 
 #
@@ -250,6 +253,7 @@ jobs:
     - name: '📤 Upload artifact: package'
       uses: actions/upload-artifact@v2
       with:
+        name: ${{ matrix.installs }}-${{ matrix.pkg }}
         path: scripts/msys2-${{ matrix.pkg }}/mingw-*ghdl*.pkg.tar.zst
 
 #
@@ -300,6 +304,9 @@ jobs:
 
     - name: '📥 Download artifact: package'
       uses: actions/download-artifact@v2
+      with:
+        path: artifact
+        name: ${{ matrix.sys.installs }}-${{ matrix.sys.pkg }}
 
     - name: '🚧 Install package and Python dependencies'
       run: |
@@ -348,6 +355,9 @@ jobs:
 
     - name: '📥 Download artifact: package'
       uses: actions/download-artifact@v2
+      with:
+        path: artifact
+        name: ${{ matrix.installs }}-${{ matrix.pkg }}
 
     - name: '🚧 Install package'
       run: pacman --noconfirm -U artifact/mingw-w64-${{ matrix.sys.arch }}-ghdl-${{ matrix.sys.pkg }}-*.zst
@@ -400,6 +410,9 @@ jobs:
 
     - name: '📥 Download artifact: package'
       uses: actions/download-artifact@v2
+      with:
+        path: artifact
+        name: ${{ matrix.installs }}-mcode
 
     - name: '🚧 Install package'
       run: pacman --noconfirm -U artifact/mingw-w64-${{ matrix.arch }}-ghdl-mcode-*.zst
@@ -419,6 +432,7 @@ jobs:
     - name: '📤 Upload artifact: zipfile'
       uses: actions/upload-artifact@v2
       with:
+        name: ${{ matrix.installs }}-mcode-standalone
         path: ${{ matrix.installs }}-mcode-standalone.zip
 
 #
@@ -458,6 +472,7 @@ jobs:
     - name: '📥 Download artifact: package'
       uses: actions/download-artifact@v2
       with:
+        path: artifact
         name: ${{ matrix.installs }}-${{ matrix.pkg }}
 
     - name: '⚙️ Install package'
@@ -496,16 +511,18 @@ jobs:
     - name: '📥 Download artifacts'
       if: "!contains(github.ref, 'refs/tags/')"
       uses: actions/download-artifact@v2
+      with:
+        path: artifacts
 
     # Do not upload assets to tagged releases
     - name: Set list of files for uploading
       id: files
+      shell: python
       run: |
-        case '${{ github.ref }}' in
-          'refs/tags/'*) _list='none' ;;
-          *)             _list='artifact/*' ;;
-        esac
-        echo "::set-output name=list::${_list}"
+        print('None'
+            if '${{ github.ref }}'.startswith('refs/tags/')
+            else'::set-output name=list::**/*.zst **/*.tgz **/*-standalone.zip'
+        )
 
     # Tagged: create a pre-release or a release (semver)
     # Untagged: update the assets of pre-release 'nightly'
@@ -515,9 +532,10 @@ jobs:
         tag: 'nightly'
         files: ${{ steps.files.outputs.list }}
 
-    - run: |
+    - name: '🔔 Trigger ghdl/docker'
+      run: |
         curl -X POST https://api.github.com/repos/ghdl/docker/dispatches \
-        -H "Content-Type: application/json" \
+        -H 'Content-Type: application/json' \
         -H 'Accept: application/vnd.github.everest-preview+json' \
         -H "Authorization: token ${{ secrets.GHDL_BOT }}" \
         --data '{"event_type": "ghdl"}'
@@ -553,6 +571,9 @@ jobs:
 
     - name: '📥 Download artifact: package'
       uses: actions/download-artifact@v2
+      with:
+        path: artifact
+        name: MINGW64-llvm
 
     - name: '🚧 Install package and Python dependencies'
       run: |
@@ -590,6 +611,7 @@ jobs:
     - name: '📥 Download artifact: coverage report'
       uses: actions/download-artifact@v2
       with:
+        path: artifact
         name: coverage
 
     - name: CodeCov

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -23,7 +23,7 @@ jobs:
     - name: '🧰 Checkout'
       uses: actions/checkout@v2
 
-    - name: Build ghdl/doc
+    - name: '⛴️ Build ghdl/doc'
       run: |
         docker build -t ghdl/doc . -f- <<-EOF
         FROM ghdl/debug:base
@@ -32,7 +32,7 @@ jobs:
         RUN cd /opt/ghdl && ./configure && make && make install
         EOF
 
-    - name: Run gnatdoc
+    - name: '📚 Run gnatdoc'
       run: |
         cat > run.sh <<-EOF
         #!/usr/bin/env sh
@@ -108,7 +108,7 @@ jobs:
 
   gpl:
     runs-on: ubuntu-latest
-    name: '🐧 GPL · mcode'
+    name: '🚧🚦🐧 GPL · mcode'
     steps:
 
     - name: '🧰 Checkout'
@@ -132,7 +132,7 @@ jobs:
           { os: 18, backend: gcc-8.3.0 },
           { os: 20, backend: gcc-9.3.0 }
         ]
-    name: '🐧 Ubuntu ${{ matrix.os }} · ${{ matrix.backend }}'
+    name: '🚧🚦🐧 Ubuntu ${{ matrix.os }} · ${{ matrix.backend }}'
     runs-on: ubuntu-${{ matrix.os }}.04
     steps:
 
@@ -162,7 +162,7 @@ jobs:
         - mcode
         - llvm
     runs-on: macOS-10.15
-    name: '🍎 macOS 10.15 · ${{ matrix.backend }}'
+    name: '🚧🚦🍎 macOS 10.15 · ${{ matrix.backend }}'
     steps:
 
     - name: '🧰 Checkout'
@@ -179,7 +179,7 @@ jobs:
     - name: '⚙️ Dependencies (brew)'
       run: ./scripts/macosx/install-ada.sh
 
-    - name: '🚧 Build and test GHDL'
+    - name: '🚧 Build and 🚦 Test GHDL'
       run: |
         PATH=$PWD/gnat/bin:$PATH
         ./scripts/ci-run.sh -c
@@ -198,20 +198,20 @@ jobs:
 # Windows MSYS2 Build
 #
 
-  win-build:
+  win-msys2-build-package:
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
         include: [
-          {icon: '🟪', installs: 'MINGW32', arch: i686,   pkg: 'mcode' },
-          #{icon: '🟪', installs: "MINGW32", arch: i686,   pkg: "llvm"  }, ! Not yet functional
-          {icon: '🟦', installs: "MINGW64", arch: x86_64, pkg: "mcode" }, #! simulation with mcode is not yet supported on win64
-          {icon: '🟦', installs: 'MINGW64', arch: x86_64, pkg: 'llvm'  },
+          #{icon: '🟪', pkg: 'llvm',  bits: '32', arch: i686 }, ! not yet functional
+          {icon: '🟦', pkg: 'llvm',  bits: '64', arch: x86_64 },
+          {icon: '🟪', pkg: 'mcode', bits: '32', arch: i686,   },
+          {icon: '🟦', pkg: 'mcode', bits: '64', arch: x86_64, }, #! simulation with mcode is not yet supported on win64
         ]
-    name: '${{ matrix.icon }} Build · ${{ matrix.installs }} · ${{ matrix.pkg }}'
+    name: '🚧${{ matrix.icon }} · ${{ matrix.pkg }}${{ matrix.bits }}'
     env:
-      MINGW_ARCH: ${{ matrix.installs }}
+      MINGW_ARCH: MINGW${{ matrix.bits }}
     defaults:
       run:
         shell: msys2 {0}
@@ -245,7 +245,7 @@ jobs:
     - name: '📤 Upload artifact: builddir'
       uses: actions/upload-artifact@v2
       with:
-        name: ${{ matrix.installs }}-${{ matrix.pkg }}-builddir
+        name: MINGW${{ matrix.bits }}-${{ matrix.pkg }}-builddir
         path: |
           scripts/msys2-${{ matrix.pkg }}/src/
           scripts/msys2-${{ matrix.pkg }}/pkg/
@@ -253,24 +253,24 @@ jobs:
     - name: '📤 Upload artifact: package'
       uses: actions/upload-artifact@v2
       with:
-        name: ${{ matrix.installs }}-${{ matrix.pkg }}
+        name: MINGW${{ matrix.bits }}-${{ matrix.pkg }}
         path: scripts/msys2-${{ matrix.pkg }}/mingw-*ghdl*.pkg.tar.zst
 
 #
 # Windows MSYS2 Test
 #
 
-  win-test:
-    needs: win-build
+  win-msys2-test:
+    needs: win-msys2-build-package
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
         sys: [
-          {icon: '🟪', installs: 'MINGW32', arch: i686,   pkg: 'mcode' },
-          #{icon: '🟪', installs: "MINGW32", arch: i686,   pkg: "llvm"  }, ! Not yet functional
-          #{icon: '🟦', installs: "MINGW64", arch: x86_64, pkg: "mcode" }, ! simulation with mcode is not yet supported on win64
-          {icon: '🟦', installs: 'MINGW64', arch: x86_64, pkg: 'llvm'  },
+          #{icon: '🟪', pkg: 'llvm',  bits: '32', arch: i686 }, ! not yet functional
+          {icon: '🟦', pkg: 'llvm',  bits: '64', arch: x86_64 },
+          {icon: '🟪', pkg: 'mcode', bits: '32', arch: i686,   },
+          #{icon: '🟦', pkg: 'mcode', bits: '64', arch: x86_64, }, ! simulation with mcode is not yet supported on win64
         ]
         suite: [
           'sanity pyunit vpi vhpi',
@@ -278,7 +278,7 @@ jobs:
           'vests',
           'synth',
         ]
-    name: '${{ matrix.sys.icon }} Test · ${{ matrix.sys.installs }} · ${{ matrix.sys.pkg }} · ${{ matrix.suite }}'
+    name: '🚦${{ matrix.sys.icon }} ${{ matrix.sys.pkg }}${{ matrix.sys.bits }} · ${{ matrix.suite }}'
     defaults:
       run:
         shell: msys2 {0}
@@ -287,7 +287,7 @@ jobs:
     - name: '${{ matrix.sys.icon }} Setup MSYS2'
       uses: msys2/setup-msys2@v2
       with:
-        msystem: ${{ matrix.sys.installs }}
+        msystem: MINGW${{ matrix.sys.bits }}
         update: true
         install: >
           mingw-w64-${{ matrix.sys.arch }}-diffutils
@@ -306,14 +306,14 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         path: artifact
-        name: ${{ matrix.sys.installs }}-${{ matrix.sys.pkg }}
+        name: MINGW${{ matrix.sys.bits }}-${{ matrix.sys.pkg }}
 
-    - name: '🚧 Install package and Python dependencies'
+    - name: '🛠️ Install package and 🐍 Python dependencies'
       run: |
         pacman --noconfirm -U artifact/mingw-w64-${{ matrix.sys.arch }}-ghdl-${{ matrix.sys.pkg }}-*.zst
         pip3 install -r testsuite/requirements.txt
 
-    - name: '🚧 Test package'
+    - name: '🚦 Test package'
       run: GHDL=ghdl ./testsuite/testsuite.sh ${{ matrix.suite }}
 
 #
@@ -321,33 +321,33 @@ jobs:
 #
 
   win-pip:
-    needs: win-build
+    needs: win-msys2-build-package
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
-        sys: [
-          {icon: '🟪', installs: 'MINGW32', arch: i686,   pkg: 'mcode' },
-          #{icon: '🟪', installs: "MINGW32", arch: i686,   pkg: "llvm"  }, ! Not yet functional
-          {icon: '🟦', installs: "MINGW64", arch: x86_64, pkg: "mcode" }, #! simulation with mcode is not yet supported on win64
-          {icon: '🟦', installs: 'MINGW64', arch: x86_64, pkg: 'llvm'  },
+        include: [
+          #{icon: '🟪', pkg: 'llvm',  bits: '32', arch: i686 }, ! Not yet functional
+          {icon: '🟦', pkg: 'llvm',  bits: '64', arch: x86_64  },
+          {icon: '🟪', pkg: 'mcode', bits: '32', arch: i686,   },
+          {icon: '🟦', pkg: 'mcode', bits: '64', arch: x86_64, }, #! simulation with mcode is not yet supported on win64
         ]
-    name: '${{ matrix.sys.icon }} pyGHDL · ${{ matrix.sys.installs }} · ${{ matrix.sys.pkg }}'
+    name: '🚦${{ matrix.icon }} pip · ${{ matrix.pkg }}${{ matrix.bits }}'
     defaults:
       run:
         shell: msys2 {0}
     steps:
 
-    - name: '${{ matrix.sys.icon }} Setup MSYS2'
+    - name: '${{ matrix.icon }} Setup MSYS2'
       uses: msys2/setup-msys2@v2
       with:
-        msystem: ${{ matrix.sys.installs }}
+        msystem: MINGW${{ matrix.bits }}
         update: true
         install: >
           git
-          mingw-w64-${{ matrix.sys.arch }}-gcc
-          mingw-w64-${{ matrix.sys.arch }}-python-pip
-          mingw-w64-${{ matrix.sys.arch }}-python-setuptools
+          mingw-w64-${{ matrix.arch }}-gcc
+          mingw-w64-${{ matrix.arch }}-python-pip
+          mingw-w64-${{ matrix.arch }}-python-setuptools
 
     - name: '⚙️ git config'
       run: git config --global core.autocrlf input
@@ -357,15 +357,15 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         path: artifact
-        name: ${{ matrix.installs }}-${{ matrix.pkg }}
+        name: MINGW${{ matrix.bits }}-${{ matrix.pkg }}
 
-    - name: '🚧 Install package'
-      run: pacman --noconfirm -U artifact/mingw-w64-${{ matrix.sys.arch }}-ghdl-${{ matrix.sys.pkg }}-*.zst
+    - name: '🛠️ Install package'
+      run: pacman --noconfirm -U artifact/mingw-w64-${{ matrix.arch }}-ghdl-${{ matrix.pkg }}-*.zst
 
-    - name: '🚧 Test installation of pyGHDL through pip'
+    - name: '🚦 Test installation of pyGHDL through pip'
       run: pip install git+https://github.com/ghdl/ghdl.git@$(ghdl version hash)
 
-    - name: '🚧 Test pyGHDL entrypoints'
+    - name: '🚦 Test pyGHDL entrypoints'
       run: |
         ghdl-dom help
         ghdl-ls --help
@@ -375,16 +375,16 @@ jobs:
 #
 
   win-generate-standalone-zip:
-    needs: win-build
+    needs: win-msys2-build-package
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
         include: [
-          {icon: '🟪', installs: 'MINGW32', arch: i686   },
-          {icon: '🟦', installs: "MINGW64", arch: x86_64 }, #! simulation with mcode is not yet supported on win64
+          {icon: '🟪', bits: '32', arch: i686,   },
+          {icon: '🟦', bits: '64', arch: x86_64, }, #! simulation with mcode is not yet supported on win64
         ]
-    name: '${{ matrix.icon }} Deps · ${{ matrix.installs }} · mcode'
+    name: '🚧🥡${{ matrix.icon }} · mcode${{ matrix.bits }}'
     defaults:
       run:
         shell: msys2 {0}
@@ -393,7 +393,7 @@ jobs:
     - name: '${{ matrix.icon }} Setup MSYS2'
       uses: msys2/setup-msys2@v2
       with:
-        msystem: ${{ matrix.installs }}
+        msystem: MINGW${{ matrix.bits }}
         update: true
         install: >-
           tree
@@ -412,17 +412,17 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         path: artifact
-        name: ${{ matrix.installs }}-mcode
+        name: MINGW${{ matrix.bits }}-mcode
 
-    - name: '🚧 Install package'
+    - name: '🛠️ Install package'
       run: pacman --noconfirm -U artifact/mingw-w64-${{ matrix.arch }}-ghdl-mcode-*.zst
 
     - name: '🥡 Generate standalone zipfile'
       run: |
-        _zipdir="${{ matrix.installs }}-mcode-standalone"
+        _zipdir='MINGW${{ matrix.bits }}-mcode-standalone'
         mkdir -p "${_zipdir}"-extract
         tar xf artifact/mingw-w64-${{ matrix.arch }}-ghdl-mcode-*.zst -C "${_zipdir}"-extract
-        cd "${_zipdir}-extract/${{ matrix.installs }}"/bin
+        cd "${_zipdir}-extract/MINGW${{ matrix.bits }}"/bin
         ../../../scripts/msys2-mcode/GetStandaloneDeps.sh
         cd ../../..
         mv "${_zipdir}"-extract/mingw${{ matrix.bits }} "${_zipdir}"
@@ -432,26 +432,26 @@ jobs:
     - name: '📤 Upload artifact: zipfile'
       uses: actions/upload-artifact@v2
       with:
-        name: ${{ matrix.installs }}-mcode-standalone
-        path: ${{ matrix.installs }}-mcode-standalone.zip
+        name: MINGW${{ matrix.bits }}-mcode-standalone
+        path: MINGW${{ matrix.bits }}-mcode-standalone.zip
 
 #
 # Windows CPython pyGHDL Test with MSYS2 installation
 #
 
   win-cpython-msys2:
-    needs: win-build
+    needs: win-msys2-build-package
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
         include: [
-          {icon: '🟪', installs: 'MINGW32', arch: i686,   pkg: 'mcode',  pyarch: x86  },
-          #{icon: '🟪', installs: "MINGW32", arch: i686,   pkg: "llvm",  pyarch: x86  }, ! Not yet functional
-          {icon: '🟦', installs: "MINGW64", arch: x86_64, pkg: "mcode", pyarch: x64 }, #! simulation with mcode is not yet supported on win64
-          {icon: '🟦', installs: 'MINGW64', arch: x86_64, pkg: 'llvm',  pyarch: x64 },
+          #{icon: '🟪', pkg: 'llvm',  bits: '32', arch: i686 }, ! not yet functional
+          {icon: '🟦', pkg: 'llvm',  bits: '64', arch: x86_64, pyarch: x64 },
+          {icon: '🟪', pkg: 'mcode', bits: '32', arch: i686,   pyarch: x86 },
+          {icon: '🟦', pkg: 'mcode', bits: '64', arch: x86_64, pyarch: x64 }, #! simulation with mcode is not yet supported on win64
         ]
-    name: '${{ matrix.icon }} CPython · ${{ matrix.installs }} · ${{ matrix.pkg }}'
+    name: '🚦🐍${{ matrix.icon }} · ${{ matrix.pkg }}${{ matrix.bits }}'
     defaults:
       run:
         shell: pwsh
@@ -460,7 +460,7 @@ jobs:
     - name: '${{ matrix.icon }} Setup MSYS2'
       uses: msys2/setup-msys2@v2
       with:
-        msystem: ${{ matrix.installs }}
+        msystem: MINGW${{ matrix.bits }}
         update: true
 
     - name: '⚙️ git config'
@@ -473,9 +473,9 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         path: artifact
-        name: ${{ matrix.installs }}-${{ matrix.pkg }}
+        name: MINGW${{ matrix.bits }}-${{ matrix.pkg }}
 
-    - name: '⚙️ Install package'
+    - name: '🛠️ Install package'
       shell: msys2 {0}
       run: |
         pacman --noconfirm -U artifact/mingw-w64-${{ matrix.arch }}-ghdl-${{ matrix.pkg }}-*.zst
@@ -490,9 +490,9 @@ jobs:
       run: |
         pip3 install -r testsuite/requirements.txt
 
-    - name: '🚧 Test package'
+    - name: '🚦 Test package'
       run: |
-        $env:GHDL_PREFIX = (& msys2 -c 'cygpath -w /') + '${{ matrix.installs }}\lib\ghdl\'
+        $env:GHDL_PREFIX = (& msys2 -c 'cygpath -w /') + 'MINGW${{ matrix.bits }}\lib\ghdl\'
         $env:PYTHONPATH = (pwd).Path
         cd testsuite
         python3 -m pytest -vsrA pyunit
@@ -502,18 +502,17 @@ jobs:
 #
 
   win-cpython-standalone:
-    needs: win-standalone
+    needs: win-generate-standalone-zip
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
-        include: [
-          {icon: '🟪', pkg: 'MINGW32-mcode', pyarch: x86 },
-          #{icon: '🟪', pkg: 'MINGW32-llvm',  pyarch: x86 }, ! Not yet functional
-          {icon: '🟦', pkg: 'MINGW64-mcode', pyarch: x64 }, #! simulation with mcode is not yet supported on win64
-          #{icon: '🟦', pkg: 'MINGW64-llvm',  pyarch: x64  },
-        ]
-    name: '${{ matrix.icon }} CPython Test · ${{ matrix.pkg }}'
+        include:
+        #- { pkg: '32-llvm', pyarch: x86 } ! not yet functional
+        #- { pkg: '64-llvm', pyarch: x64 }
+        - { pkg: '32-mcode', pyarch: x86 }
+        - { pkg: '64-mcode', pyarch: x64 } #! simulation with mcode is not yet supported on win64
+    name: '🚦🐍🥡 ${{ matrix.pkg }}'
     defaults:
       run:
         shell: pwsh
@@ -529,12 +528,12 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         path: artifact
-        name: ${{ matrix.pkg }}-standalone
+        name: MINGW${{ matrix.pkg }}-standalone
 
     - name: '⚙️ Extract package'
       run: |
-        unzip artifact\${{ matrix.pkg }}-standalone.zip
-        mv '${{ matrix.pkg }}-standalone\' GHDL-standalone
+        unzip artifact\MINGW${{ matrix.pkg }}-standalone.zip
+        mv 'MINGW${{ matrix.pkg }}-standalone\' GHDL-standalone
 
     - name: '🐍 Setup Python'
       uses: actions/setup-python@v2
@@ -546,7 +545,7 @@ jobs:
       run: |
         pip3 install -r testsuite/requirements.txt
 
-    - name: '🚧 Test package'
+    - name: '🚦 Test package'
       run: |
         $env:GHDL_PREFIX = (pwd).Path + '\GHDL-standalone\lib\ghdl'
         $env:PYTHONPATH = (pwd).Path
@@ -559,7 +558,7 @@ jobs:
 
   Release:
     if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/'))
-    needs: [ doc, lin, osx, win-test, win-pip, win-generate-standalone-zip ]
+    needs: [ doc, lin, osx, win-msys2-test, win-pip, win-generate-standalone-zip ]
     runs-on: ubuntu-latest
     name: '📦 Release'
     steps:
@@ -601,7 +600,7 @@ jobs:
 #
 
   coverage:
-    needs: win-build
+    needs: win-msys2-build-package
     runs-on: windows-latest
     name: '📈 Coverage'
     defaults:
@@ -631,12 +630,12 @@ jobs:
         path: artifact
         name: MINGW64-llvm
 
-    - name: '🚧 Install package and Python dependencies'
+    - name: '🛠️ Install package and 🐍 Python dependencies'
       run: |
         pacman --noconfirm -U artifact/mingw-w64-x86_64-ghdl-llvm-*.zst
         pip3 install -r testsuite/requirements.txt
 
-    - name: '🚧 Run tests to generate coverage report'
+    - name: '🚦 Run tests to generate coverage report'
       run: PYTHONPATH=$(pwd) python3 -m pytest -rA --cov=.. --cov-config=.coveragerc testsuite/pyunit
 
     - name: Generate XML coverage report

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -69,10 +69,10 @@ jobs:
         path: doc/_build/man/ghdl.1
 
 #
-# pyGHDL Bindings and Formatting
+# pyGHDL Bindings, Formatting and Wheel
 #
 
-  fmt:
+  pyGHDL:
     runs-on: ubuntu-latest
     name: '🐍 pyGHDL'
     steps:
@@ -85,22 +85,36 @@ jobs:
       with:
         python-version: 3.8
 
-    - name: Install dependencies
+    - name: '🔧 Install dependencies'
       run: |
         sudo apt update -qq
         sudo apt install -y gnat
-        python -m pip install black
+        python -m pip install --upgrade pip
+        python -m pip install black wheel
 
-    - name: Update Python bindings
+    - name: '🚧 Update Python bindings'
       run: ./scripts/update_py_bindings.sh
 
-    - name: Check if Python bindings changed
+    - name: '🚦 Check if Python bindings changed'
       run: |
         git diff --stat
         git diff --exit-code
 
-    - name: Check if python follows code formatting standards
+    - name: '🚦 Check if python follows code formatting standards'
       run: python -m black --check pyGHDL
+
+    - name: 🔨 Build Python package (source distribution)
+      run: python setup.py sdist
+
+    - name: 🔨 Build Python package (binary distribution - wheel)
+      run: python setup.py bdist_wheel
+
+    - name: '📤 Upload artifact: pyGHDL'
+      uses: actions/upload-artifact@v2
+      with:
+        name: pyGHDL
+        path: dist/
+        if-no-files-found: error
 
 #
 # GPL
@@ -149,6 +163,7 @@ jobs:
       with:
         name: ubuntu${{ matrix.os }}-${{ matrix.backend }}
         path: ghdl-gha-ubuntu-*.tgz
+        if-no-files-found: error
 
 #
 # MacOS
@@ -193,6 +208,7 @@ jobs:
       with:
         name: macos10.15-${{ matrix.backend }}
         path: ghdl-macos*${{ matrix.backend }}.tgz
+        if-no-files-found: error
 
 #
 # Windows MSYS2 Build
@@ -255,6 +271,7 @@ jobs:
       with:
         name: MINGW${{ matrix.bits }}-${{ matrix.pkg }}
         path: scripts/msys2-${{ matrix.pkg }}/mingw-*ghdl*.pkg.tar.zst
+        if-no-files-found: error
 
 #
 # Windows MSYS2 Test
@@ -315,60 +332,6 @@ jobs:
 
     - name: '🚦 Test package'
       run: GHDL=ghdl ./testsuite/testsuite.sh ${{ matrix.suite }}
-
-#
-# Windows MSYS2 pyGHDL pip installation
-#
-
-  win-pip:
-    needs: win-msys2-build-package
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include: [
-          #{icon: '🟪', pkg: 'llvm',  bits: '32', arch: i686 }, ! Not yet functional
-          {icon: '🟦', pkg: 'llvm',  bits: '64', arch: x86_64  },
-          {icon: '🟪', pkg: 'mcode', bits: '32', arch: i686,   },
-          {icon: '🟦', pkg: 'mcode', bits: '64', arch: x86_64, }, #! simulation with mcode is not yet supported on win64
-        ]
-    name: '🚦${{ matrix.icon }} pip · ${{ matrix.pkg }}${{ matrix.bits }}'
-    defaults:
-      run:
-        shell: msys2 {0}
-    steps:
-
-    - name: '${{ matrix.icon }} Setup MSYS2'
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: MINGW${{ matrix.bits }}
-        update: true
-        install: >
-          git
-          mingw-w64-${{ matrix.arch }}-gcc
-          mingw-w64-${{ matrix.arch }}-python-pip
-          mingw-w64-${{ matrix.arch }}-python-setuptools
-
-    - name: '⚙️ git config'
-      run: git config --global core.autocrlf input
-      shell: bash
-
-    - name: '📥 Download artifact: package'
-      uses: actions/download-artifact@v2
-      with:
-        path: artifact
-        name: MINGW${{ matrix.bits }}-${{ matrix.pkg }}
-
-    - name: '🛠️ Install package'
-      run: pacman --noconfirm -U artifact/mingw-w64-${{ matrix.arch }}-ghdl-${{ matrix.pkg }}-*.zst
-
-    - name: '🚦 Test installation of pyGHDL through pip'
-      run: pip install git+https://github.com/ghdl/ghdl.git@$(ghdl version hash)
-
-    - name: '🚦 Test pyGHDL entrypoints'
-      run: |
-        ghdl-dom help
-        ghdl-ls --help
 
 #
 # Windows Generate Standalone ZipFile
@@ -480,6 +443,14 @@ jobs:
       run: |
         pacman --noconfirm -U artifact/mingw-w64-${{ matrix.arch }}-ghdl-${{ matrix.pkg }}-*.zst
 
+    - name: '🛠️ Set envvars'
+      run: |
+        $GHDL = (& msys2 -c 'cygpath -w /') + 'MINGW${{ matrix.bits }}\bin\ghdl.exe'
+        $GHDL_HASH = (& $GHDL version hash)
+        echo "GHDL_HASH=$GHDL_HASH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        $GHDL_PREFIX = (& msys2 -c 'cygpath -w /') + 'MINGW${{ matrix.bits }}\lib\ghdl\'
+        echo "GHDL_PREFIX=$GHDL_PREFIX" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
     - name: '🐍 Setup Python'
       uses: actions/setup-python@v2
       with:
@@ -490,19 +461,27 @@ jobs:
       run: |
         pip3 install -r testsuite/requirements.txt
 
-    - name: '🚦 Test package'
+    - name: '🚦 Test installation of pyGHDL through pip'
+      run: pip install ("git+https://github.com/ghdl/ghdl.git@" + $env:GHDL_HASH)
+
+    - name: '🚦 Test pyGHDL entrypoints'
       run: |
-        $env:GHDL_PREFIX = (& msys2 -c 'cygpath -w /') + 'MINGW${{ matrix.bits }}\lib\ghdl\'
-        $env:PYTHONPATH = (pwd).Path
+        ghdl-dom help
+        ghdl-ls --help
+
+    - name: '🚦 Test pyunit testsuite'
+      run: |
         cd testsuite
         python3 -m pytest -vsrA pyunit
 
 #
-# Windows CPython pyGHDL Test with standalone zipfile
+# Windows CPython pyGHDL Test with standalone zipfile and pyGHDL wheel
 #
 
   win-cpython-standalone:
-    needs: win-generate-standalone-zip
+    needs:
+      - win-generate-standalone-zip
+      - pyGHDL
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -535,20 +514,38 @@ jobs:
         unzip artifact\MINGW${{ matrix.pkg }}-standalone.zip
         mv 'MINGW${{ matrix.pkg }}-standalone\' GHDL-standalone
 
+    - name: '🛠️ Set envvars'
+      run: |
+        $GHDL = (pwd).Path + '\GHDL-standalone\bin\ghdl.exe'
+        $GHDL_HASH = (& $GHDL version hash)
+        echo "GHDL_HASH=$GHDL_HASH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        $GHDL_PREFIX = (pwd).Path + '\GHDL-standalone\lib\ghdl'
+        echo "GHDL_PREFIX=$GHDL_PREFIX" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
     - name: '🐍 Setup Python'
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
         architecture: ${{ matrix.pyarch }}
 
-    - name: '🐍 Install Python dependencies'
-      run: |
-        pip3 install -r testsuite/requirements.txt
+    - name: '📥 Download artifact: pyGHDL'
+      uses: actions/download-artifact@v2
+      with:
+        name: pyGHDL
 
-    - name: '🚦 Test package'
+    - name: '🐍 Install pyGHDL'
       run: |
-        $env:GHDL_PREFIX = (pwd).Path + '\GHDL-standalone\lib\ghdl'
-        $env:PYTHONPATH = (pwd).Path
+        python -m pip install --upgrade pip
+        python -m pip install wheel (& ls *.whl)
+        python -m pip install -r testsuite/requirements.txt
+
+    - name: '🚦 Test pyGHDL entrypoints'
+      run: |
+        ghdl-dom help
+        ghdl-ls --help
+
+    - name: '🚦 Test pyunit testsuite'
+      run: |
         cd testsuite
         python3 -m pytest -vsrA pyunit
 
@@ -558,7 +555,14 @@ jobs:
 
   Release:
     if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/'))
-    needs: [ doc, lin, osx, win-msys2-test, win-pip, win-generate-standalone-zip ]
+    needs:
+     - doc
+     - lin
+     - osx
+     - win-msys2-test
+     - win-generate-standalone-zip
+     - win-cpython-msys2
+     - win-cpython-standalone
     runs-on: ubuntu-latest
     name: '📦 Release'
     steps:

--- a/scripts/msys2-mcode/GetStandaloneDeps.sh
+++ b/scripts/msys2-mcode/GetStandaloneDeps.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+GetMinGWLibraries() {
+  ldd "${MSYSTEM_PREFIX}/$1" | while IFS="" read -r dependency; do
+    fields=($dependency)
+    dep="${fields[2]}"
+    if [[ "$dep" == /"${MSYSTEM,,}"/* ]]; then
+      echo "$dep"
+      GetMinGWLibraries "${dep#"/${MSYSTEM,,}/"}"
+    fi
+  done
+}
+
+for dep in $(GetMinGWLibraries "lib/libghdl-2_0_0_dev.dll"); do
+  echo "$dep"
+  cp "$dep" ./
+done

--- a/setup.py
+++ b/setup.py
@@ -62,16 +62,17 @@ def get_description(file: Path) -> str:
 def get_requirements(file: Path) -> List[str]:
     requirements = []
     with file.open("r") as fh:
-        for line in fh.readlines():
-            line = line.strip()
+        for line in fh.read().splitlines():
             if line.startswith("#") or line == "":
                 continue
             elif line.startswith("-r"):
-                filename = line[3:].strip()
+                # Remove the first word/argument (-r)
+                filename = " ".join(line.split(" ")[1:])
                 requirements += get_requirements(file.parent / filename)
             elif line.startswith("https"):
-                _splitItems = line.split("#")
-                requirements.append("{} @ {}".format(_splitItems[1], _splitItems[0]))
+                # Convert 'URL#NAME' to 'NAME @ URL'
+                splitItems = line.split("#")
+                requirements.append("{} @ {}".format(splitItems[1], splitItems[0]))
             else:
                 requirements.append(line)
     return requirements

--- a/testsuite/pyunit/lsp/LanguageServer.py
+++ b/testsuite/pyunit/lsp/LanguageServer.py
@@ -1,5 +1,5 @@
-import os
-from sys import executable
+from os import environ
+from sys import executable, platform
 from io import BytesIO
 from json import load as json_load, loads as json_loads, dumps as json_dumps
 from pathlib import Path
@@ -7,8 +7,10 @@ from urllib.parse import quote
 from subprocess import run as subprocess_run, PIPE
 from typing import Optional
 from unittest import TestCase
+from pytest import mark
 
 from pyGHDL.lsp.lsp import LanguageProtocolServer, LSPConn
+
 
 class StrConn:
     __res: str
@@ -191,6 +193,11 @@ class Test003_Errors(JSONTest):
         self._RequestResponse("cmds.json", "replies.json")
 
 
+
+@mark.xfail(
+    platform == 'win32' and ('MINGW_PREFIX' not in environ),
+    reason="needs OpenSSL",
+)
 class Test004_Error_Project(JSONTest):
     subdir = Path("004errprj")
 


### PR DESCRIPTION
This PR enables the mcode build on MINGW64. Although code generation is not supported, features other than simulation do work.

Moreover, a job is added after testing on Windows, for generating "standalone" zipfiles for mcode32 and mcode64. Precisely, the MSYS2 packages are extracted and a shell script contributed by @Paebbels is used for adding DLLs.