### PR TITLE
Added DLL search path for Python ≥3.8.

### DIFF
--- a/pyGHDL/libghdl/__init__.py
+++ b/pyGHDL/libghdl/__init__.py
@@ -31,10 +31,9 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
-
 from ctypes import c_char_p, CDLL
-import os
-import sys
+from sys import platform as sys_platform, version_info as sys_version_info
+from os import environ as os_environ
 from pathlib import Path
 from shutil import which
 from typing import List
@@ -63,7 +62,7 @@ class LibGHDLException(GHDLBaseException):
 def _get_libghdl_name() -> Path:
     """Get the name of the libghdl library (with version and extension)."""
     ver = __version__.replace("-", "_").replace(".", "_")
-    ext = {"win32": "dll", "cygwin": "dll", "darwin": "dylib"}.get(sys.platform, "so")
+    ext = {"win32": "dll", "cygwin": "dll", "darwin": "dylib"}.get(sys_platform, "so")
     return Path("libghdl-{version}.{ext}".format(version=ver, ext=ext))
 
 
@@ -103,21 +102,21 @@ def _get_libghdl_path():
     # Try GHDL_PREFIX
     # GHDL_PREFIX is the prefix of the vhdl libraries, so remove the
     # last path component.
-    r = os.environ.get("GHDL_PREFIX")
+    r = os_environ.get("GHDL_PREFIX")
     try:
         return _check_libghdl_libdir(Path(r).parent, basename)
     except (TypeError, FileNotFoundError):
         pass
 
     # Try VUNIT_GHDL_PATH (path of the ghdl binary when using VUnit).
-    r = os.environ.get("VUNIT_GHDL_PATH")
+    r = os_environ.get("VUNIT_GHDL_PATH")
     try:
         return _check_libghdl_bindir(Path(r), basename)
     except (TypeError, FileNotFoundError):
         pass
 
     # Try GHDL (name/path of the ghdl binary)
-    r = os.environ.get("GHDL", "ghdl")
+    r = os_environ.get("GHDL", "ghdl")
     r = which(r)
     try:
         return _check_libghdl_bindir(Path(r).parent, basename)
@@ -143,9 +142,25 @@ def _get_libghdl_path():
 
 
 def _initialize():
+    from os import environ as os_environ
+
+    print(os_environ)
+
     # Load the shared library
     _libghdl_path = _get_libghdl_path()
-    # print("Load {}".format(_libghdl_path))
+
+    # Add DLL search path(s)
+    if (
+        sys_platform == "win32"
+        and sys_version_info.major == 3
+        and sys_version_info.minor >= 8
+    ):
+        from os import add_dll_directory as os_add_dll_directory
+
+        p1 = _libghdl_path.parent.parent / "bin"
+        os_add_dll_directory(str(p1))
+
+    # Load libghdl shared object
     libghdl = CDLL(str(_libghdl_path))
 
     # Initialize it.

--- a/pyGHDL/libghdl/__init__.py
+++ b/pyGHDL/libghdl/__init__.py
@@ -142,10 +142,6 @@ def _get_libghdl_path():
 
 
 def _initialize():
-    from os import environ as os_environ
-
-    print(os_environ)
-
     # Load the shared library
     _libghdl_path = _get_libghdl_path()
 

--- a/testsuite/pyunit/dom/Sanity.py
+++ b/testsuite/pyunit/dom/Sanity.py
@@ -32,10 +32,11 @@
 # ============================================================================
 from pathlib import Path
 from subprocess import check_call, STDOUT
+from sys import executable as sys_executable
 
 from pytest import mark
 
-from pyGHDL.dom.NonStandard import Design, Document
+from pyGHDL.dom.NonStandard import Design
 
 if __name__ == "__main__":
     print("ERROR: you called a testcase declaration file as an executable module.")
@@ -51,7 +52,7 @@ design = Design()
 @mark.xfail
 @mark.parametrize("file", [str(f.relative_to(_TESTSUITE_ROOT)) for f in _TESTSUITE_ROOT.glob("sanity/**/*.vhdl")])
 def test_AllVHDLSources(file):
-    check_call(["python", _GHDL_ROOT / "pyGHDL/cli/DOM.py", file], stderr=STDOUT)
+    check_call([sys_executable, _GHDL_ROOT / "pyGHDL/cli/DOM.py", file], stderr=STDOUT)
 
 #    document = Document(Path(file))
 #    design.Documents.append(document)


### PR DESCRIPTION
**Problem Description**
If GHDL is installed standalone outside of MinGW (tested with MSYS2/MinGW64), all DLL dependencies are resolved correctly. This is independent of GHDL / libghdl being build with mcode or llvm backend.

However, if GHDL / libghdl and it's dependencies are not copied outside of MSYS2 (e.g. `C:\msys64\mingw64\...` to `C:\Tools\GHDL`), then Pythons ctypes.CDLL has problems in finding all dependencies. This is due to the fact that `%PATH%` is not correctly used to search for dependencies.

**Solution**
With CPython 3.8, a new API (`os.add_dll_directory`) was added to add a DLL search path. This is only necessary on Windows platforms, because the problem does not exist on Linux and more over Linux would offer a `LD_LIBRARY_PATH` variable to support shared library searches.

This PR adds code to support using GHDL that was installed via `pacman` inside of MinGW64 to be used from Python packages running in a Windows native Python installation (CPython).

**Change**
```diff
    # Load the shared library
    _libghdl_path = _get_libghdl_path()

+    # Add DLL search path(s)
+    if sys_platform == "win32":
+        from os import add_dll_directory as os_add_dll_directory

+        ghdlBinPath = _libghdl_path.parent.parent / "bin"
+        os_add_dll_directory(str(ghdlBinPath))

    # Load libghdl shared object
    libghdl = CDLL(str(_libghdl_path))
```