### PR TITLE
synth: add support for numeric_std_unsigned add, sub, fix #2286

### DIFF
--- a/src/synth/synth-vhdl_oper.adb
+++ b/src/synth/synth-vhdl_oper.adb
@@ -1449,6 +1449,7 @@ package body Synth.Vhdl_Oper is
             | Iir_Predefined_Ieee_Numeric_Std_Add_Uns_Log
             | Iir_Predefined_Ieee_Numeric_Std_Add_Sgn_Log
             | Iir_Predefined_Ieee_Numeric_Std_Add_Log_Sgn
+            | Iir_Predefined_Ieee_Numeric_Std_Unsigned_Add_Slv_Slv
             | Iir_Predefined_Ieee_Std_Logic_Unsigned_Add_Slv_Log
             | Iir_Predefined_Ieee_Std_Logic_Unsigned_Add_Log_Slv
             | Iir_Predefined_Ieee_Std_Logic_Unsigned_Add_Slv_Slv
@@ -1466,7 +1467,8 @@ package body Synth.Vhdl_Oper is
             | Iir_Predefined_Ieee_Std_Logic_Arith_Add_Log_Sgn_Slv =>
             --  "+" (Unsigned, Unsigned)
             return Synth_Dyadic_Uns_Uns (Ctxt, Id_Add, L, R, Expr);
-         when Iir_Predefined_Ieee_Numeric_Std_Add_Uns_Nat =>
+         when Iir_Predefined_Ieee_Numeric_Std_Add_Uns_Nat
+            | Iir_Predefined_Ieee_Numeric_Std_Unsigned_Add_Slv_Nat =>
             --  "+" (Unsigned, Natural)
             return Synth_Dyadic_Uns_Nat (Ctxt, Id_Add, L, R, Expr);
          when Iir_Predefined_Ieee_Std_Logic_Arith_Add_Uns_Int_Slv
@@ -1475,6 +1477,7 @@ package body Synth.Vhdl_Oper is
             --  "+" (Unsigned, Integer)
             return Synth_Dyadic_Sgn_Int (Ctxt, Id_Add, L, R, Expr);
          when Iir_Predefined_Ieee_Numeric_Std_Add_Nat_Uns
+            | Iir_Predefined_Ieee_Numeric_Std_Unsigned_Add_Nat_Slv
             | Iir_Predefined_Ieee_Std_Logic_Arith_Add_Int_Uns_Uns
             | Iir_Predefined_Ieee_Std_Logic_Arith_Add_Int_Uns_Slv
             | Iir_Predefined_Ieee_Std_Logic_Unsigned_Add_Int_Slv =>
@@ -1511,6 +1514,7 @@ package body Synth.Vhdl_Oper is
             | Iir_Predefined_Ieee_Numeric_Std_Sub_Uns_Log
             | Iir_Predefined_Ieee_Numeric_Std_Sub_Sgn_Log
             | Iir_Predefined_Ieee_Numeric_Std_Sub_Log_Sgn
+            | Iir_Predefined_Ieee_Numeric_Std_Unsigned_Sub_Slv_Slv
             | Iir_Predefined_Ieee_Std_Logic_Unsigned_Sub_Slv_Slv
             | Iir_Predefined_Ieee_Std_Logic_Unsigned_Sub_Log_Slv
             | Iir_Predefined_Ieee_Std_Logic_Unsigned_Sub_Slv_Log
@@ -1534,7 +1538,8 @@ package body Synth.Vhdl_Oper is
             | Iir_Predefined_Ieee_Std_Logic_Signed_Sub_Slv_Slv =>
             --  "-" (Signed, Signed)
             return Synth_Dyadic_Sgn_Sgn (Ctxt, Id_Sub, L, R, Expr);
-         when Iir_Predefined_Ieee_Numeric_Std_Sub_Uns_Nat =>
+         when Iir_Predefined_Ieee_Numeric_Std_Sub_Uns_Nat
+            | Iir_Predefined_Ieee_Numeric_Std_Unsigned_Sub_Slv_Nat =>
             --  "-" (Unsigned, Natural)
             return Synth_Dyadic_Uns_Nat (Ctxt, Id_Sub, L, R, Expr);
          when Iir_Predefined_Ieee_Std_Logic_Arith_Sub_Uns_Int_Uns
@@ -1543,6 +1548,7 @@ package body Synth.Vhdl_Oper is
             --  "-" (Unsigned, Integer)
             return Synth_Dyadic_Sgn_Int (Ctxt, Id_Sub, L, R, Expr);
          when Iir_Predefined_Ieee_Numeric_Std_Sub_Nat_Uns
+            | Iir_Predefined_Ieee_Numeric_Std_Unsigned_Sub_Nat_Slv
             | Iir_Predefined_Ieee_Std_Logic_Arith_Sub_Int_Uns_Uns
             | Iir_Predefined_Ieee_Std_Logic_Arith_Sub_Int_Uns_Slv
             | Iir_Predefined_Ieee_Std_Logic_Unsigned_Sub_Int_Slv =>

--- a/testsuite/synth/issue2286/tb_test_addsub.vhdl
+++ b/testsuite/synth/issue2286/tb_test_addsub.vhdl
@@ -1,0 +1,51 @@
+entity tb_test_addsub is
+end tb_test_addsub;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+architecture behav of tb_test_addsub is
+  signal s_slv        : std_logic_vector(3 downto 0);
+  signal s_nat        : natural range 0 to 15;
+  signal s_add_slvslv : std_logic_vector(3 downto 0);
+  signal s_add_slvnat : std_logic_vector(3 downto 0);
+  signal s_add_natslv : std_logic_vector(3 downto 0);
+  signal s_sub_slvslv : std_logic_vector(3 downto 0);
+  signal s_sub_slvnat : std_logic_vector(3 downto 0);
+  signal s_sub_natslv : std_logic_vector(3 downto 0);
+begin
+  dut: entity work.test_addsub
+    port map (s_slv,
+              s_nat,
+              s_add_slvslv,
+              s_add_slvnat,
+              s_add_natslv,
+              s_sub_slvslv,
+              s_sub_slvnat,
+              s_sub_natslv);
+  process
+  begin
+    s_slv <= x"6";
+    s_nat <= 6;
+    wait for 1 ns;
+    assert s_add_slvslv = x"C" severity failure;
+    assert s_add_slvnat = x"C" severity failure;
+    assert s_add_natslv = x"C" severity failure;
+    assert s_sub_slvslv = x"0" severity failure;
+    assert s_sub_slvnat = x"0" severity failure;
+    assert s_sub_natslv = x"0" severity failure;
+
+    s_slv <= x"6";
+    s_nat <= 10;
+    wait for 1 ns;
+    assert s_add_slvslv = x"C" severity failure;
+    assert s_add_slvnat = x"0" severity failure;
+    assert s_add_natslv = x"0" severity failure;
+    assert s_sub_slvslv = x"0" severity failure;
+    assert s_sub_slvnat = x"C" severity failure;
+    assert s_sub_natslv = x"4" severity failure;
+
+    wait;
+  end process;
+end behav;

--- a/testsuite/synth/issue2286/test_addsub.vhdl
+++ b/testsuite/synth/issue2286/test_addsub.vhdl
@@ -1,0 +1,26 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std_unsigned.all;
+
+entity test_addsub is
+  port (
+    slv : in  std_logic_vector(3 downto 0);
+    nat : in  natural range 0 to 15;
+    add_slvslv : out std_logic_vector(3 downto 0);
+    add_slvnat : out std_logic_vector(3 downto 0);
+    add_natslv : out std_logic_vector(3 downto 0);
+    sub_slvslv : out std_logic_vector(3 downto 0);
+    sub_slvnat : out std_logic_vector(3 downto 0);
+    sub_natslv : out std_logic_vector(3 downto 0)
+  );
+end;
+
+architecture rtl of test_addsub is
+begin
+  add_slvslv <= slv + slv;
+  add_slvnat <= slv + nat;
+  add_natslv <= nat + slv;
+  sub_slvslv <= slv - slv;
+  sub_slvnat <= slv - nat;
+  sub_natslv <= nat - slv;
+end;

--- a/testsuite/synth/issue2286/testsuite.sh
+++ b/testsuite/synth/issue2286/testsuite.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+export GHDL_STD_FLAGS=--std=08
+
+synth_tb test_addsub
+
+echo "Test successful"


### PR DESCRIPTION
This should fix #2286 by adding the missing functions in `Synth_Dynamic_Predefined_Call` function of `synth-vhdl_oper.adb`.

A simple test is included.