### PR TITLE
fix(testsuite): show diffs on comparison failure

### DIFF
--- a/testsuite/gna/issue394/testsuite.sh
+++ b/testsuite/gna/issue394/testsuite.sh
@@ -4,7 +4,7 @@
 
 analyze bug.vhdl
 elab_simulate bug > out.txt 2> err.txt
-diff_nocr -q out.txt out.ref
+diff_nocr out.txt out.ref
 
 rm -f out.txt err.txt
 clean

--- a/testsuite/gna/issue450/testsuite.sh
+++ b/testsuite/gna/issue450/testsuite.sh
@@ -12,7 +12,7 @@ if c_compiler_is_available && ghdl_has_feature disptree vpi; then
   $GHDL --vpi-link -v gcc -o vpi2.vpi vpi2.o
 
   simulate disptree --vpi=./vpi2.vpi | tee disptree.out
-  diff_nocr -q disptree.ref disptree.out
+  diff_nocr disptree.ref disptree.out
 
   rm -f vpi2.o vpi2.vpi disptree.out
 fi

--- a/testsuite/gna/issue719/testsuite.sh
+++ b/testsuite/gna/issue719/testsuite.sh
@@ -3,7 +3,7 @@
 . ../../testenv.sh
 
 analyze tb.vhdl 2> tb.out
-diff_nocr -q tb.ref tb.out
+diff_nocr tb.ref tb.out
 
 rm -f tb.out
 clean

--- a/testsuite/gna/issue880/testsuite.sh
+++ b/testsuite/gna/issue880/testsuite.sh
@@ -8,7 +8,7 @@ elab psl
 if ghdl_has_feature psl psl; then
   simulate psl --psl-report=psl.out
 
-  if ! diff_nocr psl.out psl.ref > /dev/null; then
+  if ! diff_nocr psl.out psl.ref; then
       echo "report mismatch"
       exit 1
   fi
@@ -24,7 +24,7 @@ elab -fpsl psl
 if ghdl_has_feature psl psl; then
   simulate psl --psl-report=psl.out
 
-  diff_nocr -q psl.out psl.ref
+  diff_nocr psl.out psl.ref
 
   rm -f psl.out
 fi

--- a/testsuite/gna/ticket24/testsuite.sh
+++ b/testsuite/gna/ticket24/testsuite.sh
@@ -8,7 +8,7 @@ elab psl
 if ghdl_has_feature psl psl; then
   simulate psl --psl-report=psl.out
 
-  if ! diff_nocr psl.out psl.ref > /dev/null; then
+  if ! diff_nocr psl.out psl.ref; then
       echo "report mismatch"
       exit 1
   fi
@@ -24,7 +24,7 @@ elab -fpsl psl
 if ghdl_has_feature psl psl; then
   simulate psl --psl-report=psl.out
 
-  diff_nocr -q psl.out psl.ref
+  diff_nocr psl.out psl.ref
 
   rm -f psl.out
 fi


### PR DESCRIPTION
I just had a [spurious test failure](https://github.com/Xiretza/ghdl/runs/6456572177?check_suite_focus=true#step:7:798) in one of my branches (`gna/issue880` failed only in MINGW64 llvm), but unfortunately the only message was "report mismatch" because the output of the `diff` was swallowed. Replacing all occurrences of `diff.*-q` and `diff.*/dev/null` should make future test failures more debuggable.