### PR TITLE
Tweaks to make configuration system more friendly to gentoo.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -13,14 +13,14 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <gnu.org/licenses>.
-CC=@CC@
+CC=@ac_tool_prefix@@CC@
 CFLAGS=@CFLAGS@
-CXX=@CXX@
+CXX=@ac_tool_prefix@@CXX@
 CXXFLAGS=@CXXFLAGS@
 build=@build@
 srcdir=@srcdir@
 abs_srcdir=@abs_srcdir@
-GNATMAKE=@GNATMAKE@
+GNATMAKE=@ac_tool_prefix@@GNATMAKE@
 ADA_FLAGS=@ADA_FLAGS@
 MAKE=@MAKE@
 prefix=@prefix@
@@ -49,7 +49,7 @@ INSTALL_DATA=install -m 644
 PWD?=$(shell pwd)
 DESTDIR=
 bindir=$(prefix)/bin
-libdir=$(prefix)/lib
+libdir=@libdir@
 incdir=$(prefix)/include
 MKDIR=mkdir
 LN=ln -s
@@ -59,7 +59,7 @@ SED=sed
 GRT_RANLIB=ranlib
 GHDL_DESC?=tarball
 
-VHDL_LIB_DIR=$(prefix)/$(libdirsuffix)
+VHDL_LIB_DIR=$(libdir)/$(libdirsuffix)
 
 ifeq "$(enable_checks)" "true"
  # Debug + checks

--- a/configure
+++ b/configure
@@ -33,7 +33,7 @@ ADA_FLAGS=${ADA_FLAGS:-}
 MAKE=${MAKE:-make}
 LDFLAGS=${LDFLAGS:-}
 prefix=/usr/local
-libdirsuffix=lib/ghdl
+libdirsuffix=ghdl
 libdirreverse=../..
 gcc_src_dir=
 llvm_config=
@@ -50,11 +50,20 @@ default_pic=false
 EXEEXT=
 SOEXT=.so
 PIC_FLAGS=-fPIC
+ac_tool_prefix=
+libdir=
+# Unused parameters
+mandir=
+infodir=
+datadir=
+sysconfdir=
+localstatedir=
+
 
 show_help=no
 progname=$0
 
-subst_vars="CC CXX GNATMAKE ADA_FLAGS MAKE CFLAGS CXXFLAGS LDFLAGS build srcdir abs_srcdir prefix backend libdirsuffix libdirreverse gcc_src_dir llvm_config llvm_be backtrace_lib build_mode EXEEXT SOEXT PIC_FLAGS default_pic enable_werror enable_checks enable_gplcompat enable_libghdl libghdl_version ghdl_version"
+subst_vars="CC CXX GNATMAKE ADA_FLAGS MAKE CFLAGS CXXFLAGS LDFLAGS build srcdir abs_srcdir prefix backend libdirsuffix libdirreverse gcc_src_dir llvm_config llvm_be backtrace_lib build_mode EXEEXT SOEXT PIC_FLAGS default_pic enable_werror enable_checks enable_gplcompat enable_libghdl libghdl_version ghdl_version ac_tool_prefix libdir mandir infodir datadir sysconfdir localstatedir"
 
 # Find srcdir
 srcdir=`dirname $progname`
@@ -113,12 +122,30 @@ for opt do
     --default-pic)          default_pic=true;;
     --enable-coverage)      build_mode="coverage";;
     -h|-help|--help)        show_help=yes;;
+    --build=*)              build="$optarg";;
+    --host=*)               host="$optarg";;
+    --libdir=*)             libdir="$optarg";;
+    # Unused parameters
+    --mandir=*)             mandir="$optarg";;
+    --infodir=*)            infodir="$optarg";;
+    --datadir=*)            datadir="$optarg";;
+    --sysconfdir=*)         sysconfdir="$optarg";;
+    --localstatedir=*)      localstatedir="$optarg";;
+
     *)
       echo "$0: unknown option $opt; try $0 --help"
       exit 1
       ;;
   esac
 done
+
+ac_tool_prefix=
+test -n "$host_alias" && ac_tool_prefix=$host_alias-
+
+if test "x$libdir" = "x"; then
+    libdir=$prefix/lib
+fi
+
 
 # Help
 if test $show_help != no; then
@@ -342,7 +369,7 @@ rm -f config.status
     eval vval=\$$v
     echo $v=\"$vval\"
   done
-  subst_files="ghdl.gpr Makefile"
+  subst_files="ghdl.gpr Makefile scripts/gcc/Make-lang.in"
   echo "for f in $subst_files; do"
   echo '  echo "Creating $f"'
   echo "  sed \\"
@@ -412,7 +439,7 @@ sed -e "s%@COMPILER_GCC@%ghdl1-gcc$EXEEXT%" \
     -e "s%@COMPILER_LLVM@%ghdl1-llvm$EXEEXT%" \
     -e "s%@POST_PROCESSOR@%oread-$backend%" \
     -e "s%@INSTALL_PREFIX@%$prefix%" \
-    -e "s%@LIB_PREFIX@%$libdirsuffix%" \
+    -e "s%@LIB_PREFIX@%$libdir/$libdirsuffix%" \
     -e "s%@SOEXT@%$SOEXT%" \
     -e "s%@default_pic@%$default_pic%" \
     < $srcdir/src/ghdldrv/default_paths.ads.in > default_paths.ads

--- a/scripts/gcc/Make-lang.in.in
+++ b/scripts/gcc/Make-lang.in.in
@@ -104,7 +104,7 @@ vhdl/default_paths.ads: Makefile
 	echo "   Compiler_Llvm  : constant String := \"\";" >> tmp-dpaths.ads
 	echo "   Post_Processor : constant String := \"\";" >> tmp-dpaths.ads
 	echo "   Lib_Prefix     : constant String :=">> tmp-dpaths.ads
-	echo "     \"lib/ghdl\";" >> tmp-dpaths.ads
+	echo "     \"@libdir@/ghdl\";" >> tmp-dpaths.ads
 	echo "   Shared_Library_Extension : constant String :=">> tmp-dpaths.ads
 	echo "     \"$(VHDL_SOEXT)\";" >> tmp-dpaths.ads
 	echo "   Default_Pie : constant Boolean := False;" >> tmp-dpaths.ads


### PR DESCRIPTION
Intention is that these tweaks do not affect systems that do not call
configure with things like --libdir.

Fixup to add ac_tool_prefix.
Ignore things like mandir, infodir, etc that gentoo passes in and ghdl
    doesn't care about.
Allow for --libdir to override the libdir. This is how gentoo handles
    things like 32/64 bit.

**Description**
Currently ghdl has a bit of trouble building on gentoo. This is meant to be a minimal patch to address that.

**Expected behaviour**
All current uses of configuration will remain unchanged.
Gentoo ebuild will no longer require patches (https://bugs.gentoo.org/679340).


**Context**
Please, provide the following information:

- OS: gentoo
- Origin: trying to package for gentoo