### PR TITLE
Support non glibc Linux systems

### DIFF
--- a/src/grt/config/jumps.c
+++ b/src/grt/config/jumps.c
@@ -97,10 +97,8 @@ get_bt_from_ucontext (void *uctxt, struct backtrace_addrs *bt)
 #ifdef HAVE_BACKTRACE
   bt->size = backtrace (bt->addrs, sizeof (bt->addrs) / sizeof (void *));
   bt->skip = 0;
-  #pragma message "HAVE_BACKTRACE=1"
 #else
   bt->size = 0;
-  #pragma message "HAVE_BACKTRACE=0"
   return;
 #endif
 

--- a/src/grt/config/jumps.c
+++ b/src/grt/config/jumps.c
@@ -27,7 +27,7 @@
 #include <signal.h>
 #include <fcntl.h>
 
-#if ( defined (__linux__) || defined (__APPLE__) ) && !defined (__ANDROID__)
+#if ( (defined (__linux__) && defined (__GLIBC__) ) || defined (__APPLE__) ) && !defined (__ANDROID__)
 #define HAVE_BACKTRACE 1
 #include <sys/ucontext.h>
 #endif
@@ -97,8 +97,10 @@ get_bt_from_ucontext (void *uctxt, struct backtrace_addrs *bt)
 #ifdef HAVE_BACKTRACE
   bt->size = backtrace (bt->addrs, sizeof (bt->addrs) / sizeof (void *));
   bt->skip = 0;
+  #pragma message "HAVE_BACKTRACE=1"
 #else
   bt->size = 0;
+  #pragma message "HAVE_BACKTRACE=0"
   return;
 #endif
 


### PR DESCRIPTION
**Description** Please explain the changes you made here.
HAVE_BACKTRACE is now only defined as 1 on Linux systems if glibc is present, This is done by checking if the `__GLIBC__`
macro is defined, which it will be if glibc is on the system. This allows for successful building on non glibc systems (for example musl) which do not define a `backtrace()` function.

Tested build on Void Linux w/ musl & Ubuntu Linux w/ glibc

