### PR TITLE
libghw: add missing semicolon to physical type formatting

### DIFF
--- a/ghw/libghw.c
+++ b/ghw/libghw.c
@@ -2180,7 +2180,7 @@ ghw_disp_type (struct ghw_handler *h, union ghw_type *t)
 	    printf ("  %s = " GHWPRI64 " %s;\n", u->name, u->val,
 		    p->units[0].name);
 	  }
-	printf ("end units\n");
+	printf ("end units;\n");
       } break;
     case ghdl_rtik_type_array:
       {

--- a/testsuite/gna/issue418/golden_tc749.txt
+++ b/testsuite/gna/issue418/golden_tc749.txt
@@ -18,7 +18,7 @@ type time is range <> units
   sec = 1000000000000000 fs;
   min = 60000000000000000 fs;
   hr = 3600000000000000000 fs;
-end units
+end units;
 subtype time is time range -9223372036854775808 to 9223372036854775807;
 type time_vector is array (natural range <>) of time;
 type natural_vector is array (natural range <>) of natural;


### PR DESCRIPTION
**Description**

When printing the type section, physical types do not have a trailing semicolon. This causes problems when comparing the golden outputs in the testsuite with my [Rust libghw/ghwdump reimplementation](https://gitlab.com/xiretza/ghw-rs), which always prints a trailing semicolon for any type table entry. While the rest of the expected output is not completely valid VHDL either, this just looks like an oversight.