### PR TITLE
Updaing used GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  # Maintain Python packages
+  - package-ecosystem: "pip"
+    directory: "/"
+    target-branch: master
+    commit-message:
+      prefix: "[Dependabot]"
+    labels:
+      - Dependencies
+    reviewers:
+      - tgingold
+      - Paebbels
+      - umarcor
+    schedule:
+      interval: "daily"    # Checks on Monday trough Friday.
+
+  # Maintain GitHub Action runners
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: master
+    commit-message:
+      prefix: "[Dependabot]"
+    labels:
+      - Dependencies
+    reviewers:
+      - tgingold
+      - Paebbels
+      - umarcor
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
       - name: '🧰 Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: '📚 Run gnatdoc'
         run: |
@@ -33,7 +33,7 @@ jobs:
           EOF
 
       - name: '📤 Upload artifact: gnatdoc'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: gnatdoc
           path: gnatdoc
@@ -46,7 +46,7 @@ jobs:
     steps:
 
       - name: '🧰 Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: '⛴ Build ghdl/doc'
         run: |
@@ -57,7 +57,7 @@ jobs:
           EOF
 
       - name: '📥 Download artifact: gnatdoc'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: gnatdoc
           path: public/gnatdoc
@@ -71,7 +71,7 @@ jobs:
       #- run: nroff -man doc/_build/man/ghdl.1
 
       - name: '📤 Upload artifact: HTML, LaTeX and man'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: doc
           path: |
@@ -90,10 +90,10 @@ jobs:
     steps:
 
       - name: '🧰 Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: '🐍 Setup Python'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 
@@ -123,7 +123,7 @@ jobs:
         run: python setup.py bdist_wheel
 
       - name: '📤 Upload artifact: pyGHDL'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pyGHDL
           path: dist/
@@ -140,7 +140,7 @@ jobs:
     steps:
 
       - name: '🧰 Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - run: TASK=bullseye+mcode ./scripts/ci-run.sh -c --gplcompat
 
@@ -166,7 +166,7 @@ jobs:
     steps:
 
       - name: '🧰 Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: '🛳 Build and test GHDL in containers'
         run: |
@@ -174,7 +174,7 @@ jobs:
           mv ghdl-*-ubuntu${{ matrix.os }}-*.tgz ghdl-gha-ubuntu-${{ matrix.os }}.04-$(echo ${{ matrix.backend }} | sed 's#-.*##g').tgz
 
       - name: '📤 Upload artifact: package'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ubuntu${{ matrix.os }}-${{ matrix.backend }}
           path: ghdl-gha-ubuntu-*.tgz
@@ -201,11 +201,11 @@ jobs:
     steps:
 
       - name: '🧰 Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: '💾 Cache gnat'
         id: cache-gnat
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: gnat
           key: ${{ runner.os }}-gnat
@@ -225,7 +225,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: '10.14'
 
       - name: '📤 Upload artifact: package'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: macos${{ matrix.os }}-${{ matrix.backend }}
           path: ghdl-macos-${{ matrix.os }}-${{ matrix.backend }}.tgz
@@ -271,7 +271,7 @@ jobs:
         shell: bash
 
       - name: '🧰 Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # The command 'git describe' (used for version) needs the history.
           fetch-depth: 0
@@ -285,7 +285,7 @@ jobs:
           done
 
       - name: '📤 Upload artifact: builddir'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.sys }}-${{ matrix.pkg }}-builddir
           path: |
@@ -293,7 +293,7 @@ jobs:
             scripts/msys2-${{ matrix.pkg }}/msys2-${{ matrix.pkg }}.pkg.tar.gz
 
       - name: '📤 Upload artifact: package'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.sys }}-${{ matrix.pkg }}
           path: scripts/msys2-${{ matrix.pkg }}/mingw-*ghdl*.pkg.tar.zst
@@ -349,10 +349,10 @@ jobs:
         shell: bash
 
       - name: '🧰 Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: '📥 Download artifact: package'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: artifact
           name: ${{ matrix.sys.sys }}-${{ matrix.sys.pkg }}
@@ -406,10 +406,10 @@ jobs:
         shell: bash
 
       - name: '🧰 Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: '📥 Download artifact: package'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: artifact
           name: ${{ matrix.sys }}-mcode
@@ -430,7 +430,7 @@ jobs:
           zip "${_zipdir}".zip -r "${_zipdir}"
 
       - name: '📤 Upload artifact: zipfile'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.sys }}-mcode-standalone
           path: ${{ matrix.sys }}-mcode-standalone.zip
@@ -473,10 +473,10 @@ jobs:
         run: git config --global core.autocrlf input
 
       - name: '🧰 Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: '📥 Download artifact: package'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: artifact
           name: ${{ matrix.sys }}-${{ matrix.pkg }}
@@ -495,7 +495,7 @@ jobs:
           echo "GHDL_PREFIX=$GHDL_PREFIX" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: '🐍 Setup Python'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           architecture: ${{ matrix.pyarch }}
@@ -549,10 +549,10 @@ jobs:
         run: git config --global core.autocrlf input
 
       - name: '🧰 Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: '📥 Download artifact: package'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: artifact
           name: ${{ matrix.sys }}-${{ matrix.pkg }}-standalone
@@ -571,13 +571,13 @@ jobs:
           echo "GHDL_PREFIX=$GHDL_PREFIX" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: '🐍 Setup Python'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           architecture: ${{ matrix.pyarch }}
 
       - name: '📥 Download artifact: pyGHDL'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: pyGHDL
 
@@ -620,7 +620,7 @@ jobs:
 
       - name: '📥 Download artifacts'
         if: "!contains(github.ref, 'refs/tags/')"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: artifacts
 
@@ -681,10 +681,10 @@ jobs:
         shell: bash
 
       - name: '🧰 Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: '📥 Download artifact: package'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: artifact
           name: MINGW64-llvm
@@ -703,7 +703,7 @@ jobs:
 
       - name: '📤 Upload artifact: coverage report'
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: coverage
           path: coverage.xml
@@ -724,19 +724,19 @@ jobs:
     steps:
 
       - name: '📥 Download artifact: coverage report'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: .
           name: coverage
 
       - name: CodeCov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: coverage.xml
           flags: unittests
 
       - name: Codacy
-        uses: codacy/codacy-coverage-reporter-action@master
+        uses: codacy/codacy-coverage-reporter-action@v1
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage.xml

--- a/pyGHDL/libghdl/errorout.py
+++ b/pyGHDL/libghdl/errorout.py
@@ -49,7 +49,9 @@ class Msgid(IntEnum):
     Warnid_Useless = 30
     Warnid_No_Assoc = 31
     Warnid_Conformance = 32
-    Warnid_Static = 33
-    Msgid_Warning = 34
-    Msgid_Error = 35
-    Msgid_Fatal = 36
+    Warnid_Unkept_Attribute = 33
+    Warnid_Unhandled_Attribute = 34
+    Warnid_Static = 35
+    Msgid_Warning = 36
+    Msgid_Error = 37
+    Msgid_Fatal = 38

--- a/pyGHDL/libghdl/file_comments.py
+++ b/pyGHDL/libghdl/file_comments.py
@@ -45,11 +45,12 @@ import pyGHDL.libghdl.files_map as files_map
 __all__ = [
     "Comment_Index",
     "No_Comment_Index",
-    ]
+]
 
 Comment_Index = TypeVar("Comment_Index", bound=c_uint32)
 
 No_Comment_Index = 0
+
 
 @export
 @BindToLibGHDL("file_comments__find_first_comment")
@@ -62,12 +63,14 @@ def Find_First_Comment(File: SourceFileEntry, N: c_uint32) -> Comment_Index:
     """
     return 0
 
+
 @export
 @BindToLibGHDL("file_comments__get_comment_start")
 def Get_Comment_Start(File: SourceFileEntry, Idx: Comment_Index) -> SourcePtr:
     """
     Get the start of comment
     """
+
 
 @export
 @BindToLibGHDL("file_comments__get_comment_last")
@@ -76,14 +79,16 @@ def Get_Comment_Last(File: SourceFileEntry, Idx: Comment_Index) -> SourcePtr:
     Get the end of comment
     """
 
+
 def Get_Comment(File: SourceFileEntry, Idx: Comment_Index) -> str:
     """
     Get a comment
     """
     buf = files_map.Get_File_Buffer(File)
-    s = Get_Comment_Start(File, Idx);
-    l = Get_Comment_Last(File, Idx);
-    return buf[s:l+1].decode("iso-8859-1")
+    s = Get_Comment_Start(File, Idx)
+    l = Get_Comment_Last(File, Idx)
+    return buf[s : l + 1].decode("iso-8859-1")
+
 
 @export
 @BindToLibGHDL("file_comments__get_next_comment")
@@ -91,4 +96,3 @@ def Get_Next_Comment(File: SourceFileEntry, Idx: Comment_Index) -> Comment_Index
     """
     Get the next comment
     """
-


### PR DESCRIPTION
This PR updates used GitHub Actions in the workflow. It should reduced the number of warnings issued by GHA about node.js 12.

It also enables dependabot for dependency scanning and creating PRs with dependency updates (if PR gets accepted).