### PR TITLE
editorconfig: set charset=latin1 for VHDL sources

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,9 @@ indent_style = tab
 indent_size = 2
 tab_width = 2
 
+[*.{vhd,vhdl}]
+charset = latin1
+
 [*.{adb,ads,gpr}]
 indent_style = space
 indent_size = 3


### PR DESCRIPTION
VHDL supports only latin1/ISO 8859-1 as input encoding, but the editorconfig sets the charset to utf8 for all files. Override this only for VHDL sources.