### PR TITLE
Update .editorconfig with settings for Ada files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,10 @@ indent_style = tab
 indent_size = 2
 tab_width = 2
 
+[*.{adb,ads,gpr}]
+indent_style = space
+indent_size = 3
+
 [*.py]
 indent_style = space
 indent_size = 4


### PR DESCRIPTION
**Description**
Update .editorconfig with settings for Ada files.
Indent style and indent size values are the one that are currently used by the GHDL project.

(This PR aims to prevent editor with .editorconfig plugin to force the default tab indentation)