### PR TITLE
Fix issue #2126, add handling of to_ux01 to synthesis

### DIFF
--- a/src/synth/synth-vhdl_oper.adb
+++ b/src/synth/synth-vhdl_oper.adb
@@ -1969,7 +1969,8 @@ package body Synth.Vhdl_Oper is
             | Iir_Predefined_Ieee_1164_To_Stdulogicvector_Bv
             | Iir_Predefined_Ieee_Numeric_Std_To_01_Uns
             | Iir_Predefined_Ieee_Numeric_Std_To_01_Sgn
-            | Iir_Predefined_Ieee_1164_To_X01_Slv =>
+            | Iir_Predefined_Ieee_1164_To_X01_Slv
+            | Iir_Predefined_Ieee_1164_To_UX01_Slv =>
             if Is_Static (L.Val) then
                raise Internal_Error;
             end if;
@@ -1977,6 +1978,7 @@ package body Synth.Vhdl_Oper is
             return Create_Value_Net (Get_Net (Ctxt, L), Create_Res_Bound (L));
          when Iir_Predefined_Ieee_1164_To_Bit
             | Iir_Predefined_Ieee_1164_To_X01_Log
+            | Iir_Predefined_Ieee_1164_To_UX01_Log
             | Iir_Predefined_Ieee_1164_To_Stdulogic =>
             --  A no-op.
             return Create_Value_Net (Get_Net (Ctxt, L), Res_Typ);

--- a/testsuite/synth/issue2126/test.vhdl
+++ b/testsuite/synth/issue2126/test.vhdl
@@ -1,0 +1,19 @@
+-- Title      : Testcase for to_ux01 on a std_logic
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+entity test is
+
+  port (
+    sig_in : in std_logic_vector(1 downto 0);
+    sig_out : out std_logic;
+    sig_out_vec : out std_logic_vector(1 downto 0));
+end entity test;
+
+architecture str of test is
+
+begin  -- architecture str
+  sig_out <= to_ux01(sig_in(0)) and to_ux01(sig_in(1));
+  sig_out_vec <= to_ux01(sig_in);
+end architecture str;

--- a/testsuite/synth/issue2126/testsuite.sh
+++ b/testsuite/synth/issue2126/testsuite.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+GHDL_STD_FLAGS=--std=08
+
+synth_only test
+
+echo "Test successful"


### PR DESCRIPTION
**Description** 
Fixes issue #2126, adds handling of the to_ux01 function to synthesis

:rotating_light: Before submitting your PR, please read [contribute](http://ghdl.github.io/ghdl/contribute.html#fork-modify-and-pull-request) in the [Docs](http://ghdl.github.io/ghdl), and review the following checklist:

- [ ] DO indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

**When contributing to the GHDL codebase...**

- [ ] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [ ] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
- [ ] CONSIDER adding a unit test if your PR resolves an issue.
- [ ] CONSIDER modifying the docs, if your contribution is relevant to any of the content.
- [ ] AVOID breaking the continuous integration build.
- [ ] AVOID breaking the testsuite.

**When contributing to the docs...**

- [ ] DO make sure that the build is successful.

**Further comments**

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
