### PR TITLE
use --version flag to check for C compiler

### DIFF
--- a/configure
+++ b/configure
@@ -204,7 +204,7 @@ if ! $GNATMAKE --version >/dev/null 2>&1; then
 fi
 
 # Check that compiler exists
-if ! $CC -v 2> /dev/null; then
+if ! $CC --version 2> /dev/null; then
   echo "Sorry, you need a C compiler to build GHDL.  See the README"
   exit 1
 fi


### PR DESCRIPTION
**Description** Use the `--version` option over `-v` to check for existing compilers

`-v` does not only print the compiler version, but runs some commands according to `gcc --help` and `clang --help`. This has side effects, which breaks things on some setups. I also think that's what was originally intended.

**When contributing to the GHDL codebase...**

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
- [x] CONSIDER adding a unit test if your PR resolves an issue.
- [x] CONSIDER modifying the docs, if your contribution is relevant to any of the content.
- [x] AVOID breaking the continuous integration build.
- [x] AVOID breaking the testsuite.