### PR TITLE
Restore latch inference.

### DIFF
--- a/src/synth/netlists-inference.adb
+++ b/src/synth/netlists-inference.adb
@@ -914,11 +914,7 @@ package body Netlists.Inference is
            (Loc, "latch infered for net %n (use --latches)", (1 => +Name));
       end if;
 
-      if False then
-         return Infere_Latch_Create (Ctxt, Val, Prev_Val, Last_Mux, Loc);
-      else
-         return Val;
-      end if;
+      return Infere_Latch_Create (Ctxt, Val, Prev_Val, Last_Mux, Loc);
    end Infere_Latch;
 
    --  VAL is the value to be assigned to a wire at offset OFF.


### PR DESCRIPTION
Do not merge this ! This is not a real pull request.

I was wondering why yosys was freaking out on any hdl with latches in it when I saw this.
Mostly I am wondering why this is here. I applied the patch locally and tried synthesising a few designs with latches.
So far, it seems to work all right.

Is there a reason this is disabled that I am not seeing ?