### PR TITLE
doc/conf: add html_theme_options

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -189,12 +189,9 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-
     # BuildTheDocs extensions
     'btd.sphinx.autoprogram',
-
     # Other extensions
-#    'recommonmark',
     'exec',
     'sphinx_fontawesome',
     'sphinx_autodoc_typehints',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import sys
+from os import environ
 from os.path import abspath
 from pathlib import Path
 from json import loads as json_loads
@@ -86,6 +87,28 @@ if ctx.is_file():
     html_context.update(json_loads(ctx.open("r").read()))
 
 html_theme = "furo"
+
+html_css_files = [
+      "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/fontawesome.min.css",
+      "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/solid.min.css",
+      "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/brands.min.css",
+]
+
+html_theme_options = {
+    "source_repository": "https://github.com/ghdl/ghdl",
+    "source_branch": environ.get("GITHUB_REF_NAME", "main"),
+    "source_directory": "doc",
+    "footer_icons": [
+        {
+            "name": "GitHub ghdl/ghdl",
+            "url": "https://github.com/ghdl/ghdl",
+            "html": "",
+            "class": "fa-solid fa-brands fa-github",
+        },
+    ],
+}
+
+html_title = release
 
 html_static_path = ['_static']
 # '/public' will contain the output from gnatdoc

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -29,13 +29,13 @@ GHDL
    News
    ****
 
-   28.02.2022 - `GHDL v2.0 was released <https://github.com/ghdl/ghdl/milestone/10?closed=1>`__
+   2022.02.28 - `GHDL v2.0 was released <https://github.com/ghdl/ghdl/milestone/10?closed=1>`__
    ============================================================================================
 
-   02.02.2021 - `GHDL v1.0 was released <https://github.com/ghdl/ghdl/milestone/9?closed=1>`__
+   2021.02.02 - `GHDL v1.0 was released <https://github.com/ghdl/ghdl/milestone/9?closed=1>`__
    ============================================================================================
 
-   31.01.2021 - GHDL v1.0.0rc1 was tagged
+   2021.01.31 - GHDL v1.0.0rc1 was tagged
    ======================================
 
    * Python bindings were overhauled and renamed to ``pyGHDL``. Three modules are included: ``libghdl``, ``lsp`` and ``dom``.
@@ -48,14 +48,14 @@ GHDL
 
    * Assets are not added to releases or pre-releases anymore. Users should use package managers or nightly assets.
 
-   21.05.2020 - Nightly build assets available
+   2020.05.21 - Nightly build assets available
    ===========================================
 
    * After each successful CI run of branch ``master``, packages are published as assets of pre-release `nightly <https://github.com/ghdl/ghdl/releases/tag/nightly>`__.
    * GitHub Action `ghdl/setup-ghdl-ci <https://github.com/ghdl/setup-ghdl-ci>`__ was created, to allow easy installation of
      nightly GHDL assets in GitHub Actions workflows.
 
-   09.05.2020 - New repositories and a wiki were created
+   2020.05.09 - New repositories and a wiki were created
    =====================================================
 
    * The plugin for Yosys was moved from `tgingold/ghdlsynth-beta <https://github.com/tgingold/ghdlsynth-beta>`__ to
@@ -65,7 +65,7 @@ GHDL
    * A `Wiki <https://github.com/ghdl/ghdl/wiki>`__ was created. The roadmap and ideas for documentation and internship
      programs were moved there. If you want to contribute anyhow, `have a look <https://github.com/ghdl/ghdl/wiki>`__!
 
-   28.02.2020 - `GHDL v0.37 was released <https://github.com/ghdl/ghdl/milestone/8?closed=1>`__
+   2020.02.28 - `GHDL v0.37 was released <https://github.com/ghdl/ghdl/milestone/8?closed=1>`__
    ============================================================================================
 
    The major changes are:
@@ -75,10 +75,10 @@ GHDL
    * Last version that supports the Mentor variation of std_logic_arith.
      The Synopsys one is still available.
 
-   03.03.2019 - `GHDL v0.36 was released <https://github.com/ghdl/ghdl/milestone/7?closed=1>`__
+   2019.03.03 - `GHDL v0.36 was released <https://github.com/ghdl/ghdl/milestone/7?closed=1>`__
    ============================================================================================
 
-   23.02.2019 - GHDL v0.36-rc1 was released
+   2019.02.23 - GHDL v0.36-rc1 was released
    ========================================
 
    The major improvements are:
@@ -86,51 +86,51 @@ GHDL
    * more support of unbounded arrays and records
    * support of UVVM and Vunit
 
-   29.11.2018 - GHDL 20181129 was released
+   2018.11.29 - GHDL 20181129 was released
    =======================================
 
-   20.12.2017 - A new GitHub organization was created
+   2017.12.20 - A new GitHub organization was created
    ==================================================
 
    A new GitHub organization is created and the main repo is moved from `github.com/tgingold/ghdl <https://github.com/tgingold/ghdl>`__ to
    `github.com/ghdl/ghdl <https://github.com/ghdl/ghdl>`__. Old refs will continue working, because permanent redirects are set up. However, we suggest
    every contributor to update the remote URLs in their local clones.
 
-   14.12.2017 - `GHDL 0.35 was released <https://github.com/ghdl/ghdl/milestone/3?closed=1>`__
+   2017.12.14 - `GHDL 0.35 was released <https://github.com/ghdl/ghdl/milestone/3?closed=1>`__
    ===========================================================================================
 
-   15.08.2017 - `GHDL 0.34 was released <https://github.com/ghdl/ghdl/milestone/1?closed=1>`__
+   2017.08.15 - `GHDL 0.34 was released <https://github.com/ghdl/ghdl/milestone/1?closed=1>`__
    ===========================================================================================
 
-   23.10.2015 - GHDL 0.33 was released
+   2015.10.23 - GHDL 0.33 was released
    ===================================
 
 .. only:: latex
 
-   .. rubric:: 28.02.2022 - GHDL v2.0 was released.
+   .. rubric:: 2022.02.28 - GHDL v2.0 was released.
 
-   .. rubric:: 02.02.2021 - GHDL v1.0 was released.
+   .. rubric:: 2021.02.02 - GHDL v1.0 was released.
 
-   .. rubric:: 31.01.2021 - GHDL v1.0.0rc1 was tagged.
+   .. rubric:: 2021.01.31 - GHDL v1.0.0rc1 was tagged.
 
-   .. rubric:: 21.05.2020 - Nightly build assets available.
+   .. rubric:: 2020.05.21 - Nightly build assets available.
 
-   .. rubric:: 09.05.2020 - New repositories and a wiki were created.
+   .. rubric:: 2020.05.09 - New repositories and a wiki were created.
 
-   .. rubric:: 28.02.2020 - GHDL v0.37 was released.
+   .. rubric:: 2020.02.28 - GHDL v0.37 was released.
 
-   .. rubric:: 03.03.2019 - GHDL v0.36 was released.
+   .. rubric:: 2019.03.03 - GHDL v0.36 was released.
 
-   .. rubric:: 23.02.2019 - GHDL v0.36-rc1 was released.
+   .. rubric:: 2019.02.23 - GHDL v0.36-rc1 was released.
 
-   .. rubric:: 29.11.2018 - GHDL 20181129 was released.
+   .. rubric:: 2018.11.29 - GHDL 20181129 was released.
 
-   .. rubric:: 20.12.2017 - A new GitHub organization was created.
+   .. rubric:: 2017.12.20 - A new GitHub organization was created.
 
-   .. rubric:: 14.12.2017 - GHDL 0.35 was released.
+   .. rubric:: 2017.12.14 - GHDL 0.35 was released.
 
-   .. rubric:: 15.08.2017 - GHDL 0.34 was released.
+   .. rubric:: 2017.08.15 - GHDL 0.34 was released.
 
-   .. rubric:: 23.10.2015 - GHDL 0.33 was released.
+   .. rubric:: 2015.10.23 - GHDL 0.33 was released.
 
 .. include:: toc.rst

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -70,11 +70,10 @@ GHDL
 
    The major changes are:
 
-      * Experimental support of synthesis (either with --synth or with
-	the Yosys plugin).
-      * Fixes and improved support of vhdl 2008.
-      * Last version that supports the Mentor variation of
-	std_logic_arith.  The Synopsys one is still available.
+   * Experimental support of synthesis (either with --synth or with the Yosys plugin).
+   * Fixes and improved support of vhdl 2008.
+   * Last version that supports the Mentor variation of std_logic_arith.
+     The Synopsys one is still available.
 
    03.03.2019 - `GHDL v0.36 was released <https://github.com/ghdl/ghdl/milestone/7?closed=1>`__
    ============================================================================================
@@ -84,8 +83,8 @@ GHDL
 
    The major improvements are:
 
-      * more support of unbounded arrays and records
-      * support of UVVM and Vunit
+   * more support of unbounded arrays and records
+   * support of UVVM and Vunit
 
    29.11.2018 - GHDL 20181129 was released
    =======================================

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,9 +4,6 @@ sphinx
 python-dateutil>=2.8.2
 
 # Sphinx Extenstions
-# sphinxcontrib-textstyle>=0.2.1
-# sphinxcontrib-spelling>=2.2.0
-# changelog>=0.3.5
 autoapi>=2.0.1
 sphinx_fontawesome>=0.0.6
 sphinx_autodoc_typehints>=1.19.5


### PR DESCRIPTION
This PR adds html_theme_options to:

- Have an "edit" button shown at the top.
- Show the `release` only below the logo in the sidebar.
- Have a "github" button at the bottom pointing to the repo.

As an alternative to showing the release below the logo, we could show no text (just the logo). See https://pradyunsg.me/furo/customisation/#sidebar-hide-name. What do you prefer?

This PR includes some other minor issues:

- Fixing the indentation of some list in the index.
- Reversing the date format of the headings in the index so that the year is shown first.
- Cleaning unused dependencies/extensions.

Ref #2364