### PR TITLE
GCC 12

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -161,7 +161,7 @@ jobs:
           - { os: 18, backend: llvm-5.0 }
           - { os: 20, backend: llvm-10 }
           - { os: 18, backend: gcc-8.3.0 }
-          - { os: 20, backend: gcc-9.3.0 }
+          - { os: 20, backend: gcc-12.1.0 }
 
     steps:
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -278,9 +278,9 @@ copy-sources.gcc: version.ads scripts/gcc/Make-lang.in
 	 6 | 6.*)  	    gcc_ortho_lang=ortho-lang-6.c ;; \
 	 7.*)      	    gcc_ortho_lang=ortho-lang-7.c ;; \
 	 8.*)      	    gcc_ortho_lang=ortho-lang-8.c ;; \
-	 9.* | 10.* | 11.*) gcc_ortho_lang=ortho-lang-9.c ;; \
+	 9.* | 10.* | 11.* | 12.* ) gcc_ortho_lang=ortho-lang-9.c ;; \
 	 *) echo "Mismatch gcc version from $(gcc_src_dir)"; \
-	    echo "Need gcc version 4.9.x, 5.x, 6.x, 7.x, 8.x, 9.x or 10.x"; \
+	    echo "Need gcc version 4.9.x, 5.x, 6.x, 7.x, 8.x, 9.x, 10.x, 11.x or 12.x"; \
 	    exit 1 ;; \
 	esac; \
 	$(CP) -p $(srcdir)/src/ortho/gcc/$$gcc_ortho_lang \

--- a/doc/development/building/GCC.rst
+++ b/doc/development/building/GCC.rst
@@ -9,7 +9,8 @@ GCC backend
 
 * GCC (Gnu Compiler Collection)
 * GNAT (Ada compiler for GCC)
-* GCC source files. Download and untar the sources of version 4.9.x, 5.x, 6.x, 7.x, 8.x, 9.x, 10.x or 11.x (`GCC mirror sites <https://gcc.gnu.org/mirrors.html>`__).
+* GCC source files. Download and untar the sources of version 4.9.x, 5.x, 6.x, 7.x, 8.x, 9.x, 10.x, 11.x or 12.x
+  (`GCC mirror sites <https://gcc.gnu.org/mirrors.html>`__).
 
 .. HINT :: There are some dependencies for building GCC (``gmp``, ``mpfr`` and ``mpc``). If you have not installed them on your system, you can either build them manually or use the ``download_prerequisites`` script provided in the GCC source tree (recommended): ``cd /path/to/gcc/source/dir && ./contrib/download_prerequisites``.
 


### PR DESCRIPTION
This is an attempt to add GCC 12 support in the Makefile and to use it in CI. As seen below, it is failing with `gengtype: failed to compute output name for ../../gcc-srcs/gcc/vhdl/ortho-lang.c`.