### PR TITLE
vhdl-sem_types: allow methods to return file and protected types in VHDL-2019

### DIFF
--- a/src/vhdl/vhdl-sem_types.adb
+++ b/src/vhdl/vhdl-sem_types.adb
@@ -627,7 +627,9 @@ package body Vhdl.Sem_Types is
                   --  return type of the function must not be of an access type
                   --  or file type; moreover, it must not have a subelement
                   --  that is an access type of a file type.
-                  if Get_Kind (El) = Iir_Kind_Function_Declaration then
+                  if Vhdl_Std < Vhdl_19
+                     and then Get_Kind (El) = Iir_Kind_Function_Declaration
+                  then
                      Inter_Type := Get_Return_Type (El);
                      if Inter_Type /= Null_Iir
                        and then Get_Signal_Type_Flag (Inter_Type) = False


### PR DESCRIPTION
This implements [LCS2016_004](http://www.eda-twiki.org/cgi-bin/view.cgi/P1076/LCS2016_004). It is required for the VHDL-2019 standard library to analyze.