### PR TITLE
TEST DOM crash with multiple files

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -493,6 +493,13 @@ jobs:
           cd testsuite
           python3 -m pytest -vsrA pyunit
 
+      - name: Test NEORV32
+        shell: bash
+        run: |
+          set -e
+          git clone https://github.com/stnolting/neorv32
+          ghdl-dom pretty -F neorv32/rtl/core/*.vhd
+
 #
 # Windows CPython pyGHDL Test with standalone zipfile and pyGHDL wheel
 #
@@ -571,6 +578,13 @@ jobs:
         run: |
           cd testsuite
           python3 -m pytest -vsrA pyunit
+
+      - name: Test NEORV32
+        shell: bash
+        run: |
+          set -e
+          git clone https://github.com/stnolting/neorv32
+          ghdl-dom pretty -F neorv32/rtl/core/*.vhd
 
 #
 # Release


### PR DESCRIPTION
This PR is not for merging, but for showing a problem when analysing multiple files with ghdl-dom at once.
In the regular CI tests we analyse each file separatedly, in order to avoid this problem.
Actually, we hit it before and Tristan did fix it partially.

In this PR, repo NEORV32 is cloned and `rtl/core/*.vhd` are analysed at once. That generates a segmentation fault.

```
set -e
git clone https://github.com/stnolting/neorv32
ghdl-dom pretty -F neorv32/rtl/core/*.vhd
```

```
Cloning into 'neorv32'...
================================================================================
                         pyGHDL.dom - Test Application                          
================================================================================
Parsing file 'neorv32\rtl\core\neorv32_application_image.vhd'
D:\a\_temp\fbe4ff3b-599e-4360-9380-9eb730caa92d.sh: line 3:   588 Segmentation fault      ghdl-dom pretty -F neorv32/rtl/core/*.vhd
Error: Process completed with exit code 139.
```