### PR TITLE
ci: enable UCRT64 LLVM and test MINGW64 LLVM

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -592,7 +592,7 @@ jobs:
       matrix:
         sys:
 #          - {icon: '🟪', pkg: 'llvm',  sys: 'MINGW32' } ! not yet functional
-#          - {icon: '🟦', pkg: 'llvm',  sys: 'MINGW64' }
+          - {icon: '🟦', pkg: 'llvm',  sys: 'MINGW64' }
           - {icon: '🟨', pkg: 'llvm',  sys: 'UCRT64'  } #! experimental
           - {icon: '🟪', pkg: 'mcode', sys: 'MINGW32' }
 #          - {icon: '🟦', pkg: 'mcode', sys: 'MINGW64' } ! simulation with mcode is not yet supported on win64

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -524,7 +524,7 @@ jobs:
         include:
 #          - {icon: '🟪', pkg: 'llvm',  sys: 'MINGW32' } ! not yet functional
           - {icon: '🟦', pkg: 'llvm',  sys: 'MINGW64' }
-#          - {icon: '🟨', pkg: 'llvm',  sys: 'UCRT64'  } #! experimental
+          - {icon: '🟨', pkg: 'llvm',  sys: 'UCRT64'  } #! experimental
           - {icon: '🟪', pkg: 'mcode', sys: 'MINGW32' }
 #          - {icon: '🟦', pkg: 'mcode', sys: 'MINGW64' } #! simulation with mcode is not yet supported on win64
           - {icon: '🟨', pkg: 'mcode', sys: 'UCRT64'  } #! experimental; simulation with mcode is not yet supported on win64
@@ -593,7 +593,7 @@ jobs:
         sys:
 #          - {icon: '🟪', pkg: 'llvm',  sys: 'MINGW32' } ! not yet functional
 #          - {icon: '🟦', pkg: 'llvm',  sys: 'MINGW64' }
-#          - {icon: '🟨', pkg: 'llvm',  sys: 'UCRT64'  } #! experimental
+          - {icon: '🟨', pkg: 'llvm',  sys: 'UCRT64'  } #! experimental
           - {icon: '🟪', pkg: 'mcode', sys: 'MINGW32' }
 #          - {icon: '🟦', pkg: 'mcode', sys: 'MINGW64' } ! simulation with mcode is not yet supported on win64
 #          - {icon: '🟨', pkg: 'mcode', sys: 'UCRT64'  } ! experimental; simulation with mcode is not yet supported on win64


### PR DESCRIPTION
In https://github.com/ghdl/ghdl/commit/ed54e7f29fcadd7c443a5cf708b0723a82fa27aa, UCRT64 LLVM was disabled. That was/is provided through ghdl-setup-ci, and it's used by projects such as OSVVM (see https://github.com/OSVVM/OsvvmLibraries/blob/main/.github/workflows/Test.yml#L67). Those are now failing: https://github.com/OSVVM/OsvvmLibraries/actions/runs/4294470208.

This PR enables UCRT64 LLVM builds and tests. It also enables MINGW64 LLVM tests.

Alternatively, we can stop supporting UCRT64 and suggest users to consume MINGW64 LLVM only. Yet, I think that MSYS2 is making UCRT64 the default...

/cc @JimLewis