### PR TITLE
Escape port name in dot output.

### DIFF
--- a/src/synth/netlists-disp_dot.adb
+++ b/src/synth/netlists-disp_dot.adb
@@ -76,7 +76,7 @@ package body Netlists.Disp_Dot is
             for Idx in 1 .. Get_Nbr_Inputs (M) loop
                Put ("  p");
                Put_Uns32 (Uns32 (Idx - 1));
-               Put (" [label=""");
+               Put (" [label=""" & "\");
                Dump_Name (Get_Input_Desc (M, Idx - 1).Name);
                Put ("""];");
                New_Line;


### PR DESCRIPTION
This escapes port names in dot output to prevent any signal name starting with the character 'r' from being escaped.
Example : "\rstn" -> "CR stn"
This will also prevent \n and \t from being escaped.

This does not fix an issue.