### PR TITLE
Limit Sphinx to 5.3 <= XX < 6.0

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 -r ../pyGHDL/requirements.txt
 
-sphinx>=5.0.2
+sphinx >=5.3, <6.0
 #recommonmark>=0.7.1
 python-dateutil>=2.8.2
 
@@ -10,7 +10,7 @@ python-dateutil>=2.8.2
 # changelog>=0.3.5
 autoapi
 sphinx_fontawesome>=0.0.6
-sphinx_autodoc_typehints>=1.18.3
+sphinx_autodoc_typehints>=1.19.5
 
 # BuildTheDocs Extensions (mostly patched Sphinx extensions)
 btd.sphinx.autoprogram>=0.1.6.post1


### PR DESCRIPTION
This should delay the problem with Sphinx until the RTD theme is fixed with respect to docutils 0.18/0.19.