### PR TITLE
Added binding to new function 'Get_Source_Identifier'.

### DIFF
--- a/pyGHDL/dom/_Utils.py
+++ b/pyGHDL/dom/_Utils.py
@@ -36,7 +36,7 @@ from pyVHDLModel.SyntaxModel import Mode
 
 from pyGHDL.libghdl import LibGHDLException, name_table, errorout_memory
 from pyGHDL.libghdl._types import Iir
-from pyGHDL.libghdl.vhdl import nodes
+from pyGHDL.libghdl.vhdl import nodes, utils
 from pyGHDL.libghdl.vhdl.nodes import Null_Iir
 from pyGHDL.dom import DOMException
 
@@ -85,7 +85,7 @@ def GetNameOfNode(node: Iir) -> str:
     if node == Null_Iir:
         raise ValueError("GetNameOfNode: Parameter 'node' must not be 'Null_iir'.")
 
-    identifier = nodes.Get_Identifier(node)
+    identifier = utils.Get_Source_Identifier(node)
     return name_table.Get_Name_Ptr(identifier)
 
 

--- a/pyGHDL/libghdl/vhdl/utils.py
+++ b/pyGHDL/libghdl/vhdl/utils.py
@@ -1,0 +1,50 @@
+# =============================================================================
+#               ____ _   _ ____  _       _ _ _           _         _ _
+#  _ __  _   _ / ___| | | |  _ \| |     | (_) |__   __ _| |__   __| | |
+# | '_ \| | | | |  _| |_| | | | | |     | | | '_ \ / _` | '_ \ / _` | |
+# | |_) | |_| | |_| |  _  | |_| | |___ _| | | |_) | (_| | | | | (_| | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)_|_|_.__/ \__, |_| |_|\__,_|_|
+# |_|    |___/                                     |___/
+# =============================================================================
+# Authors:
+#   Tristan Gingold
+#   Patrick Lehmann
+#
+# Package module:   Python binding and low-level API for shared library 'libghdl'.
+#
+# License:
+# ============================================================================
+#  Copyright (C) 2019-2021 Tristan Gingold
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <gnu.org/licenses>.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+
+from pydecor import export
+
+from pyGHDL.libghdl._types import Iir, NameId
+from pyGHDL.libghdl._decorator import BindToLibGHDL
+
+
+@export
+@BindToLibGHDL("vhdl__utils__get_source_identifier")
+def Get_Source_Identifier(Decl: Iir) -> NameId:
+    """
+    Like ``Get_Identifier`` but return a ``NameId`` for the same casing as it appears in the source file.
+    Not useful for analysis as VHDL is case insensitive, but could be useful for error messages or tooling.
+
+    :param Decl: Iir Node. Type: ``Iir``
+    """
+    return 0


### PR DESCRIPTION
This adds a new binding for `vhdl-utils.Get_Source_Identifier` and uses this function in `pyGHDL.DOM`, so identifiers keep there casing.