### PR TITLE
fix '-Wunused' warning in ieee.numeric_std

### DIFF
--- a/libraries/ieee/numeric_std-body.vhdl
+++ b/libraries/ieee/numeric_std-body.vhdl
@@ -2370,7 +2370,6 @@ package body NUMERIC_STD is
 
   -- Id: M.1
   function STD_MATCH (L, R: STD_ULOGIC) return BOOLEAN is
-    variable VALUE: STD_ULOGIC;
   begin
     return MATCH_TABLE(L, R);
   end STD_MATCH;


### PR DESCRIPTION
Just to get rid of the superfluous warning which pops up in every elaboration, when using `-Wunused` warning switch and VHDL < 2008.

```
../../src/ieee/v93/numeric_std-body.vhdl:2373:14:warning: variable "value" is never referenced [-Wunused]
```

**Description** Please explain the changes you made here.
If the feature changes current behaviour, explain why your solution is better.

:rotating_light: Before submitting your PR, please read [contribute](http://ghdl.github.io/ghdl/contribute.html#fork-modify-and-pull-request) in the [Docs](http://ghdl.github.io/ghdl), and review the following checklist:

- [ ] DO indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

**When contributing to the GHDL codebase...**

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
- [ ] CONSIDER adding a unit test if your PR resolves an issue.
- [ ] CONSIDER modifying the docs, if your contribution is relevant to any of the content.
- [ ] AVOID breaking the continuous integration build.
- [x] AVOID breaking the testsuite.

**When contributing to the docs...**

- [ ] DO make sure that the build is successful.

**Further comments**

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
