### PR TITLE
Add explicit ?>= and ?> functions for translation.

### DIFF
--- a/src/ghdldrv/ghdlrun.adb
+++ b/src/ghdldrv/ghdlrun.adb
@@ -690,6 +690,10 @@ package body Ghdlrun is
            Grt.Std_Logic_1164.Ghdl_Std_Ulogic_Match_Lt'Address);
       Def (Trans_Decls.Ghdl_Std_Ulogic_Match_Le,
            Grt.Std_Logic_1164.Ghdl_Std_Ulogic_Match_Le'Address);
+      Def (Trans_Decls.Ghdl_Std_Ulogic_Match_Ge,
+           Grt.Std_Logic_1164.Ghdl_Std_Ulogic_Match_Ge'Address);
+      Def (Trans_Decls.Ghdl_Std_Ulogic_Match_Gt,
+           Grt.Std_Logic_1164.Ghdl_Std_Ulogic_Match_Gt'Address);
 
       Def (Trans_Decls.Ghdl_Std_Ulogic_Array_Match_Eq,
            Grt.Std_Logic_1164.Ghdl_Std_Ulogic_Array_Match_Eq'Address);

--- a/src/grt/grt-std_logic_1164.adb
+++ b/src/grt/grt-std_logic_1164.adb
@@ -91,6 +91,20 @@ package body Grt.Std_Logic_1164 is
                                        Match_Eq_Table (Left, Right)));
    end Ghdl_Std_Ulogic_Match_Le;
 
+   function Ghdl_Std_Ulogic_Match_Ge (L, R : Ghdl_E8) return Ghdl_E8
+   is
+      Lt : constant Ghdl_E8 := Ghdl_Std_Ulogic_Match_Lt(L, R);
+   begin
+      return Std_Ulogic'Pos (Not_Table (Std_Ulogic'Val(Lt))) ;
+   end Ghdl_Std_Ulogic_Match_Ge;
+
+   function Ghdl_Std_Ulogic_Match_Gt (L, R : Ghdl_E8) return Ghdl_E8
+   is
+      Le : constant Ghdl_E8 := Ghdl_Std_Ulogic_Match_Le(L, R);
+   begin
+      return Std_Ulogic'Pos (Not_Table (Std_Ulogic'Val(Le))) ;
+   end Ghdl_Std_Ulogic_Match_Gt;
+
    Assert_Arr_Msg : constant String :=
      "parameters of '?=' array operator are not of the same length";
 

--- a/src/grt/grt-std_logic_1164.ads
+++ b/src/grt/grt-std_logic_1164.ads
@@ -96,6 +96,8 @@ package Grt.Std_Logic_1164 is
    function Ghdl_Std_Ulogic_Match_Ne (L, R : Ghdl_E8) return Ghdl_E8;
    function Ghdl_Std_Ulogic_Match_Lt (L, R : Ghdl_E8) return Ghdl_E8;
    function Ghdl_Std_Ulogic_Match_Le (L, R : Ghdl_E8) return Ghdl_E8;
+   function Ghdl_Std_Ulogic_Match_Ge (L, R : Ghdl_E8) return Ghdl_E8;
+   function Ghdl_Std_Ulogic_Match_Gt (L, R : Ghdl_E8) return Ghdl_E8;
    --  For Gt and Ge, use Lt and Le with swapped parameters.
 
    function Ghdl_Std_Ulogic_Array_Match_Eq (L : Ghdl_Ptr;
@@ -114,6 +116,8 @@ private
    pragma Export (C, Ghdl_Std_Ulogic_Match_Ne, "__ghdl_std_ulogic_match_ne");
    pragma Export (C, Ghdl_Std_Ulogic_Match_Lt, "__ghdl_std_ulogic_match_lt");
    pragma Export (C, Ghdl_Std_Ulogic_Match_Le, "__ghdl_std_ulogic_match_le");
+   pragma Export (C, Ghdl_Std_Ulogic_Match_Ge, "__ghdl_std_ulogic_match_ge");
+   pragma Export (C, Ghdl_Std_Ulogic_Match_Gt, "__ghdl_std_ulogic_match_gt");
 
    pragma Export (C, Ghdl_Std_Ulogic_Array_Match_Eq,
                   "__ghdl_std_ulogic_array_match_eq");

--- a/src/vhdl/translate/trans-chap7.adb
+++ b/src/vhdl/translate/trans-chap7.adb
@@ -2693,12 +2693,12 @@ package body Trans.Chap7 is
                Left_Tree, Right_Tree, Res_Otype);
          when Iir_Predefined_Std_Ulogic_Match_Greater =>
             return Translate_Std_Ulogic_Match
-              (Ghdl_Std_Ulogic_Match_Lt,
-               Right_Tree, Left_Tree, Res_Otype);
+              (Ghdl_Std_Ulogic_Match_Gt,
+               Left_Tree, Right_Tree, Res_Otype);
          when Iir_Predefined_Std_Ulogic_Match_Greater_Equal =>
             return Translate_Std_Ulogic_Match
-              (Ghdl_Std_Ulogic_Match_Le,
-               Right_Tree, Left_Tree, Res_Otype);
+              (Ghdl_Std_Ulogic_Match_Ge,
+               Left_Tree, Right_Tree, Res_Otype);
 
          when Iir_Predefined_Bit_Array_Match_Equality =>
             return New_Compare_Op

--- a/src/vhdl/translate/trans_decls.ads
+++ b/src/vhdl/translate/trans_decls.ads
@@ -255,6 +255,8 @@ package Trans_Decls is
    Ghdl_Std_Ulogic_Match_Ne : O_Dnode;
    Ghdl_Std_Ulogic_Match_Lt : O_Dnode;
    Ghdl_Std_Ulogic_Match_Le : O_Dnode;
+   Ghdl_Std_Ulogic_Match_Ge : O_Dnode;
+   Ghdl_Std_Ulogic_Match_Gt : O_Dnode;
    Ghdl_Std_Ulogic_Array_Match_Eq : O_Dnode;
    Ghdl_Std_Ulogic_Array_Match_Ne : O_Dnode;
 

--- a/src/vhdl/translate/translation.adb
+++ b/src/vhdl/translate/translation.adb
@@ -1943,6 +1943,8 @@ package body Translation is
       Create_Std_Ulogic_Match_Subprogram ("ne", Ghdl_Std_Ulogic_Match_Ne);
       Create_Std_Ulogic_Match_Subprogram ("lt", Ghdl_Std_Ulogic_Match_Lt);
       Create_Std_Ulogic_Match_Subprogram ("le", Ghdl_Std_Ulogic_Match_Le);
+      Create_Std_Ulogic_Match_Subprogram ("ge", Ghdl_Std_Ulogic_Match_Ge);
+      Create_Std_Ulogic_Match_Subprogram ("gt", Ghdl_Std_Ulogic_Match_Gt);
 
       Create_Std_Ulogic_Array_Match_Subprogram
         ("eq", Ghdl_Std_Ulogic_Array_Match_Eq);


### PR DESCRIPTION
Instead of swapping L/R arguments to try to create `?>=` and `?>`,
create a function for each which performs the not operation of `?<`
and `?<=` as defined by the LRM.

This causes the match_operators test from #1873 to pass.