### PR TITLE
pyGHDL: exit statement handling is missing

### DIFF
--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -49,6 +49,7 @@ from pyVHDLModel.Sequential import CaseStatement as VHDLModel_CaseStatement
 from pyVHDLModel.Sequential import ForLoopStatement as VHDLModel_ForLoopStatement
 from pyVHDLModel.Sequential import NullStatement as VHDLModel_NullStatement
 from pyVHDLModel.Sequential import WaitStatement as VHDLModel_WaitStatement
+from pyVHDLModel.Sequential import ExitStatement as VHDLModel_ExitStatement
 from pyVHDLModel.Sequential import SequentialProcedureCall as VHDLModel_SequentialProcedureCall
 from pyVHDLModel.Sequential import SequentialSimpleSignalAssignment as VHDLModel_SequentialSimpleSignalAssignment
 from pyVHDLModel.Sequential import SequentialReportStatement as VHDLModel_SequentialReportStatement
@@ -475,6 +476,17 @@ class NullStatement(VHDLModel_NullStatement, DOMMixin):
     ):
         super().__init__(label)
         DOMMixin.__init__(self, waitNode)
+
+
+@export
+class ExitStatement(VHDLModel_ExitStatement, DOMMixin):
+    def __init__(
+        self,
+        exitNode: Iir,
+        label: str = None,
+    ):
+        super().__init__(label)
+        DOMMixin.__init__(self, exitNode)
 
 
 @export

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -485,8 +485,9 @@ class ExitStatement(VHDLModel_ExitStatement, DOMMixin):
         exitNode: Iir,
         label: str = None,
     ):
-        super().__init__(label)
+        super().__init__(condition=None, loopLabel=label)
         DOMMixin.__init__(self, exitNode)
+        #TODO: parse condition
 
 
 @export

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -487,7 +487,7 @@ class ExitStatement(VHDLModel_ExitStatement, DOMMixin):
     ):
         super().__init__(condition=None, loopLabel=label)
         DOMMixin.__init__(self, exitNode)
-        #TODO: parse condition
+        # TODO: parse condition
 
 
 @export

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -55,6 +55,7 @@ from pyGHDL.dom.Sequential import (
     WaitStatement,
     SequentialSimpleSignalAssignment,
     NullStatement,
+    ExitStatement,
     SequentialProcedureCall,
 )
 
@@ -880,6 +881,8 @@ def GetSequentialStatementsFromChainedNodes(
             yield SequentialAssertStatement.parse(statement, label)
         elif kind == nodes.Iir_Kind.Null_Statement:
             yield NullStatement(statement, label)
+        elif kind == nodes.Iir_Kind.Exit_Statement:
+            yield ExitStatement(statement, label)
         else:
             raise DOMException(f"Unknown statement of kind '{kind.name}' in {entity} '{name}' at {position}.")
 


### PR DESCRIPTION
There was no handling for exit statements. pyGHDL stopped with an exception instead.

