### PR TITLE
Fix --libghdl-include-dir ghdl/ suffix, etc

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -26,7 +26,9 @@ MAKE=@MAKE@
 prefix=@prefix@
 backend=@backend@
 libdirsuffix=@libdirsuffix@
+libghdldirsuffix=@libghdldirsuffix@
 libdirreverse=@libdirreverse@
+incdirsuffix=@incdirsuffix@
 EXEEXT=@EXEEXT@
 SOEXT=@SOEXT@
 PIC_FLAGS=@PIC_FLAGS@
@@ -49,8 +51,9 @@ INSTALL_DATA=install -m 644
 PWD=$(CURDIR)
 DESTDIR=
 bindir=$(prefix)/bin
-libdir=$(prefix)/lib
-incdir=$(prefix)/include
+libdir=$(prefix)/$(libdirsuffix)
+libghdldir=$(prefix)/$(libghdldirsuffix)
+incdir=$(prefix)/$(incdirsuffix)
 MKDIR=mkdir
 LN=ln -s
 CP=cp
@@ -59,7 +62,7 @@ SED=sed
 GRT_RANLIB=ranlib
 GHDL_DESC?=tarball
 
-VHDL_LIB_DIR=$(prefix)/$(libdirsuffix)
+VHDL_LIB_DIR=$(prefix)/$(libghdldirsuffix)
 
 ifeq "$(enable_checks)" "true"
  # Debug + checks
@@ -122,7 +125,7 @@ endif
 
 # Flags for libraries
 LIBSRC_DIR:=$(srcdir)/libraries
-LIBDST_DIR:=$(libdirsuffix)
+LIBDST_DIR:=$(libghdldirsuffix)
 
 LIBVHDL_FLAGS_TO_PASS=\
  LIBSRC_DIR="$(LIBSRC_DIR)" \
@@ -293,7 +296,7 @@ GHDL1_GCC_BIN=  # --GHDL1=/path/to/ghdl1
 libs.vhdl.gcc:
 	$(MAKE) -f $(srcdir)/libraries/Makefile.inc $(LIBVHDL_FLAGS_TO_PASS) GHDL="$(GHDL_GCC_BIN)" GHDL_FLAGS="$(GHDL1_GCC_BIN) $(LIB_CFLAGS)" vhdl.libs.all libs.vhdl.standard
 
-ghdllib: libs.vhdl.gcc $(libdirsuffix)/libgrt.a all.libghdl all.ghw
+ghdllib: libs.vhdl.gcc $(libghdldirsuffix)/libgrt.a all.libghdl all.ghw
 
 install.gcc: install.grt
 
@@ -462,8 +465,8 @@ all.libghdl.false:
 all.libghdl: all.libghdl.$(enable_libghdl)
 
 install.libghdl.include: install.dirs $(srcdir)/src/synth/include/synth_gates.h
-	$(INSTALL_DATA) -p $(srcdir)/src/synth/include/synth.h $(DESTDIR)$(incdir)/ghdl
-	$(INSTALL_DATA) -p $(srcdir)/src/synth/include/synth_gates.h $(DESTDIR)$(incdir)/ghdl
+	$(INSTALL_DATA) -p $(srcdir)/src/synth/include/synth.h $(DESTDIR)$(incdir)/
+	$(INSTALL_DATA) -p $(srcdir)/src/synth/include/synth_gates.h $(DESTDIR)$(incdir)/
 
 install.libghdl.lib:
 	$(INSTALL_PROGRAM) -p lib/$(libghdl_name) $(DESTDIR)$(libdir)/
@@ -504,25 +507,25 @@ all.ghw: ghwdump$(EXEEXT) lib/libghw$(SOEXT)
 install.ghw:
 	$(INSTALL_PROGRAM) -p ghwdump$(EXEEXT) $(DESTDIR)$(bindir)/
 	$(INSTALL_PROGRAM) -p lib/libghw$(SOEXT) $(DESTDIR)$(libdir)/
-	$(INSTALL_DATA) -p $(srcdir)/ghw/libghw.h $(DESTDIR)$(incdir)/ghdl/
+	$(INSTALL_DATA) -p $(srcdir)/ghw/libghw.h $(DESTDIR)$(incdir)/
 
 uninstall.ghw:
 	$(RM) $(DESTDIR)$(bindir)/ghwdump$(EXEEXT)
 	$(RM) $(DESTDIR)$(libdir)/libghw$(EXEEXT)
-	$(RM) -f $(DESTDIR)$(incdir)/ghdl/libghw.h
+	$(RM) -f $(DESTDIR)$(incdir)/libghw.h
 
 ############### grt #####################################################
 
 install.grt: \
-  $(libdirsuffix)/libgrt.a \
-  $(libdirsuffix)/grt.lst \
-  $(libdirsuffix)/grt-exec.lst \
-  $(libdirsuffix)/grt-shared.lst \
+  $(libghdldirsuffix)/libgrt.a \
+  $(libghdldirsuffix)/grt.lst \
+  $(libghdldirsuffix)/grt-exec.lst \
+  $(libghdldirsuffix)/grt-shared.lst \
   install.dirs
-	$(INSTALL_DATA) $(libdirsuffix)/libgrt.a $(DESTDIR)$(VHDL_LIB_DIR)/libgrt.a
-	$(INSTALL_DATA) $(libdirsuffix)/grt.lst $(DESTDIR)$(VHDL_LIB_DIR)/grt.lst
-	$(INSTALL_DATA) $(libdirsuffix)/grt-exec.lst $(DESTDIR)$(VHDL_LIB_DIR)/grt-exec.lst
-	$(INSTALL_DATA) $(libdirsuffix)/grt-shared.lst $(DESTDIR)$(VHDL_LIB_DIR)/grt-shared.lst
+	$(INSTALL_DATA) $(libghdldirsuffix)/libgrt.a $(DESTDIR)$(VHDL_LIB_DIR)/libgrt.a
+	$(INSTALL_DATA) $(libghdldirsuffix)/grt.lst $(DESTDIR)$(VHDL_LIB_DIR)/grt.lst
+	$(INSTALL_DATA) $(libghdldirsuffix)/grt-exec.lst $(DESTDIR)$(VHDL_LIB_DIR)/grt-exec.lst
+	$(INSTALL_DATA) $(libghdldirsuffix)/grt-shared.lst $(DESTDIR)$(VHDL_LIB_DIR)/grt-shared.lst
 	$(INSTALL_DATA) $(GRTSRCDIR)/grt.ver $(DESTDIR)$(VHDL_LIB_DIR)/grt.ver
 	test "x$(LIBBACKTRACE)" = x || test "x$(backend)" = xgcc || \
 	  $(INSTALL_DATA) $(LIBBACKTRACE) $(DESTDIR)$(VHDL_LIB_DIR)/libbacktrace.a
@@ -543,25 +546,26 @@ vpi_thunk.o: $(GRTSRCDIR)/vpi_thunk.c $(GRTSRCDIR)/vpi_thunk.h
 vhpi_thunk.o: $(GRTSRCDIR)/vhpi_thunk.c $(GRTSRCDIR)/vhpi_thunk.h
 	$(CC) -c -o $@ $< $(PIC_FLAGS) $(CFLAGS)
 
-lib/libghdlvpi$(SOEXT): vpi_thunk.o vhpi_thunk.o
+$(libdirsuffix)/libghdlvpi$(SOEXT): vpi_thunk.o vhpi_thunk.o
+	$(MKDIR) -p $(libdirsuffix)
 	$(CC) $(SHLIB_FLAGS) $(LDFLAGS) -shared -o $@ $^
 
-all.vpi: lib/libghdlvpi$(SOEXT)
+all.vpi: $(libdirsuffix)/libghdlvpi$(SOEXT)
 
 install.vpi: all.vpi install.dirs
-	$(INSTALL_PROGRAM) -p lib/libghdlvpi$(SOEXT) $(DESTDIR)$(libdir)/
-	$(INSTALL_DATA) -p $(GRTSRCDIR)/vpi_user.h $(DESTDIR)$(incdir)/ghdl/
-	$(INSTALL_DATA) -p $(GRTSRCDIR)/vhpi_user.h $(DESTDIR)$(incdir)/ghdl/
+	$(INSTALL_PROGRAM) -p $(libdirsuffix)/libghdlvpi$(SOEXT) $(DESTDIR)$(libdir)/
+	$(INSTALL_DATA) -p $(GRTSRCDIR)/vpi_user.h $(DESTDIR)$(incdir)/
+	$(INSTALL_DATA) -p $(GRTSRCDIR)/vhpi_user.h $(DESTDIR)$(incdir)/
 
 uninstall.vpi:
 	$(RM) -f $(DESTDIR)$(libdir)/libghdlvpi$(SOEXT)
-	$(RM) -f $(DESTDIR)$(incdir)/ghdl/vpi_user.h
-	$(RM) -f $(DESTDIR)$(incdir)/ghdl/vhpi_user.h
+	$(RM) -f $(DESTDIR)$(incdir)/vpi_user.h
+	$(RM) -f $(DESTDIR)$(incdir)/vhpi_user.h
 
 install.vpi.local: all.vpi
-	$(MKDIR) -p include/ghdl lib
-	$(INSTALL_DATA) -p $(GRTSRCDIR)/vpi_user.h include/ghdl/
-	$(INSTALL_DATA) -p $(GRTSRCDIR)/vhpi_user.h include/ghdl/
+	$(MKDIR) -p $(incdirsuffix) lib
+	$(INSTALL_DATA) -p $(GRTSRCDIR)/vpi_user.h $(incdirsuffix)
+	$(INSTALL_DATA) -p $(GRTSRCDIR)/vhpi_user.h $(incdirsuffix)
 
 ################ Libraries ###############################################
 
@@ -593,9 +597,8 @@ install.dirs:
 	$(MKDIR) -p $(DESTDIR)$(prefix)
 	$(MKDIR) -p $(DESTDIR)$(bindir)
 	$(MKDIR) -p $(DESTDIR)$(libdir)
-	$(MKDIR) -p $(DESTDIR)$(prefix)/$(libdirsuffix)
+	$(MKDIR) -p $(DESTDIR)$(libghdldir)
 	$(MKDIR) -p $(DESTDIR)$(incdir)
-	$(MKDIR) -p $(DESTDIR)$(incdir)/ghdl
 
 install.vhdllib: install.dirs
 #	Libraries (only if not empty)

--- a/Makefile.in
+++ b/Makefile.in
@@ -27,7 +27,6 @@ prefix=@prefix@
 backend=@backend@
 libdirsuffix=@libdirsuffix@
 libghdldirsuffix=@libghdldirsuffix@
-libdirreverse=@libdirreverse@
 incdirsuffix=@incdirsuffix@
 EXEEXT=@EXEEXT@
 SOEXT=@SOEXT@

--- a/configure
+++ b/configure
@@ -33,7 +33,9 @@ ADA_FLAGS=${ADA_FLAGS:-}
 MAKE=${MAKE:-make}
 LDFLAGS=${LDFLAGS:-}
 prefix=/usr/local
-libdirsuffix=lib/ghdl
+libdirsuffix=lib
+libghdldirsuffix=lib/ghdl
+incdirsuffix=include/ghdl
 libdirreverse=../..
 gcc_src_dir=
 llvm_config=
@@ -54,7 +56,11 @@ PIC_FLAGS=-fPIC
 show_help=no
 progname=$0
 
-subst_vars="CC CXX GNATMAKE ADA_FLAGS MAKE CFLAGS CXXFLAGS LDFLAGS build srcdir abs_srcdir prefix backend libdirsuffix libdirreverse gcc_src_dir llvm_config llvm_be backtrace_lib build_mode EXEEXT SOEXT PIC_FLAGS default_pic enable_werror enable_checks enable_gplcompat enable_libghdl libghdl_version ghdl_version"
+subst_vars="CC CXX GNATMAKE ADA_FLAGS MAKE CFLAGS CXXFLAGS LDFLAGS build
+srcdir abs_srcdir prefix backend libdirsuffix libghdldirsuffix
+libdirreverse incdirsuffix gcc_src_dir llvm_config llvm_be backtrace_lib
+build_mode EXEEXT SOEXT PIC_FLAGS default_pic enable_werror enable_checks
+enable_gplcompat enable_libghdl libghdl_version ghdl_version"
 
 # Find srcdir
 srcdir=`dirname $progname`
@@ -93,6 +99,9 @@ for opt do
       ;;
     --prefix=*)             prefix="$optarg";;
     --srcdir=*)             srcdir="$optarg";;
+    --libdir=*)             libdirsuffix="$optarg";;
+    --libghdldir=*)         libghdldirsuffix="$optarg";;
+    --incdir=*)             incdirsuffix="$optarg";;
     --with-gcc=*)           gcc_src_dir="$optarg";     backend=gcc;;
     --with-llvm=*)
       echo "--with-llvm is deprecated, use --with-llvm-config"
@@ -128,6 +137,9 @@ Usage: configure [options]
 Options [defaults in brackets]:
   --prefix=PREFIX             install in PREFIX [$prefix]
   --srcdir=SRCDIR             source code path [$srcdir]
+  --libdir=LIBDIR             lib dir path relative to PREFIX [$libdirsuffix]
+  --libghdldir=LIBDIR         ghdl lib dir path relative to PREFIX [$libdirsuffix]
+  --incdir=INCDIR             C include dir path relative to PREFIX [$incdirsuffix]
   --with-gcc=DIR              use gcc backend from DIR
   --with-llvm-config[=LLVM-CONFIG]  use llvm backend [llvm-config]
   --with-backtrace-lib=LIB.a  link with libbacktrace LIB.a to display a
@@ -249,7 +261,7 @@ if test $backend = gcc; then
   fi
   if test "x$backtrace_lib" = x ; then
     # Automatically use libbacktrace from gcc.
-    backtrace_lib="$prefix/$libdirsuffix/libbacktrace.a"
+    backtrace_lib="$prefix/$libghdldirsuffix/libbacktrace.a"
   fi
 fi
 
@@ -413,7 +425,9 @@ sed -e "s%@COMPILER_GCC@%ghdl1-gcc$EXEEXT%" \
     -e "s%@COMPILER_LLVM@%ghdl1-llvm$EXEEXT%" \
     -e "s%@POST_PROCESSOR@%oread-$backend%" \
     -e "s%@INSTALL_PREFIX@%$prefix%" \
-    -e "s%@LIB_PREFIX@%$libdirsuffix%" \
+    -e "s%@LIBDIR_SUFFIX@%$libdirsuffix%" \
+    -e "s%@LIBGHDLDIR_SUFFIX@%$libghdldirsuffix%" \
+    -e "s%@INCDIR_SUFFIX@%$incdirsuffix%" \
     -e "s%@SOEXT@%$SOEXT%" \
     -e "s%@default_pic@%$default_pic%" \
     < $srcdir/src/ghdldrv/default_paths.ads.in > default_paths.ads

--- a/configure
+++ b/configure
@@ -36,7 +36,6 @@ prefix=/usr/local
 libdirsuffix=lib
 libghdldirsuffix=lib/ghdl
 incdirsuffix=include/ghdl
-libdirreverse=../..
 gcc_src_dir=
 llvm_config=
 backtrace_lib=
@@ -58,7 +57,7 @@ progname=$0
 
 subst_vars="CC CXX GNATMAKE ADA_FLAGS MAKE CFLAGS CXXFLAGS LDFLAGS build
 srcdir abs_srcdir prefix backend libdirsuffix libghdldirsuffix
-libdirreverse incdirsuffix gcc_src_dir llvm_config llvm_be backtrace_lib
+incdirsuffix gcc_src_dir llvm_config llvm_be backtrace_lib
 build_mode EXEEXT SOEXT PIC_FLAGS default_pic enable_werror enable_checks
 enable_gplcompat enable_libghdl libghdl_version ghdl_version"
 

--- a/scripts/gcc/Make-lang.in
+++ b/scripts/gcc/Make-lang.in
@@ -103,8 +103,12 @@ vhdl/default_paths.ads: Makefile
 	echo "   Compiler_Mcode : constant String := \"\";" >> tmp-dpaths.ads
 	echo "   Compiler_Llvm  : constant String := \"\";" >> tmp-dpaths.ads
 	echo "   Post_Processor : constant String := \"\";" >> tmp-dpaths.ads
-	echo "   Lib_Prefix     : constant String :=">> tmp-dpaths.ads
+	echo "   LibDir_Suffix  : constant String :=">> tmp-dpaths.ads
+	echo "     \"lib\";" >> tmp-dpaths.ads
+	echo "   LibGhdlDir_Suffix  : constant String :=">> tmp-dpaths.ads
 	echo "     \"lib/ghdl\";" >> tmp-dpaths.ads
+	echo "   IncDir_Suffix  : constant String :=" >> tmp-dpaths.ads
+	echo "     \"include/ghdl\";" >> tmp-dpaths.ads
 	echo "   Shared_Library_Extension : constant String :=">> tmp-dpaths.ads
 	echo "     \"$(VHDL_SOEXT)\";" >> tmp-dpaths.ads
 	echo "   Default_Pie : constant Boolean := False;" >> tmp-dpaths.ads

--- a/src/ghdldrv/default_paths.ads.in
+++ b/src/ghdldrv/default_paths.ads.in
@@ -21,8 +21,12 @@ package Default_Paths is
 
    Install_Prefix : constant String :=
      "@INSTALL_PREFIX@";
-   Lib_Prefix : constant String :=
-     "@LIB_PREFIX@";
+   LibDir_Suffix : constant String :=
+     "@LIBDIR_SUFFIX@";
+   LibGhdlDir_Suffix : constant String :=
+     "@LIBGHDLDIR_SUFFIX@";
+   IncDir_Suffix : constant String :=
+     "@INCDIR_SUFFIX@";
 
    Compiler_Gcc : constant String :=
      "@COMPILER_GCC@";

--- a/src/ghdldrv/ghdldrv.adb
+++ b/src/ghdldrv/ghdldrv.adb
@@ -826,7 +826,7 @@ package body Ghdldrv is
       end case;
       Put ("linker command (--LINKER=, CC, or cc): ");
       Put_Line (Cmd.Linker_Cmd.all);
-      Put_Line ("default lib prefix: " & Default_Paths.Lib_Prefix);
+      Put_Line ("default lib prefix: " & Default_Paths.LibDir_Suffix);
 
       New_Line;
 

--- a/src/ghdldrv/ghdllocal.adb
+++ b/src/ghdldrv/ghdllocal.adb
@@ -417,13 +417,13 @@ package body Ghdllocal is
       end if;
       --  Else try default path.
       if Lib_Prefix_Path = null then
-         if Is_Absolute_Path (Default_Paths.Lib_Prefix) then
-            Lib_Prefix_Path := new String'(Default_Paths.Lib_Prefix);
+         if Is_Absolute_Path (Default_Paths.LibGhdlDir_Suffix) then
+            Lib_Prefix_Path := new String'(Default_Paths.LibGhdlDir_Suffix);
          else
             if Exec_Prefix /= null then
                Lib_Prefix_Path := new
                  String'(Exec_Prefix.all & Directory_Separator
-                           & Default_Paths.Lib_Prefix);
+                           & Default_Paths.LibGhdlDir_Suffix);
             end if;
             if Lib_Prefix_Path = null
               or else not Is_Directory (Lib_Prefix_Path.all)
@@ -432,7 +432,7 @@ package body Ghdllocal is
                Lib_Prefix_Path := new
                  String'(Default_Paths.Install_Prefix
                            & Directory_Separator
-                           & Default_Paths.Lib_Prefix);
+                           & Default_Paths.LibGhdlDir_Suffix);
             end if;
          end if;
       else

--- a/src/ghdldrv/ghdlsynth.adb
+++ b/src/ghdldrv/ghdlsynth.adb
@@ -581,7 +581,8 @@ package body Ghdlsynth is
          Ghdllocal.Set_Exec_Prefix_From_Program_Name;
       end if;
 
-      return Ghdllocal.Exec_Prefix.all & Directory_Separator & "lib"
+      return Ghdllocal.Exec_Prefix.all & Directory_Separator
+        & Default_Paths.LibDir_Suffix
         & Directory_Separator & Get_Libghdl_Name;
    end Get_Libghdl_Path;
 
@@ -590,9 +591,8 @@ package body Ghdlsynth is
       --  Compute install path
       Ghdllocal.Set_Exec_Prefix_From_Program_Name;
 
-      return Ghdllocal.Exec_Prefix.all
-        & Directory_Separator & "include"
-        & Directory_Separator & "ghdl";
+      return Ghdllocal.Exec_Prefix.all & Directory_Separator
+        & Default_Paths.IncDir_Suffix;
    end Get_Libghdl_Include_Dir;
 
    procedure Register_Commands is

--- a/src/ghdldrv/ghdlsynth.adb
+++ b/src/ghdldrv/ghdlsynth.adb
@@ -590,7 +590,9 @@ package body Ghdlsynth is
       --  Compute install path
       Ghdllocal.Set_Exec_Prefix_From_Program_Name;
 
-      return Ghdllocal.Exec_Prefix.all & Directory_Separator & "include";
+      return Ghdllocal.Exec_Prefix.all
+        & Directory_Separator & "include"
+        & Directory_Separator & "ghdl";
    end Get_Libghdl_Include_Dir;
 
    procedure Register_Commands is

--- a/src/ghdldrv/ghdlvpi.adb
+++ b/src/ghdldrv/ghdlvpi.adb
@@ -37,9 +37,8 @@ package body Ghdlvpi is
       --  Compute install path
       Ghdllocal.Set_Exec_Prefix_From_Program_Name;
 
-      return Ghdllocal.Exec_Prefix.all
-        & Directory_Separator & "include"
-        & Directory_Separator & "ghdl";
+      return Ghdllocal.Exec_Prefix.all & Directory_Separator
+        & Default_Paths.IncDir_Suffix;
    end Get_Vpi_Include_Dir;
 
    --  Return the lib directory.
@@ -50,7 +49,7 @@ package body Ghdlvpi is
          Ghdllocal.Set_Exec_Prefix_From_Program_Name;
       end if;
 
-      return Ghdllocal.Exec_Prefix.all & Directory_Separator & "lib";
+      return Ghdllocal.Exec_Prefix.all & Directory_Separator & LibDir_Suffix;
    end Get_Vpi_Lib_Dir;
 
    --  Return the lib directory, but unixify the path (for a unix shell in

--- a/src/grt/Makefile.inc
+++ b/src/grt/Makefile.inc
@@ -123,14 +123,14 @@ GRT_PRAGMA_FLAG=-gnatec$(GRTSRCDIR)/grt.adc -gnatdY
 # Rule to compile an Ada file.
 GRT_ADACOMPILE=$(GNATMAKE) -u -c $(GRT_FLAGS) $(GRT_PRAGMA_FLAG)
 
-grt-all: $(libdirsuffix)/libgrt.a \
-  $(libdirsuffix)/$(GRT_LIBBACKTRACE) \
-  $(libdirsuffix)/grt.lst \
-  $(libdirsuffix)/grt-exec.lst \
-  $(libdirsuffix)/grt-shared.lst \
-  $(libdirsuffix)/grt.ver
+grt-all: $(libghdldirsuffix)/libgrt.a \
+  $(libghdldirsuffix)/$(GRT_LIBBACKTRACE) \
+  $(libghdldirsuffix)/grt.lst \
+  $(libghdldirsuffix)/grt-exec.lst \
+  $(libghdldirsuffix)/grt-shared.lst \
+  $(libghdldirsuffix)/grt.ver
 
-$(libdirsuffix)/libgrt.a: $(GRT_ADD_OBJS) grt/run-bind.o grt/main.o grt/grt-files
+$(libghdldirsuffix)/libgrt.a: $(GRT_ADD_OBJS) grt/run-bind.o grt/main.o grt/grt-files
 	$(RM) -f $@
 	$(AR) rcv $@ `sed -e "/^-/d" -e "s!^!grt/!" < grt/grt-files` \
 	 $(GRT_ADD_OBJS) grt/run-bind.o grt/main.o
@@ -260,7 +260,7 @@ grt/grt-files.in: grt/grt-files
 	sed -e "\!^.[/\\]!d" -e "/-shared/d" -e "/-static/d" -e "/-lgnat/d" \
 	  -e "\X-L/Xd" < $< > $@
 
-$(libdirsuffix)/grt.lst: grt/grt-files.in
+$(libghdldirsuffix)/grt.lst: grt/grt-files.in
 	echo "@/libgrt.a" > $@
 	for i in $(GRT_EXTRA_LIB); do echo $$i >> $@; done
 ifneq ($(LIBBACKTRACE),)
@@ -268,19 +268,19 @@ ifneq ($(LIBBACKTRACE),)
 endif
 	cat $< >> $@
 
-$(libdirsuffix)/grt-exec.lst:
+$(libghdldirsuffix)/grt-exec.lst:
 	echo "# link options for executables" > $@
 	for i in $(GRT_EXEC_OPTS); do echo $$i >> $@; done
 
-$(libdirsuffix)/grt-shared.lst:
+$(libghdldirsuffix)/grt-shared.lst:
 	echo "# link options for shared libraries" > $@
 	for i in $(GRT_SHARED_OPTS); do echo $$i >> $@; done
 
-$(libdirsuffix)/grt.ver: $(GRTSRCDIR)/grt.ver
+$(libghdldirsuffix)/grt.ver: $(GRTSRCDIR)/grt.ver
 	cp $< $@
 
 ifneq ($(GRT_LIBBACKTRACE),)
-$(libdirsuffix)/$(GRT_LIBBACKTRACE): $(LIBBACKTRACE)
+$(libghdldirsuffix)/$(GRT_LIBBACKTRACE): $(LIBBACKTRACE)
 	cp $< $@
 endif
 


### PR DESCRIPTION
66cd5e0aa897b947533d269535fde4c0852472c2 seems to have introduced breakage in `--libghdl-include-dir` and while I'm at it I'm also proposing a patch from the ghdl Debian package to fix this sort of thing once and for all by introducing new ./configure variables for the inc/libdirsuffix.
