### PR TITLE
Makefile: install.local fixes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -472,8 +472,8 @@ install.libghdl.include: install.dirs $(srcdir)/src/synth/include/synth_gates.h
 
 test: install.libghdl.local
 install.libghdl.local: all.libghdl
-	$(INSTALL_DATA) -p $(srcdir)/src/synth/include/synth.h $(DESTDIR)$(incdirsuffix)/ghdl
-	$(INSTALL_DATA) -p $(srcdir)/src/synth/include/synth_gates.h $(DESTDIR)$(incdirsuffix)/ghdl
+	$(INSTALL_DATA) -p $(srcdir)/src/synth/include/synth.h $(incdirsuffix)/ghdl/
+	$(INSTALL_DATA) -p $(srcdir)/src/synth/include/synth_gates.h $(incdirsuffix)/ghdl/
 
 install.libghdl.lib:
 	$(INSTALL_PROGRAM) -p lib/$(libghdl_name) $(DESTDIR)$(libdir)/

--- a/Makefile.in
+++ b/Makefile.in
@@ -472,6 +472,7 @@ install.libghdl.include: install.dirs $(srcdir)/src/synth/include/synth_gates.h
 
 test: install.libghdl.local
 install.libghdl.local: all.libghdl
+	$(MKDIR) -p $(incdirsuffix)/ghdl/
 	$(INSTALL_DATA) -p $(srcdir)/src/synth/include/synth.h $(incdirsuffix)/ghdl/
 	$(INSTALL_DATA) -p $(srcdir)/src/synth/include/synth_gates.h $(incdirsuffix)/ghdl/
 
@@ -571,7 +572,7 @@ uninstall.vpi:
 
 test: install.vpi.local
 install.vpi.local: all.vpi
-	$(MKDIR) -p $(incdirsuffix) lib
+	$(MKDIR) -p $(incdirsuffix)/ghdl/
 	$(INSTALL_DATA) -p $(GRTSRCDIR)/vpi_user.h $(incdirsuffix)/ghdl/
 	$(INSTALL_DATA) -p $(GRTSRCDIR)/vhpi_user.h $(incdirsuffix)/ghdl/
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -470,7 +470,7 @@ install.libghdl.include: install.dirs $(srcdir)/src/synth/include/synth_gates.h
 	$(INSTALL_DATA) -p $(srcdir)/src/synth/include/synth.h $(DESTDIR)$(incdir)/
 	$(INSTALL_DATA) -p $(srcdir)/src/synth/include/synth_gates.h $(DESTDIR)$(incdir)/
 
-test: install.libghdl.local
+test.$(backend): install.libghdl.local
 install.libghdl.local: all.libghdl
 	$(MKDIR) -p $(incdirsuffix)/ghdl/
 	$(INSTALL_DATA) -p $(srcdir)/src/synth/include/synth.h $(incdirsuffix)/ghdl/
@@ -570,7 +570,7 @@ uninstall.vpi:
 	$(RM) -f $(DESTDIR)$(incdir)/vpi_user.h
 	$(RM) -f $(DESTDIR)$(incdir)/vhpi_user.h
 
-test: install.vpi.local
+test.$(backend): install.vpi.local
 install.vpi.local: all.vpi
 	$(MKDIR) -p $(incdirsuffix)/ghdl/
 	$(INSTALL_DATA) -p $(GRTSRCDIR)/vpi_user.h $(incdirsuffix)/ghdl/


### PR DESCRIPTION
The recent changes to the install path handling introduced some regressions in the in-tree testing workflow. These patches fix the `install.*.local` targets so they run correctly and at the right time.