### PR TITLE
ortho/gcc: handle auxbase in GCC 8

### DIFF
--- a/src/ortho/gcc/ortho-lang-8.c
+++ b/src/ortho/gcc/ortho-lang-8.c
@@ -407,6 +407,22 @@ ortho_post_options (const char **pfilename)
 {
   if (*pfilename == NULL || strcmp (*pfilename, "-") == 0)
     *pfilename = "*stdin*";
+  else if (aux_base_name == NULL)
+    {
+      /* Define auxbase.  The default mechanism in toplev.c doesn't
+         handle extensions longer than 3 characters.  */
+      char *name = xstrdup (lbasename (main_input_filename));
+      int len;
+
+      /* Remove extension.  */
+      for (len = strlen (name) - 1; len > 1; len--)
+        if (name[len] == '.')
+          {
+            name[len] = 0;
+            break;
+          }
+      aux_base_name = name;
+    }
 
   /* Default hook.  */
   lhd_post_options (pfilename);


### PR DESCRIPTION
This seems to fix the issue with GCC 8. I just copied the enhancement from https://github.com/ghdl/ghdl/commit/a5ff9b623532ef2a15ca0a6ba315f2f463142490.