### PR TITLE
Fix docstring and a small bug in PoSh precompile script

### DIFF
--- a/scripts/vendors/compile-altera.ps1
+++ b/scripts/vendors/compile-altera.ps1
@@ -81,7 +81,7 @@ param(
 	[string]$Source =     "",
 	# Set output directory name.
 	[string]$Output =     "",
-	# Set GHDL binary directory.
+	# Set path to GHDL's executable, e.g. <MyGHDLPath>/bin/ghdl.exe
 	[string]$GHDL =       ""
 )
 

--- a/scripts/vendors/compile-intel.ps1
+++ b/scripts/vendors/compile-intel.ps1
@@ -81,7 +81,7 @@ param(
 	[string]$Source =     "",
 	# Set output directory name.
 	[string]$Output =     "",
-	# Set GHDL binary directory.
+	# Set path to GHDL's executable, e.g. <MyGHDLPath>/bin/ghdl.exe
 	[string]$GHDL =       ""
 )
 

--- a/scripts/vendors/compile-lattice.ps1
+++ b/scripts/vendors/compile-lattice.ps1
@@ -94,7 +94,7 @@ param(
 	[string]$Source =     "",
 	# Set output directory name.
 	[string]$Output =     "",
-	# Set GHDL binary directory.
+	# Set path to GHDL's executable, e.g. <MyGHDLPath>/bin/ghdl.exe
 	[string]$GHDL =       ""
 )
 

--- a/scripts/vendors/compile-osvvm.ps1
+++ b/scripts/vendors/compile-osvvm.ps1
@@ -62,7 +62,7 @@ param(
 	[string]$Source =            "",
 	# Set output directory name.
 	[string]$Output =            "",
-	# Set GHDL binary directory.
+	# Set path to GHDL's executable, e.g. <MyGHDLPath>/bin/ghdl.exe
 	[string]$GHDL =              ""
 )
 

--- a/scripts/vendors/compile-uvvm.ps1
+++ b/scripts/vendors/compile-uvvm.ps1
@@ -95,7 +95,7 @@ param(
 	[string]$Source =             "",
 	# Set output directory name.
 	[string]$Output =             "",
-	# Set GHDL binary directory.
+	# Set path to GHDL's executable, e.g. <MyGHDLPath>/bin/ghdl.exe
 	[string]$GHDL =               ""
 )
 

--- a/scripts/vendors/compile-xilinx-ise.ps1
+++ b/scripts/vendors/compile-xilinx-ise.ps1
@@ -72,7 +72,7 @@ param(
 	[string]$Source =           "",
 	# Set output directory name.
 	[string]$Output =           "",
-	# Set GHDL binary directory.
+	# Set path to GHDL's executable, e.g. <MyGHDLPath>/bin/ghdl.exe
 	[string]$GHDL =             ""
 )
 

--- a/scripts/vendors/compile-xilinx-vivado.ps1
+++ b/scripts/vendors/compile-xilinx-vivado.ps1
@@ -64,7 +64,7 @@ param(
 	[string]$Source =           "",
 	# Set output directory name.
 	[string]$Output =           "",
-	# Set GHDL binary directory.
+	# Set path to GHDL's executable, e.g. <MyGHDLPath>/bin/ghdl.exe
 	[string]$GHDL =             ""
 )
 

--- a/scripts/vendors/shared.psm1
+++ b/scripts/vendors/shared.psm1
@@ -156,16 +156,19 @@ function Get-GHDLBinary
 	{	$GHDLBinary = $env:GHDL   }
 	else
 	{	try
-		{	write-host "calling which ..."
-			$GHDLBinary = (Get-Command "ghdl.exe").Source }
+		{	Write-host "Calling Get-Command ..."
+			$GHDLBinary = (Get-Command "ghdl.exe" -ErrorAction Stop).Source }
 		catch
-		{	Write-Host "Use adv. options '-GHDL' to set the GHDL executable." -ForegroundColor Red
+		{	Write-Host "Cannot find ghdl.exe." -ForegroundColor Red
+			Write-Host "Use adv. options '-GHDL' to set the GHDL executable." -ForegroundColor Red
 			Exit-CompileScript -1
 		}
 	}
 
 	if (-not (Test-Path $GHDLBinary -PathType Leaf))
-	{	Write-Host "Use adv. options '-GHDL' to set the GHDL executable." -ForegroundColor Red
+	{
+		Write-Host "$GHDLBinary is not a file." -ForegroundColor Red
+		Write-Host "Use adv. options '-GHDL' to set the GHDL executable." -ForegroundColor Red
 		Exit-CompileScript -1
 	}
 


### PR DESCRIPTION
**Update**

As discussed [here](https://github.com/ghdl/ghdl/pull/2108#discussion_r906032565) and [here](https://github.com/ghdl/ghdl/issues/2107#issuecomment-1165541878) I changed the PR to only fix the docstring in the preocompile scripts and a small bug in `shared.psm1`.



**Description**

- 290b4d41ba91ee4fb4af91ba8d92108ea8f391ce fixes the try/catch when calling `Get-Command`. Before, the catch condition
   is never met what leads to this error message, when `ghdl..exe` is not on PATH:

   ```
   Get-Command: The term 'ghdl.exe' is not recognized as a name of a cmdlet, function, script file, or executable program.
   Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
   
   Test-Path: Value cannot be null. (Parameter 'The provided Path argument was null or an empty collection.')
   
   Use adv. options '-GHDL' to set the GHDL executable.
   ```

   You can see that the scripts exists because `Test-Path` is called with an undifined variable instead of hitting the catch condition.

- 81e290191fc019e86d7b6d1a4dd2b0808068c5df updates `Get-GHDLBinary` to accept both path to directory and path path to executable.
- db736b6cc763c4b69ab581e2ed9394c78288dc2c updates the docstring of the PoSh scripts

Closes #2107


I did split the commits in case you don't like changes from 81e290191fc019e86d7b6d1a4dd2b0808068c5df  but hopfully will accept the other commits. What do you think?
