### PR TITLE
Added id to warnings related to attributes.

### DIFF
--- a/src/errorout.ads
+++ b/src/errorout.ads
@@ -131,6 +131,10 @@ package Errorout is
 
       --  Lexical conformance
       Warnid_Conformance,
+      
+      -- Attributes in the netlist is not kept during synthesis
+      Warnid_Unkept_Attribute,
+      Warnid_Unhandled_Attribute,
 
       --  Violation of staticness rules
       Warnid_Static,
@@ -330,6 +334,7 @@ private
         | Warnid_Nowrite
         | Warnid_No_Wait | Warnid_Useless
         | Warnid_Conformance
+        | Warnid_Unkept_Attribute | Warnid_Unhandled_Attribute
         | Msgid_Warning  => (Enabled => True, Error => False),
       Warnid_Delta_Cycle | Warnid_Body | Warnid_Static | Warnid_Nested_Comment
         | Warnid_Universal | Warnid_Port_Bounds

--- a/src/synth/synth-errors.adb
+++ b/src/synth/synth-errors.adb
@@ -61,6 +61,14 @@ package body Synth.Errors is
    begin
       Report_Msg (Warnid, Errorout.Elaboration, +Loc, Msg, (1 => Arg1));
    end Warning_Msg_Synth;
+   
+   procedure Warning_Msg_Synth (Warnid : Msgid_Warnings;
+                                Loc : Location_Type;
+                                Msg : String;
+                                Args : Earg_Arr := No_Eargs) is
+   begin
+      Report_Msg (Warnid, Errorout.Elaboration, +Loc, Msg, Args);
+   end Warning_Msg_Synth;
 
    procedure Warning_Msg_Synth (Loc : Location_Type;
                                 Msg : String;

--- a/src/synth/synth-errors.ads
+++ b/src/synth/synth-errors.ads
@@ -43,6 +43,10 @@ package Synth.Errors is
                                 Loc : Location_Type;
                                 Msg : String;
                                 Arg1 : Earg_Type);
+   procedure Warning_Msg_Synth (Warnid : Msgid_Warnings;
+                                Loc : Location_Type;
+                                Msg : String;
+                                Args : Earg_Arr := No_Eargs);
    procedure Warning_Msg_Synth (Loc : Location_Type;
                                 Msg : String;
                                 Args : Earg_Arr := No_Eargs);

--- a/src/synth/synth-vhdl_decls.adb
+++ b/src/synth/synth-vhdl_decls.adb
@@ -257,7 +257,9 @@ package body Synth.Vhdl_Decls is
             --  TODO: components ?
             --  TODO: Interface_Signal ?  But no instance for them.
             Warning_Msg_Synth
-              (+Attr_Value, "attribute %i for %n is not kept in the netlist",
+              (Warnid_Unkept_Attribute,
+               +Attr_Value,
+               "attribute %i for %n is not kept in the netlist",
                (+Attr_Decl, +Obj));
             return;
       end case;

--- a/src/synth/synth-vhdl_stmts.adb
+++ b/src/synth/synth-vhdl_stmts.adb
@@ -4616,7 +4616,11 @@ package body Synth.Vhdl_Stmts is
                --  Applies to nets/ports.
                null;
             when others =>
-               Warning_Msg_Synth (+Spec, "unhandled attribute %i", (1 => +Id));
+               Warning_Msg_Synth
+                 (Warnid_Unhandled_Attribute,
+                  +Spec,
+                  "unhandled attribute %i",
+                  (1 => +Id));
          end case;
          Val := Get_Value_Chain (Val);
       end loop;


### PR DESCRIPTION
This adds a warning id to two warnings related to attributes encountered during synthesis.
It is meant to be useful if enum_encoding is used, so that the warnings can be ignored.

This does not fix any issue.