### PR TITLE
news: add headings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,14 @@
-**3.0-dev** (XXXX-XX-XX)
+# News
+
+## 3.0-dev (XXXX-XX-XX)
 
 - Handle ieee operators for static expressions.
 
-**2.0** (2022-02-28)
+## 2.0 (2022-02-28)
 
 - Improvements to VHDL 2008 supports and synthesis.
 
-**1.0** (2021-02-02)
+## 1.0 (2021-02-02)
 
 - Plugin for Yosys moved from [tgingold/ghdlsynth-beta](https://github.com/tgingold/ghdlsynth-beta) to [ghdl/ghdl-yosys-plugin](https://github.com/ghdl/ghdl-yosys-plugin).
 - Python bindings overhauled and renamed to `pyGHDL`. Three modules are included: `libghdl`, `lsp` and `dom`.
@@ -19,7 +21,7 @@
 - Assets not added to releases or pre-releases anymore. Users should use package managers or nightly assets (updated after each successful CI run of branch `master`): [nightly](https://github.com/ghdl/ghdl/releases/tag/nightly).
 - Main documentation site(s) moved to [ghdl.github.io/ghdl](https://ghdl.github.io/ghdl/) and [ghdl.github.io/ghdl-cosim](https://ghdl.github.io/ghdl-cosim/).
 
-**0.37** (2020-02-28)
+## 0.37 (2020-02-28)
 
 - Python binding added
 - Experimental support of synthesis (either with --synth or with the Yosys plugin)
@@ -28,18 +30,18 @@
 - Add support for assume.
 - Last version that supports the Mentor variation of `std_logic_arith`. The Synopsys one is still available.
 
-**0.36** (2019-03-03)
+## 0.36 (2019-03-03)
 
 - A new GitHub organization is created and the main repo is moved from [github.com/tgingold/ghdl](https://github.com/tgingold/ghdl) to [github.com/ghdl/ghdl](https://github.com/ghdl/ghdl). Old refs will continue working, because permanent redirects are set up. However, we suggest every contributor to update the remote URLs in their local clones.
 - Add support for unbounded arrays.
 
-**0.35** (2017-12-14)
+## 0.35 (2017-12-14)
 
 - Assert and report messages are sent to stdout (#394)
 - Improve support for unbounded records
 - Bugs fixed
 
-**0.34** (2017-08-15)
+## 0.34 (2017-08-15)
 
 - Display stack backtraces on errors or assert failures
 - Compile scripts for vendor libraries (Xilinx, Altera, osvvm, vunit)
@@ -52,14 +54,14 @@
 - New option `--psl-report`, to report status of PSL assert and cover.
 - VHDL2008: support nested package
 
-**0.33** (2015-10-04)
+## 0.33 (2015-10-04)
 
 - Improve support of VHDL2008
 - Support [OSVVM](http://osvvm.org) 2015
 - Support VUnit: [LarsAsplund/vunit](https://github.com/LarsAsplund/vunit)
 - Many bugs fixed
 
-**0.32** (2014-11-XX)
+## 0.32 (2014-11-XX)
 
 - Updated to build with `gcc-4.9.2`.
 - support:
@@ -76,7 +78,7 @@
 	- OSVVM 2014_01
 - Bugs fixed
 
-**0.31** (2014-01-XX)
+## 0.31 (2014-01-XX)
 
 - Updated to build with `gcc-4.8.2`.
 - Supports OSVVM (Open-Source VHDL Verification Methodology) (see [osvvm.org](http://osvvm.org)) in its VHDL-2002 form.
@@ -84,11 +86,11 @@
 - Many bugs and support issues fixed.
 - New home on `https://sourceforge.net/projects/ghdl-updates/`
 
-**0.30** (-)
+## 0.30 (-)
 
 Never released, swith to Dunoon Edition.
 
-**0.29** (2010-01-09)
+## 0.29 (2010-01-09)
 
 - Initial implementation of embedded PSL assertions.
 - Improve:
@@ -99,7 +101,7 @@ Never released, swith to Dunoon Edition.
 	- when the bound of a string literal type is not locally static.
 	- gcov crash
 
-**0.28** (2009-09-17)
+## 0.28 (2009-09-17)
 
 - Add `--std=08` to enable VHDL2008 features.
 - Support all-sensitized processes from VHDL2008.
@@ -110,7 +112,7 @@ Never released, swith to Dunoon Edition.
   - direct drivers elaboration for unconstrained array signals.
   - many minor bugs.
 
-**0.27** (2008-07-01)
+## 0.27 (2008-07-01)
 
 - Improve SDF annotation (handles much more annotations)
 - Add `--ieee-asserts=` option to control assert messages from ieee packages.
@@ -123,7 +125,7 @@ Never released, swith to Dunoon Edition.
   - clear timeout in wait for.
   - minor bugs.
 
-**0.26** (2007-04-08)
+## 0.26 (2007-04-08)
 
 - `GHDL_PREFIX` environment variable overrides default installation prefix.
 - simulation speed improved with 'direct drivers'.
@@ -140,7 +142,7 @@ Never released, swith to Dunoon Edition.
 	- crash when bad array prefix
 	- correctly extract sensitivity of record aggregate
 
-**0.25** (2006-08-11)
+## 0.25 (2006-08-11)
 
 - VPI functions to schedules values.
 - `math_real` now works under windows.
@@ -160,7 +162,7 @@ Never released, swith to Dunoon Edition.
 	- handle in-conversion for signal associated with an expression.
 	- emit an error when a function tries to exit without a return.
 
-**0.24** (2006-06-25)
+## 0.24 (2006-06-25)
 
 - Handle enums with more than 256 elements.
 - Relax expr static rules in 93c to analyze Xilinx core lib from 8.1
@@ -180,14 +182,14 @@ Never released, swith to Dunoon Edition.
 	- time and character read procedure of std.textio.
 	- initialize by value parameters (instead of copy-in).
 
-**0.23** (2006-05-16)
+## 0.23 (2006-05-16)
 
 - bug fix:
 	- handle implicit conversion in resolution functions.
 	- missing implicit conversion added.
 	- avoid a crash in error.
 
-**0.22** (2006-03-28)
+## 0.22 (2006-03-28)
 
 - direntry added in `ghdl.texi`
 - updated:
@@ -203,7 +205,7 @@ Never released, swith to Dunoon Edition.
 	- configuration issue
 	- `--warn-no-vital-generic` is now working
 
-**0.21** (2005-12-18)
+## 0.21 (2005-12-18)
 
 - local optimizations (loops, indexed name).
 - simulation speed improved by 20% due to processes mngt optimizations.
@@ -225,7 +227,7 @@ Never released, swith to Dunoon Edition.
 	- handle missing `EOL` for `readline`.
 	- for `x86_64`
 
-**0.20** (2005-10-15)
+## 0.20 (2005-10-15)
 
 - stack memory usage improved for shortcurt operations.
 - gtkwave now displays nice waves for bit and std_ulogic signals.
@@ -245,7 +247,7 @@ Never released, swith to Dunoon Edition.
 	- for reading `.ghw` files.
 	- in `--xref`.
 
-**0.19** (2005-08-17)
+## 0.19 (2005-08-17)
 
 - `ADAFLAGS` has been replaced by `GHDL_ADAFLAGS` to ease compilation.
 - `ieee.math_real` and `ieee.math_complex` added (only partially, based on a
@@ -278,7 +280,7 @@ Never released, swith to Dunoon Edition.
 	- allow conversion in component configuration.
 	- conversion in associations with not statically defined array signals.
 
-**0.18** (2005-03-12)
+## 0.18 (2005-03-12)
 
 - Keep last line number to speed-up line number look-up (improvement).
 - `--warn-default-binding` added, `--warn-binding` rewritten.
@@ -291,7 +293,7 @@ Never released, swith to Dunoon Edition.
 	- correctly set the default value of collapsed ports.
 	- handling of stack2 (aka large concatenation bug).
 
-**0.17** (2005-02-26)
+## 0.17 (2005-02-26)
 
 - command `--elab-run` added.
 - Code generation for aggregate improved.
@@ -311,7 +313,7 @@ Never released, swith to Dunoon Edition.
 	- non-object name in sensitivity list crashed.
 	- correctly handle alias of signals in processes.
 
-**0.16** (2005-01-02)
+## 0.16 (2005-01-02)
 
 - `std.textio`: readline has no limits on line length.
 - command `-r` (run) added.
@@ -321,13 +323,13 @@ Never released, swith to Dunoon Edition.
 	- parse error: `begin` in aggregates.
 	- bad `unused subprogram` warnings.
 
-**0.15** (2004-10-13)
+## 0.15 (2004-10-13)
 
 - library file format modified to handle relative pathes.
 - install fixed to use relative pathes.
 - internal change: ortho API modified (constant are not anymore expressions).
 
-**0.14** (2004-08-29)
+## 0.14 (2004-08-29)
 
 - pretty printing in HTML command, `--pp-html`, added.
 - xref generation in HTML command, `--xref-html`, added.
@@ -355,7 +357,7 @@ Never released, swith to Dunoon Edition.
 	- parameters of protected type: handled and checked.
 	- `gen_tree.c` modified to work with sparc.
 
-**0.13** (2004-06-26)
+## 0.13 (2004-06-26)
 
 - support of 64bits integers and 32bits time (not yet user available)
 - handle `'high` and `'low` attributes on non-locally static types and subtypes.
@@ -378,7 +380,7 @@ Never released, swith to Dunoon Edition.
 	- multiple visibility of declarations (eg: direct and alias).
 	- names attribute of non-object aliases.
 
-**0.12** (2004-05-30)
+## 0.12 (2004-05-30)
 
 - simulation speed improved (2 fold) due to reduced activity optimization.
 - type conversion handled in associations
@@ -394,14 +396,14 @@ Never released, swith to Dunoon Edition.
 	- association of an unconstrained port with an expression.
 	- declaring an uncons. array subtype of an uncons. array subtype.
 
-**0.11.1** (2004-04-24)
+## 0.11.1 (2004-04-24)
 
 - bug fix:
 	- corner case of signal not updated
 	- handle `'stable`, `'quiet` with a paramater > 0
 	- typos (missing `+ `) in sparc.S
 
-**0.11** (2004-04-17)
+## 0.11 (2004-04-17)
 
 - signal collapsing improved.
 - simulation kernel speed improved (maybe 5x faster).
@@ -415,7 +417,7 @@ Never released, swith to Dunoon Edition.
 	- implicit conversion in formal function convertor.
 	- return type is a type mark.
 
-**0.10** (2004-02-28)
+## 0.10 (2004-02-28)
 
 - architecture with many instances can be compiled with less memory.
 - `--stats` option added to the simulator, to evaluate performance.
@@ -428,7 +430,7 @@ Never released, swith to Dunoon Edition.
 	- absolute source files.
 	- empty sequence of statements in case alternatives.
 
-**0.9** (2004-02-01)
+## 0.9 (2004-02-01)
 
 - VITAL level 0 restrictions checks added.
 - VITAL 2000 packages provided.
@@ -442,7 +444,7 @@ Never released, swith to Dunoon Edition.
 	- concurrent procedure call creates a non-sensitized process.
 	- effective value of non-scalar resolved signal might not be set.
 
-**0.8** (2003-11-05)
+## 0.8 (2003-11-05)
 
 - protected types (from 1076a/1076-2000) implemented.
 - file declarations are finalized in subprograms.
@@ -456,7 +458,7 @@ Never released, swith to Dunoon Edition.
 	- signal declaration not allowed in processes.
 	- several bugs fixed.
 
-**0.7** (2003-08-02)
+## 0.7 (2003-08-02)
 
 - layout of internal nodes improved.
 - incremental binding (vhdl93).
@@ -471,7 +473,7 @@ Never released, swith to Dunoon Edition.
 	- correctly handle operators names at function call.
 	- several small bugs fixed.
 
-**0.6** (2003-06-09)
+## 0.6 (2003-06-09)
 
 - internal modifications (single linked list used instead of arrays).
 - Mentor version of std_logic_arith is provided.
@@ -484,7 +486,7 @@ Never released, swith to Dunoon Edition.
 	- `selected_name` list in use clauses.
 	- many other small bug fixes.
 
-**0.5** (2003-05-10)
+## 0.5 (2003-05-10)
 
 - foreign attribute handled.  You can now call subprograms defined in a foreign
   language (such as C or Ada).
@@ -494,11 +496,11 @@ Never released, swith to Dunoon Edition.
 	- triple use.
 	- incomplete types
 
-**0.4.1** (2003-04-07)
+## 0.4.1 (2003-04-07)
 
 - bug fix: in the vcd output.
 
-**0.4** (2003-04-02)
+## 0.4 (2003-04-02)
 
 - `libgrt` does not depend on GNAT library anymore.
   Installation requirements are reduced.


### PR DESCRIPTION
The NEWS file (https://github.com/ghdl/ghdl/blob/master/NEWS.md) is a markdown source. However, headings are not used.

GitHub and GitLab do automatically generate a ToC for markdown sources. This PR adds headings to `NEWS.md`, so that the automatically generated ToCs can be used for more easily navigating the document. See https://github.com/umarcor/ghdl/blob/umarcor/news-headings/NEWS.md and:

![image](https://user-images.githubusercontent.com/38422348/223152861-1ee1a9c1-c143-4fc5-be8e-ce95fa44f78e.png)
