### PR TITLE
Fix name of Lattice Diamond settings variable

### DIFF
--- a/scripts/vendors/compile-lattice.sh
+++ b/scripts/vendors/compile-lattice.sh
@@ -227,7 +227,7 @@ GHDLSetup $VHDLStandard
 # -> $DestDir
 # <= $SourceDirectory
 # <= $DestinationDirectory
-SetupDirectories LatticeDiamond "Lattice Diamond"
+SetupDirectories Lattice_Diamond "Lattice Diamond"
 
 # create "lattice" directory and change to it
 # => $DestinationDirectory


### PR DESCRIPTION
**Description**

The Lattice Diamond variable in config.sh is called `Lattice_Diamond_Settings`. `LatticeDiamond` was an incorrect prefix which never matched the settings, so they were never used.