### PR TITLE
Fixed PoSh scripting

### DIFF
--- a/scripts/vendors/compile-altera.ps1
+++ b/scripts/vendors/compile-altera.ps1
@@ -147,7 +147,7 @@ New-DestinationDirectory $DestinationDirectory
 cd $DestinationDirectory
 
 
-$VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables $VHDL93 $VHDL2008
+$VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables -VHDL93:$VHDL93 -VHDL2008:$VHDL2008
 
 # define global GHDL Options
 $Analyze_Parameters = @(

--- a/scripts/vendors/compile-intel.ps1
+++ b/scripts/vendors/compile-intel.ps1
@@ -147,7 +147,7 @@ New-DestinationDirectory $DestinationDirectory
 cd $DestinationDirectory
 
 
-$VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables $VHDL93 $VHDL2008
+$VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables -VHDL93:$VHDL93 -VHDL2008:$VHDL2008
 
 # define global GHDL Options
 $Analyze_Parameters = @(

--- a/scripts/vendors/compile-lattice.ps1
+++ b/scripts/vendors/compile-lattice.ps1
@@ -174,7 +174,7 @@ $GHDLBinary =           Get-GHDLBinary $GHDL
 New-DestinationDirectory $DestinationDirectory
 cd $DestinationDirectory
 
-$VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables $VHDL93 $VHDL2008
+$VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables -VHDL93:$VHDL93 -VHDL2008:$VHDL2008
 
 # define global GHDL Options
 $Analyze_Parameters = @(

--- a/scripts/vendors/compile-uvvm.ps1
+++ b/scripts/vendors/compile-uvvm.ps1
@@ -167,7 +167,7 @@ New-DestinationDirectory $DestinationDirectory
 cd $DestinationDirectory
 
 
-$VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables
+$VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables -VHDL2008
 
 # define global GHDL Options
 $Analyze_Parameters = @(

--- a/scripts/vendors/compile-xilinx-ise.ps1
+++ b/scripts/vendors/compile-xilinx-ise.ps1
@@ -140,7 +140,7 @@ if ($VHDL2008)
 {	Write-Host "Not all Xilinx primitives are VHDL-2008 compatible! Setting HaltOnError to FALSE." -ForegroundColor Red
 	$HaltOnError =      $false
 }
-$VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables $VHDL93 $VHDL2008
+$VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables -VHDL93:$VHDL93 -VHDL2008:$VHDL2008
 
 # define global GHDL Options
 $Analyze_Parameters = @(

--- a/scripts/vendors/compile-xilinx-vivado.ps1
+++ b/scripts/vendors/compile-xilinx-vivado.ps1
@@ -131,7 +131,7 @@ if ($VHDL2008)
 {	Write-Host "Not all Xilinx primitives are VHDL-2008 compatible! Setting HaltOnError to FALSE." -ForegroundColor Red
 	$HaltOnError =      $false
 }
-$VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables $VHDL93 $VHDL2008
+$VHDLVersion,$VHDLStandard,$VHDLFlavor = Get-VHDLVariables -VHDL93:$VHDL93 -VHDL2008:$VHDL2008
 
 # define global GHDL Options
 $Analyze_Parameters = @(

--- a/scripts/vendors/shared.psm1
+++ b/scripts/vendors/shared.psm1
@@ -285,16 +285,16 @@ function Start-PackageCompilation
 
 	Write-Host "Compiling library '$Library' ..." -ForegroundColor Yellow
 	$LibraryDirectory=  "$DestinationDirectory/$Library/$VHDLVersion"
-	$EnableVerbose -and (Write-Host "  Creating library $Library ..."  -ForegroundColor Gray      ) | Out-Null
-	$EnableDebug -and   (Write-Host "    mkdir $LibraryDirectory"      -ForegroundColor DarkGray  ) | Out-Null
+	$EnableVerbose -and (Write-Host "  Creating library $Library ..."  -ForegroundColor Gray       ) | Out-Null
+	$EnableDebug -and   (Write-Host "    mkdir $LibraryDirectory"      -ForegroundColor DarkGray   ) | Out-Null
 	mkdir $LibraryDirectory -ErrorAction SilentlyContinue | Out-Null
-	$EnableDebug -and   (Write-Host "    cd $LibraryDirectory"         -ForegroundColor DarkGray  ) | Out-Null
+	$EnableDebug -and   (Write-Host "    cd $LibraryDirectory"         -ForegroundColor DarkGray   ) | Out-Null
 	cd $LibraryDirectory
 	$ErrorCount = 0
 	foreach ($File in $SourceFiles)
-	{	Write-Host "  Analyzing package file '$File'" -ForegroundColor DarkCyan
+	{	$EnableVerbose -and (Write-Host "  Analyzing package file '$File'" -ForegroundColor DarkCyan ) | Out-Null
 		$InvokeExpr = "& '$GHDLBinary' -a " + ($Parameters -join " ") + " --work=$Library " + $File + " 2>&1"
-		$EnableDebug -and (Write-Host "    $InvokeExpr"                  -ForegroundColor DarkGray  ) | Out-Null
+		$EnableDebug -and (Write-Host "    $InvokeExpr"                    -ForegroundColor DarkGray ) | Out-Null
 		$ErrorRecordFound = Invoke-Expression $InvokeExpr | Restore-NativeCommandStream | Write-ColoredGHDLLine $SuppressWarnings -Indent:"$Indent"
 		if (($LastExitCode -ne 0) -or $ErrorRecordFound)
 		{	$ErrorCount += 1

--- a/scripts/vendors/shared.psm1
+++ b/scripts/vendors/shared.psm1
@@ -188,8 +188,8 @@ function Get-VHDLVariables
 	#>
 	[CmdletBinding()]
 	param(
-		[bool]$VHDL93 =   $false,
-		[bool]$VHDL2008 = $true
+		[switch]$VHDL93 =   $false,
+		[switch]$VHDL2008 = $true
 	)
 
 	if ($VHDL93)


### PR DESCRIPTION
This fixes the vendor scripts written in PowerShell for a bug concerning `bool` vs. `switch` parameters.

Fixes #1766, fixes #1767.

-----------------
The problem is described here: [How to pass a switch parameter to another PowerShell script?](https://stackoverflow.com/questions/38009106/how-to-pass-a-switch-parameter-to-another-powershell-script)