### PR TITLE
PSL: Add handling of N_HDL_Bool to Dump_Expr procedure

### DIFF
--- a/src/psl/psl-prints.adb
+++ b/src/psl/psl-prints.adb
@@ -104,7 +104,8 @@ package body PSL.Prints is
    is
    begin
       case Get_Kind (N) is
-         when N_HDL_Expr =>
+         when N_HDL_Expr
+           | N_HDL_Bool =>
             if HDL_Expr_Printer = null then
                Put ("Expr");
             else


### PR DESCRIPTION
I'm trying to read in & understand GHDLs processing of PSL constructs a little bit better. So I found out that one can print the resulting NFAs on the console in a Grapvhiz-compatible format - very nice feature 🙂.

During experimenting with that on some PSL examples I stumbled over the error, that `N_HDL_Bool` type can't be printed, resulting in a GHDL error:

```
$ ghdl -a --std=08 issue_2153.vhd
NFA to determinize:
digraph nfa {
  rankdir=LR;
  node [shape = circle, style = bold]; /* Start: */ 0;
  node [shape = doublecircle, style = solid]; /* Final: */ 1;
  node [shape = circle, style = solid];
  0 -> 1 [ label = "HDL_Expr" /* Node = 10 */ /* Edge = 4 */ ];
  0 -> 0 [ label = "!HDL_Expr && !HDL_Expr" /* Node = 26 */ /* Edge = 5 */ ];
}
Result state 0 for 0
Result state 1 for
Handle result state 0
 Final: expr=!HDL_Expr
   Dest 0 expr=!HDL_Expr && !HDL_Expr
 Add edge 0 to 0, expr=((!dump_expr: cannot handle N_HDL_BOOL

******************** GHDL Bug occurred ***************************
Please report this bug on https://github.com/ghdl/ghdl/issues
GHDL release: 3.0.0-dev (0.37.0.r2969.gd6d1c73c8.dirty) [Dunoon edition]
Compiled with GNAT Version: 9.4.0
Target: x86_64-linux-gnu
/home/torsten/Projects/git.goodcleanfun.de/psl_with_ghdl/issues/
Command line:
/opt/ghdl/bin/ghdl1-llvm --std=08 -P/opt/ghdl/lib/ghdl/ieee/v08/ -P/opt/ghdl/lib/ghdl/ -fpic -c -o issue_2153.o issue_2153.vhd
Exception TYPES.INTERNAL_ERROR raised
Exception information:
raised TYPES.INTERNAL_ERROR : psl-errors.adb:37
Call stack traceback locations:
0x450eac 0x45d92e 0x45d78a 0x45d7de 0x45d7de 0x4669a0 0x466f94 0x46863e 0x4686f3 0x4696f9 0x46960e 0x4697ce 0x46960e 0x4697ce 0x46987f 0x469960 0x615c48 0x615d93 0x616caa 0x6170fc 0x619868 0x595dc0 0x71ce3a 0x71ebc5 0x72020f 0x40ca0b 0x7f183939a081 0x40b74c 0xfffffffffffffffe
******************************************************************

ghdl:error: compilation error
```

This PR adds handling of `N_HDL_Bool` type to the `Dump_Expr (N : Node)` procedure. With the fix, GHDL doesn't crash anymore:

```
$ ghdl -a --std=08 issue_2153.vhd
NFA to determinize:
digraph nfa {
  rankdir=LR;
  node [shape = circle, style = bold]; /* Start: */ 0;
  node [shape = doublecircle, style = solid]; /* Final: */ 1;
  node [shape = circle, style = solid];
  0 -> 1 [ label = "HDL_Expr" /* Node = 10 */ /* Edge = 4 */ ];
  0 -> 0 [ label = "!HDL_Expr && !HDL_Expr" /* Node = 26 */ /* Edge = 5 */ ];
}
Result state 0 for 0
Result state 1 for
Handle result state 0
 Final: expr=!HDL_Expr
   Dest 0 expr=!HDL_Expr && !HDL_Expr
 Add edge 0 to 0, expr=((!Expr && !Expr) && !Expr), reduced=(!Expr && !Expr)
 Add edge 0 to 1, expr=(!(!Expr && !Expr) && !Expr), reduced=(!Expr && Expr)
```