### PR TITLE
Fix access check failed from iir_kind_selected_element

### DIFF
--- a/src/synth/synth-vhdl_expr.adb
+++ b/src/synth/synth-vhdl_expr.adb
@@ -2230,6 +2230,7 @@ package body Synth.Vhdl_Expr is
          when Iir_Kind_High_Array_Attribute
            |  Iir_Kind_Low_Array_Attribute
            |  Iir_Kind_Indexed_Name
+           |  Iir_Kind_Selected_Element
            |  Iir_Kind_Integer_Literal =>
             --  For array attributes: the type is the type of the index, which
             --  is not synthesized as a type (only as an index).


### PR DESCRIPTION
**Description** Adds iir_kind_selected_element to Synth_Expression. This fixes a crash in the codebase I am working on. Even after bisecting through the codebase by commenting out code, I'm still not sure what the problematic lines are so I'm unable to make a testcase for this. 

:rotating_light: Before submitting your PR, please read [contribute](http://ghdl.github.io/ghdl/contribute.html#fork-modify-and-pull-request) in the [Docs](http://ghdl.github.io/ghdl), and review the following checklist:

- [ ] DO indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

**When contributing to the GHDL codebase...**

- [X] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [X] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
- [ ] CONSIDER adding a unit test if your PR resolves an issue.
- [ ] CONSIDER modifying the docs, if your contribution is relevant to any of the content.
- [ ] AVOID breaking the continuous integration build.
- [ ] AVOID breaking the testsuite.

**When contributing to the docs...**

- [ ] DO make sure that the build is successful.

**Further comments**

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
