### PR TITLE
add cpp header check for libghw

### DIFF
--- a/ghw/libghw.h
+++ b/ghw/libghw.h
@@ -26,6 +26,10 @@
 #include "config.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The libghw uses the standard c99 int32_t and int64_t.  They are declared
    in stdint.h.  Header inttypes.h includes stdint.h and provides macro for
    printf and co specifiers.  Use it if known to be available.  */
@@ -469,4 +473,9 @@ void ghw_disp_range (union ghw_type *type, union ghw_range *rng);
 void ghw_disp_type (struct ghw_handler *h, union ghw_type *t);
 
 void ghw_disp_types (struct ghw_handler *h);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* _LIBGHW_H_ */


### PR DESCRIPTION
C++ compilers mangle the names in the libghw header. This prevents that from happening so they can properly be linked to a C++ application.
