### PR TITLE
Dot output ports

### DIFF
--- a/src/synth/netlists-disp_dot.adb
+++ b/src/synth/netlists-disp_dot.adb
@@ -124,6 +124,7 @@ package body Netlists.Disp_Dot is
                -- an output port of the top module !
                -- Do not write the net, the top module has
                -- already done it.
+               null;
             else
                Put_Net_Instance_To_Instance(Inst, D, N);
             end if;
@@ -133,6 +134,10 @@ package body Netlists.Disp_Dot is
    end Disp_Dot_Instance;
 
    procedure Disp_Dot_Module (M : Module) is
+      Self : constant Instance := Get_Self_Instance (M);
+      N : Net;
+      I : Input;
+      D : Instance;
    begin
       Put ("digraph m");
       Put_Uns32 (Uns32 (M));
@@ -144,40 +149,32 @@ package body Netlists.Disp_Dot is
       end if;
 
       --  Handle inputs and outputs.
-      declare
-         Self : constant Instance := Get_Self_Instance (M);
-         N : Net;
-         I : Input;
-         D : Instance;
-      begin
-         for Idx in 1 .. Get_Nbr_Inputs (M) loop
-            Put_Port_Input(M, Idx);
+      for Idx in 1 .. Get_Nbr_Inputs (M) loop
+         Put_Port_Input(M, Idx);
 
-            N := Get_Output (Self, Idx - 1);
-            I := Get_First_Sink (N);
-            while I /= No_Input loop
-               D := Get_Input_Parent (I);
-               Put_Net_Port_To_Instance(Idx, D, N);
-               I := Get_Next_Sink (I);
-            end loop;
-            New_Line;
+         N := Get_Output (Self, Idx - 1);
+         I := Get_First_Sink (N);
+         while I /= No_Input loop
+            D := Get_Input_Parent (I);
+            Put_Net_Port_To_Instance(Idx, D, N);
+            I := Get_Next_Sink (I);
          end loop;
-         
-         for Idx in 1 .. Get_Nbr_Outputs(M) loop
-            Put_Port_Output(M, Idx);
-            I := Get_Input(Self, Idx - 1);
-            N := Get_Driver(I);
-            D := Get_Net_Parent(N);
-            Put_Net_Instance_To_Port(D, Idx, N);
-            New_Line;
-         end loop;
-         
-         for Inst of Instances (M) loop
-            Disp_Dot_Instance (Self, Inst);
-            New_Line;
-         end loop;
-         
-      end;
+         New_Line;
+      end loop;
+      
+      for Idx in 1 .. Get_Nbr_Outputs(M) loop
+         Put_Port_Output(M, Idx);
+         I := Get_Input(Self, Idx - 1);
+         N := Get_Driver(I);
+         D := Get_Net_Parent(N);
+         Put_Net_Instance_To_Port(D, Idx, N);
+         New_Line;
+      end loop;
+      
+      for Inst of Instances (M) loop
+         Disp_Dot_Instance (Self, Inst);
+         New_Line;
+      end loop;
 
       Put_Line ("}");
    end Disp_Dot_Module;

--- a/src/synth/netlists-disp_dot.adb
+++ b/src/synth/netlists-disp_dot.adb
@@ -137,43 +137,46 @@ package body Netlists.Disp_Dot is
       Put ("digraph m");
       Put_Uns32 (Uns32 (M));
       Put_Line (" {");
+      
+      -- uh ?
+      if Self = No_Instance then
+         return;
+      end if;
 
-      --  Handle inputs.
+      --  Handle inputs and outputs.
       declare
          Self : constant Instance := Get_Self_Instance (M);
          N : Net;
          I : Input;
          D : Instance;
       begin
-         if Self /= No_Instance then
-            for Idx in 1 .. Get_Nbr_Inputs (M) loop
-               Put_Port_Input(M, Idx);
+         for Idx in 1 .. Get_Nbr_Inputs (M) loop
+            Put_Port_Input(M, Idx);
 
-               N := Get_Output (Self, Idx - 1);
-               I := Get_First_Sink (N);
-               while I /= No_Input loop
-                  D := Get_Input_Parent (I);
-                  Put_Net_Port_To_Instance(Idx, D, N);
-                  I := Get_Next_Sink (I);
-               end loop;
-               New_Line;
+            N := Get_Output (Self, Idx - 1);
+            I := Get_First_Sink (N);
+            while I /= No_Input loop
+               D := Get_Input_Parent (I);
+               Put_Net_Port_To_Instance(Idx, D, N);
+               I := Get_Next_Sink (I);
             end loop;
-            
-            for Idx in 1 .. Get_Nbr_Outputs(M) loop
-               Put_Port_Output(M, Idx);
-               I := Get_Input(Self, Idx - 1);
-               N := Get_Driver(I);
-               D := Get_Net_Parent(N);
-               Put_Net_Instance_To_Port(D, Idx, N);
-               New_Line;
-            end loop;
-            
-            for Inst of Instances (M) loop
-               Disp_Dot_Instance (Self, Inst);
-               New_Line;
-            end loop;
-                        
-         end if;
+            New_Line;
+         end loop;
+         
+         for Idx in 1 .. Get_Nbr_Outputs(M) loop
+            Put_Port_Output(M, Idx);
+            I := Get_Input(Self, Idx - 1);
+            N := Get_Driver(I);
+            D := Get_Net_Parent(N);
+            Put_Net_Instance_To_Port(D, Idx, N);
+            New_Line;
+         end loop;
+         
+         for Inst of Instances (M) loop
+            Disp_Dot_Instance (Self, Inst);
+            New_Line;
+         end loop;
+         
       end;
 
       Put_Line ("}");

--- a/src/synth/netlists-disp_dot.adb
+++ b/src/synth/netlists-disp_dot.adb
@@ -24,15 +24,15 @@ with Netlists.Iterators; use Netlists.Iterators;
 with Netlists.Dump; use Netlists.Dump;
 
 package body Netlists.Disp_Dot is
-   
+
    -- That can't be right.
    -- This must already be defined somewhere.
    type Port_Dir is (Port_Input, Port_Output);
-   
+
    Prefix_Port_Input  : constant String := "pi";
    Prefix_Port_Output : constant String := "po";
    Prefix_Instance    : constant String := "i";
-   
+
    procedure Put_Port (Dir : in Port_Dir; M : in Module; Idx : in Port_Nbr) is
    begin
       Put("  ");
@@ -49,12 +49,12 @@ package body Netlists.Disp_Dot is
       Put("""];");
       New_Line;
    end Put_Port;
-   
+
    procedure Put_Port_Input (M : in Module; Idx : in Port_Nbr) is
    begin
       Put_Port(Port_Input, M, Idx);
    end Put_Port_Input;
-   
+
    procedure Put_Instance (Inst : in Instance; M : in Module) is
    begin
       Put ("  " & Prefix_Instance);
@@ -63,13 +63,14 @@ package body Netlists.Disp_Dot is
       Dump_Name (Get_Module_Name (M));
       Put_Line ("""];");
    end Put_Instance;
-   
+
    procedure Put_Port_Output (M : in Module; Idx : in Port_Nbr) is
    begin
       Put_Port(Port_Output, M, Idx);
    end Put_Port_Output;
-   
-   procedure Put_Net_Port_To_Instance (Idx : in Port_Nbr; D : in Instance; N : in Net) is
+
+   procedure Put_Net_Port_To_Instance (Idx : in Port_Nbr;
+                                       D : in Instance; N : in Net) is
    begin
       Put ("  " & Prefix_Port_Input);
       Put_Uns32 (Uns32 (Idx - 1));
@@ -80,8 +81,9 @@ package body Netlists.Disp_Dot is
       Put ("""]");
       Put_Line (";");
    end Put_Net_Port_To_Instance;
-   
-   procedure Put_Net_Instance_To_Port (D : in Instance; Idx : in Port_Nbr; N : in Net) is
+
+   procedure Put_Net_Instance_To_Port (D : in Instance;
+                                       Idx : in Port_Nbr; N : in Net) is
    begin
       Put("  " & Prefix_Instance);
       Put_Uns32(Uns32(D));
@@ -92,8 +94,9 @@ package body Netlists.Disp_Dot is
       Put ("""]");
       Put_Line (";");
    end Put_Net_Instance_To_Port;
-   
-   procedure Put_Net_Instance_To_Instance (Inst, D : in Instance; N : in Net) is
+
+   procedure Put_Net_Instance_To_Instance (Inst, D : in Instance;
+                                           N : in Net) is
    begin
       Put ("  " & Prefix_Instance);
       Put_Uns32 (Uns32 (Inst));
@@ -104,7 +107,7 @@ package body Netlists.Disp_Dot is
       Put ("""]");
       Put_Line (";");
    end Put_Net_Instance_To_Instance;
-   
+
    procedure Disp_Dot_Instance (Self : in Instance; Inst : Instance)
    is
       M : constant Module := Get_Module (Inst);
@@ -142,7 +145,7 @@ package body Netlists.Disp_Dot is
       Put ("digraph m");
       Put_Uns32 (Uns32 (M));
       Put_Line (" {");
-      
+
       -- uh ?
       if Self = No_Instance then
          return;
@@ -161,7 +164,7 @@ package body Netlists.Disp_Dot is
          end loop;
          New_Line;
       end loop;
-      
+
       for Idx in 1 .. Get_Nbr_Outputs(M) loop
          Put_Port_Output(M, Idx);
          I := Get_Input(Self, Idx - 1);
@@ -170,7 +173,7 @@ package body Netlists.Disp_Dot is
          Put_Net_Instance_To_Port(D, Idx, N);
          New_Line;
       end loop;
-      
+
       for Inst of Instances (M) loop
          Disp_Dot_Instance (Self, Inst);
          New_Line;

--- a/src/synth/netlists-disp_dot.adb
+++ b/src/synth/netlists-disp_dot.adb
@@ -155,8 +155,8 @@ package body Netlists.Disp_Dot is
             for Idx in 1 .. Get_Nbr_Outputs(M) loop
                Put_Port_Output(M, Idx);
                I := Get_Input(Self, Idx - 1);
-               D := Get_Input_Parent(I);
                N := Get_Driver(I);
+               D := Get_Net_Parent(N);
                Put_Net_Instance_To_Port(D, Idx, N);
                New_Line;
             end loop;

--- a/src/synth/netlists-disp_dot.adb
+++ b/src/synth/netlists-disp_dot.adb
@@ -105,7 +105,7 @@ package body Netlists.Disp_Dot is
       Put_Line (";");
    end Put_Net_Instance_To_Instance;
    
-   procedure Disp_Dot_Instance (Inst : Instance)
+   procedure Disp_Dot_Instance (Self : in Instance; Inst : Instance)
    is
       M : constant Module := Get_Module (Inst);
       N : Net;
@@ -119,7 +119,14 @@ package body Netlists.Disp_Dot is
          I := Get_First_Sink (N);
          while I /= No_Input loop
             D := Get_Input_Parent (I);
-            Put_Net_Instance_To_Instance(Inst, D, N);
+            if D = Self then
+               -- Hold on a second, this net goes straight to
+               -- an output port of the top module !
+               -- Do not write the net, the top module has
+               -- already done it.
+            else
+               Put_Net_Instance_To_Instance(Inst, D, N);
+            end if;
             I := Get_Next_Sink (I);
          end loop;
       end loop;
@@ -160,14 +167,14 @@ package body Netlists.Disp_Dot is
                Put_Net_Instance_To_Port(D, Idx, N);
                New_Line;
             end loop;
+            
+            for Inst of Instances (M) loop
+               Disp_Dot_Instance (Self, Inst);
+               New_Line;
+            end loop;
                         
          end if;
       end;
-
-      for Inst of Instances (M) loop
-         Disp_Dot_Instance (Inst);
-         New_Line;
-      end loop;
 
       Put_Line ("}");
    end Disp_Dot_Module;


### PR DESCRIPTION
This fixes the output ports being absent from the dot output of synthesis, and removes the dummy instance that was present.
There is no relevant issue.