### PR TITLE
pyGHDL updates

### DIFF
--- a/doc/_templates/autoapi/module.rst
+++ b/doc/_templates/autoapi/module.rst
@@ -1,4 +1,9 @@
-{{ node.name }}
+.. # Template modified  by Patrick Lehmann
+     * removed automodule on top, because private members are activated for autodoc (no doubled documentation).
+     * Made sections like 'submodules' bold text, but no headlines to reduce number of ToC levels.
+
+=={{ '=' * node.name|length }}==
+``{{ node.name }}``
 =={{ '=' * node.name|length }}==
 
 .. automodule:: {{ node.name }}
@@ -7,9 +12,8 @@
 {%- block modules -%}
 {%- if subnodes %}
 
-.. #-----------------------------------
-{##}
 **Submodules**
+
 
 .. toctree::
 {% for item in subnodes %}
@@ -21,122 +25,89 @@
 {##}
 .. currentmodule:: {{ node.name }}
 {##}
-
-.. #-----------------------------------
-{##}
-{%- if node.variables %}
-**Variables**
-{##}
-{% for item, obj in node.variables.items() -%}
-- :py:data:`{{ item }}`
-{% endfor -%}
-{%- endif -%}
-
-
-{%- if node.exceptions %}
-{##}
-**Exceptions**
-{##}
-{% for item, obj in node.exceptions.items() -%}
-- :py:exc:`{{ item }}`:
-  {{ obj|summary }}
-
-{% endfor -%}
-{%- endif -%}
-
-
-{%- if node.classes %}
-{##}
-**Classes**
-{##}
-{% for item, obj in node.classes.items() -%}
-- :py:class:`{{ item }}`:
-  {{ obj|summary }}
-
-{% endfor -%}
-{%- endif -%}
-
-
+{%- block functions -%}
 {%- if node.functions %}
-{##}
+
 **Functions**
-{##}
+
 {% for item, obj in node.functions.items() -%}
 - :py:func:`{{ item }}`:
   {{ obj|summary }}
 
 {% endfor -%}
-{%- endif -%}
 
-
-{%- block variables -%}
-{%- if node.variables %}
-{% for item, obj in node.variables.items() %}
-.. autodata:: {{ item }}
-   :annotation:
-
-   .. code-block:: guess
-
-      {{ obj|pprint|indent(6) }}
+{% for item in node.functions %}
+.. autofunction:: {{ item }}
 {##}
 {%- endfor -%}
 {%- endif -%}
 {%- endblock -%}
-
-
-{%- block exceptions -%}
-{%- if node.exceptions %}
-
-.. #-----------------------------------
-
-{% for item in node.exceptions %}
-.. autoexception:: {{ item }}
-   :members:
-   :private-members:
-   :inherited-members:
-   :undoc-members:
-{##}
-   .. rubric:: Inheritance
-   .. inheritance-diagram:: {{ item }}
-{##}
-   .. rubric:: Members
-{##}
-{%- endfor -%}
-{%- endif -%}
-{%- endblock -%}
-
 
 {%- block classes -%}
 {%- if node.classes %}
 
-.. #-----------------------------------
+**Classes**
+
+{% for item, obj in node.classes.items() -%}
+- :py:class:`{{ item }}`:
+  {{ obj|summary }}
+
+{% endfor -%}
 
 {% for item in node.classes %}
 .. autoclass:: {{ item }}
    :members:
    :private-members:
-   :undoc-members:
+   :special-members:
    :inherited-members:
-{##}
+   :exclude-members: __weakref__
+
    .. rubric:: Inheritance
    .. inheritance-diagram:: {{ item }}
-{##}
-   .. rubric:: Members
+      :parts: 1
 {##}
 {%- endfor -%}
 {%- endif -%}
 {%- endblock -%}
 
+{%- block exceptions -%}
+{%- if node.exceptions %}
 
-{%- block functions -%}
-{%- if node.functions %}
+**Exceptions**
 
-.. #-----------------------------------
+{% for item, obj in node.exceptions.items() -%}
+- :py:exc:`{{ item }}`:
+  {{ obj|summary }}
 
-**Functions**
+{% endfor -%}
 
-{% for item in node.functions %}
-.. autofunction:: {{ item }}
+{% for item in node.exceptions %}
+.. autoexception:: {{ item }}
+
+   .. rubric:: Inheritance
+   .. inheritance-diagram:: {{ item }}
+      :parts: 1
+{##}
+{%- endfor -%}
+{%- endif -%}
+{%- endblock -%}
+
+{%- block variables -%}
+{%- if node.variables %}
+
+**Variables**
+
+{% for item, obj in node.variables.items() -%}
+- :py:data:`{{ item }}`
+{% endfor -%}
+
+{% for item, obj in node.variables.items() %}
+.. autodata:: {{ item }}
+   :annotation:
+
+   .. code-block:: text
+
+      {{ obj|pprint|indent(6) }}
 {##}
 {%- endfor -%}
 {%- endif -%}

--- a/doc/_templates/autoapi/module.rst
+++ b/doc/_templates/autoapi/module.rst
@@ -25,7 +25,17 @@
 {##}
 .. currentmodule:: {{ node.name }}
 {##}
-{%- block functions -%}
+
+{%- if node.variables %}
+
+**Variables**
+
+{% for item, obj in node.variables.items() -%}
+- :py:data:`{{ item }}`
+  {#{ obj|summary }#}
+{% endfor -%}
+{%- endif -%}
+
 {%- if node.functions %}
 
 **Functions**
@@ -35,42 +45,8 @@
   {{ obj|summary }}
 
 {% endfor -%}
-
-{% for item in node.functions %}
-.. autofunction:: {{ item }}
-{##}
-{%- endfor -%}
 {%- endif -%}
-{%- endblock -%}
 
-{%- block classes -%}
-{%- if node.classes %}
-
-**Classes**
-
-{% for item, obj in node.classes.items() -%}
-- :py:class:`{{ item }}`:
-  {{ obj|summary }}
-
-{% endfor -%}
-
-{% for item in node.classes %}
-.. autoclass:: {{ item }}
-   :members:
-   :private-members:
-   :special-members:
-   :inherited-members:
-   :exclude-members: __weakref__
-
-   .. rubric:: Inheritance
-   .. inheritance-diagram:: {{ item }}
-      :parts: 1
-{##}
-{%- endfor -%}
-{%- endif -%}
-{%- endblock -%}
-
-{%- block exceptions -%}
 {%- if node.exceptions %}
 
 **Exceptions**
@@ -80,6 +56,68 @@
   {{ obj|summary }}
 
 {% endfor -%}
+{%- endif -%}
+
+{%- if node.classes %}
+
+**Classes**
+
+{% for item, obj in node.classes.items() -%}
+- :py:class:`{{ item }}`:
+  {{ obj|summary }}
+
+{% endfor -%}
+{%- endif -%}
+
+{%- block variables -%}
+{%- if node.variables %}
+
+---------------------
+
+**Variables**
+
+{#% for item, obj in node.variables.items() -%}
+- :py:data:`{{ item }}`
+{% endfor -%#}
+
+{% for item, obj in node.variables.items() %}
+.. autodata:: {{ item }}
+   :annotation:
+
+   .. code-block:: text
+
+      {{ obj|pprint|indent(6) }}
+{##}
+{%- endfor -%}
+{%- endif -%}
+{%- endblock -%}
+
+{%- block functions -%}
+{%- if node.functions %}
+
+---------------------
+
+**Functions**
+
+{% for item in node.functions %}
+.. autofunction:: {{ item }}
+{##}
+{%- endfor -%}
+{%- endif -%}
+{%- endblock -%}
+
+{%- block exceptions -%}
+{%- if node.exceptions %}
+
+---------------------
+
+**Exceptions**
+
+{#% for item, obj in node.exceptions.items() -%}
+- :py:exc:`{{ item }}`:
+  {{ obj|summary }}
+
+{% endfor -%#}
 
 {% for item in node.exceptions %}
 .. autoexception:: {{ item }}
@@ -92,22 +130,30 @@
 {%- endif -%}
 {%- endblock -%}
 
-{%- block variables -%}
-{%- if node.variables %}
+{%- block classes -%}
+{%- if node.classes %}
 
-**Variables**
+---------------------
 
-{% for item, obj in node.variables.items() -%}
-- :py:data:`{{ item }}`
-{% endfor -%}
+**Classes**
 
-{% for item, obj in node.variables.items() %}
-.. autodata:: {{ item }}
-   :annotation:
+{#% for item, obj in node.classes.items() -%}
+- :py:class:`{{ item }}`:
+  {{ obj|summary }}
 
-   .. code-block:: text
+{% endfor -%#}
 
-      {{ obj|pprint|indent(6) }}
+{% for item in node.classes %}
+.. autoclass:: {{ item }}
+   :members:
+   :private-members:
+   :special-members:
+   :inherited-members:
+   :exclude-members: __weakref__
+
+   .. rubric:: Inheritance
+   .. inheritance-diagram:: {{ item }}
+      :parts: 1
 {##}
 {%- endfor -%}
 {%- endif -%}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -174,26 +174,24 @@ extensions = [
     # Standard Sphinx extensions
     'sphinx.ext.autodoc',
     'sphinx.ext.extlinks',
+	  'sphinx.ext.inheritance_diagram',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
-#    'sphinx.ext.graphviz',
+    'sphinx.ext.graphviz',
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
 
     # BuildTheDocs extensions
     'btd.sphinx.autoprogram',
-    'btd.sphinx.graphviz',
-    'btd.sphinx.inheritance_diagram',
+#    'btd.sphinx.graphviz',
+#    'btd.sphinx.inheritance_diagram',
 
     # Other extensions
 #    'recommonmark',
     'exec',
-#     'DocumentMember',
     'sphinx_fontawesome',
     'sphinx_autodoc_typehints',
-
-    # local extensions (patched)
     'autoapi.sphinx',
 ]
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -63,7 +63,7 @@ exclude_patterns = [
 ]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'stata-dark'
+pygments_style = 'manni'
 
 
 # ==============================================================================
@@ -202,7 +202,7 @@ extensions = [
 # Sphinx.Ext.InterSphinx
 # ==============================================================================
 intersphinx_mapping = {
-   'python':    ('https://docs.python.org/3.6/', None),
+   'python':    ('https://docs.python.org/3', None),
    'cosim':     ('https://ghdl.github.io/ghdl-cosim', None),
    'poc':       ('https://poc-library.readthedocs.io/en/release', None),
    'vhdlmodel': ('https://vhdl.github.io/pyVHDLModel', None),
@@ -215,12 +215,7 @@ intersphinx_mapping = {
 # ==============================================================================
 # see: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#configuration
 autodoc_member_order = "bysource"       # alphabetical, groupwise, bysource
-# autodoc_default_options = {
-#     "members": True,
-#     'undoc-members': True,
-#     #'private-members': True,
-#     'inherited-members': True,
-# }
+autodoc_typehints = "both"
 
 
 # ==============================================================================
@@ -230,11 +225,28 @@ graphviz_output_format = "svg"
 
 
 # ==============================================================================
+# Sphinx.Ext.Inheritance_Diagram
+# ==============================================================================
+inheritance_node_attrs = {
+#	"shape": "ellipse",
+#	"fontsize": 14,
+#	"height": 0.75,
+	"color": "dodgerblue1",
+	"style": "filled"
+}
+
+# ==============================================================================
 # Sphinx.Ext.ToDo
 # ==============================================================================
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 todo_link_only = True
+
+
+# ==============================================================================
+# Sphinx.Ext.Coverage
+# ==============================================================================
+coverage_show_missing_items = True
 
 
 # ==============================================================================

--- a/doc/prolog.inc
+++ b/doc/prolog.inc
@@ -12,3 +12,7 @@
 .. |hr| raw:: html
 
    <hr />
+
+.. role:: pycode(code)
+   :language: python
+   :class: highlight

--- a/pyGHDL/__init__.py
+++ b/pyGHDL/__init__.py
@@ -38,13 +38,13 @@
 GHDL offers two Python interfaces and a language server protocol service. All
 this is provided from a ``pyGHDL`` packages with four sub-packages:
 
-* ``pyGHDL.cli`` - Command line interface (CLI) applications.
-* ``pyGHDL.dom`` - A high-level API offering a document object model (DOM).
+* :mod:`pyGHDL.cli` - Command line interface (CLI) applications.
+* :mod:`pyGHDL.dom` - A high-level API offering a document object model (DOM).
   The underlying abstract VHDL language model is provided by :doc:`pyVHDLModel <vhdlmodel:index>`.
   The DOM is using ``libghdl`` for file analysis and parsing.
-* ``pyGHDL.libghdl`` - A low-level API directly interacting with the shared library ``libghdl....so``/``libghdl....dll``.
+* :mod:`pyGHDL.libghdl` - A low-level API directly interacting with the shared library ``libghdl....so``/``libghdl....dll``.
   This is a procedural and C-like interface. It comes with some Python generators for easier iterating linked lists.
-* ``pyGHDL.lsp`` - A :wikipedia:`language server protocol <Language_Server_Protocol>` (LSP)
+* :mod:`pyGHDL.lsp` - A :wikipedia:`language server protocol <Language_Server_Protocol>` (LSP)
   written in Python. The implementation offers an HTTPS service that can be used e.g. by editors and IDEs supporting LSP.
 """
 __author__ = "Tristan Gingold and contributors"

--- a/pyGHDL/dom/Attribute.py
+++ b/pyGHDL/dom/Attribute.py
@@ -121,30 +121,14 @@ class AttributeSpecification(VHDLModel_AttributeSpecification, DOMMixin):
                 print("[NOT IMPLEMENTED] Signature name in attribute specifications.")
             else:
                 position = Position.parse(name)
-                raise DOMException(
-                    "Unknown name kind '{kind}' in attribute specification '{attr}' at {file}:{line}:{column}.".format(
-                        kind=nameKind.name,
-                        attr=attributeNode,
-                        file=position.Filename,
-                        line=position.Line,
-                        column=position.Column,
-                    )
-                )
+                raise DOMException(f"Unknown name kind '{nameKind.name}' in attribute specification '{attributeNode}' at {position}.")
 
         entityClassToken = nodes.Get_Entity_Class(attributeNode)
         try:
             entityClass = _TOKEN_TRANSLATION[entityClassToken]
         except KeyError:
             position = Position.parse(attributeNode)
-            raise DOMException(
-                "Unknown token '{token}' in attribute specification for entity class '{entityClass}' at {file}:{line}:{column}.".format(
-                    token=entityClassToken.name,
-                    entityClass=attributeNode,
-                    file=position.Filename,
-                    line=position.Line,
-                    column=position.Column,
-                )
-            )
+            raise DOMException(f"Unknown token '{entityClassToken.name}' in attribute specification for entity class '{attributeNode}' at {position}.")
 
         expression = GetExpressionFromNode(nodes.Get_Expression(attributeNode))
 

--- a/pyGHDL/dom/Attribute.py
+++ b/pyGHDL/dom/Attribute.py
@@ -121,14 +121,18 @@ class AttributeSpecification(VHDLModel_AttributeSpecification, DOMMixin):
                 print("[NOT IMPLEMENTED] Signature name in attribute specifications.")
             else:
                 position = Position.parse(name)
-                raise DOMException(f"Unknown name kind '{nameKind.name}' in attribute specification '{attributeNode}' at {position}.")
+                raise DOMException(
+                    f"Unknown name kind '{nameKind.name}' in attribute specification '{attributeNode}' at {position}."
+                )
 
         entityClassToken = nodes.Get_Entity_Class(attributeNode)
         try:
             entityClass = _TOKEN_TRANSLATION[entityClassToken]
         except KeyError:
             position = Position.parse(attributeNode)
-            raise DOMException(f"Unknown token '{entityClassToken.name}' in attribute specification for entity class '{attributeNode}' at {position}.")
+            raise DOMException(
+                f"Unknown token '{entityClassToken.name}' in attribute specification for entity class '{attributeNode}' at {position}."
+            )
 
         expression = GetExpressionFromNode(nodes.Get_Expression(attributeNode))
 

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -552,7 +552,9 @@ class CaseGenerateStatement(VHDLModel_CaseGenerateStatement, DOMMixin):
                     rng = GetNameFromNode(choiceRange)
                 else:
                     pos = Position.parse(alternative)
-                    raise DOMException(f"Unknown choice range kind '{choiceRangeKind.name}' in case...generate statement at line {pos.Line}.")
+                    raise DOMException(
+                        f"Unknown choice range kind '{choiceRangeKind.name}' in case...generate statement at line {pos.Line}."
+                    )
 
                 choice = RangedGenerateChoice(alternative, rng)
                 if sameAlternative:
@@ -569,7 +571,9 @@ class CaseGenerateStatement(VHDLModel_CaseGenerateStatement, DOMMixin):
                 continue
             else:
                 pos = Position.parse(alternative)
-                raise DOMException(f"Unknown choice kind '{choiceKind.name}' in case...generate statement at line {pos.Line}.")
+                raise DOMException(
+                    f"Unknown choice kind '{choiceKind.name}' in case...generate statement at line {pos.Line}."
+                )
 
             if choices is not None:
                 cases.append(GenerateCase.parse(caseNode, choices))
@@ -623,7 +627,9 @@ class ForGenerateStatement(VHDLModel_ForGenerateStatement, DOMMixin):
             rng = GetNameFromNode(discreteRange)
         else:
             pos = Position.parse(generateNode)
-            raise DOMException(f"Unknown discrete range kind '{rangeKind.name}' in for...generate statement at line {pos.Line}.")
+            raise DOMException(
+                f"Unknown discrete range kind '{rangeKind.name}' in for...generate statement at line {pos.Line}."
+            )
 
         body = nodes.Get_Generate_Statement_Body(generateNode)
         declarationChain = nodes.Get_Declaration_Chain(body)

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -552,11 +552,7 @@ class CaseGenerateStatement(VHDLModel_CaseGenerateStatement, DOMMixin):
                     rng = GetNameFromNode(choiceRange)
                 else:
                     pos = Position.parse(alternative)
-                    raise DOMException(
-                        "Unknown choice range kind '{kind}' in case...generate statement at line {line}.".format(
-                            kind=choiceRangeKind.name, line=pos.Line
-                        )
-                    )
+                    raise DOMException(f"Unknown choice range kind '{choiceRangeKind.name}' in case...generate statement at line {pos.Line}.")
 
                 choice = RangedGenerateChoice(alternative, rng)
                 if sameAlternative:
@@ -573,19 +569,13 @@ class CaseGenerateStatement(VHDLModel_CaseGenerateStatement, DOMMixin):
                 continue
             else:
                 pos = Position.parse(alternative)
-                raise DOMException(
-                    "Unknown choice kind '{kind}' in case...generate statement at line {line}.".format(
-                        kind=choiceKind.name, line=pos.Line
-                    )
-                )
+                raise DOMException(f"Unknown choice kind '{choiceKind.name}' in case...generate statement at line {pos.Line}.")
 
             if choices is not None:
                 cases.append(GenerateCase.parse(caseNode, choices))
 
             caseNode = alternative
-            choices = [
-                choice,
-            ]
+            choices = [choice]
 
             alternative = nodes.Get_Chain(alternative)
 
@@ -633,11 +623,7 @@ class ForGenerateStatement(VHDLModel_ForGenerateStatement, DOMMixin):
             rng = GetNameFromNode(discreteRange)
         else:
             pos = Position.parse(generateNode)
-            raise DOMException(
-                "Unknown discete range kind '{kind}' in for...generate statement at line {line}.".format(
-                    kind=rangeKind.name, line=pos.Line
-                )
-            )
+            raise DOMException(f"Unknown discrete range kind '{rangeKind.name}' in for...generate statement at line {pos.Line}.")
 
         body = nodes.Get_Generate_Statement_Body(generateNode)
         declarationChain = nodes.Get_Declaration_Chain(body)

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -314,11 +314,7 @@ class Context(VHDLModel_Context, DOMMixin):
                 items.append(UseClause.parse(item))
             else:
                 pos = Position.parse(item)
-                raise DOMException(
-                    "Unknown context item kind '{kind}' in context at line {line}.".format(
-                        kind=kind.name, line=pos.Line
-                    )
-                )
+                raise DOMException(f"Unknown context item kind '{kind.name}' in context at line {pos.Line}.")
 
         return cls(contextNode, name, items)
 

--- a/pyGHDL/dom/Expression.py
+++ b/pyGHDL/dom/Expression.py
@@ -519,11 +519,7 @@ class Aggregate(VHDLModel_Aggregate, DOMMixin):
                     rng = GetNameFromNode(choiceRange)
                 else:
                     pos = Position.parse(item)
-                    raise DOMException(
-                        "Unknown discete range kind '{kind}' in for...generate statement at line {line}.".format(
-                            kind=rangeKind.name, line=pos.Line
-                        )
-                    )
+                    raise DOMException(f"Unknown discrete range kind '{rangeKind.name}' in for...generate statement at line {pos.Line}.")
 
                 choices.append(RangedAggregateElement(item, rng, value))
             elif kind == nodes.Iir_Kind.Choice_By_Name:
@@ -533,8 +529,6 @@ class Aggregate(VHDLModel_Aggregate, DOMMixin):
             elif kind == nodes.Iir_Kind.Choice_By_Others:
                 choices.append(OthersAggregateElement(item, value))
             else:
-                raise DOMException(
-                    "Unknown choice kind '{kind}' in aggregate '{aggr}'.".format(kind=kind.name, aggr=node)
-                )
+                raise DOMException(f"Unknown choice kind '{kind.name}' in aggregate '{node}'.")
 
         return cls(node, choices)

--- a/pyGHDL/dom/Expression.py
+++ b/pyGHDL/dom/Expression.py
@@ -519,7 +519,9 @@ class Aggregate(VHDLModel_Aggregate, DOMMixin):
                     rng = GetNameFromNode(choiceRange)
                 else:
                     pos = Position.parse(item)
-                    raise DOMException(f"Unknown discrete range kind '{rangeKind.name}' in for...generate statement at line {pos.Line}.")
+                    raise DOMException(
+                        f"Unknown discrete range kind '{rangeKind.name}' in for...generate statement at line {pos.Line}."
+                    )
 
                 choices.append(RangedAggregateElement(item, rng, value))
             elif kind == nodes.Iir_Kind.Choice_By_Name:

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -100,7 +100,7 @@ class Design(VHDLModel_Design):
         # Collect error messages in memory
         errorout_memory.Install_Handler()
 
-        #libghdl_set_option("--std=08")
+        # libghdl_set_option("--std=08")
 
         parse.Flag_Parse_Parenthesis.value = True
 

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -59,7 +59,7 @@ from pyGHDL.libghdl import (
     errorout_memory,
     LibGHDLException,
     utils,
-    files_map_editor,
+    files_map_editor, ENCODING,
 )
 from pyGHDL.libghdl.vhdl import nodes, sem_lib, parse
 from pyGHDL.dom import DOMException, Position
@@ -151,11 +151,11 @@ class Document(VHDLModel_Document):
                 self.__domTranslateTime = time.perf_counter() - t1
 
     def __loadFromPath(self):
-        with self._filename.open("r", encoding="utf-8") as file:
+        with self._filename.open("r", encoding=ENCODING) as file:
             self.__loadFromString(file.read())
 
     def __loadFromString(self, sourceCode: str):
-        sourcesBytes = sourceCode.encode("utf-8")
+        sourcesBytes = sourceCode.encode(ENCODING)
         sourceLength = len(sourcesBytes)
         bufferLength = sourceLength + 128
         self.__ghdlFileID = name_table.Get_Identifier(str(self._filename))

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -59,7 +59,8 @@ from pyGHDL.libghdl import (
     errorout_memory,
     LibGHDLException,
     utils,
-    files_map_editor, ENCODING,
+    files_map_editor,
+    ENCODING,
 )
 from pyGHDL.libghdl.vhdl import nodes, sem_lib, parse
 from pyGHDL.dom import DOMException, Position
@@ -191,7 +192,9 @@ class Document(VHDLModel_Document):
                         contextItems.append(ContextReference.parse(item))
                     else:
                         pos = Position.parse(item)
-                        raise DOMException(f"Unknown context item kind '{itemKind.name}' in context at line {pos.Line}.")
+                        raise DOMException(
+                            f"Unknown context item kind '{itemKind.name}' in context at line {pos.Line}."
+                        )
 
             if nodeKind == nodes.Iir_Kind.Entity_Declaration:
                 entity = Entity.parse(libraryUnit, contextItems)

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -60,10 +60,10 @@ from pyGHDL.libghdl import (
     files_map,
     errorout_memory,
     LibGHDLException,
-    flags,
     utils,
     files_map_editor,
 )
+from pyGHDL.libghdl.flags import Flags, VhdlStandard
 from pyGHDL.libghdl.vhdl import nodes, sem_lib, parse
 from pyGHDL.dom import DOMException, Position
 from pyGHDL.dom._Utils import GetIirKindOfNode, CheckForErrors, GetNameOfNode
@@ -100,7 +100,7 @@ class Design(VHDLModel_Design):
         # Collect error messages in memory
         errorout_memory.Install_Handler()
 
-        libghdl_set_option("--std=08")
+        #libghdl_set_option("--std=08")
 
         parse.Flag_Parse_Parenthesis.value = True
 
@@ -145,14 +145,17 @@ class Document(VHDLModel_Document):
             # Parse input file
             t1 = time.perf_counter()
 
+            if vhdlVersion is vhdlVersion.VHDL2008:
+                Flags().Vhdl_Std = VhdlStandard.Vhdl_08
+
             if vhdlVersion.IsAMS():
-                flags.AMS_Vhdl.value = True
+                Flags().AMS_Vhdl = True
 
             self.__ghdlFile = sem_lib.Load_File(self.__ghdlSourceFileEntry)
             CheckForErrors()
 
             if vhdlVersion.IsAMS():
-                flags.AMS_Vhdl.value = False
+                Flags().AMS_Vhdl = False
 
             self.__ghdlProcessingTime = time.perf_counter() - t1
 

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -138,14 +138,14 @@ class Document(VHDLModel_Document):
         else:
             self.__loadFromString(sourceCode)
 
-        if dontParse == False:
+        if not dontParse:
             # Parse input file
             t1 = time.perf_counter()
             self.__ghdlFile = sem_lib.Load_File(self.__ghdlSourceFileEntry)
             CheckForErrors()
             self.__ghdlProcessingTime = time.perf_counter() - t1
 
-            if dontTranslate == False:
+            if not dontTranslate:
                 t1 = time.perf_counter()
                 self.translate()
                 self.__domTranslateTime = time.perf_counter() - t1
@@ -191,11 +191,7 @@ class Document(VHDLModel_Document):
                         contextItems.append(ContextReference.parse(item))
                     else:
                         pos = Position.parse(item)
-                        raise DOMException(
-                            "Unknown context item kind '{kind}' in context at line {line}.".format(
-                                kind=itemKind.name, line=pos.Line
-                            )
-                        )
+                        raise DOMException(f"Unknown context item kind '{itemKind.name}' in context at line {pos.Line}.")
 
             if nodeKind == nodes.Iir_Kind.Entity_Declaration:
                 entity = Entity.parse(libraryUnit, contextItems)
@@ -238,7 +234,7 @@ class Document(VHDLModel_Document):
                 self.VerificationModes.append(vmod)
 
             else:
-                raise DOMException("Unknown design unit kind '{kind}'.".format(kind=nodeKind.name))
+                raise DOMException(f"Unknown design unit kind '{nodeKind.name}'.")
 
     @property
     def LibGHDLProcessingTime(self) -> float:

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -291,7 +291,9 @@ class CaseStatement(VHDLModel_CaseStatement, DOMMixin):
                     rng = GetNameFromNode(choiceRange)
                 else:
                     pos = Position.parse(alternative)
-                    raise DOMException(f"Unknown choice range kind '{choiceRangeKind.name}' in case statement at line {pos.Line}.")
+                    raise DOMException(
+                        f"Unknown choice range kind '{choiceRangeKind.name}' in case statement at line {pos.Line}."
+                    )
 
                 choice = RangedChoice(alternative, rng)
                 if sameAlternative:
@@ -362,7 +364,9 @@ class ForLoopStatement(VHDLModel_ForLoopStatement, DOMMixin):
             rng = GetNameFromNode(discreteRange)
         else:
             pos = Position.parse(loopNode)
-            raise DOMException(f"Unknown discrete range kind '{rangeKind.name}' in for...loop statement at line {pos.Line}.")
+            raise DOMException(
+                f"Unknown discrete range kind '{rangeKind.name}' in for...loop statement at line {pos.Line}."
+            )
 
         statementChain = nodes.Get_Sequential_Statement_Chain(loopNode)
         statements = GetSequentialStatementsFromChainedNodes(statementChain, "for", label)

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -291,11 +291,7 @@ class CaseStatement(VHDLModel_CaseStatement, DOMMixin):
                     rng = GetNameFromNode(choiceRange)
                 else:
                     pos = Position.parse(alternative)
-                    raise DOMException(
-                        "Unknown choice range kind '{kind}' in case statement at line {line}.".format(
-                            kind=choiceRangeKind.name, line=pos.Line
-                        )
-                    )
+                    raise DOMException(f"Unknown choice range kind '{choiceRangeKind.name}' in case statement at line {pos.Line}.")
 
                 choice = RangedChoice(alternative, rng)
                 if sameAlternative:
@@ -312,11 +308,7 @@ class CaseStatement(VHDLModel_CaseStatement, DOMMixin):
                 continue
             else:
                 pos = Position.parse(alternative)
-                raise DOMException(
-                    "Unknown choice kind '{kind}' in case statement at line {line}.".format(
-                        kind=choiceKind.name, line=pos.Line
-                    )
-                )
+                raise DOMException(f"Unknown choice kind '{choiceKind.name}' in case statement at line {pos.Line}.")
 
             if choices is not None:
                 cases.append(Case.parse(cNode, choices, label))
@@ -370,11 +362,7 @@ class ForLoopStatement(VHDLModel_ForLoopStatement, DOMMixin):
             rng = GetNameFromNode(discreteRange)
         else:
             pos = Position.parse(loopNode)
-            raise DOMException(
-                "Unknown discete range kind '{kind}' in for...loop statement at line {line}.".format(
-                    kind=rangeKind.name, line=pos.Line
-                )
-            )
+            raise DOMException(f"Unknown discrete range kind '{rangeKind.name}' in for...loop statement at line {pos.Line}.")
 
         statementChain = nodes.Get_Sequential_Statement_Chain(loopNode)
         statements = GetSequentialStatementsFromChainedNodes(statementChain, "for", label)

--- a/pyGHDL/dom/Type.py
+++ b/pyGHDL/dom/Type.py
@@ -168,7 +168,9 @@ class ArrayType(VHDLModel_ArrayType, DOMMixin):
                 indexSubtype = GetSimpleTypeFromNode(index)
                 indices.append(indexSubtype)
             else:
-                raise DOMException(f"Unknown kind '{indexKind.name}' for an index in the array definition of `{typeName}`.")
+                raise DOMException(
+                    f"Unknown kind '{indexKind.name}' for an index in the array definition of `{typeName}`."
+                )
 
         elementSubtypeIndication = nodes.Get_Element_Subtype_Indication(typeDefinitionNode)
         elementSubtype = GetSubtypeIndicationFromIndicationNode(elementSubtypeIndication, "array declaration", typeName)

--- a/pyGHDL/dom/Type.py
+++ b/pyGHDL/dom/Type.py
@@ -128,11 +128,7 @@ class PhysicalType(VHDLModel_PhysicalType, DOMMixin):
             rng = GetNameFromNode(rangeConstraint)
         else:
             pos = Position.parse(typeDefinitionNode)
-            raise DOMException(
-                "Unknown range kind '{kind}' in physical type definition at line {line}.".format(
-                    kind=rangeKind.name, line=pos.Line
-                )
-            )
+            raise DOMException(f"Unknown range kind '{rangeKind.name}' in physical type definition at line {pos.Line}.")
 
         primaryUnit = nodes.Get_Primary_Unit(typeDefinitionNode)
         primaryUnitName = GetNameOfNode(primaryUnit)
@@ -172,11 +168,7 @@ class ArrayType(VHDLModel_ArrayType, DOMMixin):
                 indexSubtype = GetSimpleTypeFromNode(index)
                 indices.append(indexSubtype)
             else:
-                raise DOMException(
-                    "Unknown kind '{kind}' for an index in the array definition of `{typeName}`.".format(
-                        kind=indexKind.name, typeName=typeName
-                    )
-                )
+                raise DOMException(f"Unknown kind '{indexKind.name}' for an index in the array definition of `{typeName}`.")
 
         elementSubtypeIndication = nodes.Get_Element_Subtype_Indication(typeDefinitionNode)
         elementSubtype = GetSubtypeIndicationFromIndicationNode(elementSubtypeIndication, "array declaration", typeName)

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -199,7 +199,7 @@ def GetNameFromNode(node: Iir) -> Name:
         prefixName = GetNameFromNode(nodes.Get_Prefix(node))
         return AllName(node, prefixName)
     else:
-        raise DOMException("Unknown name kind '{kind}'".format(kind=kind.name))
+        raise DOMException(f"Unknown name kind '{kind.name}'")
 
 
 def GetAssociations(node: Iir) -> List:
@@ -216,11 +216,7 @@ def GetAssociations(node: Iir) -> List:
 
             associations.append(expr)
         else:
-            raise DOMException(
-                "Unknown association kind '{kind}' in array index/slice or function call '{node}'.".format(
-                    kind=kind.name, node=node
-                )
-            )
+            raise DOMException(f"Unknown association kind '{kind.name}' in array index/slice or function call '{node}'.")
 
     return associations
 
@@ -243,16 +239,7 @@ def GetArrayConstraintsFromSubtypeIndication(
             constraints.append(GetNameFromNode(constraint))
         else:
             position = Position.parse(constraint)
-            raise DOMException(
-                "Unknown constraint kind '{kind}' for constraint '{constraint}' in subtype indication '{indication}' at {file}:{line}:{column}.".format(
-                    kind=constraintKind.name,
-                    constraint=constraint,
-                    indication=subtypeIndication,
-                    file=position.Filename,
-                    line=position.Line,
-                    column=position.Column,
-                )
-            )
+            raise DOMException(f"Unknown constraint kind '{constraintKind.name}' for constraint '{constraint}' in subtype indication '{subtypeIndication}' at {position}.")
 
     return constraints
 
@@ -279,15 +266,7 @@ def GetTypeFromNode(node: Iir) -> BaseType:
         return ProtectedType.parse(typeName, typeDefinition)
     else:
         position = Position.parse(typeDefinition)
-        raise DOMException(
-            "GetTypeFromNode: Unknown type definition kind '{kind}' for type '{name}' at {file}:{line}:{column}.".format(
-                kind=kind.name,
-                name=typeName,
-                file=position.Filename,
-                line=position.Line,
-                column=position.Column,
-            )
-        )
+        raise DOMException(f"GetTypeFromNode: Unknown type definition kind '{kind.name}' for type '{typeName}' at {position}.")
 
 
 @export
@@ -315,15 +294,7 @@ def GetAnonymousTypeFromNode(node: Iir) -> BaseType:
         return ArrayType(typeDefinition, "????", [], None)
     else:
         position = Position.parse(typeDefinition)
-        raise DOMException(
-            "GetAnonymousTypeFromNode: Unknown type definition kind '{kind}' for type '{name}' at {file}:{line}:{column}.".format(
-                kind=kind.name,
-                name=typeName,
-                file=position.Filename,
-                line=position.Line,
-                column=position.Column,
-            )
-        )
+        raise DOMException(f"GetAnonymousTypeFromNode: Unknown type definition kind '{kind.name}' for type '{typeName}' at {position}.")
 
 
 @export
@@ -349,11 +320,7 @@ def GetSubtypeIndicationFromIndicationNode(subtypeIndicationNode: Iir, entity: s
     elif kind == nodes.Iir_Kind.Array_Subtype_Definition:
         return GetCompositeConstrainedSubtypeFromNode(subtypeIndicationNode)
     else:
-        raise DOMException(
-            "Unknown kind '{kind}' for an subtype indication in a {entity} of `{name}`.".format(
-                kind=kind.name, entity=entity, name=name
-            )
-        )
+        raise DOMException(f"Unknown kind '{kind.name}' for an subtype indication in a {entity} of `{name}`.")
 
 
 @export
@@ -471,15 +438,7 @@ def GetExpressionFromNode(node: Iir) -> ExpressionUnion:
         cls = __EXPRESSION_TRANSLATION[kind]
     except KeyError:
         position = Position.parse(node)
-        raise DOMException(
-            "Unknown expression kind '{kind}' in expression '{expr}' at {file}:{line}:{column}.".format(
-                kind=kind.name,
-                expr=node,
-                file=position.Filename,
-                line=position.Line,
-                column=position.Column,
-            )
-        )
+        raise DOMException(f"Unknown expression kind '{kind.name}' in expression '{node}' at {position}.")
 
     return cls.parse(node)
 
@@ -536,15 +495,7 @@ def GetGenericsFromChainedNodes(
                 yield GenericFunctionInterfaceItem.parse(generic)
             else:
                 position = Position.parse(generic)
-                raise DOMException(
-                    "Unknown generic kind '{kind}' in generic '{generic}' at {file}:{line}:{column}.".format(
-                        kind=kind.name,
-                        generic=generic,
-                        file=position.Filename,
-                        line=position.Line,
-                        column=position.Column,
-                    )
-                )
+                raise DOMException(f"Unknown generic kind '{kind.name}' in generic '{generic}' at {position}.")
 
         generic = nodes.Get_Chain(generic)
 
@@ -586,15 +537,7 @@ def GetPortsFromChainedNodes(
             continue
         else:
             position = Position.parse(port)
-            raise DOMException(
-                "Unknown port kind '{kind}' in port '{port}' at {file}:{line}:{column}.".format(
-                    kind=kind.name,
-                    port=port,
-                    file=position.Filename,
-                    line=position.Line,
-                    column=position.Column,
-                )
-            )
+            raise DOMException(f"Unknown port kind '{kind.name}' in port '{port}' at {position}.")
 
 
 @export
@@ -623,15 +566,7 @@ def GetParameterFromChainedNodes(
             param = ParameterFileInterfaceItem.parse(parameter)
         else:
             position = Position.parse(parameter)
-            raise DOMException(
-                "Unknown parameter kind '{kind}' in parameter '{param}' at {file}:{line}:{column}.".format(
-                    kind=kind.name,
-                    param=parameter,
-                    file=position.Filename,
-                    line=position.Line,
-                    column=position.Column,
-                )
-            )
+            raise DOMException(f"Unknown parameter kind '{kind.name}' in parameter '{parameter}' at {position}.")
 
         # Lookahead for parameters with multiple identifiers at once
         if nodes.Get_Has_Identifier_List(parameter):
@@ -679,11 +614,7 @@ def GetMapAspect(mapAspect: Iir, cls: Type, entity: str) -> Generator[Associatio
             yield cls(generic, OpenName(generic), formal)
         else:
             pos = Position.parse(generic)
-            raise DOMException(
-                "Unknown association kind '{kind}' in {entity} map at line {line}.".format(
-                    kind=kind.name, entity=entity, line=pos.Line
-                )
-            )
+            raise DOMException(f"Unknown association kind '{kind.name}' in {entity} map at line {pos.Line}.")
 
 
 def GetGenericMapAspect(
@@ -751,16 +682,7 @@ def GetDeclaredItemsFromChainedNodes(nodeChain: Iir, entity: str, name: str) -> 
                     pass
                 else:
                     position = Position.parse(item)
-                    raise DOMException(
-                        "Found unexpected function body '{functionName}' in {entity} '{name}' at {file}:{line}:{column}.".format(
-                            functionName=GetNameOfNode(item),
-                            entity=entity,
-                            name=name,
-                            file=position.Filename,
-                            line=position.Line,
-                            column=position.Column,
-                        )
-                    )
+                    raise DOMException(f"Found unexpected function body '{GetNameOfNode(item)}' in {entity} '{name}' at {position}.")
             elif kind == nodes.Iir_Kind.Procedure_Declaration:
                 if nodes.Get_Has_Body(item):
                     yield Procedure.parse(item)
@@ -775,16 +697,7 @@ def GetDeclaredItemsFromChainedNodes(nodeChain: Iir, entity: str, name: str) -> 
                     pass
                 else:
                     position = Position.parse(item)
-                    raise DOMException(
-                        "Found unexpected procedure body '{functionName}' in {entity} '{name}' at {file}:{line}:{column}.".format(
-                            functionName=GetNameOfNode(item),
-                            entity=entity,
-                            name=name,
-                            file=position.Filename,
-                            line=position.Line,
-                            column=position.Column,
-                        )
-                    )
+                    raise DOMException(f"Found unexpected procedure body '{GetNameOfNode(item)}' in {entity} '{name}' at {position}.")
             elif kind == nodes.Iir_Kind.Protected_Type_Body:
                 yield ProtectedTypeBody.parse(item)
             elif kind == nodes.Iir_Kind.Object_Alias_Declaration:
@@ -814,37 +727,28 @@ def GetDeclaredItemsFromChainedNodes(nodeChain: Iir, entity: str, name: str) -> 
 
                 yield PackageInstantiation.parse(item)
             elif kind == nodes.Iir_Kind.Configuration_Specification:
-                print("[NOT IMPLEMENTED] Configuration specification in {name}".format(name=name))
+                print(f"[NOT IMPLEMENTED] Configuration specification in {name}")
             elif kind == nodes.Iir_Kind.Psl_Default_Clock:
                 yield DefaultClock.parse(item)
             elif kind == nodes.Iir_Kind.Group_Declaration:
-                print("[NOT IMPLEMENTED] Group declaration in {name}".format(name=name))
+                print(f"[NOT IMPLEMENTED] Group declaration in {name}")
             elif kind == nodes.Iir_Kind.Group_Template_Declaration:
-                print("[NOT IMPLEMENTED] Group template declaration in {name}".format(name=name))
+                print(f"[NOT IMPLEMENTED] Group template declaration in {name}")
             elif kind == nodes.Iir_Kind.Disconnection_Specification:
-                print("[NOT IMPLEMENTED] Disconnect specification in {name}".format(name=name))
+                print(f"[NOT IMPLEMENTED] Disconnect specification in {name}")
             elif kind == nodes.Iir_Kind.Nature_Declaration:
-                print("[NOT IMPLEMENTED] Nature declaration in {name}".format(name=name))
+                print(f"[NOT IMPLEMENTED] Nature declaration in {name}")
             elif kind == nodes.Iir_Kind.Free_Quantity_Declaration:
-                print("[NOT IMPLEMENTED] Free quantity declaration in {name}".format(name=name))
+                print(f"[NOT IMPLEMENTED] Free quantity declaration in {name}")
             elif kind == nodes.Iir_Kind.Across_Quantity_Declaration:
-                print("[NOT IMPLEMENTED] Across quantity declaration in {name}".format(name=name))
+                print(f"[NOT IMPLEMENTED] Across quantity declaration in {name}")
             elif kind == nodes.Iir_Kind.Through_Quantity_Declaration:
-                print("[NOT IMPLEMENTED] Through quantity declaration in {name}".format(name=name))
+                print(f"[NOT IMPLEMENTED] Through quantity declaration in {name}")
             elif kind == nodes.Iir_Kind.Terminal_Declaration:
-                print("[NOT IMPLEMENTED] Terminal declaration in {name}".format(name=name))
+                print(f"[NOT IMPLEMENTED] Terminal declaration in {name}")
             else:
                 position = Position.parse(item)
-                raise DOMException(
-                    "Unknown declared item kind '{kind}' in {entity} '{name}' at {file}:{line}:{column}.".format(
-                        kind=kind.name,
-                        entity=entity,
-                        name=name,
-                        file=position.Filename,
-                        line=position.Line,
-                        column=position.Column,
-                    )
-                )
+                raise DOMException(f"Unknown declared item kind '{kind.name}' in {entity} '{name}' at {position}.")
 
             lastKind = None
             item = nodes.Get_Chain(item)
@@ -892,17 +796,9 @@ def GetConcurrentStatementsFromChainedNodes(
         elif kind == nodes.Iir_Kind.Concurrent_Simple_Signal_Assignment:
             yield ConcurrentSimpleSignalAssignment.parse(statement, label)
         elif kind == nodes.Iir_Kind.Concurrent_Conditional_Signal_Assignment:
-            print(
-                "[NOT IMPLEMENTED] Concurrent (conditional) signal assignment (label: '{label}') at line {line}".format(
-                    label=label, line=pos.Line
-                )
-            )
+            print(f"[NOT IMPLEMENTED] Concurrent (conditional) signal assignment (label: '{label}') at line {pos.Line}")
         elif kind == nodes.Iir_Kind.Concurrent_Selected_Signal_Assignment:
-            print(
-                "[NOT IMPLEMENTED] Concurrent (selected) signal assignment (label: '{label}') at line {line}".format(
-                    label=label, line=pos.Line
-                )
-            )
+            print(f"[NOT IMPLEMENTED] Concurrent (selected) signal assignment (label: '{label}') at line {pos.Line}")
         elif kind == nodes.Iir_Kind.Concurrent_Procedure_Call_Statement:
             yield ConcurrentProcedureCall.parse(statement, label)
         elif kind == nodes.Iir_Kind.Component_Instantiation_Statement:
@@ -915,15 +811,7 @@ def GetConcurrentStatementsFromChainedNodes(
             elif instantiatedUnitKind == nodes.Iir_Kind.Simple_Name:
                 yield ComponentInstantiation.parse(statement, instantiatedUnit, label)
             else:
-                raise DOMException(
-                    "Unknown instantiation kind '{kind}' in instantiation of label {label} at {file}:{line}:{column}.".format(
-                        kind=instantiatedUnitKind.name,
-                        label=label,
-                        file=pos.Filename,
-                        line=pos.Line,
-                        column=pos.Column,
-                    )
-                )
+                raise DOMException(f"Unknown instantiation kind '{instantiatedUnitKind.name}' in instantiation of label {label} at {position}.")
         elif kind == nodes.Iir_Kind.Block_Statement:
             yield ConcurrentBlockStatement.parse(statement, label)
         elif kind == nodes.Iir_Kind.If_Generate_Statement:
@@ -935,22 +823,9 @@ def GetConcurrentStatementsFromChainedNodes(
         elif kind == nodes.Iir_Kind.Psl_Assert_Directive:
             yield ConcurrentAssertStatement.parse(statement, label)
         elif kind == nodes.Iir_Kind.Simple_Simultaneous_Statement:
-            print(
-                "[NOT IMPLEMENTED] Simple simultaneous statement (label: '{label}') at line {line}".format(
-                    label=label, line=pos.Line
-                )
-            )
+            print(f"[NOT IMPLEMENTED] Simple simultaneous statement (label: '{label}') at line {pos.Line}")
         else:
-            raise DOMException(
-                "Unknown statement of kind '{kind}' in {entity} '{name}' at {file}:{line}:{column}.".format(
-                    kind=kind.name,
-                    entity=entity,
-                    name=name,
-                    file=pos.Filename,
-                    line=pos.Line,
-                    column=pos.Column,
-                )
-            )
+            raise DOMException(f"Unknown statement of kind '{kind.name}' in {entity} '{name}' at {position}.")
 
 
 def GetSequentialStatementsFromChainedNodes(
@@ -974,11 +849,7 @@ def GetSequentialStatementsFromChainedNodes(
             nodes.Iir_Kind.Variable_Assignment_Statement,
             nodes.Iir_Kind.Conditional_Variable_Assignment_Statement,
         ):
-            print(
-                "[NOT IMPLEMENTED] Variable assignment (label: '{label}') at line {line}".format(
-                    label=label, line=pos.Line
-                )
-            )
+            print(f"[NOT IMPLEMENTED] Variable assignment (label: '{label}') at line {pos.Line}")
         elif kind == nodes.Iir_Kind.Wait_Statement:
             yield WaitStatement.parse(statement, label)
         elif kind == nodes.Iir_Kind.Procedure_Call_Statement:
@@ -990,16 +861,7 @@ def GetSequentialStatementsFromChainedNodes(
         elif kind == nodes.Iir_Kind.Null_Statement:
             yield NullStatement(statement, label)
         else:
-            raise DOMException(
-                "Unknown statement of kind '{kind}' in {entity} '{name}' at {file}:{line}:{column}.".format(
-                    kind=kind.name,
-                    entity=entity,
-                    name=name,
-                    file=pos.Filename,
-                    line=pos.Line,
-                    column=pos.Column,
-                )
-            )
+            raise DOMException(f"Unknown statement of kind '{kind.name}' in {entity} '{name}' at {position}.")
 
 
 def GetAliasFromNode(aliasNode: Iir):

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -808,9 +808,13 @@ def GetConcurrentStatementsFromChainedNodes(
         elif kind == nodes.Iir_Kind.Concurrent_Simple_Signal_Assignment:
             yield ConcurrentSimpleSignalAssignment.parse(statement, label)
         elif kind == nodes.Iir_Kind.Concurrent_Conditional_Signal_Assignment:
-            print(f"[NOT IMPLEMENTED] Concurrent (conditional) signal assignment (label: '{label}') at line {position.Line}")
+            print(
+                f"[NOT IMPLEMENTED] Concurrent (conditional) signal assignment (label: '{label}') at line {position.Line}"
+            )
         elif kind == nodes.Iir_Kind.Concurrent_Selected_Signal_Assignment:
-            print(f"[NOT IMPLEMENTED] Concurrent (selected) signal assignment (label: '{label}') at line {position.Line}")
+            print(
+                f"[NOT IMPLEMENTED] Concurrent (selected) signal assignment (label: '{label}') at line {position.Line}"
+            )
         elif kind == nodes.Iir_Kind.Concurrent_Procedure_Call_Statement:
             yield ConcurrentProcedureCall.parse(statement, label)
         elif kind == nodes.Iir_Kind.Component_Instantiation_Statement:

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -216,7 +216,9 @@ def GetAssociations(node: Iir) -> List:
 
             associations.append(expr)
         else:
-            raise DOMException(f"Unknown association kind '{kind.name}' in array index/slice or function call '{node}'.")
+            raise DOMException(
+                f"Unknown association kind '{kind.name}' in array index/slice or function call '{node}'."
+            )
 
     return associations
 
@@ -239,7 +241,9 @@ def GetArrayConstraintsFromSubtypeIndication(
             constraints.append(GetNameFromNode(constraint))
         else:
             position = Position.parse(constraint)
-            raise DOMException(f"Unknown constraint kind '{constraintKind.name}' for constraint '{constraint}' in subtype indication '{subtypeIndication}' at {position}.")
+            raise DOMException(
+                f"Unknown constraint kind '{constraintKind.name}' for constraint '{constraint}' in subtype indication '{subtypeIndication}' at {position}."
+            )
 
     return constraints
 
@@ -266,7 +270,9 @@ def GetTypeFromNode(node: Iir) -> BaseType:
         return ProtectedType.parse(typeName, typeDefinition)
     else:
         position = Position.parse(typeDefinition)
-        raise DOMException(f"GetTypeFromNode: Unknown type definition kind '{kind.name}' for type '{typeName}' at {position}.")
+        raise DOMException(
+            f"GetTypeFromNode: Unknown type definition kind '{kind.name}' for type '{typeName}' at {position}."
+        )
 
 
 @export
@@ -294,7 +300,9 @@ def GetAnonymousTypeFromNode(node: Iir) -> BaseType:
         return ArrayType(typeDefinition, "????", [], None)
     else:
         position = Position.parse(typeDefinition)
-        raise DOMException(f"GetAnonymousTypeFromNode: Unknown type definition kind '{kind.name}' for type '{typeName}' at {position}.")
+        raise DOMException(
+            f"GetAnonymousTypeFromNode: Unknown type definition kind '{kind.name}' for type '{typeName}' at {position}."
+        )
 
 
 @export
@@ -682,7 +690,9 @@ def GetDeclaredItemsFromChainedNodes(nodeChain: Iir, entity: str, name: str) -> 
                     pass
                 else:
                     position = Position.parse(item)
-                    raise DOMException(f"Found unexpected function body '{GetNameOfNode(item)}' in {entity} '{name}' at {position}.")
+                    raise DOMException(
+                        f"Found unexpected function body '{GetNameOfNode(item)}' in {entity} '{name}' at {position}."
+                    )
             elif kind == nodes.Iir_Kind.Procedure_Declaration:
                 if nodes.Get_Has_Body(item):
                     yield Procedure.parse(item)
@@ -697,7 +707,9 @@ def GetDeclaredItemsFromChainedNodes(nodeChain: Iir, entity: str, name: str) -> 
                     pass
                 else:
                     position = Position.parse(item)
-                    raise DOMException(f"Found unexpected procedure body '{GetNameOfNode(item)}' in {entity} '{name}' at {position}.")
+                    raise DOMException(
+                        f"Found unexpected procedure body '{GetNameOfNode(item)}' in {entity} '{name}' at {position}."
+                    )
             elif kind == nodes.Iir_Kind.Protected_Type_Body:
                 yield ProtectedTypeBody.parse(item)
             elif kind == nodes.Iir_Kind.Object_Alias_Declaration:
@@ -811,7 +823,9 @@ def GetConcurrentStatementsFromChainedNodes(
             elif instantiatedUnitKind == nodes.Iir_Kind.Simple_Name:
                 yield ComponentInstantiation.parse(statement, instantiatedUnit, label)
             else:
-                raise DOMException(f"Unknown instantiation kind '{instantiatedUnitKind.name}' in instantiation of label {label} at {position}.")
+                raise DOMException(
+                    f"Unknown instantiation kind '{instantiatedUnitKind.name}' in instantiation of label {label} at {position}."
+                )
         elif kind == nodes.Iir_Kind.Block_Statement:
             yield ConcurrentBlockStatement.parse(statement, label)
         elif kind == nodes.Iir_Kind.If_Generate_Statement:

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -796,7 +796,7 @@ def GetConcurrentStatementsFromChainedNodes(
         label = nodes.Get_Label(statement)
         label = name_table.Get_Name_Ptr(label) if label != nodes.Null_Iir else None
 
-        pos = Position.parse(statement)
+        position = Position.parse(statement)
 
         kind = GetIirKindOfNode(statement)
         if kind == nodes.Iir_Kind.Sensitized_Process_Statement:
@@ -808,9 +808,9 @@ def GetConcurrentStatementsFromChainedNodes(
         elif kind == nodes.Iir_Kind.Concurrent_Simple_Signal_Assignment:
             yield ConcurrentSimpleSignalAssignment.parse(statement, label)
         elif kind == nodes.Iir_Kind.Concurrent_Conditional_Signal_Assignment:
-            print(f"[NOT IMPLEMENTED] Concurrent (conditional) signal assignment (label: '{label}') at line {pos.Line}")
+            print(f"[NOT IMPLEMENTED] Concurrent (conditional) signal assignment (label: '{label}') at line {position.Line}")
         elif kind == nodes.Iir_Kind.Concurrent_Selected_Signal_Assignment:
-            print(f"[NOT IMPLEMENTED] Concurrent (selected) signal assignment (label: '{label}') at line {pos.Line}")
+            print(f"[NOT IMPLEMENTED] Concurrent (selected) signal assignment (label: '{label}') at line {position.Line}")
         elif kind == nodes.Iir_Kind.Concurrent_Procedure_Call_Statement:
             yield ConcurrentProcedureCall.parse(statement, label)
         elif kind == nodes.Iir_Kind.Component_Instantiation_Statement:
@@ -837,7 +837,7 @@ def GetConcurrentStatementsFromChainedNodes(
         elif kind == nodes.Iir_Kind.Psl_Assert_Directive:
             yield ConcurrentAssertStatement.parse(statement, label)
         elif kind == nodes.Iir_Kind.Simple_Simultaneous_Statement:
-            print(f"[NOT IMPLEMENTED] Simple simultaneous statement (label: '{label}') at line {pos.Line}")
+            print(f"[NOT IMPLEMENTED] Simple simultaneous statement (label: '{label}') at line {position.Line}")
         else:
             raise DOMException(f"Unknown statement of kind '{kind.name}' in {entity} '{name}' at {position}.")
 
@@ -849,7 +849,7 @@ def GetSequentialStatementsFromChainedNodes(
         label = nodes.Get_Label(statement)
         label = name_table.Get_Name_Ptr(label) if label != nodes.Null_Iir else None
 
-        pos = Position.parse(statement)
+        position = Position.parse(statement)
         kind = GetIirKindOfNode(statement)
         if kind == nodes.Iir_Kind.If_Statement:
             yield IfStatement.parse(statement, label)
@@ -863,7 +863,7 @@ def GetSequentialStatementsFromChainedNodes(
             nodes.Iir_Kind.Variable_Assignment_Statement,
             nodes.Iir_Kind.Conditional_Variable_Assignment_Statement,
         ):
-            print(f"[NOT IMPLEMENTED] Variable assignment (label: '{label}') at line {pos.Line}")
+            print(f"[NOT IMPLEMENTED] Variable assignment (label: '{label}') at line {position.Line}")
         elif kind == nodes.Iir_Kind.Wait_Statement:
             yield WaitStatement.parse(statement, label)
         elif kind == nodes.Iir_Kind.Procedure_Call_Statement:

--- a/pyGHDL/dom/_Utils.py
+++ b/pyGHDL/dom/_Utils.py
@@ -62,9 +62,7 @@ def CheckForErrors() -> None:
             fileName = ""  # name_table.Get_Name_Ptr(files_map.Get_File_Name(rec.file))
             message = errorout_memory.Get_Error_Message(i + 1)
 
-            errors.append(
-                "{file}:{line}:{column}: {msg}".format(file=fileName, line=rec.line, column=rec.offset, msg=message)
-            )
+            errors.append(f"{fileName}:{rec.line}:{rec.offset}: {message}")
 
         errorout_memory.Clear_Errors()
 

--- a/pyGHDL/dom/_Utils.py
+++ b/pyGHDL/dom/_Utils.py
@@ -53,6 +53,7 @@ __MODE_TRANSLATION = {
 Translation table if IIR modes to pyVHDLModel mode enumeration values.
 """
 
+
 @export
 def CheckForErrors() -> None:
     """

--- a/pyGHDL/dom/_Utils.py
+++ b/pyGHDL/dom/_Utils.py
@@ -49,17 +49,30 @@ __MODE_TRANSLATION = {
     nodes.Iir_Mode.Buffer_Mode: Mode.Buffer,
     nodes.Iir_Mode.Linkage_Mode: Mode.Linkage,
 }
-
+"""
+Translation table if IIR modes to pyVHDLModel mode enumeration values.
+"""
 
 @export
 def CheckForErrors() -> None:
+    """
+    Check if an error occurred in libghdl and raise an exception if so.
+
+    **Behavior:**
+
+    1. read the error buffer and clear it afterwards
+    2. convert it into a list of internal messages for a :exc:`LibGHDLException`
+    3. raise a :exc:`DOMException` with a nested :exc:`LibGHDLException` as a ``__cause__``.
+
+    :raises DOMException: If an error occurred in libghdl.
+    """
     errorCount = errorout_memory.Get_Nbr_Messages()
-    errors = []
     if errorCount != 0:
+        errors = []
         for i in range(errorCount):
             rec = errorout_memory.Get_Error_Record(i + 1)
             # FIXME: needs help from @tgingold
-            fileName = ""  # name_table.Get_Name_Ptr(files_map.Get_File_Name(rec.file))
+            fileName = "????"  # name_table.Get_Name_Ptr(files_map.Get_File_Name(rec.file))
             message = errorout_memory.Get_Error_Message(i + 1)
 
             errors.append(f"{fileName}:{rec.line}:{rec.offset}: {message}")
@@ -71,9 +84,13 @@ def CheckForErrors() -> None:
 
 @export
 def GetIirKindOfNode(node: Iir) -> nodes.Iir_Kind:
-    """Return the kind of a node in the IIR tree."""
+    """Return the kind of a node in the IIR tree.
+
+    :returns:           The IIR kind of a node.
+    :raises ValueError: If parameter ``node`` is :py:data:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`.
+    """
     if node == Null_Iir:
-        raise ValueError("GetIirKindOfNode: Parameter 'node' must not be 'Null_iir'.")
+        raise ValueError("GetIirKindOfNode: Parameter 'node' must not be 'Null_Iir'.")
 
     kind: int = nodes.Get_Kind(node)
     return nodes.Iir_Kind(kind)
@@ -81,9 +98,12 @@ def GetIirKindOfNode(node: Iir) -> nodes.Iir_Kind:
 
 @export
 def GetNameOfNode(node: Iir) -> str:
-    """Return the python string from node :obj:`node` identifier."""
+    """Return the Python string from node ``node`` identifier.
+
+    :raises ValueError: If parameter ``node`` is :py:data:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`.
+    """
     if node == Null_Iir:
-        raise ValueError("GetNameOfNode: Parameter 'node' must not be 'Null_iir'.")
+        raise ValueError("GetNameOfNode: Parameter 'node' must not be 'Null_Iir'.")
 
     identifier = utils.Get_Source_Identifier(node)
     return name_table.Get_Name_Ptr(identifier)
@@ -91,9 +111,13 @@ def GetNameOfNode(node: Iir) -> str:
 
 @export
 def GetModeOfNode(node: Iir) -> Mode:
-    """Return the mode of a :obj:`node`."""
+    """Return the mode of a ``node``.
+
+    :raises ValueError:   If parameter ``node`` is :py:data:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`.
+    :raises DOMException: If mode returned by libghdl is not known by :py:data:`__MODE_TRANSLATION`.
+    """
     if node == Null_Iir:
-        raise ValueError("GetModeOfNode: Parameter 'node' must not be 'Null_iir'.")
+        raise ValueError("GetModeOfNode: Parameter 'node' must not be 'Null_Iir'.")
 
     try:
         return __MODE_TRANSLATION[nodes.Get_Mode(node)]

--- a/pyGHDL/dom/_Utils.py
+++ b/pyGHDL/dom/_Utils.py
@@ -97,5 +97,5 @@ def GetModeOfNode(node: Iir) -> Mode:
 
     try:
         return __MODE_TRANSLATION[nodes.Get_Mode(node)]
-    except KeyError:
-        raise LibGHDLException("Unknown mode.")
+    except KeyError as ex:
+        raise DOMException(f"Unknown mode '{ex.args[0]}'.") from ex

--- a/pyGHDL/dom/_Utils.py
+++ b/pyGHDL/dom/_Utils.py
@@ -66,6 +66,8 @@ def CheckForErrors() -> None:
                 "{file}:{line}:{column}: {msg}".format(file=fileName, line=rec.line, column=rec.offset, msg=message)
             )
 
+        errorout_memory.Clear_Errors()
+
         raise DOMException("Error raised in libghdl.") from LibGHDLException("libghdl: Internal error.", errors)
 
 

--- a/pyGHDL/dom/__init__.py
+++ b/pyGHDL/dom/__init__.py
@@ -9,8 +9,6 @@
 # Authors:
 #   Patrick Lehmann
 #
-# Package package:  Document object model (DOM) for pyGHDL.libghdl.
-#
 # License:
 # ============================================================================
 #  Copyright (C) 2019-2021 Tristan Gingold
@@ -30,6 +28,9 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Document object model (DOM) for :mod:`pyGHDL.libghdl` based on :doc:`pyVHDLModel <vhdlmodel:index>`.
+"""
 from pathlib import Path
 
 from pyTooling.Decorators import export

--- a/pyGHDL/dom/__init__.py
+++ b/pyGHDL/dom/__init__.py
@@ -83,7 +83,7 @@ class Position:
         return self._column
 
     def __str__(self):
-        return "{file}:{line}:{column}".format(file=self._filename, line=self._line, column=self._column)
+        return f"{self._filename}:{self._line}:{self._column}"
 
 
 @export

--- a/pyGHDL/dom/formatting/prettyprint.py
+++ b/pyGHDL/dom/formatting/prettyprint.py
@@ -307,20 +307,26 @@ class PrettyPrint:
         elif isinstance(generic, GenericTypeInterfaceItem):
             return self.formatGenericType(generic, level)
         else:
-            raise PrettyPrintException(f"Unhandled generic kind '{generic.__class__.__name__}' for generic '{generic.Identifiers[0]}'.")
+            raise PrettyPrintException(
+                f"Unhandled generic kind '{generic.__class__.__name__}' for generic '{generic.Identifiers[0]}'."
+            )
 
     def formatPort(self, port: Union[NamedEntity, PortInterfaceItem], level: int = 0) -> StringBuffer:
         if isinstance(port, PortSignalInterfaceItem):
             return self.formatPortSignal(port, level)
         else:
-            raise PrettyPrintException(f"Unhandled port kind '{port.__class__.__name__}' for port '{port.Identifiers[0]}'.")
+            raise PrettyPrintException(
+                f"Unhandled port kind '{port.__class__.__name__}' for port '{port.Identifiers[0]}'."
+            )
 
     def formatGenericConstant(self, generic: GenericConstantInterfaceItem, level: int = 0) -> StringBuffer:
         buffer = []
         prefix = "  " * level
 
-        subTypeIndication = self.formatSubtypeIndication(generic.Subtype, 'generic', generic.Identifiers[0])
-        buffer.append(f"{prefix}  - {', '.join(generic.Identifiers)} : {generic.Mode!s} {subTypeIndication}{self.formatInitialValue(generic)}")
+        subTypeIndication = self.formatSubtypeIndication(generic.Subtype, "generic", generic.Identifiers[0])
+        buffer.append(
+            f"{prefix}  - {', '.join(generic.Identifiers)} : {generic.Mode!s} {subTypeIndication}{self.formatInitialValue(generic)}"
+        )
 
         return buffer
 
@@ -336,8 +342,10 @@ class PrettyPrint:
         buffer = []
         prefix = "  " * level
 
-        subTypeIndication = self.formatSubtypeIndication(port.Subtype, 'port', port.Identifiers[0])
-        buffer.append(f"{prefix}  - {', '.join(port.Identifiers)} : {port.Mode} {subTypeIndication}{self.formatInitialValue(port)}")
+        subTypeIndication = self.formatSubtypeIndication(port.Subtype, "port", port.Identifiers[0])
+        buffer.append(
+            f"{prefix}  - {', '.join(port.Identifiers)} : {port.Mode} {subTypeIndication}{self.formatInitialValue(port)}"
+        )
 
         return buffer
 
@@ -426,7 +434,9 @@ class PrettyPrint:
 
             return f"{subtypeIndication.SymbolName}({', '.join(constraints)})"
         else:
-            raise PrettyPrintException(f"Unhandled subtype kind '{subtypeIndication.__class__.__name__}' for {entity} '{name}'.")
+            raise PrettyPrintException(
+                f"Unhandled subtype kind '{subtypeIndication.__class__.__name__}' for {entity} '{name}'."
+            )
 
     def formatInitialValue(self, item: WithDefaultExpressionMixin) -> str:
         return f" := {item.DefaultExpression}" if item.DefaultExpression is not None else ""
@@ -438,8 +448,7 @@ class PrettyPrint:
         if isinstance(statement, ProcessStatement):
             buffer.append(f"{prefix}- {statement.Label}: process(...)")
         elif isinstance(statement, EntityInstantiation):
-            buffer.append(f"{prefix}- {statement.Label}: entity {statement.Entity}"
-            )
+            buffer.append(f"{prefix}- {statement.Label}: entity {statement.Entity}")
         elif isinstance(statement, ComponentInstantiation):
             buffer.append(f"{prefix}- {statement.Label}: component {statement.Component}")
         elif isinstance(statement, ConfigurationInstantiation):

--- a/pyGHDL/dom/formatting/prettyprint.py
+++ b/pyGHDL/dom/formatting/prettyprint.py
@@ -117,14 +117,14 @@ class PrettyPrint:
     def formatDesign(self, design: Design, level: int = 0) -> StringBuffer:
         buffer = []
         prefix = "  " * level
-        buffer.append("{prefix}Libraries:".format(prefix=prefix))
+        buffer.append(f"{prefix}Libraries:")
         for library in design.Libraries.values():
-            buffer.append("{prefix}  - Name: {name}".format(prefix=prefix, name=library.Identifier))
+            buffer.append(f"{prefix}  - Name: {library.Identifier}")
             for line in self.formatLibrary(library, level + 2):
                 buffer.append(line)
-        buffer.append("{prefix}Documents:".format(prefix=prefix))
+        buffer.append(f"{prefix}Documents:")
         for document in design.Documents:
-            buffer.append("{prefix}  - Path: '{doc!s}':".format(doc=document.Path, prefix=prefix))
+            buffer.append(f"{prefix}  - Path: '{document.Path}':")
             for line in self.formatDocument(document, level + 2):
                 buffer.append(line)
 
@@ -133,48 +133,36 @@ class PrettyPrint:
     def formatLibrary(self, library: Library, level: int = 0) -> StringBuffer:
         buffer = []
         prefix = "  " * level
-        buffer.append("{prefix}Entities:".format(prefix=prefix))
+        buffer.append(f"{prefix}Entities:")
         for entity in library.Entities:
-            buffer.append(
-                "{prefix}  - {name}({architectures})".format(
-                    prefix=prefix,
-                    name=entity.Identifier,
-                    architectures=", ".join([a.Identifier for a in entity.Architectures]),
-                )
-            )
-        buffer.append("{prefix}Packages:".format(prefix=prefix))
+            buffer.append(f"{prefix}  - {entity.Identifier}({', '.join([a.Identifier for a in entity.Architectures])})")
+        buffer.append(f"{prefix}Packages:")
         for package in library.Packages:
             if isinstance(package, Package):
-                buffer.append("{prefix}  - {name}".format(prefix=prefix, name=package.Identifier))
+                buffer.append(f"{prefix}  - {package.Identifier}")
             elif isinstance(package, PackageInstantiation):
-                buffer.append(
-                    "{prefix}  - {name} instantiate from {package}".format(
-                        prefix=prefix,
-                        name=package.Identifier,
-                        package=package.PackageReference,
-                    )
-                )
-        buffer.append("{prefix}Configurations:".format(prefix=prefix))
+                buffer.append(f"{prefix}  - {package.Identifier} instantiate from {package.PackageReference}")
+        buffer.append(f"{prefix}Configurations:")
         for configuration in library.Configurations:
-            buffer.append("{prefix}  - {name}".format(prefix=prefix, name=configuration.Identifier))
-        buffer.append("{prefix}Contexts:".format(prefix=prefix))
+            buffer.append(f"{prefix}  - {configuration.Identifier}")
+        buffer.append(f"{prefix}Contexts:")
         for context in library.Contexts:
-            buffer.append("{prefix}  - {name}".format(prefix=prefix, name=context.Identifier))
+            buffer.append(f"{prefix}  - {context.Identifier}")
 
         return buffer
 
     def formatDocument(self, document: Document, level: int = 0) -> StringBuffer:
         buffer = []
         prefix = "  " * level
-        buffer.append("{prefix}Entities:".format(prefix=prefix))
+        buffer.append(f"{prefix}Entities:")
         for entity in document.Entities:
             for line in self.formatEntity(entity, level + 1):
                 buffer.append(line)
-        buffer.append("{prefix}Architectures:".format(prefix=prefix))
+        buffer.append(f"{prefix}Architectures:")
         for architecture in document.Architectures:
             for line in self.formatArchitecture(architecture, level + 1):
                 buffer.append(line)
-        buffer.append("{prefix}Packages:".format(prefix=prefix))
+        buffer.append(f"{prefix}Packages:")
         for package in document.Packages:
             if isinstance(package, Package):
                 gen = self.formatPackage
@@ -183,15 +171,15 @@ class PrettyPrint:
 
             for line in gen(package, level + 1):
                 buffer.append(line)
-        buffer.append("{prefix}PackageBodies:".format(prefix=prefix))
+        buffer.append(f"{prefix}PackageBodies:")
         for packageBodies in document.PackageBodies:
             for line in self.formatPackageBody(packageBodies, level + 1):
                 buffer.append(line)
-        buffer.append("{prefix}Configurations:".format(prefix=prefix))
+        buffer.append(f"{prefix}Configurations:")
         for configuration in document.Configurations:
             for line in self.formatConfiguration(configuration, level + 1):
                 buffer.append(line)
-        buffer.append("{prefix}Contexts:".format(prefix=prefix))
+        buffer.append(f"{prefix}Contexts:")
         for context in document.Contexts:
             for line in self.formatContext(context, level + 1):
                 buffer.append(line)
@@ -201,60 +189,48 @@ class PrettyPrint:
     def formatEntity(self, entity: Entity, level: int = 0) -> StringBuffer:
         buffer = []
         prefix = "  " * level
-        buffer.append(
-            "{prefix}- Name: {name}\n{prefix}  File: {file}\n{prefix}  Position: {line}:{column}".format(
-                name=entity.Identifier,
-                prefix=prefix,
-                file=entity.Position.Filename.name,
-                line=entity.Position.Line,
-                column=entity.Position.Column,
-            )
-        )
-        buffer.append("{prefix}  Generics:".format(prefix=prefix))
+        buffer.append(f"{prefix}- Name: {entity.Identifier}")
+        buffer.append(f"{prefix}  File: {entity.Position.Filename.name}")
+        buffer.append(f"{prefix}  Position: {entity.Position.Line}:{entity.Position.Column}")
+        buffer.append(f"{prefix}  Generics:")
         for generic in entity.GenericItems:
             for line in self.formatGeneric(generic, level + 1):
                 buffer.append(line)
-        buffer.append("{prefix}  Ports:".format(prefix=prefix))
+        buffer.append(f"{prefix}  Ports:")
         for port in entity.PortItems:
             for line in self.formatPort(port, level + 1):
                 buffer.append(line)
-        buffer.append("{prefix}  Declared:".format(prefix=prefix))
+        buffer.append(f"{prefix}  Declared:")
         for item in entity.DeclaredItems:
             for line in self.formatDeclaredItems(item, level + 1):
                 buffer.append(line)
-        buffer.append("{prefix}  Statements:".format(prefix=prefix))
+        buffer.append(f"{prefix}  Statements:")
         for item in entity.Statements:
-            buffer.append("{prefix}    ...".format(prefix=prefix))
-        buffer.append("{prefix}  Architecures:".format(prefix=prefix))
+            buffer.append("{prefix}    ...")
+        buffer.append(f"{prefix}  Architectures:")
         for item in entity.Architectures:
-            buffer.append("{prefix}  - {name}".format(prefix=prefix, name=item.Identifier))
+            buffer.append(f"{prefix}  - {item.Identifier}")
 
         return buffer
 
     def formatArchitecture(self, architecture: Architecture, level: int = 0) -> StringBuffer:
         buffer = []
         prefix = "  " * level
-        buffer.append(
-            "{prefix}- Name: {name}\n{prefix}  File: {file}\n{prefix}  Position: {line}:{column}".format(
-                name=architecture.Identifier,
-                prefix=prefix,
-                file=architecture.Position.Filename.name,
-                line=architecture.Position.Line,
-                column=architecture.Position.Column,
-            )
-        )
-        buffer.append("{prefix}  Entity: {entity}".format(entity=architecture.Entity.SymbolName, prefix=prefix))
-        buffer.append("{prefix}  Declared:".format(prefix=prefix))
+        buffer.append(f"{prefix}- Name: {architecture.Identifier}")
+        buffer.append(f"{prefix}  File: {architecture.Position.Filename.name}")
+        buffer.append(f"{prefix}  Position: {architecture.Position.Line}:{architecture.Position.Column}")
+        buffer.append(f"{prefix}  Entity: {architecture.Entity.SymbolName}")
+        buffer.append(f"{prefix}  Declared:")
         for item in architecture.DeclaredItems:
             for line in self.formatDeclaredItems(item, level + 2):
                 buffer.append(line)
-        buffer.append("{prefix}  Hierarchy:".format(prefix=prefix))
+        buffer.append(f"{prefix}  Hierarchy:")
         for item in architecture.Statements:
             for line in self.formatHierarchy(item, level + 2):
                 buffer.append(line)
-        buffer.append("{prefix}  Statements:".format(prefix=prefix))
+        buffer.append(f"{prefix}  Statements:")
         for item in architecture.Statements:
-            buffer.append("{prefix}    ...".format(prefix=prefix))
+            buffer.append(f"{prefix}    ...")
         #            for line in self.formatStatements(item, level + 2):
         #                buffer.append(line)
 
@@ -263,12 +239,12 @@ class PrettyPrint:
     def formatComponent(self, component: Component, level: int = 0) -> StringBuffer:
         buffer = []
         prefix = "  " * level
-        buffer.append("{prefix}- Component: {name}".format(name=component.Identifier, prefix=prefix))
-        buffer.append("{prefix}  Generics:".format(prefix=prefix))
+        buffer.append(f"{prefix}- Component: {component.Identifier}")
+        buffer.append(f"{prefix}  Generics:")
         for generic in component.GenericItems:
             for line in self.formatGeneric(generic, level + 1):
                 buffer.append(line)
-        buffer.append("{prefix}  Ports:".format(prefix=prefix))
+        buffer.append(f"{prefix}  Ports:")
         for port in component.PortItems:
             for line in self.formatPort(port, level + 1):
                 buffer.append(line)
@@ -278,16 +254,10 @@ class PrettyPrint:
     def formatPackage(self, package: Package, level: int = 0) -> StringBuffer:
         buffer = []
         prefix = "  " * level
-        buffer.append(
-            "{prefix}- Name: {name}\n{prefix}  File: {file}\n{prefix}  Position: {line}:{column}".format(
-                name=package.Identifier,
-                prefix=prefix,
-                file=package.Position.Filename.name,
-                line=package.Position.Line,
-                column=package.Position.Column,
-            )
-        )
-        buffer.append("{prefix}  Declared:".format(prefix=prefix))
+        buffer.append(f"{prefix}- Name: {package.Identifier}")
+        buffer.append(f"{prefix}  File: {package.Position.Filename.name}")
+        buffer.append(f"{prefix}  Position: {package.Position.Line}:{package.Position.Column}")
+        buffer.append(f"{prefix}  Declared:")
         for item in package.DeclaredItems:
             for line in self.formatDeclaredItems(item, level + 1):
                 buffer.append(line)
@@ -297,9 +267,9 @@ class PrettyPrint:
     def formatPackageInstance(self, package: PackageInstantiation, level: int = 0) -> StringBuffer:
         buffer = []
         prefix = "  " * level
-        buffer.append("{prefix}- Name: {name}".format(name=package.Identifier, prefix=prefix))
-        buffer.append("{prefix}  Package: {name!s}".format(prefix=prefix, name=package.PackageReference))
-        buffer.append("{prefix}  Generic Map: ...".format(prefix=prefix))
+        buffer.append(f"{prefix}- Name: {package.Identifier}")
+        buffer.append(f"{prefix}  Package: {package.PackageReference!s}")
+        buffer.append(f"{prefix}  Generic Map: ...")
         #        for item in package.GenericItems:
         #            for line in self.formatGeneric(item, level + 1):
         #                buffer.append(line)
@@ -309,8 +279,8 @@ class PrettyPrint:
     def formatPackageBody(self, packageBody: PackageBody, level: int = 0) -> StringBuffer:
         buffer = []
         prefix = "  " * level
-        buffer.append("{prefix}- Name: {name}".format(name=packageBody.Identifier, prefix=prefix))
-        buffer.append("{prefix}  Declared:".format(prefix=prefix))
+        buffer.append(f"{prefix}- Name: {packageBody.Identifier}")
+        buffer.append(f"{prefix}  Declared:")
         for item in packageBody.DeclaredItems:
             for line in self.formatDeclaredItems(item, level + 1):
                 buffer.append(line)
@@ -320,14 +290,14 @@ class PrettyPrint:
     def formatConfiguration(self, configuration: Configuration, level: int = 0) -> StringBuffer:
         buffer = []
         prefix = "  " * level
-        buffer.append("{prefix}- Name: {name}".format(name=configuration.Identifier, prefix=prefix))
+        buffer.append(f"{prefix}- Name: {configuration.Identifier}")
 
         return buffer
 
     def formatContext(self, context: Context, level: int = 0) -> StringBuffer:
         buffer = []
         prefix = "  " * level
-        buffer.append("{prefix}- Name: {name}".format(name=context.Identifier, prefix=prefix))
+        buffer.append(f"{prefix}- Name: {context.Identifier}")
 
         return buffer
 
@@ -337,35 +307,20 @@ class PrettyPrint:
         elif isinstance(generic, GenericTypeInterfaceItem):
             return self.formatGenericType(generic, level)
         else:
-            raise PrettyPrintException(
-                "Unhandled generic kind '{kind}' for generic '{name}'.".format(
-                    kind=generic.__class__.__name__, name=generic.Identifiers[0]
-                )
-            )
+            raise PrettyPrintException(f"Unhandled generic kind '{generic.__class__.__name__}' for generic '{generic.Identifiers[0]}'.")
 
     def formatPort(self, port: Union[NamedEntity, PortInterfaceItem], level: int = 0) -> StringBuffer:
         if isinstance(port, PortSignalInterfaceItem):
             return self.formatPortSignal(port, level)
         else:
-            raise PrettyPrintException(
-                "Unhandled port kind '{kind}' for port '{name}'.".format(
-                    kind=port.__class__.__name__, name=port.Identifiers[0]
-                )
-            )
+            raise PrettyPrintException(f"Unhandled port kind '{port.__class__.__name__}' for port '{port.Identifiers[0]}'.")
 
     def formatGenericConstant(self, generic: GenericConstantInterfaceItem, level: int = 0) -> StringBuffer:
         buffer = []
         prefix = "  " * level
 
-        buffer.append(
-            "{prefix}  - {name} : {mode!s} {subtypeindication}{initialValue}".format(
-                prefix=prefix,
-                name=", ".join(generic.Identifiers),
-                mode=generic.Mode,
-                subtypeindication=self.formatSubtypeIndication(generic.Subtype, "generic", generic.Identifiers[0]),
-                initialValue=self.formatInitialValue(generic),
-            )
-        )
+        subTypeIndication = self.formatSubtypeIndication(generic.Subtype, 'generic', generic.Identifiers[0])
+        buffer.append(f"{prefix}  - {', '.join(generic.Identifiers)} : {generic.Mode!s} {subTypeIndication}{self.formatInitialValue(generic)}")
 
         return buffer
 
@@ -373,12 +328,7 @@ class PrettyPrint:
         buffer = []
         prefix = "  " * level
 
-        buffer.append(
-            "{prefix}  - type {name}".format(
-                prefix=prefix,
-                name=generic.Identifier,
-            )
-        )
+        buffer.append(f"{prefix}  - type {generic.Identifier}")
 
         return buffer
 
@@ -386,15 +336,8 @@ class PrettyPrint:
         buffer = []
         prefix = "  " * level
 
-        buffer.append(
-            "{prefix}  - {name} : {mode!s} {subtypeindication}{initialValue}".format(
-                prefix=prefix,
-                name=", ".join(port.Identifiers),
-                mode=port.Mode,
-                subtypeindication=self.formatSubtypeIndication(port.Subtype, "port", port.Identifiers[0]),
-                initialValue=self.formatInitialValue(port),
-            )
-        )
+        subTypeIndication = self.formatSubtypeIndication(port.Subtype, 'port', port.Identifiers[0])
+        buffer.append(f"{prefix}  - {', '.join(port.Identifiers)} : {port.Mode} {subTypeIndication}{self.formatInitialValue(port)}")
 
         return buffer
 
@@ -403,115 +346,55 @@ class PrettyPrint:
         prefix = "  " * level
 
         if isinstance(item, BaseConstant):
-            if isinstance(item, Constant):
-                default = " := {expr}".format(expr=str(item.DefaultExpression))
-            else:
-                default = ""
-
-            buffer.append(
-                "{prefix}- constant {name} : {subtype}{default}".format(
-                    prefix=prefix,
-                    name=", ".join(item.Identifiers),
-                    subtype=self.formatSubtypeIndication(item.Subtype, "constant", item.Identifiers[0]),
-                    default=default,
-                )
-            )
+            subTypeIndication = self.formatSubtypeIndication(item.Subtype, "constant", item.Identifiers[0])
+            initValue = f" := {item.DefaultExpression}" if isinstance(item, Constant) else ""
+            buffer.append(f"{prefix}- constant {', '.join(item.Identifiers)} : {subTypeIndication}{initValue}")
         elif isinstance(item, SharedVariable):
-            buffer.append(
-                "{prefix}- shared variable {name} : {subtype}".format(
-                    prefix=prefix,
-                    name=", ".join(item.Identifiers),
-                    subtype=self.formatSubtypeIndication(item.Subtype, "shared variable", item.Identifiers[0]),
-                )
-            )
+            subTypeIndication = self.formatSubtypeIndication(item.Subtype, "shared variable", item.Identifiers[0])
+            buffer.append(f"{prefix}- shared variable {', '.join(item.Identifiers)} : {subTypeIndication}")
         elif isinstance(item, Signal):
-            buffer.append(
-                "{prefix}- signal {name} : {subtype}{initValue}".format(
-                    prefix=prefix,
-                    name=", ".join(item.Identifiers),
-                    subtype=self.formatSubtypeIndication(item.Subtype, "signal", item.Identifiers[0]),
-                    initValue=" := {expr}".format(expr=str(item.DefaultExpression))
-                    if item.DefaultExpression is not None
-                    else "",
-                )
-            )
+            subTypeIndication = self.formatSubtypeIndication(item.Subtype, "signal", item.Identifiers[0])
+            initValue = f" := {item.DefaultExpression}" if item.DefaultExpression is not None else ""
+            buffer.append(f"{prefix}- signal {', '.join(item.Identifiers)} : {subTypeIndication}{initValue}")
         elif isinstance(item, File):
-            buffer.append(
-                "{prefix}- File {name} : {subtype}".format(
-                    prefix=prefix,
-                    name=", ".join(item.Identifiers),
-                    subtype=self.formatSubtypeIndication(item.Subtype, "file", item.Identifiers[0]),
-                )
-            )
+            subTypeIndication = self.formatSubtypeIndication(item.Subtype, "file", item.Identifiers[0])
+            buffer.append(f"{prefix}- File {', '.join(item.Identifiers)} : {subTypeIndication}")
         elif isinstance(item, (FullType, IncompleteType)):
-            buffer.append("{prefix}- {type}".format(prefix=prefix, type=self.formatType(item)))
+            buffer.append(f"{prefix}- {self.formatType(item)}")
         elif isinstance(item, Subtype):
-            buffer.append(
-                "{prefix}- subtype {name} is ?????".format(
-                    prefix=prefix,
-                    name=item.Identifier,
-                )
-            )
+            buffer.append(f"{prefix}- subtype {item.Identifier} is ?????")
         elif isinstance(item, Alias):
-            buffer.append(
-                "{prefix}- alias {name} is ?????".format(
-                    prefix=prefix,
-                    name=item.Identifier,
-                )
-            )
+            buffer.append(f"{prefix}- alias {item.Identifier} is ?????")
         elif isinstance(item, Function):
-            buffer.append(
-                "{prefix}- function {name} return {returnType!s}".format(
-                    prefix=prefix, name=item.Identifier, returnType=item.ReturnType
-                )
-            )
+            buffer.append(f"{prefix}- function {item.Identifier} return {item.ReturnType}")
         elif isinstance(item, Procedure):
-            buffer.append(
-                "{prefix}- procedure {name}".format(
-                    prefix=prefix,
-                    name=item.Identifier,
-                )
-            )
+            buffer.append(f"{prefix}- procedure {item.Identifier}")
         elif isinstance(item, Component):
             for line in self.formatComponent(item, level):
                 buffer.append(line)
         elif isinstance(item, Attribute):
-            buffer.append(
-                "{prefix}- attribute {name} : {type!s}".format(prefix=prefix, name=item.Identifier, type=item.Subtype)
-            )
+            buffer.append(f"{prefix}- attribute {item.Identifier} : {item.Subtype}")
         elif isinstance(item, AttributeSpecification):
-            buffer.append(
-                "{prefix}- attribute {name!s} of {entity} : {entityClass} is {value}".format(
-                    prefix=prefix,
-                    name=item.Attribute,
-                    entity="????",
-                    entityClass="????",
-                    value="????",
-                )
-            )
+            buffer.append(f"{prefix}- attribute {item.Attribute} of {'????'} : {'????'} is {'????'}")
         elif isinstance(item, UseClause):
-            buffer.append("{prefix}- use {names}".format(prefix=prefix, names=", ".join([str(n) for n in item.Names])))
+            buffer.append(f"{prefix}- use {', '.join([str(n) for n in item.Names])}")
         elif isinstance(item, Package):
-            buffer.append("{prefix}- package {name} is ..... end package".format(prefix=prefix, name=item.Identifier))
+            buffer.append(f"{prefix}- package {item.Identifier} is ..... end package")
         elif isinstance(item, PackageInstantiation):
-            buffer.append(
-                "{prefix}- package {name} is new {name2!s} generic map (.....)".format(
-                    prefix=prefix, name=item.Identifier, name2=item.PackageReference
-                )
-            )
+            buffer.append(f"{prefix}- package {item.Identifier} is new {item.PackageReference} generic map (.....)")
         elif isinstance(item, DefaultClock):
-            buffer.append("{prefix}- default {name} is {expr}".format(prefix=prefix, name=item.Identifier, expr="..."))
+            buffer.append(f"{prefix}- default {item.Identifier} is {'...'}")
         else:
-            raise PrettyPrintException("Unhandled declared item kind '{name}'.".format(name=item.__class__.__name__))
+            raise PrettyPrintException(f"Unhandled declared item kind '{item.__class__.__name__}'.")
 
         return buffer
 
     def formatType(self, item: BaseType) -> str:
-        result = "type {name} is ".format(name=item.Identifier)
+        result = f"type {item.Identifier} is "
         if isinstance(item, IncompleteType):
             result += ""
         elif isinstance(item, IntegerType):
-            result += "range {range!s}".format(range=item.Range)
+            result += f"range {item.Range!s}"
         elif isinstance(item, EnumeratedType):
             result += "(........)"
         elif isinstance(item, PhysicalType):
@@ -529,116 +412,71 @@ class PrettyPrint:
         elif isinstance(item, ProtectedTypeBody):
             result += "protected body ..... end protected body"
         else:
-            raise PrettyPrintException("Unknown type '{name}'".format(name=item.__class__.__name__))
+            raise PrettyPrintException(f"Unknown type '{item.__class__.__name__}'")
 
         return result
 
     def formatSubtypeIndication(self, subtypeIndication, entity: str, name: str) -> str:
         if isinstance(subtypeIndication, SimpleSubtypeSymbol):
-            return "{type}".format(type=subtypeIndication.SymbolName)
+            return f"{subtypeIndication.SymbolName}"
         elif isinstance(subtypeIndication, ConstrainedCompositeSubtypeSymbol):
             constraints = []
             for constraint in subtypeIndication.Constraints:
                 constraints.append(str(constraint))
 
-            return "{type}({constraints})".format(type=subtypeIndication.SymbolName, constraints=", ".join(constraints))
+            return f"{subtypeIndication.SymbolName}({', '.join(constraints)})"
         else:
-            raise PrettyPrintException(
-                "Unhandled subtype kind '{type}' for {entity} '{name}'.".format(
-                    type=subtypeIndication.__class__.__name__, entity=entity, name=name
-                )
-            )
+            raise PrettyPrintException(f"Unhandled subtype kind '{subtypeIndication.__class__.__name__}' for {entity} '{name}'.")
 
     def formatInitialValue(self, item: WithDefaultExpressionMixin) -> str:
-        if item.DefaultExpression is None:
-            return ""
-
-        return " := {expr!s}".format(expr=item.DefaultExpression)
+        return f" := {item.DefaultExpression}" if item.DefaultExpression is not None else ""
 
     def formatHierarchy(self, statement: ConcurrentStatement, level: int = 0) -> StringBuffer:
         buffer = []
         prefix = "  " * level
 
         if isinstance(statement, ProcessStatement):
-            buffer.append("{prefix}- {label}: process(...)".format(prefix=prefix, label=statement.Label))
+            buffer.append(f"{prefix}- {statement.Label}: process(...)")
         elif isinstance(statement, EntityInstantiation):
-            buffer.append(
-                "{prefix}- {label}: entity {name}".format(prefix=prefix, label=statement.Label, name=statement.Entity)
+            buffer.append(f"{prefix}- {statement.Label}: entity {statement.Entity}"
             )
         elif isinstance(statement, ComponentInstantiation):
-            buffer.append(
-                "{prefix}- {label}: component {name}".format(
-                    prefix=prefix, label=statement.Label, name=statement.Component
-                )
-            )
+            buffer.append(f"{prefix}- {statement.Label}: component {statement.Component}")
         elif isinstance(statement, ConfigurationInstantiation):
-            buffer.append(
-                "{prefix}- {label}: configuration {name}".format(
-                    prefix=prefix, label=statement.Label, name=statement.Configuration
-                )
-            )
+            buffer.append(f"{prefix}- {statement.Label}: configuration {statement.Configuration}")
         elif isinstance(statement, ConcurrentBlockStatement):
-            buffer.append("{prefix}- {label}: block".format(prefix=prefix, label=statement.Label))
+            buffer.append(f"{prefix}- {statement.Label}: block")
             for stmt in statement.Statements:
                 for line in self.formatHierarchy(stmt, level + 2):
                     buffer.append(line)
         elif isinstance(statement, IfGenerateStatement):
-            buffer.append(
-                "{prefix}- {label}: if {condition} generate".format(
-                    prefix=prefix,
-                    label=statement.Label,
-                    condition=statement.IfBranch.Condition,
-                )
-            )
+            buffer.append(f"{prefix}- {statement.Label}: if {statement.IfBranch.Condition} generate")
             for stmt in statement.IfBranch.Statements:
                 for line in self.formatHierarchy(stmt, level + 2):
                     buffer.append(line)
             for elsifBranch in statement.ElsifBranches:
-                buffer.append(
-                    "{prefix}  {label}: elsif {condition} generate".format(
-                        prefix=prefix,
-                        label=statement.Label,
-                        condition=elsifBranch.Condition,
-                    )
-                )
+                buffer.append(f"{prefix}  {statement.Label}: elsif {elsifBranch.Condition} generate")
                 for stmt in elsifBranch.Statements:
                     for line in self.formatHierarchy(stmt, level + 2):
                         buffer.append(line)
             if statement.ElseBranch is not None:
-                buffer.append("{prefix}  {label}: else generate".format(prefix=prefix, label=statement.Label))
+                buffer.append(f"{prefix}  {statement.Label}: else generate")
                 for stmt in statement.ElseBranch.Statements:
                     for line in self.formatHierarchy(stmt, level + 2):
                         buffer.append(line)
         elif isinstance(statement, CaseGenerateStatement):
-            buffer.append(
-                "{prefix}- {label}: case {expression} generate".format(
-                    prefix=prefix,
-                    label=statement.Label,
-                    expression=statement.SelectExpression,
-                )
-            )
+            buffer.append(f"{prefix}- {statement.Label}: case {statement.SelectExpression} generate")
             for case in statement.Cases:
-                buffer.append("{prefix}    {case!s}".format(prefix=prefix, label=case.Label, case=case))
+                buffer.append(f"{prefix}    {case!s}")
                 for stmt in case.Statements:
                     for line in self.formatHierarchy(stmt, level + 2):
                         buffer.append(line)
         elif isinstance(statement, ForGenerateStatement):
-            buffer.append(
-                "{prefix}- {label}: for {index} in {range} generate".format(
-                    prefix=prefix,
-                    label=statement.Label,
-                    index=statement.LoopIndex,
-                    range=statement.Range,
-                )
-            )
+            buffer.append(f"{prefix}- {statement.Label}: for {statement.LoopIndex} in {statement.Range} generate")
             for stmt in statement.Statements:
                 for line in self.formatHierarchy(stmt, level + 2):
                     buffer.append(line)
         elif isinstance(statement, ConcurrentProcedureCall):
-            buffer.append(
-                "{prefix}- {label}: {name!s}(...)".format(
-                    prefix=prefix, label=statement.Label, name=statement.Procedure
-                )
-            )
+            buffer.append(f"{prefix}- {statement.Label}: {statement.Procedure!s}(...)")
 
         return buffer

--- a/pyGHDL/dom/requirements.txt
+++ b/pyGHDL/dom/requirements.txt
@@ -1,4 +1,4 @@
 -r ../libghdl/requirements.txt
 
-pyVHDLModel==0.14.4
+pyVHDLModel==0.15.0
 #https://github.com/VHDL/pyVHDLModel/archive/dev.zip#pyVHDLModel

--- a/pyGHDL/libghdl/__init__.py
+++ b/pyGHDL/libghdl/__init__.py
@@ -48,6 +48,8 @@ from pyGHDL import __version__ as ghdlVersion
 
 Nullable = Optional
 
+ENCODING = "latin-1"
+
 
 class LibGHDLException(GHDLBaseException):
     _internalErrors: Nullable[List[str]]
@@ -164,7 +166,7 @@ def _initialize():
     libghdl.libghdl__set_hooks_for_analysis()
 
     # Set the prefix in order to locate the VHDL libraries.
-    prefix = str(_libghdl_path.parent.parent).encode("utf-8")
+    prefix = str(_libghdl_path.parent.parent).encode(ENCODING)
     libghdl.libghdl__set_exec_prefix(c_char_p(prefix), len(prefix))
 
     return libghdl
@@ -197,7 +199,7 @@ def set_option(Opt: str) -> bool:
     :param Opt: Option to set.
     :return:    Return ``True``, if the option is known and handled.
     """
-    Opt = Opt.encode("utf-8")
+    Opt = Opt.encode(ENCODING)
     return libghdl.libghdl__set_option(c_char_p(Opt), len(Opt)) == 0
 
 
@@ -233,7 +235,7 @@ def analyze_file(fname: str) -> Iir:
     :param fname: File name
     :return:      Internal Intermediate Representation (IIR)
     """
-    fname = fname.encode("utf-8")
+    fname = fname.encode(ENCODING)
     return libghdl.libghdl__analyze_file(c_char_p(fname), len(fname))
 
 

--- a/pyGHDL/libghdl/__init__.py
+++ b/pyGHDL/libghdl/__init__.py
@@ -10,11 +10,9 @@
 #   Tristan Gingold
 #   Patrick Lehmann
 #
-# Package package:  Python binding and low-level API for shared library 'libghdl'.
-#
 # License:
 # ============================================================================
-#  Copyright (C) 2019-2021 Tristan Gingold
+#  Copyright (C) 2019-2022 Tristan Gingold
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -31,6 +29,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding and low-level API for shared library ``libghdl``.
+
+In case of an error, a :exc:`LibGHDLException` is raised.
+"""
 from ctypes import c_char_p, CDLL
 from sys import platform as sys_platform, version_info as sys_version_info
 from os import environ as os_environ
@@ -48,9 +51,12 @@ from pyGHDL import __version__ as ghdlVersion
 
 Nullable = Optional
 
+__all__ = ["ENCODING"]
+
 ENCODING = "latin-1"
 
 
+@export
 class LibGHDLException(GHDLBaseException):
     _internalErrors: Nullable[List[str]]
 
@@ -63,6 +69,7 @@ class LibGHDLException(GHDLBaseException):
         return self._internalErrors
 
 
+@export
 def _get_libghdl_name() -> Path:
     """Get the name of the libghdl library (with version and extension)."""
     version = ghdlVersion.replace("-", "_").replace(".", "_")
@@ -70,6 +77,7 @@ def _get_libghdl_name() -> Path:
     return Path(f"libghdl-{version}.{ext}")
 
 
+@export
 def _check_libghdl_libdir(libdir: Path, basename: Path) -> Path:
     """Returns libghdl path in :obj:`libdir`, if found."""
     if libdir is None:
@@ -82,6 +90,7 @@ def _check_libghdl_libdir(libdir: Path, basename: Path) -> Path:
     raise FileNotFoundError(str(res))
 
 
+@export
 def _check_libghdl_bindir(bindir: Path, basename: Path) -> Path:
     if bindir is None:
         raise ValueError("Parameter 'bindir' is None.")
@@ -89,11 +98,12 @@ def _check_libghdl_bindir(bindir: Path, basename: Path) -> Path:
     return _check_libghdl_libdir((bindir / "../lib").resolve(), basename)
 
 
+@export
 def _get_libghdl_path():
     """\
     Locate the directory where the shared library is installed.
 
-    Search order:
+    **Search order:**
 
     1. `GHDL_PREFIX` - directory (prefix) of the vhdl libraries.
     2. `VUNIT_GHDL_PATH` - path of the `ghdl` binary when using VUnit.
@@ -145,6 +155,7 @@ def _get_libghdl_path():
     raise Exception(f"Cannot find libghdl {basename}")
 
 
+@export
 def _initialize():
     # Load the shared library
     _libghdl_path = _get_libghdl_path()
@@ -192,15 +203,15 @@ def initialize() -> None:
 
 @export
 # @BindToLibGHDL("libghdl__set_option")
-def set_option(Opt: str) -> bool:
+def set_option(opt: str) -> bool:
     """\
     Set option :obj:`opt`.
 
-    :param Opt: Option to set.
+    :param opt: Option to set.
     :return:    Return ``True``, if the option is known and handled.
     """
-    Opt = Opt.encode(ENCODING)
-    return libghdl.libghdl__set_option(c_char_p(Opt), len(Opt)) == 0
+    opt = opt.encode(ENCODING)
+    return libghdl.libghdl__set_option(c_char_p(opt), len(opt)) == 0
 
 
 @export

--- a/pyGHDL/libghdl/errorout_memory.py
+++ b/pyGHDL/libghdl/errorout_memory.py
@@ -36,6 +36,7 @@ from ctypes import c_int8, c_int32, c_char_p, Structure
 
 from pyTooling.Decorators import export
 
+from pyGHDL.libghdl import ENCODING
 from pyGHDL.libghdl._types import ErrorIndex
 from pyGHDL.libghdl._decorator import BindToLibGHDL
 
@@ -122,7 +123,7 @@ def Get_Error_Message(Idx: ErrorIndex) -> str:
     :param Idx: Index from 1 to ``Nbr_Messages`` See :func:`Get_Nbr_Messages`.
     :return:    Error message.
     """
-    return _Get_Error_Message(Idx).decode("utf-8")
+    return _Get_Error_Message(Idx).decode(ENCODING)
 
 
 @export

--- a/pyGHDL/libghdl/files_map_editor.py
+++ b/pyGHDL/libghdl/files_map_editor.py
@@ -36,7 +36,7 @@ from ctypes import c_int32, c_char_p, c_bool, c_uint32
 
 from pyTooling.Decorators import export
 
-from pyGHDL.libghdl import libghdl
+from pyGHDL.libghdl import libghdl, ENCODING
 from pyGHDL.libghdl._decorator import BindToLibGHDL
 from pyGHDL.libghdl._types import SourceFileEntry
 
@@ -85,7 +85,7 @@ def Replace_Text(
     :param Text:         undocumented
     :return:             Return True in case of success, False in case of failure (the gap is too small).
     """
-    buffer = Text.encode("utf-8")
+    buffer = Text.encode(ENCODING)
     return _Replace_Text(
         File,
         Start_Line,

--- a/pyGHDL/libghdl/flags.py
+++ b/pyGHDL/libghdl/flags.py
@@ -49,12 +49,12 @@ assert sizeof(c_bool) == 1
 class VhdlStandard(IntEnum):
     """An enumeration representing libghdl's internal ``Vhdl_Std_Type`` enumeration type."""
 
-    Vhdl_87 = 0   #: VHDL'87
-    Vhdl_93 = 1   #: VHDL'93
-    Vhdl_00 = 2   #: VHDL'2000
-    Vhdl_02 = 3   #: VHDL'2002
-    Vhdl_08 = 4   #: VHDL'2008
-    Vhdl_19 = 5   #: VHDL'2019
+    Vhdl_87 = 0  #: VHDL'87
+    Vhdl_93 = 1  #: VHDL'93
+    Vhdl_00 = 2  #: VHDL'2000
+    Vhdl_02 = 3  #: VHDL'2002
+    Vhdl_08 = 4  #: VHDL'2008
+    Vhdl_19 = 5  #: VHDL'2019
 
 
 @export
@@ -94,7 +94,6 @@ class Flags(metaclass=ExtendedType, singleton=True):
     def Verbose(self, value: bool):
         self.__Verbose.value = value
 
-
     @property
     def MB_Comment(self) -> bool:
         """
@@ -108,7 +107,6 @@ class Flags(metaclass=ExtendedType, singleton=True):
     def MB_Comment(self, value: bool):
         self.__MB_Comment.value = value
 
-
     @property
     def Explicit(self) -> bool:
         """
@@ -121,7 +119,6 @@ class Flags(metaclass=ExtendedType, singleton=True):
     @Explicit.setter
     def Explicit(self, value: bool):
         self.__Explicit.value = value
-
 
     @property
     def Relaxed(self) -> bool:
@@ -142,18 +139,16 @@ class Flags(metaclass=ExtendedType, singleton=True):
     def Relaxed(self, value: bool):
         self.__Relaxed.value = value
 
-
     @property
-    def Elaborate_With_Outdated (self) -> bool:
+    def Elaborate_With_Outdated(self) -> bool:
         """
         If set, a default aspect entity aspect might be an outdated unit. Used by ghdldrv.
         """
-        return self.__Elaborate_With_Outdated .value
+        return self.__Elaborate_With_Outdated.value
 
-    @Elaborate_With_Outdated .setter
-    def Elaborate_With_Outdated (self, value: bool):
-        self.__Elaborate_With_Outdated .value = value
-
+    @Elaborate_With_Outdated.setter
+    def Elaborate_With_Outdated(self, value: bool):
+        self.__Elaborate_With_Outdated.value = value
 
     @property
     def Force_Analysis(self) -> bool:
@@ -167,7 +162,6 @@ class Flags(metaclass=ExtendedType, singleton=True):
     def Force_Analysis(self, value: bool):
         self.__Force_Analysis.value = value
 
-
     @property
     def Vhdl_Std(self) -> VhdlStandard:
         """
@@ -180,7 +174,6 @@ class Flags(metaclass=ExtendedType, singleton=True):
     @Vhdl_Std.setter
     def Vhdl_Std(self, value: VhdlStandard):
         self.__Vhdl_Std.value = int(value)
-
 
     @property
     def AMS_Vhdl(self) -> bool:

--- a/pyGHDL/libghdl/flags.py
+++ b/pyGHDL/libghdl/flags.py
@@ -36,12 +36,7 @@ from ctypes import c_bool, sizeof
 
 from pyGHDL.libghdl import libghdl
 
-__all__ = [
-    "Flag_Elocations",
-    "Verbose",
-    "Flag_Elaborate_With_Outdated",
-    "Flag_Force_Analysis",
-]
+__all__ = ["Flag_Elocations", "Verbose", "Flag_Elaborate_With_Outdated", "Flag_Force_Analysis", "AMS_Vhdl"]
 
 assert sizeof(c_bool) == 1
 
@@ -52,3 +47,5 @@ Verbose = c_bool.in_dll(libghdl, "flags__verbose")
 Flag_Elaborate_With_Outdated = c_bool.in_dll(libghdl, "flags__flag_elaborate_with_outdated")
 
 Flag_Force_Analysis = c_bool.in_dll(libghdl, "flags__flag_force_analysis")
+
+AMS_Vhdl = c_bool.in_dll(libghdl, "flags__ams_vhdl")

--- a/pyGHDL/libghdl/flags.py
+++ b/pyGHDL/libghdl/flags.py
@@ -36,16 +36,27 @@ from ctypes import c_bool, sizeof
 
 from pyGHDL.libghdl import libghdl
 
-__all__ = ["Flag_Elocations", "Verbose", "Flag_Elaborate_With_Outdated", "Flag_Force_Analysis", "AMS_Vhdl"]
+__all__ = [
+    "Flag_Elocations",
+    "Verbose",
+    "MB_Comment",
+    "Explicit",
+    "Relaxed",
+    "Flag_Elaborate_With_Outdated",
+    "Flag_Force_Analysis",
+    "AMS_Vhdl",
+]
 
 assert sizeof(c_bool) == 1
 
 Flag_Elocations = c_bool.in_dll(libghdl, "flags__flag_elocations")
 
-Verbose = c_bool.in_dll(libghdl, "flags__verbose")               #: Internal boolean flag representing :option:`-v`.
-MB_Comment = c_bool.in_dll(libghdl, "flags__mb_comment")         #: Internal boolean flag representing :option:`--mb-comments`.
-Explicit = c_bool.in_dll(libghdl, "flags__flag_explicit")        #: Internal boolean flag representing :option:`-fexplicit`.
-Relaxed = c_bool.in_dll(libghdl, "flags__flag_relaxed_rules")    #: Internal boolean flag representing :option:`-frelaxed`.
+Verbose = c_bool.in_dll(libghdl, "flags__verbose")  #: Internal boolean flag representing :option:`-v`.
+MB_Comment = c_bool.in_dll(libghdl, "flags__mb_comment")  #: Internal boolean flag representing :option:`--mb-comment`.
+Explicit = c_bool.in_dll(libghdl, "flags__flag_explicit")  #: Internal boolean flag representing :option:`-fexplicit`.
+Relaxed = c_bool.in_dll(
+    libghdl, "flags__flag_relaxed_rules"
+)  #: Internal boolean flag representing :option:`-frelaxed`.
 
 Flag_Elaborate_With_Outdated = c_bool.in_dll(libghdl, "flags__flag_elaborate_with_outdated")
 

--- a/pyGHDL/libghdl/flags.py
+++ b/pyGHDL/libghdl/flags.py
@@ -49,6 +49,20 @@ __all__ = [
 
 assert sizeof(c_bool) == 1
 
+
+@export
+@unique
+class VhdlStandard(IntEnum):
+    """An enumeration representing libghdl's internal ``Vhdl_Std_Type`` enumeration type."""
+
+    Vhdl_87 = 0   #: VHDL'87
+    Vhdl_93 = 1   #: VHDL'93
+    Vhdl_00 = 2   #: VHDL'2000
+    Vhdl_02 = 3   #: VHDL'2002
+    Vhdl_08 = 4   #: VHDL'2008
+    Vhdl_19 = 5   #: VHDL'2019
+
+    
 Flag_Elocations = c_bool.in_dll(libghdl, "flags__flag_elocations")
 
 Verbose = c_bool.in_dll(libghdl, "flags__verbose")  #: Internal boolean flag representing :option:`-v`.

--- a/pyGHDL/libghdl/flags.py
+++ b/pyGHDL/libghdl/flags.py
@@ -42,7 +42,10 @@ assert sizeof(c_bool) == 1
 
 Flag_Elocations = c_bool.in_dll(libghdl, "flags__flag_elocations")
 
-Verbose = c_bool.in_dll(libghdl, "flags__verbose")
+Verbose = c_bool.in_dll(libghdl, "flags__verbose")               #: Internal boolean flag representing :option:`-v`.
+MB_Comment = c_bool.in_dll(libghdl, "flags__mb_comment")         #: Internal boolean flag representing :option:`--mb-comments`.
+Explicit = c_bool.in_dll(libghdl, "flags__flag_explicit")        #: Internal boolean flag representing :option:`-fexplicit`.
+Relaxed = c_bool.in_dll(libghdl, "flags__flag_relaxed_rules")    #: Internal boolean flag representing :option:`-frelaxed`.
 
 Flag_Elaborate_With_Outdated = c_bool.in_dll(libghdl, "flags__flag_elaborate_with_outdated")
 

--- a/pyGHDL/libghdl/flags.py
+++ b/pyGHDL/libghdl/flags.py
@@ -32,20 +32,14 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 
-from ctypes import c_bool, sizeof
+from ctypes import c_bool, sizeof, c_int
+from enum import IntEnum, unique
+
+from pyTooling.Decorators import export
+from pyTooling.MetaClasses import ExtendedType
 
 from pyGHDL.libghdl import libghdl
 
-__all__ = [
-    "Flag_Elocations",
-    "Verbose",
-    "MB_Comment",
-    "Explicit",
-    "Relaxed",
-    "Flag_Elaborate_With_Outdated",
-    "Flag_Force_Analysis",
-    "AMS_Vhdl",
-]
 
 assert sizeof(c_bool) == 1
 
@@ -62,18 +56,141 @@ class VhdlStandard(IntEnum):
     Vhdl_08 = 4   #: VHDL'2008
     Vhdl_19 = 5   #: VHDL'2019
 
-    
-Flag_Elocations = c_bool.in_dll(libghdl, "flags__flag_elocations")
 
-Verbose = c_bool.in_dll(libghdl, "flags__verbose")  #: Internal boolean flag representing :option:`-v`.
-MB_Comment = c_bool.in_dll(libghdl, "flags__mb_comment")  #: Internal boolean flag representing :option:`--mb-comment`.
-Explicit = c_bool.in_dll(libghdl, "flags__flag_explicit")  #: Internal boolean flag representing :option:`-fexplicit`.
-Relaxed = c_bool.in_dll(
-    libghdl, "flags__flag_relaxed_rules"
-)  #: Internal boolean flag representing :option:`-frelaxed`.
+@export
+class Flags(metaclass=ExtendedType, singleton=True):
+    __Elocations = c_bool.in_dll(libghdl, "flags__flag_elocations")
+    __Verbose = c_bool.in_dll(libghdl, "flags__verbose")
+    __MB_Comment = c_bool.in_dll(libghdl, "flags__mb_comment")
+    __Explicit = c_bool.in_dll(libghdl, "flags__flag_explicit")
+    __Relaxed = c_bool.in_dll(libghdl, "flags__flag_relaxed_rules")
 
-Flag_Elaborate_With_Outdated = c_bool.in_dll(libghdl, "flags__flag_elaborate_with_outdated")
+    __Elaborate_With_Outdated = c_bool.in_dll(libghdl, "flags__flag_elaborate_with_outdated")
+    __Force_Analysis = c_bool.in_dll(libghdl, "flags__flag_force_analysis")
+    __Vhdl_Std = c_int.in_dll(libghdl, "flags__vhdl_std")
+    __AMS_Vhdl = c_bool.in_dll(libghdl, "flags__ams_vhdl")
 
-Flag_Force_Analysis = c_bool.in_dll(libghdl, "flags__flag_force_analysis")
+    @property
+    def Elocations(self) -> bool:
+        """
+        If set to true, the parser builds extended locations (defined in Ada package elocations). This saves possibly many
+        locations per node, so it uses more memory.  Useful when a tool (like a style checker) wants to know the precise layout.
+        Not used to report errors.
+        """
+        return self.__Elocations.value
 
-AMS_Vhdl = c_bool.in_dll(libghdl, "flags__ams_vhdl")
+    @Elocations.setter
+    def Elocations(self, value: bool):
+        self.__Elocations.value = value
+
+    @property
+    def Verbose(self) -> bool:
+        """
+        Internal boolean flag representing :option:`-v`.
+        """
+        return self.__Verbose.value
+
+    @Verbose.setter
+    def Verbose(self, value: bool):
+        self.__Verbose.value = value
+
+
+    @property
+    def MB_Comment(self) -> bool:
+        """
+        If set, a multi-bytes sequence can appear in a comment, i.e. all characters except ``VT``, ``CR``, ``LF`` and ``FF`` are allowed in a comment.
+
+        Internal boolean flag representing CLI option :option:`--mb-comment`.
+        """
+        return self.__MB_Comment.value
+
+    @MB_Comment.setter
+    def MB_Comment(self, value: bool):
+        self.__MB_Comment.value = value
+
+
+    @property
+    def Explicit(self) -> bool:
+        """
+        If set, explicit subprogram declarations take precedence over implicit declarations, even through use clauses.
+
+        Internal boolean flag representing CLI option :option:`-fexplicit`.
+        """
+        return self.__Explicit.value
+
+    @Explicit.setter
+    def Explicit(self, value: bool):
+        self.__Explicit.value = value
+
+
+    @property
+    def Relaxed(self) -> bool:
+        """
+        If true, relax some rules:
+
+         * the scope of an object declaration names start after the declaration, so that it is possible to use the old name in the default expression:
+
+           .. code-block:: vhdl
+
+              constant x : xtype := x;
+
+        Internal boolean flag representing CLI option :option:`-frelaxed`.
+        """
+        return self.__Relaxed.value
+
+    @Relaxed.setter
+    def Relaxed(self, value: bool):
+        self.__Relaxed.value = value
+
+
+    @property
+    def Elaborate_With_Outdated (self) -> bool:
+        """
+        If set, a default aspect entity aspect might be an outdated unit. Used by ghdldrv.
+        """
+        return self.__Elaborate_With_Outdated .value
+
+    @Elaborate_With_Outdated .setter
+    def Elaborate_With_Outdated (self, value: bool):
+        self.__Elaborate_With_Outdated .value = value
+
+
+    @property
+    def Force_Analysis(self) -> bool:
+        """
+        Set if analysis is done even after parsing errors. The analysis code that handles and tolerates incorrect parse tree
+        should check that this flag is set.
+        """
+        return self.__Force_Analysis.value
+
+    @Force_Analysis.setter
+    def Force_Analysis(self, value: bool):
+        self.__Force_Analysis.value = value
+
+
+    @property
+    def Vhdl_Std(self) -> VhdlStandard:
+        """
+        Standard accepted.
+
+        Internal boolean flag representing CLI option :option:`--std=<STANDARD>`.
+        """
+        return VhdlStandard(self.__Vhdl_Std.value)
+
+    @Vhdl_Std.setter
+    def Vhdl_Std(self, value: VhdlStandard):
+        self.__Vhdl_Std.value = int(value)
+
+
+    @property
+    def AMS_Vhdl(self) -> bool:
+        """
+        Enable VHDL-AMS extensions.
+
+        Internal boolean flag representing CLI option :option:`--ams`.
+        """
+        return self.__AMS_Vhdl.value
+
+    @AMS_Vhdl.setter
+    def AMS_Vhdl(self, value: bool):
+        self.__AMS_Vhdl.value = value

--- a/pyGHDL/libghdl/libraries.py
+++ b/pyGHDL/libghdl/libraries.py
@@ -50,15 +50,18 @@ __all__ = ["Library_Location", "Work_Library"]
 
 Library_Location: LocationType = c_int32.in_dll(libghdl, "libraries__library_location")
 """
-A location for library declarations (such as library WORK). Use ``.value`` to
-access this variable inside libghdl.
+A location for library declarations (such as library WORK).
+
+Use the property ``.value`` to access the variable's value.
 """
 
 Work_Library: Iir_Library_Declaration = c_int32.in_dll(libghdl, "libraries__work_library")
 """
-Library declaration for the work library. Note: the identifier of the work_library
-is ``work_library_name``, which may be different from 'WORK'. Use ``.value`` to
-access this variable inside libghdl.
+Library declaration for the work library.
+
+.. note:: The identifier of the work_library is ``work_library_name``, which may be different from 'WORK'.
+
+Use the property ``.value`` to access the variable's value.
 """
 
 

--- a/pyGHDL/libghdl/name_table.py
+++ b/pyGHDL/libghdl/name_table.py
@@ -36,6 +36,7 @@ from ctypes import c_char, c_char_p
 
 from pyTooling.Decorators import export
 
+from pyGHDL.libghdl import ENCODING
 from pyGHDL.libghdl._types import NameId
 from pyGHDL.libghdl._decorator import BindToLibGHDL
 
@@ -73,7 +74,7 @@ def Get_Name_Ptr(Id: NameId) -> str:
     :param Id: NameId for the identifier to query.
     :return:   Identifier as string.
     """
-    return _Get_Name_Ptr(Id).decode("utf-8")
+    return _Get_Name_Ptr(Id).decode(ENCODING)
 
 
 # @export
@@ -95,7 +96,7 @@ def Get_Character(Id: NameId) -> str:
     :param Id: NameId for the identifier to query.
     :return:   Get the character of the identifier.
     """
-    return _Get_Character(Id).decode("utf-8")
+    return _Get_Character(Id).decode(ENCODING)
 
 
 # @export
@@ -119,5 +120,5 @@ def Get_Identifier(string: str) -> NameId:
     :param string: String to create or lookup.
     :return:       Id in name table.
     """
-    string = string.encode("utf-8")
+    string = string.encode(ENCODING)
     return _Get_Identifier(c_char_p(string), len(string))

--- a/pyGHDL/libghdl/str_table.py
+++ b/pyGHDL/libghdl/str_table.py
@@ -36,6 +36,7 @@ from ctypes import c_char_p
 
 from pyTooling.Decorators import export
 
+from pyGHDL.libghdl import ENCODING
 from pyGHDL.libghdl._types import String8Id
 from pyGHDL.libghdl._decorator import BindToLibGHDL
 
@@ -57,4 +58,4 @@ def Get_String8_Ptr(Id: String8Id, Length: int) -> str:
     :param Id: String8Id for the string to query.
     :return:   String8 as string.
     """
-    return _String8_Address(Id)[:Length].decode("utf-8")
+    return _String8_Address(Id)[:Length].decode(ENCODING)

--- a/pyGHDL/libghdl/vhdl/nodes.py
+++ b/pyGHDL/libghdl/vhdl/nodes.py
@@ -30,6 +30,9 @@ from pyGHDL.libghdl._types import (
 from pyGHDL.libghdl.vhdl.tokens import Tok
 
 Null_Iir = 0
+"""
+Null element for an IIR node reference.
+"""
 
 Null_Iir_List = 0
 Iir_List_All = 1

--- a/pyGHDL/libghdl/vhdl/scanner.py
+++ b/pyGHDL/libghdl/vhdl/scanner.py
@@ -97,7 +97,7 @@ def Get_Token_Offset() -> int:
 
 @export
 @BindToLibGHDL("vhdl__scanner__get_token_position")
-def Get_Token_Position():
+def Get_Token_Position() -> int:
     """
     Get the current token's position.
 
@@ -108,7 +108,7 @@ def Get_Token_Position():
 
 @export
 @BindToLibGHDL("vhdl__scanner__get_position")
-def Get_Position():
+def Get_Position() -> int:
     """
     Get the current position.
 

--- a/pyGHDL/libghdl/vhdl/std_package.py
+++ b/pyGHDL/libghdl/vhdl/std_package.py
@@ -46,12 +46,24 @@ __all__ = ["Std_Location", "Standard_Package", "Character_Type_Definition"]
 
 
 Std_Location: LocationType = c_int32.in_dll(libghdl, "vhdl__std_package__std_location")
-"""Virtual location for the ``std.standard`` package. Use ``.value`` to access this variable inside libghdl."""
+"""
+Virtual location for the ``std.standard`` package.
+
+Use the property ``.value`` to access the variable's value.
+"""
 
 Standard_Package: Iir_Package_Declaration = c_int32.in_dll(libghdl, "vhdl__std_package__standard_package")
-"""Virtual package ``std.package``. Use ``.value`` to access this variable inside libghdl."""
+"""
+Virtual package ``std.package``.
+
+Use the property ``.value`` to access the variable's value.
+"""
 
 Character_Type_Definition: Iir_Enumeration_Type_Definition = c_int32.in_dll(
     libghdl, "vhdl__std_package__character_type_definition"
 )
-"""Predefined character. Use ``.value`` to access this variable inside libghdl."""
+"""
+Predefined character.
+
+Use the property ``.value`` to access the variable's value.
+"""

--- a/pyGHDL/lsp/workspace.py
+++ b/pyGHDL/lsp/workspace.py
@@ -4,7 +4,7 @@ import json
 from ctypes import byref
 import pyGHDL.libghdl as libghdl
 import pyGHDL.libghdl.errorout_memory as errorout_memory
-import pyGHDL.libghdl.flags as flags
+from pyGHDL.libghdl.flags import Flags
 import pyGHDL.libghdl.errorout as errorout
 import pyGHDL.libghdl.files_map as files_map
 import pyGHDL.libghdl.libraries as libraries
@@ -44,15 +44,15 @@ class Workspace(object):
         self._prj = {}
         self._last_linted_doc = None
         errorout_memory.Install_Handler()
-        flags.Flag_Elocations.value = True
-        # flags.Verbose.value = True
+        Flags().Elocations = True
+        # Flags.Verbose = True
         # We do analysis even in case of errors.
         parse.Flag_Parse_Parenthesis.value = True
         # Force analysis to get more feedback + navigation even in case
         # of errors.
-        flags.Flag_Force_Analysis.value = True
+        Flags().Force_Analysis = True
         # Do not consider analysis order issues.
-        flags.Flag_Elaborate_With_Outdated.value = True
+        Flags().Elaborate_With_Outdated = True
         libghdl.errorout.Enable_Warning(errorout.Msgid.Warnid_Unused, True)
         libghdl.errorout.Enable_Warning(errorout.Msgid.Warnid_No_Assoc, True)
         self.read_project()

--- a/testsuite/pyunit/dom/Sanity.py
+++ b/testsuite/pyunit/dom/Sanity.py
@@ -34,6 +34,7 @@ from pathlib import Path
 
 from pytest import mark
 
+from pyVHDLModel import VHDLVersion
 from pyGHDL.dom.NonStandard import Design, Document
 
 
@@ -54,6 +55,8 @@ design = Design()
 def test_AllVHDLSources(file):
     filePath = _TESTSUITE_ROOT / file
 
+    vhdlVersion = VHDLVersion.AMS2017 if "ams" in file else VHDLVersion.VHDL2008
+
     lib = design.GetLibrary("sanity")
-    document = Document(filePath)
+    document = Document(filePath, vhdlVersion=vhdlVersion)
     design.AddDocument(document, lib)

--- a/testsuite/pyunit/dom/VHDLLibraries.py
+++ b/testsuite/pyunit/dom/VHDLLibraries.py
@@ -1,0 +1,93 @@
+# =============================================================================
+#               ____ _   _ ____  _          _
+#  _ __  _   _ / ___| | | |  _ \| |      __| | ___  _ __ ___
+# | '_ \| | | | |  _| |_| | | | | |     / _` |/ _ \| '_ ` _ \
+# | |_) | |_| | |_| |  _  | |_| | |___ | (_| | (_) | | | | | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)__,_|\___/|_| |_| |_|
+# |_|    |___/
+# =============================================================================
+# Authors:
+#   Patrick Lehmann
+#   Unai Martinez-Corral
+#
+# Testsuite:        Parse files from ieee2008 directory.
+#
+# License:
+# ============================================================================
+#  Copyright (C) 2019-2022 Tristan Gingold
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <gnu.org/licenses>.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+from pathlib import Path
+
+from pytest import mark
+
+from pyGHDL.dom.NonStandard import Design, Document
+
+
+if __name__ == "__main__":
+    print("ERROR: you called a testcase declaration file as an executable module.")
+    print("Use: 'python -m unitest <testcase module>'")
+    exit(1)
+
+
+_GHDL_ROOT = Path(__file__).parent.parent.parent.parent.resolve()
+_LIBRARIES_ROOT = _GHDL_ROOT / "libraries"
+
+_IEEE2008_ROOT = _LIBRARIES_ROOT / "ieee2008"
+_MENTOR_ROOT = _LIBRARIES_ROOT / "mentor"
+_SYNOPSYS_ROOT = _LIBRARIES_ROOT / "synopsys"
+_VITAL_ROOT = _LIBRARIES_ROOT / "vital2000"
+
+
+design = Design()
+
+
+@mark.parametrize("file", [str(f.relative_to(_IEEE2008_ROOT)) for f in _IEEE2008_ROOT.glob("*.vhdl")])
+def test_IEEE2008(file):
+    filePath = _IEEE2008_ROOT / file
+
+    lib = design.GetLibrary("ieee2008")
+    document = Document(filePath)
+    design.AddDocument(document, lib)
+
+
+@mark.parametrize("file", [str(f.relative_to(_MENTOR_ROOT)) for f in _MENTOR_ROOT.glob("*.vhdl")])
+def test_Mentor(file):
+    filePath = _MENTOR_ROOT / file
+
+    lib = design.GetLibrary("mentor")
+    document = Document(filePath)
+    design.AddDocument(document, lib)
+
+
+@mark.parametrize("file", [str(f.relative_to(_SYNOPSYS_ROOT)) for f in _SYNOPSYS_ROOT.glob("*.vhdl")])
+def test_Synopsys(file):
+    filePath = _SYNOPSYS_ROOT / file
+
+    lib = design.GetLibrary("synopsys")
+    document = Document(filePath)
+    design.AddDocument(document, lib)
+
+
+@mark.xfail(reason="Needs further investigations.")
+@mark.parametrize("file", [str(f.relative_to(_VITAL_ROOT)) for f in _VITAL_ROOT.glob("*.vhdl")])
+def test_Synopsys(file):
+    filePath = _VITAL_ROOT / file
+
+    lib = design.GetLibrary("vital")
+    document = Document(filePath)
+    design.AddDocument(document, lib)


### PR DESCRIPTION
# New Features
* Use VHDL library files (ieee2008, synopsys, mentor, vital2000) for additional pyGHDL.DOM testcases.
* Added `vhdlVersion` parameter to `Document` class, so VHDL-AMS can be enabled per source file.
* Added new libghdl C-bindings for:
  * `flags.AMS_Vhdl` which refers to the `--ams` CLI option.
  * `flags.MB_Comment` which refers to the `--mb_comment` CLI option.
  * `flags.Explicit` which refers to the `-fexplicit` CLI option.
  * `flags.Relaxed` which refers to the `-frelaxed` CLI option.

# Changes
* Changed `"...".format(...)` to f-strings.
* Changed default encoding used by pyGHDL.libghdl and pyGHDL.DOM from `utf-8` to `latin-1`.  
  This was required by VHDL library source files. The global encoding setting is reachable via `pyGHDL.libghdl.ENCODING` and can be monkey-patched.
* Updated autoapi template.
* Updated dependency to pyVHDLModel to v0.15.0, which fixes error messages created by GHDL's Sphinx documentation build.

# Bug Fixes
* After reading error messages from the error message buffer. A call to `Clear_Errors` was missing.
* Added missing typehints.