### PR TITLE
Fix opening files relative to the current vhdl

### DIFF
--- a/src/synth/elab-vhdl_insts.adb
+++ b/src/synth/elab-vhdl_insts.adb
@@ -513,6 +513,8 @@ package body Elab.Vhdl_Insts is
    begin
       Apply_Block_Configuration (Config, Arch);
 
+      Elab.Vhdl_Files.Set_Design_Unit (Arch);
+
       Elab_Declarations (Syn_Inst, Get_Declaration_Chain (Entity));
       Elab_Concurrent_Statements
         (Syn_Inst, Get_Concurrent_Statement_Chain (Entity));


### PR DESCRIPTION
86fd1ab3 introduced a regression opening files in a different directory to the toplevel (log below).
I'm running with ghdl-yosys-plugin. I have modified ghdl's testsuite synth issue1190 to have the toplevel in a separate directory, it reproduces running as a ghdl-yosys-plugin test. It won't reproduce as part of ghdl's own testsuite, I'm not sure what the difference is. 

https://github.com/mkj/ghdl-yosys-plugin/tree/matt/relative-test/testsuite/issues/relative-file
```
env YOSYS=$HOME/inst/oss-cad-suite-20211201/bin/yosys ./testsuite.sh
INFO: not in CI
Synthesize  hdl/top.vhdl hdl/subdir/ram.vhdl -e
· /home/matt/inst/oss-cad-suite-20211201/bin/yosys -q -p ghdl  hdl/top.vhdl hdl/subdir/ram.vhdl -e
note: top entity is "top"
hdl/subdir/ram.vhdl:22:18:error: cannot open file: data/memory.dat
        file     fh  : text is in filename;
                 ^
hdl/subdir/ram.vhdl:14:9:warning: no assignment for port "data_o"
        data_o : out std_logic_vector(31 downto 0)
        ^
ERROR: vhdl import failed.
```

This patch fixes the failure.
Please note that my change here is a bit of a guess how to fix it - I'm not very familiar with the codebase. 


- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
- [ ] CONSIDER adding a unit test if your PR resolves an issue.
- [ ] CONSIDER modifying the docs, if your contribution is relevant to any of the content.
- [ ] AVOID breaking the continuous integration build.
- [x] AVOID breaking the testsuite.


https://github.com/mkj/microwatt/blob/matt/orangecrab/litedram/generated/orangecrab-85-0.2/litedram-initmem.vhdl#L51

```
yosys  -p " ghdl --std=08 --no-formal -gMEMORY_SIZE=8192 -gRAM_INIT_FILE=hello_world/hello_world.hex -gRESET_LOW=true -gCLK_INPUT=48000000 -gCLK_FREQUENCY=48000000 -gICACHE_NUM_LINES=4 -gUSE_LITEDRAM=true decode_types.vhdl common.vhdl wishbone_types.vhdl fetch1.vhdl utils.vhdl plru.vhdl cache_ram.vhdl icache.vhdl decode1.vhdl helpers.vhdl insn_helpers.vhdl control.vhdl decode2.vhdl register_file.vhdl cr_file.vhdl crhelpers.vhdl ppc_fx_insns.vhdl rotator.vhdl logical.vhdl countzero.vhdl multiply.vhdl divider.vhdl execute1.vhdl loadstore1.vhdl mmu.vhdl dcache.vhdl writeback.vhdl core_debug.vhdl core.vhdl fpu.vhdl pmu.vhdl wishbone_arbiter.vhdl wishbone_bram_wrapper.vhdl sync_fifo.vhdl wishbone_debug_master.vhdl xics.vhdl syscon.vhdl gpio.vhdl soc.vhdl spi_rxtx.vhdl spi_flash_ctrl.vhdl litedram/extras/litedram-wrapper-l2.vhdl litedram/generated/orangecrab-85-0.2/litedram-initmem.vhdl fpga/soc_reset.vhdl fpga/pp_fifo.vhd fpga/pp_soc_uart.vhd fpga/main_bram.vhdl nonrandom.vhdl fpga/clk_gen_ecp5.vhd fpga/top-orangecrab0.2.vhdl dmi_dtm_ecp5.vhdl -e toplevel; scratchpad -set abc9.D 10417; synth_ecp5  -json microwatt.json  -abc2 -abc9" uart16550/raminfr.v uart16550/uart_defines.v uart16550/uart_receiver.v uart16550/uart_regs.v uart16550/uart_rfifo.v uart16550/uart_sync_flops.v uart16550/uart_tfifo.v uart16550/uart_top.v uart16550/uart_transmitter.v uart16550/uart_wb.v valentyusb/generated/orangecrab-85-0.2/gateware/valentyusb.v litesdcard/generated/lattice/litesdcard_core.v litescope/generated/orangecrab-85-0.2/gateware/litescope.v litedram/generated/orangecrab-85-0.2/litedram_core.v
...

litedram/generated/orangecrab-85-0.2/litedram-initmem.vhdl:97:9:(report note): Opening file litedram_core.init
litedram/generated/orangecrab-85-0.2/litedram-initmem.vhdl:51:14:error: cannot open file: litedram_core.init
        file ram_file : text open read_mode is name;
...
******************** GHDL Bug occurred ***************************
Please report this bug on https://github.com/ghdl/ghdl/issues
GHDL release: 2.0.0-dev (1.0.0.r907.g51d120d8.dirty) [Dunoon edition]
Compiled with unknown compiler version
Target: x86_64-linux-gnu
/home/matt/3rd/fpga/microwatt/
Command line:

Exception CONSTRAINT_ERROR raised
Exception information:
raised CONSTRAINT_ERROR : elab-vhdl_context.adb:524 discriminant check failed
******************************************************************
```