### PR TITLE
doc: update requirements

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -174,7 +174,7 @@ extensions = [
     # Standard Sphinx extensions
     'sphinx.ext.autodoc',
     'sphinx.ext.extlinks',
-	  'sphinx.ext.inheritance_diagram',
+    'sphinx.ext.inheritance_diagram',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.graphviz',
@@ -184,8 +184,6 @@ extensions = [
 
     # BuildTheDocs extensions
     'btd.sphinx.autoprogram',
-#    'btd.sphinx.graphviz',
-#    'btd.sphinx.inheritance_diagram',
 
     # Other extensions
 #    'recommonmark',

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -14,5 +14,3 @@ sphinx_autodoc_typehints>=1.19.5
 
 # BuildTheDocs Extensions (mostly patched Sphinx extensions)
 btd.sphinx.autoprogram>=0.1.7.post1
-btd.sphinx.graphviz>=2.3.1.post1
-btd.sphinx.inheritance_diagram>=2.3.1.post1


### PR DESCRIPTION
In #2283, the docs conf file was changed to use upstream `sphinx.ext.inheritance_diagram` and `sphinx.ext.graphviz`. However, the requirements file was not updated accordingly. This PR removes `btd.sphinx.graphviz` and `btd.sphinx.inheritance_diagram` from `docs/requirements.txt`.