### PR TITLE
pyGHDL: fix range handling in subtype indication

### DIFF
--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -333,7 +333,13 @@ def GetScalarConstrainedSubtypeFromNode(
     typeMarkName = GetNameOfNode(typeMark)
     simpleTypeMark = SimpleName(typeMark, typeMarkName)
     rangeConstraint = nodes.Get_Range_Constraint(subtypeIndicationNode)
-    r = GetRangeFromNode(rangeConstraint)
+
+    r = None
+    # Check if RangeExpression. Might also be an AttributeName (see §3.1)
+    if GetIirKindOfNode(rangeConstraint) == nodes.Iir_Kind.Range_Expression:
+        r = GetRangeFromNode(rangeConstraint)
+    #todo: Get actual range from AttributeName node?
+
     return ConstrainedScalarSubtypeSymbol(subtypeIndicationNode, str(simpleTypeMark), r)  # XXX: hacked
 
 

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -338,7 +338,7 @@ def GetScalarConstrainedSubtypeFromNode(
     # Check if RangeExpression. Might also be an AttributeName (see §3.1)
     if GetIirKindOfNode(rangeConstraint) == nodes.Iir_Kind.Range_Expression:
         r = GetRangeFromNode(rangeConstraint)
-    #todo: Get actual range from AttributeName node?
+    # todo: Get actual range from AttributeName node?
 
     return ConstrainedScalarSubtypeSymbol(subtypeIndicationNode, str(simpleTypeMark), r)  # XXX: hacked
 


### PR DESCRIPTION
According to §3.1, range can be a range expression or an attribute name. This must be respected when accessing the fields of the node. Trying to access the range expression fields on an attribute name node led to a libGHDL exception.

The bug is triggered by declarations using an attribute name as range:
```
signal int : integer range entries'range;
```