### PR TITLE
pyGHDL: added missing type annotations. Fix #2192

### DIFF
--- a/pyGHDL/libghdl/vhdl/scanner.py
+++ b/pyGHDL/libghdl/vhdl/scanner.py
@@ -97,7 +97,7 @@ def Get_Token_Offset() -> int:
 
 @export
 @BindToLibGHDL("vhdl__scanner__get_token_position")
-def Get_Token_Position():
+def Get_Token_Position() -> int:
     """
     Get the current token's position.
 
@@ -108,7 +108,7 @@ def Get_Token_Position():
 
 @export
 @BindToLibGHDL("vhdl__scanner__get_position")
-def Get_Position():
+def Get_Position() -> int:
     """
     Get the current position.
 


### PR DESCRIPTION
Added return type annotations to the functions `Get_Token_Position` and `Get_Position` in `scanner.py` to fix #2192 