### PR TITLE
Add null subtype indication handling in Annotate_Declaration_Type

### DIFF
--- a/src/vhdl/vhdl-annotations.adb
+++ b/src/vhdl/vhdl-annotations.adb
@@ -674,7 +674,9 @@ package body Vhdl.Annotations is
          return;
       end if;
       Ind := Get_Subtype_Indication (Decl);
-      if Get_Kind (Ind) in Iir_Kinds_Denoting_Name then
+      if Ind = Null_Iir then
+         return;
+      elsif Get_Kind (Ind) in Iir_Kinds_Denoting_Name then
          return;
       end if;
       Annotate_Type_Definition (Block_Info, Ind);


### PR DESCRIPTION
This patch fixes a crash occurring on certain VHDL code bases (no matter which VHDL version has been specified). Get_Subtype_Indication would return Null_Iir causing GHDL to hard crash without any meaningful error message.

~We cannot unfortunately share the code triggering this issue at the moment due to intellectual property concerns, but we are working on delivering a small code example for test suite.~

**When contributing to the GHDL codebase...**

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
- [ ] CONSIDER adding a unit test if your PR resolves an issue.
- [x] CONSIDER modifying the docs, if your contribution is relevant to any of the content.
- [x] AVOID breaking the continuous integration build.
- [x] AVOID breaking the testsuite.
