### PR TITLE
Bumped dependencies to support pyTooling ≥2.0.

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,8 +1,8 @@
 -r ../pyGHDL/requirements.txt
 
-sphinx>=3.4.2
+sphinx>=5.0.2
 #recommonmark>=0.7.1
-python-dateutil>=2.8.1
+python-dateutil>=2.8.2
 
 # Sphinx Extenstions
 # sphinxcontrib-textstyle>=0.2.1
@@ -10,7 +10,7 @@ python-dateutil>=2.8.1
 # changelog>=0.3.5
 autoapi
 sphinx_fontawesome>=0.0.6
-sphinx_autodoc_typehints>=1.11.1
+sphinx_autodoc_typehints>=1.18.3
 
 # BuildTheDocs Extensions (mostly patched Sphinx extensions)
 btd.sphinx.autoprogram>=0.1.6.post1

--- a/pyGHDL/cli/dom.py
+++ b/pyGHDL/cli/dom.py
@@ -307,6 +307,9 @@ class Application(LineTerminal, ArgParseMixin):
                         for architecture in architectures:
                             entity.Architectures.append(architecture)
 
+        if not self._design.Documents:
+            self.WriteFatal(f"No files processed at all.")
+
         PP = PrettyPrint()
 
         buffer = []

--- a/pyGHDL/cli/dom.py
+++ b/pyGHDL/cli/dom.py
@@ -41,7 +41,7 @@ from pyGHDL.dom import DOMException
 
 from pyGHDL.libghdl import LibGHDLException
 from pyTooling.Decorators import export
-from pyTooling.MetaClasses import Singleton
+from pyTooling.MetaClasses import ExtendedType
 from pyTooling.TerminalUI import LineTerminal, Severity
 from pyAttributes import Attribute
 from pyAttributes.ArgParseAttributes import (
@@ -117,10 +117,6 @@ class Application(LineTerminal, ArgParseMixin):
 
     def __init__(self, debug=False, verbose=False, quiet=False, sphinx=False):
         super().__init__(verbose, debug, quiet)
-
-        # Initialize the Terminal class
-        # --------------------------------------------------------------------------
-        Singleton.Register(LineTerminal, self)
 
         # Initialize DOM with an empty design
         # --------------------------------------------------------------------------
@@ -347,7 +343,7 @@ def main():  # mccabe:disable=MC0001
 
     try:
         # handover to a class instance
-        app = Application(debug, verbose, quiet)
+        app = Application()  #debug, verbose, quiet)
         app.Run()
         app.exit()
     except PrettyPrintException as ex:

--- a/pyGHDL/cli/dom.py
+++ b/pyGHDL/cli/dom.py
@@ -343,7 +343,7 @@ def main():  # mccabe:disable=MC0001
 
     try:
         # handover to a class instance
-        app = Application()  #debug, verbose, quiet)
+        app = Application()  # debug, verbose, quiet)
         app.Run()
         app.exit()
     except PrettyPrintException as ex:

--- a/pyGHDL/cli/requirements.txt
+++ b/pyGHDL/cli/requirements.txt
@@ -1,5 +1,5 @@
 -r ../dom/requirements.txt
 
-pyTooling>=1.6.0,<=1.10.0
-pyTooling.TerminalUI>=1.5.3,<=1.5.7
+pyTooling>=2.1.0
+pyTooling.TerminalUI>=1.5.9
 pyAttributes>=2.3.2

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -98,6 +98,7 @@ class Design(VHDLModel_Design):
         errorout_memory.Install_Handler()
 
         libghdl_set_option("--std=08")
+        libghdl_set_option("--ams")
 
         parse.Flag_Parse_Parenthesis.value = True
 

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -823,6 +823,16 @@ def GetDeclaredItemsFromChainedNodes(nodeChain: Iir, entity: str, name: str) -> 
                 print("[NOT IMPLEMENTED] Group template declaration in {name}".format(name=name))
             elif kind == nodes.Iir_Kind.Disconnection_Specification:
                 print("[NOT IMPLEMENTED] Disconnect specification in {name}".format(name=name))
+            elif kind == nodes.Iir_Kind.Nature_Declaration:
+                print("[NOT IMPLEMENTED] Nature declaration in {name}".format(name=name))
+            elif kind == nodes.Iir_Kind.Free_Quantity_Declaration:
+                print("[NOT IMPLEMENTED] Free quantity declaration in {name}".format(name=name))
+            elif kind == nodes.Iir_Kind.Across_Quantity_Declaration:
+                print("[NOT IMPLEMENTED] Across quantity declaration in {name}".format(name=name))
+            elif kind == nodes.Iir_Kind.Through_Quantity_Declaration:
+                print("[NOT IMPLEMENTED] Through quantity declaration in {name}".format(name=name))
+            elif kind == nodes.Iir_Kind.Terminal_Declaration:
+                print("[NOT IMPLEMENTED] Terminal declaration in {name}".format(name=name))
             else:
                 position = Position.parse(item)
                 raise DOMException(
@@ -924,6 +934,12 @@ def GetConcurrentStatementsFromChainedNodes(
             yield ForGenerateStatement.parse(statement, label)
         elif kind == nodes.Iir_Kind.Psl_Assert_Directive:
             yield ConcurrentAssertStatement.parse(statement, label)
+        elif kind == nodes.Iir_Kind.Simple_Simultaneous_Statement:
+            print(
+                "[NOT IMPLEMENTED] Simple simultaneous statement (label: '{label}') at line {line}".format(
+                    label=label, line=pos.Line
+                )
+            )
         else:
             raise DOMException(
                 "Unknown statement of kind '{kind}' in {entity} '{name}' at {file}:{line}:{column}.".format(

--- a/pyGHDL/dom/requirements.txt
+++ b/pyGHDL/dom/requirements.txt
@@ -1,4 +1,4 @@
 -r ../libghdl/requirements.txt
 
-pyVHDLModel==0.14.3
+pyVHDLModel==0.14.4
 #https://github.com/VHDL/pyVHDLModel/archive/dev.zip#pyVHDLModel

--- a/pyGHDL/dom/requirements.txt
+++ b/pyGHDL/dom/requirements.txt
@@ -1,4 +1,4 @@
 -r ../libghdl/requirements.txt
 
-pyVHDLModel==0.14.1
+pyVHDLModel==0.14.3
 #https://github.com/VHDL/pyVHDLModel/archive/dev.zip#pyVHDLModel

--- a/pyGHDL/libghdl/requirements.txt
+++ b/pyGHDL/libghdl/requirements.txt
@@ -1,1 +1,1 @@
-pyTooling>=1.6.0,<=1.10.0
+pyTooling>=2.0.1

--- a/pyGHDL/libghdl/requirements.txt
+++ b/pyGHDL/libghdl/requirements.txt
@@ -1,1 +1,1 @@
-pyTooling>=2.0.1
+pyTooling>=2.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
-    "pyTooling >= 1.7.0",
-    "setuptools >= 35.0.2",
-    "wheel >= 0.29.0"
+    "pyTooling >= 2.1.0",
+    "setuptools >= 62.3.3",
+    "wheel >= 0.37.1"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/testsuite/pyunit/dom/Sanity.py
+++ b/testsuite/pyunit/dom/Sanity.py
@@ -44,14 +44,16 @@ if __name__ == "__main__":
 
 
 _TESTSUITE_ROOT = Path(__file__).parent.parent.parent.resolve()
-_GHDL_ROOT = _TESTSUITE_ROOT.parent
+_SANITY_TESTS_ROOT = _TESTSUITE_ROOT / "sanity"
 
 
 design = Design()
 
 
-@mark.parametrize("file", [str(f.relative_to(_GHDL_ROOT)) for f in _TESTSUITE_ROOT.glob("sanity/**/*.vhdl")])
+@mark.parametrize("file", [str(f.relative_to(_TESTSUITE_ROOT)) for f in _SANITY_TESTS_ROOT.glob("**/*.vhdl")])
 def test_AllVHDLSources(file):
+    filePath = _TESTSUITE_ROOT / file
+
     lib = design.GetLibrary("sanity")
-    document = Document(Path(file))
+    document = Document(filePath)
     design.AddDocument(document, lib)

--- a/testsuite/pyunit/dom/Sanity.py
+++ b/testsuite/pyunit/dom/Sanity.py
@@ -48,6 +48,7 @@ _GHDL_ROOT = _TESTSUITE_ROOT.parent
 
 # design = Design()
 
+@mark.xfail(reason="Was it every working?")
 @mark.parametrize("file", [str(f.relative_to(_GHDL_ROOT)) for f in _TESTSUITE_ROOT.glob("sanity/**/*.vhdl")])
 def test_AllVHDLSources(file):
     check_call([sys_executable, _GHDL_ROOT / "pyGHDL/cli/dom.py", "pretty", "-f", file], stderr=STDOUT)

--- a/testsuite/pyunit/dom/Sanity.py
+++ b/testsuite/pyunit/dom/Sanity.py
@@ -13,7 +13,7 @@
 #
 # License:
 # ============================================================================
-#  Copyright (C) 2019-2021 Tristan Gingold
+#  Copyright (C) 2019-2022 Tristan Gingold
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -46,10 +46,9 @@ if __name__ == "__main__":
 _TESTSUITE_ROOT = Path(__file__).parent.parent.parent.resolve()
 _GHDL_ROOT = _TESTSUITE_ROOT.parent
 
+# design = Design()
 
-design = Design()
-
-@mark.parametrize("file", [str(f.relative_to(_TESTSUITE_ROOT)) for f in _TESTSUITE_ROOT.glob("sanity/**/*.vhdl")])
+@mark.parametrize("file", [str(f.relative_to(_GHDL_ROOT)) for f in _TESTSUITE_ROOT.glob("sanity/**/*.vhdl")])
 def test_AllVHDLSources(file):
     check_call([sys_executable, _GHDL_ROOT / "pyGHDL/cli/dom.py", "pretty", "-f", file], stderr=STDOUT)
 

--- a/testsuite/pyunit/dom/Sanity.py
+++ b/testsuite/pyunit/dom/Sanity.py
@@ -31,31 +31,27 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 from pathlib import Path
-from subprocess import check_call, STDOUT
-from sys import executable as sys_executable
 
 from pytest import mark
 
-from pyGHDL.dom.NonStandard import Design
+from pyGHDL.dom.NonStandard import Design, Document
+
 
 if __name__ == "__main__":
     print("ERROR: you called a testcase declaration file as an executable module.")
     print("Use: 'python -m unitest <testcase module>'")
     exit(1)
 
+
 _TESTSUITE_ROOT = Path(__file__).parent.parent.parent.resolve()
 _GHDL_ROOT = _TESTSUITE_ROOT.parent
 
-# design = Design()
 
-@mark.xfail(reason="Was it every working?")
+design = Design()
+
+
 @mark.parametrize("file", [str(f.relative_to(_GHDL_ROOT)) for f in _TESTSUITE_ROOT.glob("sanity/**/*.vhdl")])
 def test_AllVHDLSources(file):
-    check_call([sys_executable, _GHDL_ROOT / "pyGHDL/cli/dom.py", "pretty", "-f", file], stderr=STDOUT)
-
-    # try:
-    #     lib = design.GetLibrary("sanity")
-    #     document = Document(Path(file))
-    #     design.AddDocument(document, lib)
-    # except DOMException as ex:
-    #     print(ex)
+    lib = design.GetLibrary("sanity")
+    document = Document(Path(file))
+    design.AddDocument(document, lib)


### PR DESCRIPTION
# New Features

* Enabled `--ams` on all analysis runs with pyGHDL.
  * This solves problems with `sanity/004all08/ams08.vhdl` due to not enabled VHDL-AMS support.

# Changes

* Bumped dependencies
  * Sphinx 5.0.x
  * pyTooling 2.1.x
* Added more `[NOT IMPLEMENTED]` printouts for (yet) unsupported VHDL-AMS language constructs.

# Bug Fixes

* Changed execution of sanity checks to run in same process, but not as external instance with `subprocess.call`.
