### PR TITLE
Upstreaming patches from Debian packaging

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -171,14 +171,17 @@ include $(srcdir)/src/grt/Makefile.inc
 
 version.tmp: $(srcdir)/src/version.in force
 #	Create version.tmp from version.in, using git date/hash, or envvars.
-	GHDL_VER_DESC=$${GHDL_VER_DESC:-tarball}; \
-	GHDL_VER_REF=$${GHDL_VER_REF:-unknown}; \
-	GHDL_VER_HASH=$${GHDL_VER_HASH:-unknown}; \
+	GHDL_AUTO_VER_DESC=tarball; \
+	GHDL_AUTO_VER_REF=unknown; \
+	GHDL_AUTO_VER_HASH=unknown; \
 	if test -d $(srcdir)/.git && desc=`cd $(srcdir); git describe --dirty --long`; then \
-	  GHDL_VER_DESC=`echo $$desc | sed -e 's/\([^-]*-g\)/r\1/' -e 's/-/./g' -e 's/^v//g'`; \
-	  GHDL_VER_REF=`cd $(srcdir); git rev-parse --abbrev-ref HEAD`; \
-	  GHDL_VER_HASH=`cd $(srcdir); git rev-parse HEAD`; \
+	  GHDL_AUTO_VER_DESC=`echo $$desc | sed -e 's/\([^-]*-g\)/r\1/' -e 's/-/./g' -e 's/^v//g'`; \
+	  GHDL_AUTO_VER_REF=`cd $(srcdir); git rev-parse --abbrev-ref HEAD`; \
+	  GHDL_AUTO_VER_HASH=`cd $(srcdir); git rev-parse HEAD`; \
 	fi; \
+	GHDL_VER_DESC=$${GHDL_VER_DESC:-$$GHDL_AUTO_VER_DESC}; \
+	GHDL_VER_REF=$${GHDL_VER_REF:-$$GHDL_AUTO_VER_REF}; \
+	GHDL_VER_HASH=$${GHDL_VER_HASH:-$$GHDL_AUTO_VER_HASH}; \
 	sed \
 	  -e "s#@VER@#$(ghdl_version)#" \
 	  -e "s#@DESC@#$${GHDL_VER_DESC}#" \

--- a/Makefile.in
+++ b/Makefile.in
@@ -629,6 +629,7 @@ clean: force
 
 distclean: clean
 	$(RM) -f default_paths.ads ortho_code-x86-flags.ads
+	$(RM) -f elf_arch.ads ghdlsynth_maybe.ads
 	$(RM) -f grt/grt-backtrace-impl.ads
 	$(RM) -f Makefile config.status ghdl.gpr
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -46,7 +46,7 @@ default_pic=@default_pic@
 
 INSTALL_PROGRAM=install -m 755
 INSTALL_DATA=install -m 644
-PWD?=$(shell pwd)
+PWD=$(CURDIR)
 DESTDIR=
 bindir=$(prefix)/bin
 libdir=$(prefix)/lib

--- a/doc/ghdl.1
+++ b/doc/ghdl.1
@@ -94,10 +94,8 @@ Dump VCD to FILENAME (a waveform dump, viewable with\-\-for instance\-\-\fBgtkwa
 Back annotate SDF onto design using TYPE (min|typ|max), instance PATH, and SDF file FILENAME, i.e. \fI./sdf_design \-\-sdf=typ=top/inst=inst.sdf\fP
 
 .SH "SEE ALSO"
-.TP
-.B gtkwave (1)
+.BR gtkwave (1)
 .PP
-.br 
 The texinfo manual fully documents GHDL. You may also browse it at
 \fB<https://ghdl.github.io/ghdl/>\fP.
 .SH "AUTHOR"


### PR DESCRIPTION
The Debian packaging uses a few patches against upstream to make packages build correctly and according to policy. A bunch of these are not Debian specific and should have been upstreamed a while ago, and here they are now. These are just a few lines of changes mainly in the Makefile.in.

The CURDIR change actually fixed a build failure under certain conditions, but I forgot under which conditions that happened and could not reproduce it anymore. Anyway, making sure not to use the PWD from the environment variables is probably a good idea since its value in the environment is not really dependable.