### PR TITLE
Add --std=19 command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This directory contains the sources of GHDL, the open-source analyzer, compiler,
 
 # Main features
 
-Full support for the [1987](https://ieeexplore.ieee.org/document/26487/), [1993](https://ieeexplore.ieee.org/document/392561/), [2002](https://ieeexplore.ieee.org/document/1003477/) versions of the [IEEE](https://www.ieee.org) [1076](https://standards.ieee.org/develop/wg/P1076.html) VHDL standard, and partial for the latest [2008](https://ieeexplore.ieee.org/document/4772740/) revision.
+Full support for the [1987](https://ieeexplore.ieee.org/document/26487/), [1993](https://ieeexplore.ieee.org/document/392561/), [2002](https://ieeexplore.ieee.org/document/1003477/) versions of the [IEEE](https://www.ieee.org) [1076](https://standards.ieee.org/develop/wg/P1076.html) VHDL standard, and partial for the [2008](https://ieeexplore.ieee.org/document/4772740/) and [2019](https://ieeexplore.ieee.org/document/8938196/) revisions.
 
 Partial support of [PSL](https://en.wikipedia.org/wiki/Property_Specification_Language).
 

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -42,7 +42,7 @@ At the same time, like a design written in another `HDL`, a set of VHDL sources 
 :dfn:`synthesis tool` into a netlist, that is, a detailed gate-level implementation.
 
 The development of VHDL started in 1983 and the standard is named `IEEE <https://www.ieee.org/>`__ `1076`.
-Five revisions exist:
+Six revisions exist:
 `1987 <http://ieeexplore.ieee.org/document/26487/>`__,
 `1993 <http://ieeexplore.ieee.org/document/392561/>`__,
 `2002 <http://ieeexplore.ieee.org/document/1003477/>`__,
@@ -91,7 +91,8 @@ It supports the
 `1987 <http://ieeexplore.ieee.org/document/26487/>`__,
 `1993 <http://ieeexplore.ieee.org/document/392561/>`__ and
 `2002 <http://ieeexplore.ieee.org/document/1003477/>`__ revisions and, partially,
-`2008 <http://ieeexplore.ieee.org/document/4772740/>`__.
+`2008 <http://ieeexplore.ieee.org/document/4772740/>`__ and
+`2019 <https://ieeexplore.ieee.org/document/8938196/>`__.
 :wikipedia:`Property Specification Language (PSL) <Property_Specification_Language>` is also partially supported.
 
 Several third party projects are supported:

--- a/doc/using/ImplementationOfVHDL.rst
+++ b/doc/using/ImplementationOfVHDL.rst
@@ -31,6 +31,8 @@ VHDL standards
 
 .. index:: v08
 
+.. index:: v19
+
 Unfortunately, there are many versions of the VHDL
 language, and they aren't backward compatible.
 
@@ -67,7 +69,7 @@ Minor corrections were added by the 2002 revision of the VHDL standard. This
 revision is not fully backward compatible with VHDL-00 since, for example,
 the value of the `'instance_name` attribute has slightly changed.
 
-The latest version is 2008. Many features have been added, and GHDL
+The latest version is 2019. Many features have been added, and GHDL
 doesn't implement all of them.
 
 You can select the VHDL standard expected by GHDL with the
@@ -93,6 +95,9 @@ You can select the VHDL standard expected by GHDL with the
 08
   Select VHDL-2008 standard (partially implemented).
 
+19
+  Select VHDL-2019 standard (partially implemented).
+
 Multiple standards can be used in a design:
 
 +-----+----------------+
@@ -103,6 +108,8 @@ Multiple standards can be used in a design:
 |  93 | 93, 93c, 00, 02|
 +-----+----------------+
 |  08 |       08       |
++-----+----------------+
+|  19 |       19       |
 +-----+----------------+
 
 .. note::
@@ -175,7 +182,7 @@ GHDL understands embedded PSL annotations in VHDL files:
        ghdl -a -fpsl vhdl_design.vhdl
        ghdl -e vhdl_design
 
-PSL annotations (VHDL-2008 only)
+PSL annotations (VHDL-2008 and later)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Since VHDL-2008 PSL is integrated in the VHDL language. You can use
@@ -197,7 +204,7 @@ PSL in a VHDL(-2008) design without embedding it in comments.
        ghdl -a --std=08 vhdl_design.vhdl
        ghdl -e --std=08 vhdl_design
 
-PSL vunit files (VHDL-2008 / Synthesis only)
+PSL vunit files (VHDL-2008 and later, synthesis only)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 GHDL supports vunit (Verification Unit) files.
@@ -269,7 +276,7 @@ changed with the :option:`--work` option of GHDL.
 To keep the list of design units in a design library, GHDL creates
 library files. The name of these files is :file:`<LIB_NAME>-obj<GROUP>.cf`, where
 `<LIB_NAME>` is the name of the library, and `<GROUP>` the VHDL version (87,
-93 or 08) used to analyze the design units.
+93, 08, or 19) used to analyze the design units.
 
 For details on ``GROUP`` values see section :ref:`VHDL_standards`.
 

--- a/src/flags.adb
+++ b/src/flags.adb
@@ -26,6 +26,8 @@ package body Flags is
             Flag_String (1 .. 2) := "93";
          when Vhdl_08 =>
             Flag_String (1 .. 2) := "08";
+         when Vhdl_19 =>
+            Flag_String (1 .. 2) := "19";
       end case;
       if Flag_Integer_64 then
          Flag_String (3) := 'I';

--- a/src/flags.ads
+++ b/src/flags.ads
@@ -24,7 +24,7 @@ package Flags is
    --  List of vhdl standards.
    --  VHDL_93c is vhdl_93 with backward compatibility with 87 (file).
    type Vhdl_Std_Type is
-     (Vhdl_87, Vhdl_93, Vhdl_00, Vhdl_02, Vhdl_08);
+     (Vhdl_87, Vhdl_93, Vhdl_00, Vhdl_02, Vhdl_08, Vhdl_19);
 
    --  Standard accepted.
    Vhdl_Std: Vhdl_Std_Type := Vhdl_93;

--- a/src/ghdldrv/ghdllocal.adb
+++ b/src/ghdldrv/ghdllocal.adb
@@ -367,6 +367,8 @@ package body Ghdllocal is
             return "v93";
          when Vhdl_08 =>
             return "v08";
+         when Vhdl_19 =>
+            return "v19";
       end case;
    end Get_Version_Path;
 

--- a/src/libraries.adb
+++ b/src/libraries.adb
@@ -139,6 +139,8 @@ package body Libraries is
             return Image_Identifier (Library) & "-obj93.cf";
          when Vhdl_08 =>
             return Image_Identifier (Library) & "-obj08.cf";
+         when Vhdl_19 =>
+            return Image_Identifier (Library) & "-obj19.cf";
       end case;
    end Library_To_File_Name;
 
@@ -181,6 +183,8 @@ package body Libraries is
                   Path (L + 2 .. L + 4) := "v93";
                when Vhdl_08 =>
                   Path (L + 2 .. L + 4) := "v08";
+               when Vhdl_19 =>
+                  Path (L + 2 .. L + 4) := "v19";
             end case;
             L := L + 5;
             Path (L) := GNAT.OS_Lib.Directory_Separator;

--- a/src/options.adb
+++ b/src/options.adb
@@ -124,9 +124,11 @@ package body Options is
                Vhdl_Std := Vhdl_02;
             elsif Opt (7 .. 8) = "08" then
                Vhdl_Std := Vhdl_08;
+            elsif Opt (7 .. 8) = "19" then
+               Vhdl_Std := Vhdl_19;
             else
                Error_Msg_Option ("unknown language standard: " & Opt (7 ..8) &
-                                 ". Should be one of: 87, 93, 02, 08");
+                                 ". Should be one of: 87, 93, 02, 08, 19");
                return Option_Err;
             end if;
          elsif Opt'Length = 9 and then Opt (7 .. 9) = "93c" then
@@ -135,7 +137,7 @@ package body Options is
             Flag_Relaxed_Files87 := True;
          else
             Error_Msg_Option ("unknown language standard. " &
-                              "Should be one of: 87, 93, 02, 08");
+                              "Should be one of: 87, 93, 02, 08, 19");
             return Option_Err;
          end if;
       elsif Opt'Length = 5 and then Opt (1 .. 5) = "--ams" then

--- a/src/vhdl/vhdl-sem_assocs.adb
+++ b/src/vhdl/vhdl-sem_assocs.adb
@@ -503,7 +503,7 @@ package body Vhdl.Sem_Assocs is
             if Vhdl02_Assocs_Map (Fmode, Amode) then
                return True;
             end if;
-         when Vhdl_08 =>
+         when Vhdl_08 | Vhdl_19 =>
             if Vhdl08_Assocs_Map (Fmode, Amode) then
                return True;
             end if;

--- a/src/vhdl/vhdl-std_package.adb
+++ b/src/vhdl/vhdl-std_package.adb
@@ -1060,7 +1060,8 @@ package body Vhdl.Std_Package is
                Pure := True;
             when Vhdl_93
                | Vhdl_00
-               | Vhdl_08 =>
+               | Vhdl_08
+               | Vhdl_19 =>
                Pure := False;
          end case;
          Set_Pure_Flag (Function_Now, Pure);


### PR DESCRIPTION
**Description**

This simply adds the command line option and updates the documentation. There is not yet any difference in simulator behaviour between `--std=08` and `--std=19`. Furher, since no 2019 standard library has been added yet, `--std=19` can't actually be used outside of bootstrapping.