### PR TITLE
Debian Bullseye was released

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,7 @@ begin
 end;
 ```
 
-```sh :image: ghdl/ghdl:buster-mcode
+```sh :image: ghdl/ghdl:bullseye-mcode
 ghdl -a ent.vhd
 ghdl --elab-run ent
 ```

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -131,7 +131,7 @@ jobs:
       - name: '🧰 Checkout'
         uses: actions/checkout@v2
 
-      - run: TASK=buster+mcode ./scripts/ci-run.sh -c --gplcompat
+      - run: TASK=bullseye+mcode ./scripts/ci-run.sh -c --gplcompat
 
 #
 # GNU/Linux

--- a/scripts/ci-run.sh
+++ b/scripts/ci-run.sh
@@ -384,7 +384,7 @@ ci_run () {
       tests="sanity"
 
       case "$GHDL_IMAGE_TAG" in
-        *ubuntu20*|*buster*)
+        *ubuntu20*|*buster*|*bullseye*)
           GHDL_TEST_IMAGE="test:$GHDL_IMAGE_TAG-py"
           gstart "[CI] Docker build $GHDL_TEST_IMAGE" "$ANSI_BLUE"
           docker build -t "$GHDL_TEST_IMAGE" . -f- <<-EOF


### PR DESCRIPTION
Since Debian Bullseye was released, ghdl/docker was updated accordingly. This PR changes the usage of Buster images to Bullseye.