### PR TITLE
Add missing -g for generic override to CLI help for RUNOPTS

### DIFF
--- a/src/grt/grt-options.adb
+++ b/src/grt/grt-options.adb
@@ -95,6 +95,7 @@ package body Grt.Options is
       P ("                        warning at the end of simulation");
       --  P (" --threads=N       use N threads for simulation");
       P ("Additional features:");
+      P ("  -gNAME=VALUE     override the generic NAME of the top unit");
       P (" --has-feature=X   test presence of feature X");
       P (" --list-features   display the list of features");
       Grt.Hooks.Call_Help_Hooks;


### PR DESCRIPTION
**Description**

The `-g` run option to override a generic in the top-level entity is documented here:
https://ghdl.github.io/ghdl/using/Simulation.html

But it is not included in the CLI help for run options listed by `ghdl run-help` (i.e. the `RUNOPTS` when running `ghdl help -r`).

This PR simply adds `-g` to `ghdl run-help` under the "Additional features" category (I'm not sure where it would best fit in). Output with the change below:

```
$ ghdl run-help
These options can only be placed at [RUNOPTS]
Options are:
 --help, -h        disp this help
 --assert-level=LEVEL   stop simulation if assert at LEVEL
       LEVEL is note,warning,error,failure,none
 --backtrace-severity=LEVEL  display a backtrace for assertions
 --ieee-asserts=POLICY  enable or disable asserts from IEEE
       POLICY is enable, disable, disable-at-0
 --asserts=POLICY  enable or disable asserts
 --stop-time=X     stop the simulation at time X
       X is expressed as a time value, without spaces: 1ns, ps...
 --stop-delta=X    stop the simulation cycle after X delta
 --expect-failure  invert exit status
 --max-stack-alloc=X  error if variables are larger than X KB
 --no-run          do not simulate, only elaborate
 --unbuffered      disable buffering on stdout, stderr and
                   files opened in write or append mode (TEXTIO).
 --read-wave-opt=FILENAME  read a wave option file.
 --write-wave-opt=FILENAME  write a wave option file.
 --psl-report-uncovered Reports all uncovered PSL cover points as
                        warning at the end of simulation
Additional features:
  -gNAME=VALUE     override the generic NAME of the top unit
 --has-feature=X   test presence of feature X
 --list-features   display the list of features
 --disp-tree[=KIND] disp the design hierarchy after elaboration
       KIND is inst, proc, port (default)
 --vcd=FILENAME     dump signal values into a VCD file
 --vcd-nodate       do not write date in VCD file
 --vcd-4states      reduce std_logic to verilog 0/1/x/z
 --vcdgz=FILENAME   dump signal values into a VCD gzip'ed file
 --wave=FILENAME    dump signal values into a wave file
 --fst=FILENAME     dump signal values into an FST file
 --vpi=FILENAME      load VPI library
 --vpi-trace[=FILE]  trace vpi calls to stdout or provided FILE
 --vhpi=FILENAME[:ENTRYPOINT]  load VHPI library, optionally
                               provide entry point name
 --vhpi-trace[=FILE]  trace vhpi calls to stdout or provided FILE
 --sdf=[min=|typ=|max=]TOP=FILENAME
    annotate TOP with SDF delay file FILENAME
 --dump-rti         dump Run Time Information
 --psl-report=FILE  report psl result at end of simulation
trace options:
 --disp-time       disp time as simulation advances
 --trace-signals   disp signals after each cycle
 --trace-processes disp process name before each cycle
 --stats           display run-time statistics
debug options:
 --disp-order      disp signals order
 --disp-sources    disp sources while displaying signals
 --disp-sig-types  disp signal types
 --disp-signals-map    disp map bw declared sigs and internal sigs
 --disp-signals-table  disp internal signals
 --checks          do internal checks after each process run
 --activity=LEVEL  watch activity of LEVEL signals
       LEVEL is all, min (default) or none (unsafe)
```

Note: `-g` is listed as an option when running `ghdl help synth`, but I assume synth options are unrelated to run/sim.

**Issues**
There are no issues reported for this as I can see. Related issues and PRs (all closed/merged):
- #607
- #608
- #806
