### PR TITLE
Fix outdated link in precompile vendor readme

### DIFF
--- a/scripts/vendors/README.md
+++ b/scripts/vendors/README.md
@@ -8,7 +8,7 @@ vendor libraries, if the vendor tool is present on the computer.
 There are also popular simulation and verification libraries like [OSVVM][osvvm]
 and [UVVM][uvvm], which can be pre-compile, too.
 
-The compilation scripts are writen in the shell languages: PowerShell for Windows
+The compilation scripts are written in the shell languages: PowerShell for Windows
 and Bash for Linux, MacOS, MSYS2/MinGW. The compile scripts can colorize the GHDL
 warning and error lines with the help of grc/grcat ([generic colourizer][grc]).
 

--- a/scripts/vendors/README.md
+++ b/scripts/vendors/README.md
@@ -17,7 +17,7 @@ warning and error lines with the help of grc/grcat ([generic colourizer][grc]).
  [grc]: http://kassiopeia.juls.savba.sk/~garabik/software/grc.html
 
 See the [GHDL Documentation](https://ghdl.github.io/ghdl) for a detailed
-documentation on how to use [Precompile Scripts](https://ghdl.github.io/ghdl/getting/PrecompileVendorPrimitives.html)
+documentation on how to use [Precompile Scripts](https://ghdl.github.io/ghdl/getting.html#precompile-vendor-primitives)
 
 ---------------------------------------------------------------------
 
@@ -106,7 +106,7 @@ the path to the GHDL executable can be specified with `--ghdl` (Bash) or
 `-GHDL` (PoSh).
 
 For a detailed documentation and all command line options see
-[Precompile Scripts](https://ghdl.github.io/ghdl/getting/PrecompileVendorPrimitives.html)
+[Precompile Scripts](https://ghdl.github.io/ghdl/getting.html#precompile-vendor-primitives)
 
 
 ---------------------------------------------------------------------


### PR DESCRIPTION
**Description**

The [readme](https://github.com/ghdl/ghdl/blob/79e241b79eef8c6364038cbc3608e792f31e6124/scripts/vendors/README.md) for using the precompile vendor scripts contains outdated links to the docs. This PR fixes the links to
<http://ghdl.github.io/ghdl/getting.html#precompile-vendor-primitives> (and fixes a tiny typo).


