### PR TITLE
Limiting versions of pyTooling to >=2.13, but <3.0.

### DIFF
--- a/pyGHDL/cli/requirements.txt
+++ b/pyGHDL/cli/requirements.txt
@@ -1,5 +1,5 @@
 -r ../dom/requirements.txt
 
-pyTooling>=2.11.0
+pyTooling>=2.13.0, <3.0
 pyTooling.TerminalUI>=1.5.9
 pyAttributes>=2.3.2

--- a/pyGHDL/libghdl/requirements.txt
+++ b/pyGHDL/libghdl/requirements.txt
@@ -1,1 +1,1 @@
-pyTooling>=2.11.0
+pyTooling>=2.13.0, <3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "pyTooling >= 2.11.0",
+    "pyTooling >= 2.13.0",
     "setuptools >= 62.3.3",
     "wheel >= 0.38.1"
 ]


### PR DESCRIPTION
In preparation for a breaking change in pyTooling, the version will be limited to >=2.13, but <3.0.

In `pyTooling` 3.0, `pyTooling.TerminalUI` will be integrated instead of a standalone project. There will be at the beginning no API change, but the two packages will overlap in installation directories.

------------
When pyTooling 3.0 is released, the dependency structure in GHDL can be simplified.