### PR TITLE
Updated for latest pyVHDLModel v0.17.x

### DIFF
--- a/pyGHDL/dom/InterfaceItem.py
+++ b/pyGHDL/dom/InterfaceItem.py
@@ -30,7 +30,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
-from typing import List
+from typing import List, Iterable
 
 from pyTooling.Decorators import export
 
@@ -74,31 +74,22 @@ class GenericConstantInterfaceItem(VHDLModel_GenericConstantInterfaceItem, DOMMi
         DOMMixin.__init__(self, node)
 
     @classmethod
-    def parse(cls, genericNode: Iir) -> "GenericConstantInterfaceItem":
+    def parse(cls, genericNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "GenericConstantInterfaceItem":
         name = GetNameOfNode(genericNode)
+        identifiers = [name]
+        if furtherIdentifiers is not None:
+            identifiers.extend(furtherIdentifiers)
         mode = GetModeOfNode(genericNode)
         subtypeIndication = GetSubtypeIndicationFromNode(genericNode, "generic", name)
         default = nodes.Get_Default_Value(genericNode)
         value = GetExpressionFromNode(default) if default else None
 
-        return cls(
-            genericNode,
-            [
-                name,
-            ],
-            mode,
-            subtypeIndication,
-            value,
-        )
+        return cls(genericNode, identifiers, mode, subtypeIndication, value)
 
 
 @export
 class GenericTypeInterfaceItem(VHDLModel_GenericTypeInterfaceItem, DOMMixin):
-    def __init__(
-        self,
-        node: Iir,
-        identifier: str,
-    ):
+    def __init__(self, node: Iir, identifier: str):
         super().__init__(identifier)
         DOMMixin.__init__(self, node)
 
@@ -111,11 +102,7 @@ class GenericTypeInterfaceItem(VHDLModel_GenericTypeInterfaceItem, DOMMixin):
 
 @export
 class GenericPackageInterfaceItem(VHDLModel_GenericPackageInterfaceItem, DOMMixin):
-    def __init__(
-        self,
-        node: Iir,
-        name: str,
-    ):
+    def __init__(self, node: Iir, name: str):
         super().__init__(name)
         DOMMixin.__init__(self, node)
 
@@ -128,11 +115,7 @@ class GenericPackageInterfaceItem(VHDLModel_GenericPackageInterfaceItem, DOMMixi
 
 @export
 class GenericProcedureInterfaceItem(VHDLModel_GenericProcedureInterfaceItem, DOMMixin):
-    def __init__(
-        self,
-        node: Iir,
-        identifier: str,
-    ):
+    def __init__(self, node: Iir, identifier: str):
         super().__init__(identifier)
         DOMMixin.__init__(self, node)
 
@@ -145,11 +128,7 @@ class GenericProcedureInterfaceItem(VHDLModel_GenericProcedureInterfaceItem, DOM
 
 @export
 class GenericFunctionInterfaceItem(VHDLModel_GenericFunctionInterfaceItem, DOMMixin):
-    def __init__(
-        self,
-        node: Iir,
-        identifier: str,
-    ):
+    def __init__(self, node: Iir, identifier: str):
         super().__init__(identifier)
         DOMMixin.__init__(self, node)
 
@@ -174,23 +153,18 @@ class PortSignalInterfaceItem(VHDLModel_PortSignalInterfaceItem, DOMMixin):
         DOMMixin.__init__(self, node)
 
     @classmethod
-    def parse(cls, portNode: Iir) -> "PortSignalInterfaceItem":
+    def parse(cls, portNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "PortSignalInterfaceItem":
         name = GetNameOfNode(portNode)
+        identifiers = [name]
+        if furtherIdentifiers is not None:
+            identifiers.extend(furtherIdentifiers)
         mode = GetModeOfNode(portNode)
         subtypeIndication = GetSubtypeIndicationFromNode(portNode, "port", name)
 
         defaultValue = nodes.Get_Default_Value(portNode)
         value = GetExpressionFromNode(defaultValue) if defaultValue != nodes.Null_Iir else None
 
-        return cls(
-            portNode,
-            [
-                name,
-            ],
-            mode,
-            subtypeIndication,
-            value,
-        )
+        return cls(portNode, identifiers, mode, subtypeIndication, value)
 
 
 @export
@@ -207,23 +181,18 @@ class ParameterConstantInterfaceItem(VHDLModel_ParameterConstantInterfaceItem, D
         DOMMixin.__init__(self, node)
 
     @classmethod
-    def parse(cls, parameterNode: Iir) -> "ParameterConstantInterfaceItem":
+    def parse(cls, parameterNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "ParameterConstantInterfaceItem":
         name = GetNameOfNode(parameterNode)
+        identifiers = [name]
+        if furtherIdentifiers is not None:
+            identifiers.extend(furtherIdentifiers)
         mode = GetModeOfNode(parameterNode)
         subtypeIndication = GetSubtypeIndicationFromNode(parameterNode, "parameter", name)
 
         defaultValue = nodes.Get_Default_Value(parameterNode)
         value = GetExpressionFromNode(defaultValue) if defaultValue != nodes.Null_Iir else None
 
-        return cls(
-            parameterNode,
-            [
-                name,
-            ],
-            mode,
-            subtypeIndication,
-            value,
-        )
+        return cls(parameterNode, identifiers, mode, subtypeIndication, value)
 
 
 @export
@@ -240,23 +209,18 @@ class ParameterVariableInterfaceItem(VHDLModel_ParameterVariableInterfaceItem, D
         DOMMixin.__init__(self, node)
 
     @classmethod
-    def parse(cls, parameterNode: Iir) -> "ParameterVariableInterfaceItem":
+    def parse(cls, parameterNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "ParameterVariableInterfaceItem":
         name = GetNameOfNode(parameterNode)
+        identifiers = [name]
+        if furtherIdentifiers is not None:
+            identifiers.extend(furtherIdentifiers)
         mode = GetModeOfNode(parameterNode)
         subtypeIndication = GetSubtypeIndicationFromNode(parameterNode, "parameter", name)
 
         defaultValue = nodes.Get_Default_Value(parameterNode)
         value = GetExpressionFromNode(defaultValue) if defaultValue != nodes.Null_Iir else None
 
-        return cls(
-            parameterNode,
-            [
-                name,
-            ],
-            mode,
-            subtypeIndication,
-            value,
-        )
+        return cls(parameterNode, identifiers, mode, subtypeIndication, value)
 
 
 @export
@@ -273,23 +237,18 @@ class ParameterSignalInterfaceItem(VHDLModel_ParameterSignalInterfaceItem, DOMMi
         DOMMixin.__init__(self, node)
 
     @classmethod
-    def parse(cls, parameterNode: Iir) -> "ParameterSignalInterfaceItem":
+    def parse(cls, parameterNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "ParameterSignalInterfaceItem":
         name = GetNameOfNode(parameterNode)
+        identifiers = [name]
+        if furtherIdentifiers is not None:
+            identifiers.extend(furtherIdentifiers)
         mode = GetModeOfNode(parameterNode)
         subtypeIndication = GetSubtypeIndicationFromNode(parameterNode, "parameter", name)
 
         defaultValue = nodes.Get_Default_Value(parameterNode)
         value = GetExpressionFromNode(defaultValue) if defaultValue != nodes.Null_Iir else None
 
-        return cls(
-            parameterNode,
-            [
-                name,
-            ],
-            mode,
-            subtypeIndication,
-            value,
-        )
+        return cls(parameterNode, identifiers, mode, subtypeIndication, value)
 
 
 @export
@@ -304,14 +263,11 @@ class ParameterFileInterfaceItem(VHDLModel_ParameterFileInterfaceItem, DOMMixin)
         DOMMixin.__init__(self, node)
 
     @classmethod
-    def parse(cls, parameterNode: Iir) -> "ParameterFileInterfaceItem":
+    def parse(cls, parameterNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "ParameterFileInterfaceItem":
         name = GetNameOfNode(parameterNode)
+        identifiers = [name]
+        if furtherIdentifiers is not None:
+            identifiers.extend(furtherIdentifiers)
         subtypeIndication = GetSubtypeIndicationFromNode(parameterNode, "parameter", name)
 
-        return cls(
-            parameterNode,
-            [
-                name,
-            ],
-            subtypeIndication,
-        )
+        return cls(parameterNode, identifiers, subtypeIndication)

--- a/pyGHDL/dom/Object.py
+++ b/pyGHDL/dom/Object.py
@@ -13,7 +13,7 @@
 #
 # License:
 # ============================================================================
-#  Copyright (C) 2019-2021 Tristan Gingold
+#  Copyright (C) 2019-2022 Tristan Gingold
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -30,7 +30,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
-from typing import Union, List
+from typing import Union, List, Iterable
 
 from pyTooling.Decorators import export
 
@@ -66,34 +66,26 @@ class Constant(VHDLModel_Constant, DOMMixin):
         DOMMixin.__init__(self, node)
 
     @classmethod
-    def parse(cls, constantNode: Iir) -> Union["Constant", "DeferredConstant"]:
+    def parse(
+        cls, constantNode: Iir, furtherIdentifiers: Iterable[str] = None
+    ) -> Union["Constant", "DeferredConstant"]:
         from pyGHDL.dom._Translate import (
             GetSubtypeIndicationFromNode,
             GetExpressionFromNode,
         )
 
         name = GetNameOfNode(constantNode)
+        identifiers = [name]
+        if furtherIdentifiers is not None:
+            identifiers.extend(furtherIdentifiers)
         subtypeIndication = GetSubtypeIndicationFromNode(constantNode, "constant", name)
         defaultValue = nodes.Get_Default_Value(constantNode)
         if defaultValue != nodes.Null_Iir:
             defaultExpression = GetExpressionFromNode(defaultValue)
 
-            return cls(
-                constantNode,
-                [
-                    name,
-                ],
-                subtypeIndication,
-                defaultExpression,
-            )
+            return cls(constantNode, identifiers, subtypeIndication, defaultExpression)
         else:
-            return DeferredConstant(
-                constantNode,
-                [
-                    name,
-                ],
-                subtypeIndication,
-            )
+            return DeferredConstant(constantNode, identifiers, subtypeIndication)
 
 
 @export
@@ -103,19 +95,16 @@ class DeferredConstant(VHDLModel_DeferredConstant, DOMMixin):
         DOMMixin.__init__(self, node)
 
     @classmethod
-    def parse(cls, constantNode: Iir) -> "DeferredConstant":
+    def parse(cls, constantNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "DeferredConstant":
         from pyGHDL.dom._Translate import GetSubtypeIndicationFromNode
 
         name = GetNameOfNode(constantNode)
+        identifiers = [name]
+        if furtherIdentifiers is not None:
+            identifiers.extend(furtherIdentifiers)
         subtypeIndication = GetSubtypeIndicationFromNode(constantNode, "deferred constant", name)
 
-        return cls(
-            constantNode,
-            [
-                name,
-            ],
-            subtypeIndication,
-        )
+        return cls(constantNode, identifiers, subtypeIndication)
 
 
 @export
@@ -131,27 +120,23 @@ class Variable(VHDLModel_Variable, DOMMixin):
         DOMMixin.__init__(self, node)
 
     @classmethod
-    def parse(cls, variableNode: Iir) -> "Variable":
+    def parse(cls, variableNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "Variable":
         from pyGHDL.dom._Translate import (
             GetSubtypeIndicationFromNode,
             GetExpressionFromNode,
         )
 
         name = GetNameOfNode(variableNode)
+        identifiers = [name]
+        if furtherIdentifiers is not None:
+            identifiers.extend(furtherIdentifiers)
         subtypeIndication = GetSubtypeIndicationFromNode(variableNode, "variable", name)
         defaultValue = nodes.Get_Default_Value(variableNode)
         defaultExpression = None
         if defaultValue != nodes.Null_Iir:
             defaultExpression = GetExpressionFromNode(defaultValue)
 
-        return cls(
-            variableNode,
-            [
-                name,
-            ],
-            subtypeIndication,
-            defaultExpression,
-        )
+        return cls(variableNode, identifiers, subtypeIndication, defaultExpression)
 
 
 @export
@@ -161,19 +146,16 @@ class SharedVariable(VHDLModel_SharedVariable, DOMMixin):
         DOMMixin.__init__(self, node)
 
     @classmethod
-    def parse(cls, variableNode: Iir) -> "SharedVariable":
+    def parse(cls, variableNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "SharedVariable":
         from pyGHDL.dom._Translate import GetSubtypeIndicationFromNode
 
         name = GetNameOfNode(variableNode)
+        identifiers = [name]
+        if furtherIdentifiers is not None:
+            identifiers.extend(furtherIdentifiers)
         subtypeIndication = GetSubtypeIndicationFromNode(variableNode, "variable", name)
 
-        return cls(
-            variableNode,
-            [
-                name,
-            ],
-            subtypeIndication,
-        )
+        return cls(variableNode, identifiers, subtypeIndication)
 
 
 @export
@@ -189,25 +171,21 @@ class Signal(VHDLModel_Signal, DOMMixin):
         DOMMixin.__init__(self, node)
 
     @classmethod
-    def parse(cls, signalNode: Iir) -> "Signal":
+    def parse(cls, signalNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "Signal":
         from pyGHDL.dom._Translate import (
             GetSubtypeIndicationFromNode,
             GetExpressionFromNode,
         )
 
         name = GetNameOfNode(signalNode)
+        identifiers = [name]
+        if furtherIdentifiers is not None:
+            identifiers.extend(furtherIdentifiers)
         subtypeIndication = GetSubtypeIndicationFromNode(signalNode, "signal", name)
         default = nodes.Get_Default_Value(signalNode)
         defaultExpression = GetExpressionFromNode(default) if default else None
 
-        return cls(
-            signalNode,
-            [
-                name,
-            ],
-            subtypeIndication,
-            defaultExpression,
-        )
+        return cls(signalNode, identifiers, subtypeIndication, defaultExpression)
 
 
 @export
@@ -217,18 +195,15 @@ class File(VHDLModel_File, DOMMixin):
         DOMMixin.__init__(self, node)
 
     @classmethod
-    def parse(cls, fileNode: Iir) -> "File":
+    def parse(cls, fileNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "File":
         from pyGHDL.dom._Translate import GetSubtypeIndicationFromNode
 
         name = GetNameOfNode(fileNode)
+        identifiers = [name]
+        if furtherIdentifiers is not None:
+            identifiers.extend(furtherIdentifiers)
         subtypeIndication = GetSubtypeIndicationFromNode(fileNode, "file", name)
 
         # FIXME: handle file open stuff
 
-        return cls(
-            fileNode,
-            [
-                name,
-            ],
-            subtypeIndication,
-        )
+        return cls(fileNode, identifiers, subtypeIndication)

--- a/pyGHDL/dom/Type.py
+++ b/pyGHDL/dom/Type.py
@@ -13,7 +13,7 @@
 #
 # License:
 # ============================================================================
-#  Copyright (C) 2019-2021 Tristan Gingold
+#  Copyright (C) 2019-2022 Tristan Gingold
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -30,7 +30,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
-from typing import List, Union, Iterator, Tuple
+from typing import List, Union, Iterator, Tuple, Iterable
 
 from pyTooling.Decorators import export
 
@@ -185,20 +185,18 @@ class RecordTypeElement(VHDLModel_RecordTypeElement, DOMMixin):
         DOMMixin.__init__(self, node)
 
     @classmethod
-    def parse(cls, elementDeclarationNode: Iir) -> "RecordTypeElement":
+    def parse(cls, elementDeclarationNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "RecordTypeElement":
         from pyGHDL.dom._Utils import GetNameOfNode
         from pyGHDL.dom._Translate import GetSubtypeIndicationFromNode
 
         elementName = GetNameOfNode(elementDeclarationNode)
         elementType = GetSubtypeIndicationFromNode(elementDeclarationNode, "record element", elementName)
 
-        return cls(
-            elementDeclarationNode,
-            [
-                elementName,
-            ],
-            elementType,
-        )
+        identifiers = [elementName]
+        if furtherIdentifiers is not None:
+            identifiers.extend(furtherIdentifiers)
+
+        return cls(elementDeclarationNode, identifiers, elementType)
 
 
 @export
@@ -214,12 +212,11 @@ class RecordType(VHDLModel_RecordType, DOMMixin):
         elements = []
         elementDeclarations = nodes.Get_Elements_Declaration_List(typeDefinitionNode)
 
+        furtherIdentifiers = []
         elementCount = flists.Flast(elementDeclarations) + 1
         index = 0
         while index < elementCount:
             elementDeclaration = flists.Get_Nth_Element(elementDeclarations, index)
-
-            element = RecordTypeElement.parse(elementDeclaration)
 
             # Lookahead for elements with multiple identifiers at once
             if nodes.Get_Has_Identifier_List(elementDeclaration):
@@ -228,7 +225,7 @@ class RecordType(VHDLModel_RecordType, DOMMixin):
                     nextNode: Iir = flists.Get_Nth_Element(elementDeclarations, index)
                     # Consecutive identifiers are found, if the subtype indication is Null
                     if nodes.Get_Subtype_Indication(nextNode) == nodes.Null_Iir:
-                        element.Identifiers.append(GetNameOfNode(nextNode))
+                        furtherIdentifiers.append(GetNameOfNode(nextNode))
                     else:
                         break
                     index += 1
@@ -239,7 +236,9 @@ class RecordType(VHDLModel_RecordType, DOMMixin):
             else:
                 index += 1
 
+            element = RecordTypeElement.parse(elementDeclaration, furtherIdentifiers)
             elements.append(element)
+            furtherIdentifiers.clear()
 
         return cls(typeDefinitionNode, typeName, elements)
 

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -464,13 +464,12 @@ def GetGenericsFromChainedNodes(
         GenericFunctionInterfaceItem,
     )
 
+    furtherIdentifiers = []
     generic = nodeChain
     while generic != nodes.Null_Iir:
         kind = GetIirKindOfNode(generic)
         if kind == nodes.Iir_Kind.Interface_Constant_Declaration:
             from pyGHDL.dom.InterfaceItem import GenericConstantInterfaceItem
-
-            genericConstant = GenericConstantInterfaceItem.parse(generic)
 
             # Lookahead for generics with multiple identifiers at once
             if nodes.Get_Has_Identifier_List(generic):
@@ -478,7 +477,7 @@ def GetGenericsFromChainedNodes(
                 for nextGeneric in utils.chain_iter(nextNode):
                     # Consecutive identifiers are found, if the subtype indication is Null
                     if nodes.Get_Subtype_Indication(nextGeneric) == nodes.Null_Iir:
-                        genericConstant.Identifiers.append(GetNameOfNode(nextGeneric))
+                        furtherIdentifiers.append(GetNameOfNode(nextGeneric))
                     else:
                         generic = nextGeneric
                         break
@@ -492,7 +491,8 @@ def GetGenericsFromChainedNodes(
             else:
                 generic = nodes.Get_Chain(generic)
 
-            yield genericConstant
+            yield GenericConstantInterfaceItem.parse(generic, furtherIdentifiers)
+            furtherIdentifiers.clear()
             continue
         else:
             if kind == nodes.Iir_Kind.Interface_Type_Declaration:
@@ -517,13 +517,14 @@ def GetPortsFromChainedNodes(
     nodeChain: Iir,
 ) -> Generator[PortInterfaceItem, None, None]:
 
+    furtherIdentifiers = []
     port = nodeChain
     while port != nodes.Null_Iir:
         kind = GetIirKindOfNode(port)
         if kind == nodes.Iir_Kind.Interface_Signal_Declaration:
             from pyGHDL.dom.InterfaceItem import PortSignalInterfaceItem
 
-            portSignal = PortSignalInterfaceItem.parse(port)
+            portToParse = port
 
             # Lookahead for ports with multiple identifiers at once
             if nodes.Get_Has_Identifier_List(port):
@@ -531,7 +532,7 @@ def GetPortsFromChainedNodes(
                 for nextPort in utils.chain_iter(nextNode):
                     # Consecutive identifiers are found, if the subtype indication is Null
                     if nodes.Get_Subtype_Indication(nextPort) == nodes.Null_Iir:
-                        portSignal.Identifiers.append(GetNameOfNode(nextPort))
+                        furtherIdentifiers.append(GetNameOfNode(nextPort))
                     else:
                         port = nextPort
                         break
@@ -545,7 +546,8 @@ def GetPortsFromChainedNodes(
             else:
                 port = nodes.Get_Chain(port)
 
-            yield portSignal
+            yield PortSignalInterfaceItem.parse(portToParse, furtherIdentifiers)
+            furtherIdentifiers.clear()
             continue
         else:
             position = Position.parse(port)
@@ -559,25 +561,30 @@ def GetParameterFromChainedNodes(
     nodeChain: Iir,
 ) -> Generator[ParameterInterfaceItem, None, None]:
 
+    identifiers = []
     parameter = nodeChain
     while parameter != nodes.Null_Iir:
         kind = GetIirKindOfNode(parameter)
         if kind == nodes.Iir_Kind.Interface_Constant_Declaration:
             from pyGHDL.dom.InterfaceItem import ParameterConstantInterfaceItem
 
-            param = ParameterConstantInterfaceItem.parse(parameter)
+            parseMethod = ParameterConstantInterfaceItem.parse
+            parseNode = parameter
         elif kind == nodes.Iir_Kind.Interface_Variable_Declaration:
             from pyGHDL.dom.InterfaceItem import ParameterVariableInterfaceItem
 
-            param = ParameterVariableInterfaceItem.parse(parameter)
+            parseMethod = ParameterVariableInterfaceItem.parse
+            parseNode = parameter
         elif kind == nodes.Iir_Kind.Interface_Signal_Declaration:
             from pyGHDL.dom.InterfaceItem import ParameterSignalInterfaceItem
 
-            param = ParameterSignalInterfaceItem.parse(parameter)
+            parseMethod = ParameterSignalInterfaceItem.parse
+            parseNode = parameter
         elif kind == nodes.Iir_Kind.Interface_File_Declaration:
             from pyGHDL.dom.InterfaceItem import ParameterFileInterfaceItem
 
-            param = ParameterFileInterfaceItem.parse(parameter)
+            parseMethod = ParameterFileInterfaceItem.parse
+            parseNode = parameter
         else:
             position = Position.parse(parameter)
             raise DOMException(
@@ -590,7 +597,7 @@ def GetParameterFromChainedNodes(
             for nextParameter in utils.chain_iter(nextNode):
                 # Consecutive identifiers are found, if the subtype indication is Null
                 if nodes.Get_Subtype_Indication(nextParameter) == nodes.Null_Iir:
-                    param.Identifiers.append(GetNameOfNode(nextParameter))
+                    identifiers.append(GetNameOfNode(nextParameter))
                 else:
                     parameter = nextParameter
                     break
@@ -604,7 +611,7 @@ def GetParameterFromChainedNodes(
         else:
             parameter = nodes.Get_Chain(parameter)
 
-        yield param
+        yield parseMethod(parseNode, identifiers)
 
 
 def GetMapAspect(mapAspect: Iir, cls: Type, entity: str) -> Generator[AssociationItem, None, None]:
@@ -650,6 +657,7 @@ def GetParameterMapAspect(
 
 
 def GetDeclaredItemsFromChainedNodes(nodeChain: Iir, entity: str, name: str) -> Generator[ModelEntity, None, None]:
+    furtherIdentifiers = []
     item = nodeChain
     lastKind = None
     while item != nodes.Null_Iir:
@@ -657,23 +665,27 @@ def GetDeclaredItemsFromChainedNodes(nodeChain: Iir, entity: str, name: str) -> 
         if kind == nodes.Iir_Kind.Constant_Declaration:
             from pyGHDL.dom.Object import Constant
 
-            obj = Constant.parse(item)
-
+            objectParseMethod = Constant.parse
+            objectItem = item
         elif kind == nodes.Iir_Kind.Variable_Declaration:
             from pyGHDL.dom.Object import SharedVariable
 
             if nodes.Get_Shared_Flag(item):
-                obj = SharedVariable.parse(item)
+                objectParseMethod = SharedVariable.parse
+                objectItem = item
             else:
-                obj = Variable.parse(item)
+                objectParseMethod = Variable.parse
+                objectItem = item
         elif kind == nodes.Iir_Kind.Signal_Declaration:
             from pyGHDL.dom.Object import Signal
 
-            obj = Signal.parse(item)
+            objectParseMethod = Signal.parse
+            objectItem = item
         elif kind == nodes.Iir_Kind.File_Declaration:
             from pyGHDL.dom.Object import File
 
-            obj = File.parse(item)
+            objectParseMethod = File.parse
+            objectItem = item
         else:
             if kind == nodes.Iir_Kind.Type_Declaration:
                 yield GetTypeFromNode(item)
@@ -782,7 +794,7 @@ def GetDeclaredItemsFromChainedNodes(nodeChain: Iir, entity: str, name: str) -> 
             for nextItem in utils.chain_iter(nextNode):
                 # Consecutive identifiers are found, if the subtype indication is Null
                 if nodes.Get_Subtype_Indication(nextItem) == nodes.Null_Iir:
-                    obj.Identifiers.append(GetNameOfNode(nextItem))
+                    furtherIdentifiers.append(GetNameOfNode(nextItem))
                 else:
                     item = nextItem
                     break
@@ -796,7 +808,8 @@ def GetDeclaredItemsFromChainedNodes(nodeChain: Iir, entity: str, name: str) -> 
         else:
             item = nodes.Get_Chain(item)
 
-        yield obj
+        yield objectParseMethod(objectItem, furtherIdentifiers)
+        furtherIdentifiers.clear()
 
 
 def GetConcurrentStatementsFromChainedNodes(

--- a/pyGHDL/dom/__init__.py
+++ b/pyGHDL/dom/__init__.py
@@ -39,8 +39,6 @@ from pyGHDL.libghdl import files_map, name_table
 from pyGHDL.libghdl._types import Iir
 from pyGHDL.libghdl.vhdl import nodes
 
-__all__ = []
-
 
 @export
 class Position:

--- a/pyGHDL/dom/requirements.txt
+++ b/pyGHDL/dom/requirements.txt
@@ -1,4 +1,4 @@
 -r ../libghdl/requirements.txt
 
-pyVHDLModel==0.14.4
+pyVHDLModel==0.17.1
 #https://github.com/VHDL/pyVHDLModel/archive/dev.zip#pyVHDLModel


### PR DESCRIPTION
This bumps the dependency for pyVHDLModel to v0.17.x and updates the handling of language constructs with multiple identifiers.

Should be reviewed and merged after #2261.

-------
(This should also handle #2257 and #2260)