### PR TITLE
GCC 12 compatibility

### DIFF
--- a/src/ghdldrv/ghdldrv.adb
+++ b/src/ghdldrv/ghdldrv.adb
@@ -1192,7 +1192,6 @@ package body Ghdldrv is
    procedure Perform_Action (Cmd : in out Command_Elab; Args : Argument_List)
    is
       Success : Boolean;
-      pragma Unreferenced (Success);
    begin
       Set_Elab_Units (Cmd, "-e", Args);
       Setup_Compiler (Cmd, False);
@@ -1202,6 +1201,7 @@ package body Ghdldrv is
          Link (Cmd, Add_Std => True, Disp_Only => False);
       end if;
       Delete_File (Filelist_Name.all, Success);
+      pragma Unreferenced (Success);
    end Perform_Action;
 
    --  Command Run.

--- a/src/ortho/mcode/ortho_code-x86-abi.adb
+++ b/src/ortho/mcode/ortho_code-x86-abi.adb
@@ -24,7 +24,6 @@ with Ortho_Code.Debug;
 with Ortho_Code.Disps;
 with Ortho_Code.Flags;
 with Ortho_Code.Dwarf;
-with Ortho_Code.X86; use Ortho_Code.X86;
 with Ortho_Code.X86.Insns;
 with Ortho_Code.X86.Emits;
 with Binary_File;

--- a/src/synth/netlists-disp_dot.ads
+++ b/src/synth/netlists-disp_dot.ads
@@ -16,8 +16,6 @@
 --  You should have received a copy of the GNU General Public License
 --  along with this program.  If not, see <gnu.org/licenses>.
 
-with Netlists;
-
 package Netlists.Disp_Dot is
    procedure Disp_Dot_Top_Module (M : Module);
 end Netlists.Disp_Dot;

--- a/src/synth/netlists-inference.ads
+++ b/src/synth/netlists-inference.ads
@@ -16,7 +16,6 @@
 --  You should have received a copy of the GNU General Public License
 --  along with this program.  If not, see <gnu.org/licenses>.
 
-with Netlists; use Netlists;
 with Netlists.Builders; use Netlists.Builders;
 
 package Netlists.Inference is

--- a/src/synth/synth-vhdl_stmts.adb
+++ b/src/synth/synth-vhdl_stmts.adb
@@ -1933,11 +1933,11 @@ package body Synth.Vhdl_Stmts is
                                            Assoc_Chain : Node)
    is
       Infos : Target_Info_Array (1 .. 0);
-      pragma Unreferenced (Infos);
       Init : Association_Iterator_Init;
    begin
       Init := Association_Iterator_Build (Inter_Chain, Assoc_Chain);
       Synth_Subprogram_Association (Subprg_Inst, Caller_Inst, Init, Infos);
+      pragma Unreferenced (Infos);
    end Synth_Subprogram_Association;
 
    --  Create wires for out and inout interface variables.

--- a/src/vhdl/translate/trans-chap2.adb
+++ b/src/vhdl/translate/trans-chap2.adb
@@ -1006,7 +1006,6 @@ package body Trans.Chap2 is
       Info   : constant Ortho_Info_Acc := Get_Info (Spec);
       Final  : Boolean;
       Constr : O_Assoc_List;
-      pragma Unreferenced (Final);
    begin
       if not Is_Nested then
          Start_Subprogram_Body (Info.Package_Elab_Spec_Subprg);
@@ -1039,6 +1038,7 @@ package body Trans.Chap2 is
             (Info.Package_Spec_Scope'Access, Info.Package_Spec_Scope));
       end if;
       Chap4.Elab_Declaration_Chain (Spec, Final);
+      pragma Unreferenced (Final);
 
       if not Is_Nested then
          Close_Temp;

--- a/src/vhdl/translate/trans-rtis.adb
+++ b/src/vhdl/translate/trans-rtis.adb
@@ -21,7 +21,7 @@ with Vhdl.Utils; use Vhdl.Utils;
 with Vhdl.Configuration;
 with Libraries;
 with Trans.Chap7;
-with Trans; use Trans.Helpers;
+use Trans.Helpers;
 with Trans.Helpers2; use Trans.Helpers2;
 
 package body Trans.Rtis is


### PR DESCRIPTION
GCC 12 introduced a couple new diagnostics, which are causing compile failures due to -Wall. One of those was already reported in #2056, but there were a couple more, which are fixed here.
