### PR TITLE
Document changes to -frelaxed from #2165

### DIFF
--- a/doc/using/InvokingGHDL.rst
+++ b/doc/using/InvokingGHDL.rst
@@ -432,6 +432,10 @@ Options
   * Default binding indication rules of VHDL-02 are used. Default binding rules are often used, but they are
     particularly obscure before VHDL-02.
 
+  * Allow a subprogram body to match its declaration when the argument lists are semantically identical but
+    do not satisfy formal rules (e.g when a function declaration uses the keyword ``in`` for an
+    argument but its body does not).
+
   * Within an object declaration, allow references to the name (which references the hidden declaration).
     This ignores the error in the following code:
 


### PR DESCRIPTION
**Description** 
Document how -frelaxed treats conformance rules for subprograms after #2165 

**Note**
I have not performed the below activity because I do not know how to build the docs.
```
**When contributing to the docs...**
- [ ] DO make sure that the build is successful.
```