### PR TITLE
Fix getting vendor tool directory from environment variable using PowerShell

### DIFF
--- a/scripts/vendors/compile-altera.ps1
+++ b/scripts/vendors/compile-altera.ps1
@@ -118,7 +118,7 @@ if ($All)
 
 function Get-AlteraQuartusDirectory
 {	if (Test-Path env:QUARTUS_ROOTDIR)
-	{	return $QUARTUS_ROOTDIR + "\" + (Get-VendorToolSourceDirectory)    }
+	{	return $env:QUARTUS_ROOTDIR + "\" + (Get-VendorToolSourceDirectory)    }
 	else
 	{	$EnvSourceDir = ""
 		foreach ($Drive in Get-PSDrive -PSProvider 'FileSystem')

--- a/scripts/vendors/compile-intel.ps1
+++ b/scripts/vendors/compile-intel.ps1
@@ -118,7 +118,7 @@ if ($All)
 
 function Get-AlteraQuartusDirectory
 {	if (Test-Path env:QUARTUS_ROOTDIR)
-	{	return $QUARTUS_ROOTDIR + "\" + (Get-VendorToolSourceDirectory)    }
+	{	return $env:QUARTUS_ROOTDIR + "\" + (Get-VendorToolSourceDirectory)    }
 	else
 	{	$EnvSourceDir = ""
 		foreach ($Drive in Get-PSDrive -PSProvider 'FileSystem')

--- a/scripts/vendors/compile-lattice.ps1
+++ b/scripts/vendors/compile-lattice.ps1
@@ -146,7 +146,7 @@ if ($All)
 
 function Get-LatticeDiamondDirectory
 {	if (Test-Path env:FOUNDRY)
-	{	return $FOUNDRY + "\..\" + (Get-VendorToolSourceDirectory)    }
+	{	return $env:FOUNDRY + "\..\" + (Get-VendorToolSourceDirectory)    }
 	else
 	{	$EnvSourceDir = ""
 		foreach ($Drive in Get-PSDrive -PSProvider 'FileSystem')

--- a/scripts/vendors/compile-xilinx-ise.ps1
+++ b/scripts/vendors/compile-xilinx-ise.ps1
@@ -108,7 +108,7 @@ if ($All)
 
 function Get-XilinxISEDirectory
 {	if (Test-Path env:XILINX)
-	{	return $XILINX + "\" + (Get-VendorToolSourceDirectory)    }
+	{	return $env:XILINX + "\" + (Get-VendorToolSourceDirectory)    }
 	else
 	{	$EnvSourceDir = ""
 		foreach ($Drive in Get-PSDrive -PSProvider 'FileSystem')

--- a/scripts/vendors/compile-xilinx-vivado.ps1
+++ b/scripts/vendors/compile-xilinx-vivado.ps1
@@ -99,7 +99,7 @@ if ($All)
 
 function Get-XilinxVivadoDirectory
 {	if (Test-Path env:XILINX_VIVADO)
-	{	return $XILINX_VIVADO + "\" + (Get-VendorToolSourceDirectory)    }
+	{	return $env:XILINX_VIVADO + "\" + (Get-VendorToolSourceDirectory)    }
 	else
 	{	$EnvSourceDir = ""
 		foreach ($Drive in Get-PSDrive -PSProvider 'FileSystem')


### PR DESCRIPTION
**Description** Fix a bug where compiling vendor libraries on Windows using PowerShell fails when a system environment 
variable for the root path of the vendor tool is set. 

Close #1973 

:rotating_light: Before submitting your PR, please read [contribute](http://ghdl.github.io/ghdl/contribute.html#fork-modify-and-pull-request) in the [Docs](http://ghdl.github.io/ghdl), and review the following checklist:

- [x] DO indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

**When contributing to the GHDL codebase...**

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [ ] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
- [ ] CONSIDER adding a unit test if your PR resolves an issue.
- [x] CONSIDER modifying the docs, if your contribution is relevant to any of the content.
- [x] AVOID breaking the continuous integration build.
- [x] AVOID breaking the testsuite.


**Further comments**

This is my first pull request. I really don't now how to check everything on the list, in particular how to start a build or run the tests using the CI.

