### PR TITLE
pyGHDL: Reworked Symbols and Names

### DIFF
--- a/pyGHDL/cli/requirements.txt
+++ b/pyGHDL/cli/requirements.txt
@@ -1,5 +1,4 @@
 -r ../dom/requirements.txt
 
 pyTooling>=4.0.1, <5.0
-pyTooling.TerminalUI>=1.5.9
 pyAttributes>=2.3.2

--- a/pyGHDL/dom/Attribute.py
+++ b/pyGHDL/dom/Attribute.py
@@ -45,7 +45,7 @@ from pyGHDL.libghdl.vhdl import nodes
 from pyGHDL.libghdl.vhdl.tokens import Tok
 from pyGHDL.dom import DOMMixin, Position, DOMException, Expression
 from pyGHDL.dom._Utils import GetNameOfNode, GetIirKindOfNode, GetDocumentationOfNode
-from pyGHDL.dom._Translate import GetNameFromNode, GetExpressionFromNode
+from pyGHDL.dom._Translate import GetName, GetExpressionFromNode
 from pyGHDL.dom.Names import SimpleName
 from pyGHDL.dom.Symbol import SimpleSubtypeSymbol
 
@@ -109,7 +109,7 @@ class AttributeSpecification(VHDLModel_AttributeSpecification, DOMMixin):
     @classmethod
     def parse(cls, attributeNode: Iir) -> "AttributeSpecification":
         attributeDesignator = nodes.Get_Attribute_Designator(attributeNode)
-        attributeName = GetNameFromNode(attributeDesignator)
+        attributeName = GetName(attributeDesignator)
         documentation = GetDocumentationOfNode(attributeNode)
 
         names = []

--- a/pyGHDL/dom/Attribute.py
+++ b/pyGHDL/dom/Attribute.py
@@ -63,7 +63,7 @@ class Attribute(VHDLModel_Attribute, DOMMixin):
         subtypeMark = nodes.Get_Type_Mark(attributeNode)
         subtypeName = GetNameOfNode(subtypeMark)
 
-        subtype = SimpleSubtypeSymbol(subtypeMark, subtypeName)
+        subtype = SimpleSubtypeSymbol(subtypeMark, SimpleName(subtypeName))
         return cls(attributeNode, name, subtype, documentation)
 
 

--- a/pyGHDL/dom/Attribute.py
+++ b/pyGHDL/dom/Attribute.py
@@ -63,7 +63,7 @@ class Attribute(VHDLModel_Attribute, DOMMixin):
         subtypeMark = nodes.Get_Type_Mark(attributeNode)
         subtypeName = GetNameOfNode(subtypeMark)
 
-        subtype = SimpleSubtypeSymbol(subtypeMark, SimpleName(subtypeName))
+        subtype = SimpleSubtypeSymbol(subtypeMark, SimpleName(subtypeMark, subtypeName))
         return cls(attributeNode, name, subtype, documentation)
 
 

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -70,12 +70,6 @@ from pyVHDLModel.Concurrent import (
 from pyGHDL.libghdl import Iir, utils
 from pyGHDL.libghdl.vhdl import nodes
 from pyGHDL.dom import DOMMixin, DOMException, Position
-from pyGHDL.dom._Utils import (
-    GetNameOfNode,
-    GetEntityInstantiationSymbol,
-    GetComponentInstantiationSymbol,
-    GetConfigurationInstantiationSymbol,
-)
 from pyGHDL.dom.Range import Range
 from pyGHDL.dom.Symbol import (
     ArchitectureSymbol,
@@ -146,7 +140,7 @@ class EntityInstantiation(VHDLModel_EntityInstantiation, DOMMixin):
 
     @classmethod
     def parse(cls, instantiationNode: Iir, instantiatedUnit: Iir, label: str) -> "EntityInstantiation":
-        from pyGHDL.dom._Translate import GetGenericMapAspect, GetPortMapAspect
+        from pyGHDL.dom._Translate import GetName, GetGenericMapAspect, GetPortMapAspect
 
         entityId = nodes.Get_Entity_Name(instantiatedUnit)
         entitySymbol = GetEntityInstantiationSymbol(entityId)
@@ -154,7 +148,7 @@ class EntityInstantiation(VHDLModel_EntityInstantiation, DOMMixin):
         architectureSymbol = None
         architectureId = nodes.Get_Architecture(instantiatedUnit)
         if architectureId != nodes.Null_Iir:
-            architectureSymbol = ArchitectureSymbol(GetNameOfNode(architectureId), entitySymbol)
+            architectureSymbol = ArchitectureSymbol(GetName(architectureId), entitySymbol)
 
         genericAssociations = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(instantiationNode))
         portAssociations = GetPortMapAspect(nodes.Get_Port_Map_Aspect_Chain(instantiationNode))
@@ -230,13 +224,13 @@ class ProcessStatement(VHDLModel_ProcessStatement, DOMMixin):
 
     @classmethod
     def parse(cls, processNode: Iir, label: str, hasSensitivityList: bool) -> "ProcessStatement":
-        from pyGHDL.dom._Translate import GetDeclaredItemsFromChainedNodes, GetSequentialStatementsFromChainedNodes
+        from pyGHDL.dom._Translate import GetName, GetDeclaredItemsFromChainedNodes, GetSequentialStatementsFromChainedNodes
 
         sensitivityList = None
         if hasSensitivityList:
             sensitivityList = []
             for item in utils.list_iter(nodes.Get_Sensitivity_List(processNode)):
-                sensitivityList.append(GetNameOfNode(item))
+                sensitivityList.append(GetName(item))
 
         declaredItems = GetDeclaredItemsFromChainedNodes(nodes.Get_Declaration_Chain(processNode), "process", label)
         statements = GetSequentialStatementsFromChainedNodes(
@@ -490,7 +484,7 @@ class CaseGenerateStatement(VHDLModel_CaseGenerateStatement, DOMMixin):
         from pyGHDL.dom._Translate import (
             GetExpressionFromNode,
             GetRangeFromNode,
-            GetNameFromNode,
+            GetName,
         )
 
         expression = GetExpressionFromNode(nodes.Get_Expression(generateNode))
@@ -524,7 +518,7 @@ class CaseGenerateStatement(VHDLModel_CaseGenerateStatement, DOMMixin):
                     nodes.Iir_Kind.Attribute_Name,
                     nodes.Iir_Kind.Parenthesis_Name,
                 ):
-                    rng = GetNameFromNode(choiceRange)
+                    rng = GetName(choiceRange)
                 else:
                     pos = Position.parse(alternative)
                     raise DOMException(
@@ -585,11 +579,11 @@ class ForGenerateStatement(VHDLModel_ForGenerateStatement, DOMMixin):
             GetDeclaredItemsFromChainedNodes,
             GetConcurrentStatementsFromChainedNodes,
             GetRangeFromNode,
-            GetNameFromNode,
+            GetName,
         )
 
         spec = nodes.Get_Parameter_Specification(generateNode)
-        loopIndex = GetNameOfNode(spec)
+        loopIndex = GetName(spec)
 
         discreteRange = nodes.Get_Discrete_Range(spec)
         rangeKind = GetIirKindOfNode(discreteRange)
@@ -599,7 +593,7 @@ class ForGenerateStatement(VHDLModel_ForGenerateStatement, DOMMixin):
             nodes.Iir_Kind.Attribute_Name,
             nodes.Iir_Kind.Parenthesis_Name,
         ):
-            rng = GetNameFromNode(discreteRange)
+            rng = GetName(discreteRange)
         else:
             pos = Position.parse(generateNode)
             raise DOMException(
@@ -651,10 +645,10 @@ class ConcurrentSimpleSignalAssignment(VHDLModel_ConcurrentSimpleSignalAssignmen
 
     @classmethod
     def parse(cls, assignmentNode: Iir, label: str) -> "ConcurrentSimpleSignalAssignment":
-        from pyGHDL.dom._Translate import GetNameFromNode
+        from pyGHDL.dom._Translate import GetName
 
         target = nodes.Get_Target(assignmentNode)
-        targetName = GetNameFromNode(target)
+        targetName = GetName(target)
 
         waveform = []
         for wave in utils.chain_iter(nodes.Get_Waveform_Chain(assignmentNode)):
@@ -677,12 +671,12 @@ class ConcurrentProcedureCall(VHDLModel_ConcurrentProcedureCall, DOMMixin):
 
     @classmethod
     def parse(cls, concurrentCallNode: Iir, label: str) -> "ConcurrentProcedureCall":
-        from pyGHDL.dom._Translate import GetNameFromNode, GetParameterMapAspect
+        from pyGHDL.dom._Translate import GetName, GetParameterMapAspect
 
         callNode = nodes.Get_Procedure_Call(concurrentCallNode)
 
         prefix = nodes.Get_Prefix(callNode)
-        procedureName = GetNameFromNode(prefix)
+        procedureName = GetName(prefix)
         parameterAssociations = GetParameterMapAspect(nodes.Get_Parameter_Association_Chain(callNode))
 
         return cls(concurrentCallNode, label, procedureName, parameterAssociations)

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -115,9 +115,9 @@ class ComponentInstantiation(VHDLModel_ComponentInstantiation, DOMMixin):
 
     @classmethod
     def parse(cls, instantiationNode: Iir, instantiatedUnit: Iir, label: str) -> "ComponentInstantiation":
-        from pyGHDL.dom._Translate import GetGenericMapAspect, GetPortMapAspect
+        from pyGHDL.dom._Translate import GetName, GetGenericMapAspect, GetPortMapAspect
 
-        componentSymbol = GetComponentInstantiationSymbol(instantiatedUnit)
+        componentSymbol = ComponentInstantiationSymbol(instantiatedUnit, GetName(instantiatedUnit))
         genericAssociations = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(instantiationNode))
         portAssociations = GetPortMapAspect(nodes.Get_Port_Map_Aspect_Chain(instantiationNode))
 
@@ -142,8 +142,8 @@ class EntityInstantiation(VHDLModel_EntityInstantiation, DOMMixin):
     def parse(cls, instantiationNode: Iir, instantiatedUnit: Iir, label: str) -> "EntityInstantiation":
         from pyGHDL.dom._Translate import GetName, GetGenericMapAspect, GetPortMapAspect
 
-        entityId = nodes.Get_Entity_Name(instantiatedUnit)
-        entitySymbol = GetEntityInstantiationSymbol(entityId)
+        entityName = nodes.Get_Entity_Name(instantiatedUnit)
+        entitySymbol = EntityInstantiationSymbol(entityName, GetName(entityName))
 
         architectureSymbol = None
         architectureId = nodes.Get_Architecture(instantiatedUnit)
@@ -171,10 +171,10 @@ class ConfigurationInstantiation(VHDLModel_ConfigurationInstantiation, DOMMixin)
 
     @classmethod
     def parse(cls, instantiationNode: Iir, instantiatedUnit: Iir, label: str) -> "ConfigurationInstantiation":
-        from pyGHDL.dom._Translate import GetGenericMapAspect, GetPortMapAspect
+        from pyGHDL.dom._Translate import GetName, GetGenericMapAspect, GetPortMapAspect
 
-        configurationId = nodes.Get_Configuration_Name(instantiatedUnit)
-        configurationSymbol = GetConfigurationInstantiationSymbol(configurationId)
+        configurationName = nodes.Get_Configuration_Name(instantiatedUnit)
+        configurationSymbol = ConfigurationInstantiationSymbol(configurationName, GetName(configurationName))
 
         genericAssociations = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(instantiationNode))
         portAssociations = GetPortMapAspect(nodes.Get_Port_Map_Aspect_Chain(instantiationNode))

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -574,7 +574,7 @@ class ForGenerateStatement(VHDLModel_ForGenerateStatement, DOMMixin):
 
     @classmethod
     def parse(cls, generateNode: Iir, label: str) -> "ForGenerateStatement":
-        from pyGHDL.dom._Utils import GetIirKindOfNode
+        from pyGHDL.dom._Utils import GetIirKindOfNode, GetNameOfNode
         from pyGHDL.dom._Translate import (
             GetDeclaredItemsFromChainedNodes,
             GetConcurrentStatementsFromChainedNodes,
@@ -583,7 +583,7 @@ class ForGenerateStatement(VHDLModel_ForGenerateStatement, DOMMixin):
         )
 
         spec = nodes.Get_Parameter_Specification(generateNode)
-        loopIndex = GetName(spec)
+        loopIndex = GetNameOfNode(spec)
 
         discreteRange = nodes.Get_Discrete_Range(spec)
         rangeKind = GetIirKindOfNode(discreteRange)

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -224,7 +224,11 @@ class ProcessStatement(VHDLModel_ProcessStatement, DOMMixin):
 
     @classmethod
     def parse(cls, processNode: Iir, label: str, hasSensitivityList: bool) -> "ProcessStatement":
-        from pyGHDL.dom._Translate import GetName, GetDeclaredItemsFromChainedNodes, GetSequentialStatementsFromChainedNodes
+        from pyGHDL.dom._Translate import (
+            GetName,
+            GetDeclaredItemsFromChainedNodes,
+            GetSequentialStatementsFromChainedNodes,
+        )
 
         sensitivityList = None
         if hasSensitivityList:

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -73,7 +73,7 @@ from pyGHDL.dom.Symbol import (
     LibraryReferenceSymbol,
     PackageSymbol,
     PackageMemberReferenceSymbol,
-    AllPackageMembersReferenceSymbol
+    AllPackageMembersReferenceSymbol,
 )
 
 

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -66,6 +66,7 @@ from pyGHDL.dom import DOMMixin, Position, DOMException
 from pyGHDL.dom._Utils import GetNameOfNode, GetDocumentationOfNode, GetPackageMemberSymbol
 from pyGHDL.dom._Translate import GetGenericsFromChainedNodes, GetPortsFromChainedNodes, GetName
 from pyGHDL.dom._Translate import GetDeclaredItemsFromChainedNodes, GetConcurrentStatementsFromChainedNodes
+from pyGHDL.dom.Names  import SimpleName
 from pyGHDL.dom.Symbol import EntitySymbol, ContextReferenceSymbol, LibraryReferenceSymbol, PackageSymbol, PackageMemberReferenceSymbol
 
 
@@ -245,11 +246,11 @@ class PackageBody(VHDLModel_PackageBody, DOMMixin):
 
     @classmethod
     def parse(cls, packageBodyNode: Iir, contextItems: Iterable[VHDLModel_ContextUnion]):
-        packageName = GetName(packageBodyNode)
-        packageSymbol = PackageSymbol(packageBodyNode, packageName)
+        packageIdentifier = GetNameOfNode(packageBodyNode)
+        packageSymbol = PackageSymbol(packageBodyNode, SimpleName(packageBodyNode, packageIdentifier))
         documentation = GetDocumentationOfNode(packageBodyNode)
         declaredItems = GetDeclaredItemsFromChainedNodes(
-            nodes.Get_Declaration_Chain(packageBodyNode), "package", packageName
+            nodes.Get_Declaration_Chain(packageBodyNode), "package", packageIdentifier
         )
 
         # FIXME: read use clauses
@@ -309,7 +310,7 @@ class Context(VHDLModel_Context, DOMMixin):
             kind = GetIirKindOfNode(item)
             if kind is nodes.Iir_Kind.Library_Clause:
                 libraryIdentifier = GetNameOfNode(item)
-                names.append(LibraryReferenceSymbol(item, libraryIdentifier))
+                names.append(LibraryReferenceSymbol(item, SimpleName(item, libraryIdentifier)))
                 if nodes.Get_Has_Identifier_List(item):
                     continue
 

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -66,13 +66,14 @@ from pyGHDL.dom import DOMMixin, Position, DOMException
 from pyGHDL.dom._Utils import GetNameOfNode, GetDocumentationOfNode
 from pyGHDL.dom._Translate import GetGenericsFromChainedNodes, GetPortsFromChainedNodes, GetName
 from pyGHDL.dom._Translate import GetDeclaredItemsFromChainedNodes, GetConcurrentStatementsFromChainedNodes
-from pyGHDL.dom.Names import SimpleName
+from pyGHDL.dom.Names import SimpleName, AllName
 from pyGHDL.dom.Symbol import (
     EntitySymbol,
     ContextReferenceSymbol,
     LibraryReferenceSymbol,
     PackageSymbol,
     PackageMemberReferenceSymbol,
+    AllPackageMembersReferenceSymbol
 )
 
 
@@ -92,10 +93,14 @@ class UseClause(VHDLModel_UseClause, DOMMixin):
     @classmethod
     def parse(cls, useNode: Iir):
         nameNode = nodes.Get_Selected_Name(useNode)
-        uses = [PackageMemberReferenceSymbol(nameNode, GetName(nameNode))]
+        name = GetName(nameNode)
+        symbolType = AllPackageMembersReferenceSymbol if isinstance(name, AllName) else PackageMemberReferenceSymbol
+        uses = [symbolType(nameNode, name)]
         for use in utils.chain_iter(nodes.Get_Use_Clause_Chain(useNode)):
             nameNode = nodes.Get_Selected_Name(use)
-            uses.append(PackageMemberReferenceSymbol(nameNode, GetName(nameNode)))
+            name = GetName(nameNode)
+            symbolType = AllPackageMembersReferenceSymbol if isinstance(name, AllName) else PackageMemberReferenceSymbol
+            uses.append(symbolType(nameNode, name))
 
         return cls(useNode, uses)
 

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -66,8 +66,14 @@ from pyGHDL.dom import DOMMixin, Position, DOMException
 from pyGHDL.dom._Utils import GetNameOfNode, GetDocumentationOfNode, GetPackageMemberSymbol
 from pyGHDL.dom._Translate import GetGenericsFromChainedNodes, GetPortsFromChainedNodes, GetName
 from pyGHDL.dom._Translate import GetDeclaredItemsFromChainedNodes, GetConcurrentStatementsFromChainedNodes
-from pyGHDL.dom.Names  import SimpleName
-from pyGHDL.dom.Symbol import EntitySymbol, ContextReferenceSymbol, LibraryReferenceSymbol, PackageSymbol, PackageMemberReferenceSymbol
+from pyGHDL.dom.Names import SimpleName
+from pyGHDL.dom.Symbol import (
+    EntitySymbol,
+    ContextReferenceSymbol,
+    LibraryReferenceSymbol,
+    PackageSymbol,
+    PackageMemberReferenceSymbol,
+)
 
 
 @export

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -63,7 +63,7 @@ from pyGHDL.libghdl import utils
 from pyGHDL.libghdl._types import Iir
 from pyGHDL.libghdl.vhdl import nodes
 from pyGHDL.dom import DOMMixin, Position, DOMException
-from pyGHDL.dom._Utils import GetNameOfNode, GetDocumentationOfNode, GetPackageMemberSymbol
+from pyGHDL.dom._Utils import GetNameOfNode, GetDocumentationOfNode
 from pyGHDL.dom._Translate import GetGenericsFromChainedNodes, GetPortsFromChainedNodes, GetName
 from pyGHDL.dom._Translate import GetDeclaredItemsFromChainedNodes, GetConcurrentStatementsFromChainedNodes
 from pyGHDL.dom.Names import SimpleName

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -66,7 +66,7 @@ from pyGHDL.dom import DOMMixin, Position, DOMException
 from pyGHDL.dom._Utils import GetNameOfNode, GetDocumentationOfNode, GetPackageMemberSymbol
 from pyGHDL.dom._Translate import GetGenericsFromChainedNodes, GetPortsFromChainedNodes, GetName
 from pyGHDL.dom._Translate import GetDeclaredItemsFromChainedNodes, GetConcurrentStatementsFromChainedNodes
-from pyGHDL.dom.Symbol import EntitySymbol, ContextReferenceSymbol, LibraryReferenceSymbol, PackageSymbol
+from pyGHDL.dom.Symbol import EntitySymbol, ContextReferenceSymbol, LibraryReferenceSymbol, PackageSymbol, PackageMemberReferenceSymbol
 
 
 @export
@@ -84,9 +84,11 @@ class UseClause(VHDLModel_UseClause, DOMMixin):
 
     @classmethod
     def parse(cls, useNode: Iir):
-        uses = [GetPackageMemberSymbol(nodes.Get_Selected_Name(useNode))]
+        nameNode = nodes.Get_Selected_Name(useNode)
+        uses = [PackageMemberReferenceSymbol(nameNode, GetName(nameNode))]
         for use in utils.chain_iter(nodes.Get_Use_Clause_Chain(useNode)):
-            uses.append(GetPackageMemberSymbol(nodes.Get_Selected_Name(use)))
+            nameNode = nodes.Get_Selected_Name(use)
+            uses.append(PackageMemberReferenceSymbol(nameNode, GetName(nameNode)))
 
         return cls(useNode, uses)
 
@@ -99,9 +101,11 @@ class ContextReference(VHDLModel_ContextReference, DOMMixin):
 
     @classmethod
     def parse(cls, contextNode: Iir):
-        contexts = [GetContextSymbol(nodes.Get_Selected_Name(contextNode))]
+        nameNode = nodes.Get_Selected_Name(contextNode)
+        contexts = [ContextReferenceSymbol(nameNode, GetName(nameNode))]
         for context in utils.chain_iter(nodes.Get_Context_Reference_Chain(contextNode)):
-            contexts.append(GetContextSymbol(nodes.Get_Selected_Name(context)))
+            nameNode = nodes.Get_Selected_Name(context)
+            contexts.append(ContextReferenceSymbol(nameNode, GetName(nameNode)))
 
         return cls(contextNode, contexts)
 

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -63,8 +63,8 @@ from pyGHDL.libghdl import utils
 from pyGHDL.libghdl._types import Iir
 from pyGHDL.libghdl.vhdl import nodes
 from pyGHDL.dom import DOMMixin, Position, DOMException
-from pyGHDL.dom._Utils import GetNameOfNode, GetDocumentationOfNode, GetPackageMemberSymbol, GetContextSymbol
-from pyGHDL.dom._Translate import GetGenericsFromChainedNodes, GetPortsFromChainedNodes
+from pyGHDL.dom._Utils import GetNameOfNode, GetDocumentationOfNode, GetPackageMemberSymbol
+from pyGHDL.dom._Translate import GetGenericsFromChainedNodes, GetPortsFromChainedNodes, GetName
 from pyGHDL.dom._Translate import GetDeclaredItemsFromChainedNodes, GetConcurrentStatementsFromChainedNodes
 from pyGHDL.dom.Symbol import EntitySymbol, ContextReferenceSymbol, LibraryReferenceSymbol, PackageSymbol
 
@@ -158,7 +158,7 @@ class Architecture(VHDLModel_Architecture, DOMMixin):
         name = GetNameOfNode(architectureNode)
         documentation = GetDocumentationOfNode(architectureNode)
         entityNameNode = nodes.Get_Entity_Name(architectureNode)
-        entitySymbol = EntitySymbol(entityNameNode, GetNameOfNode(entityNameNode))
+        entitySymbol = EntitySymbol(entityNameNode, GetName(entityNameNode))
         declaredItems = GetDeclaredItemsFromChainedNodes(
             nodes.Get_Declaration_Chain(architectureNode), "architecture", name
         )
@@ -241,7 +241,7 @@ class PackageBody(VHDLModel_PackageBody, DOMMixin):
 
     @classmethod
     def parse(cls, packageBodyNode: Iir, contextItems: Iterable[VHDLModel_ContextUnion]):
-        packageName = GetNameOfNode(packageBodyNode)
+        packageName = GetName(packageBodyNode)
         packageSymbol = PackageSymbol(packageBodyNode, packageName)
         documentation = GetDocumentationOfNode(packageBodyNode)
         declaredItems = GetDeclaredItemsFromChainedNodes(

--- a/pyGHDL/dom/Expression.py
+++ b/pyGHDL/dom/Expression.py
@@ -488,7 +488,7 @@ class Aggregate(VHDLModel_Aggregate, DOMMixin):
         from pyGHDL.dom._Translate import (
             GetExpressionFromNode,
             GetRangeFromNode,
-            GetNameFromNode,
+            GetName,
         )
 
         choices = []
@@ -512,7 +512,7 @@ class Aggregate(VHDLModel_Aggregate, DOMMixin):
                     nodes.Iir_Kind.Attribute_Name,
                     nodes.Iir_Kind.Parenthesis_Name,
                 ):
-                    rng = GetNameFromNode(choiceRange)
+                    rng = GetName(choiceRange)
                 else:
                     pos = Position.parse(item)
                     raise DOMException(
@@ -521,7 +521,7 @@ class Aggregate(VHDLModel_Aggregate, DOMMixin):
 
                 choices.append(RangedAggregateElement(item, rng, value))
             elif kind == nodes.Iir_Kind.Choice_By_Name:
-                name = GetNameFromNode(nodes.Get_Choice_Name(item))
+                name = GetName(nodes.Get_Choice_Name(item))
                 symbol = Symbol(item, name)
                 choices.append(NamedAggregateElement(item, symbol, value))
             elif kind == nodes.Iir_Kind.Choice_By_Others:

--- a/pyGHDL/dom/Expression.py
+++ b/pyGHDL/dom/Expression.py
@@ -439,9 +439,9 @@ class QualifiedExpression(VHDLModel_QualifiedExpression, DOMMixin):
 
     @classmethod
     def parse(cls, node: Iir) -> "QualifiedExpression":
-        from pyGHDL.dom._Translate import GetExpressionFromNode, GetNameOfNode
+        from pyGHDL.dom._Translate import GetExpressionFromNode, GetName
 
-        typeMarkName = GetNameOfNode(nodes.Get_Type_Mark(node))
+        typeMarkName = GetName(nodes.Get_Type_Mark(node))
         subtype = SimpleSubtypeSymbol(node, typeMarkName)
         operand = GetExpressionFromNode(nodes.Get_Expression(node))
         return cls(node, subtype, operand)

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -40,6 +40,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from pyGHDL.dom.Names import SimpleName
 from pyTooling.Decorators import export, InheritDocString
 
 from pyVHDLModel import VHDLVersion
@@ -208,7 +209,7 @@ class Document(VHDLModel_Document):
                     itemKind = GetIirKindOfNode(item)
                     if itemKind is nodes.Iir_Kind.Library_Clause:
                         libraryIdentifier = GetNameOfNode(item)
-                        contextNames.append(LibraryReferenceSymbol(item, libraryIdentifier))
+                        contextNames.append(LibraryReferenceSymbol(item, SimpleName(item, libraryIdentifier)))
                         if nodes.Get_Has_Identifier_List(item):
                             continue
 

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -335,7 +335,7 @@ class ForLoopStatement(VHDLModel_ForLoopStatement, DOMMixin):
 
     @classmethod
     def parse(cls, loopNode: Iir, label: str) -> "ForLoopStatement":
-        from pyGHDL.dom._Utils import GetIirKindOfNode
+        from pyGHDL.dom._Utils import GetNameOfNode, GetIirKindOfNode
         from pyGHDL.dom._Translate import (
             GetSequentialStatementsFromChainedNodes,
             GetRangeFromNode,
@@ -343,7 +343,7 @@ class ForLoopStatement(VHDLModel_ForLoopStatement, DOMMixin):
         )
 
         spec = nodes.Get_Parameter_Specification(loopNode)
-        loopIndex = GetName(spec)
+        loopIndex = GetNameOfNode(spec)
 
         discreteRange = nodes.Get_Discrete_Range(spec)
         rangeKind = GetIirKindOfNode(discreteRange)

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -58,7 +58,6 @@ from pyVHDLModel.Sequential import SequentialAssertStatement as VHDLModel_Sequen
 from pyGHDL.libghdl import Iir, utils
 from pyGHDL.libghdl.vhdl import nodes
 from pyGHDL.dom import DOMMixin, Position, DOMException
-from pyGHDL.dom._Utils import GetNameOfNode
 from pyGHDL.dom.Range import Range
 from pyGHDL.dom.Concurrent import WaveformElement, ParameterAssociationItem  # TODO: move out from concurrent?
 
@@ -247,7 +246,7 @@ class CaseStatement(VHDLModel_CaseStatement, DOMMixin):
         from pyGHDL.dom._Translate import (
             GetExpressionFromNode,
             GetRangeFromNode,
-            GetNameFromNode,
+            GetName,
         )
 
         expression = GetExpressionFromNode(nodes.Get_Expression(caseNode))
@@ -281,7 +280,7 @@ class CaseStatement(VHDLModel_CaseStatement, DOMMixin):
                     nodes.Iir_Kind.Attribute_Name,
                     nodes.Iir_Kind.Parenthesis_Name,
                 ):
-                    rng = GetNameFromNode(choiceRange)
+                    rng = GetName(choiceRange)
                 else:
                     pos = Position.parse(alternative)
                     raise DOMException(
@@ -340,11 +339,11 @@ class ForLoopStatement(VHDLModel_ForLoopStatement, DOMMixin):
         from pyGHDL.dom._Translate import (
             GetSequentialStatementsFromChainedNodes,
             GetRangeFromNode,
-            GetNameFromNode,
+            GetName,
         )
 
         spec = nodes.Get_Parameter_Specification(loopNode)
-        loopIndex = GetNameOfNode(spec)
+        loopIndex = GetName(spec)
 
         discreteRange = nodes.Get_Discrete_Range(spec)
         rangeKind = GetIirKindOfNode(discreteRange)
@@ -354,7 +353,7 @@ class ForLoopStatement(VHDLModel_ForLoopStatement, DOMMixin):
             nodes.Iir_Kind.Attribute_Name,
             nodes.Iir_Kind.Parenthesis_Name,
         ):
-            rng = GetNameFromNode(discreteRange)
+            rng = GetName(discreteRange)
         else:
             pos = Position.parse(loopNode)
             raise DOMException(
@@ -381,10 +380,10 @@ class SequentialSimpleSignalAssignment(VHDLModel_SequentialSimpleSignalAssignmen
 
     @classmethod
     def parse(cls, assignmentNode: Iir, label: str = None) -> "SequentialSimpleSignalAssignment":
-        from pyGHDL.dom._Translate import GetNameFromNode
+        from pyGHDL.dom._Translate import GetName
 
         target = nodes.Get_Target(assignmentNode)
-        targetName = GetNameFromNode(target)
+        targetName = GetName(target)
 
         waveform = []
         for wave in utils.chain_iter(nodes.Get_Waveform_Chain(assignmentNode)):
@@ -407,12 +406,12 @@ class SequentialProcedureCall(VHDLModel_SequentialProcedureCall, DOMMixin):
 
     @classmethod
     def parse(cls, callNode: Iir, label: str) -> "SequentialProcedureCall":
-        from pyGHDL.dom._Translate import GetNameFromNode, GetParameterMapAspect
+        from pyGHDL.dom._Translate import GetName, GetParameterMapAspect
 
         cNode = nodes.Get_Procedure_Call(callNode)
 
         prefix = nodes.Get_Prefix(cNode)
-        procedureName = GetNameFromNode(prefix)
+        procedureName = GetName(prefix)
         parameterAssociations = GetParameterMapAspect(nodes.Get_Parameter_Association_Chain(cNode))
 
         return cls(callNode, procedureName, parameterAssociations, label)

--- a/pyGHDL/dom/Subprogram.py
+++ b/pyGHDL/dom/Subprogram.py
@@ -67,6 +67,7 @@ class Function(VHDLModel_Function, DOMMixin):
     @classmethod
     def parse(cls, functionNode: Iir) -> "Function":
         from pyGHDL.dom._Translate import (
+            GetName,
             GetGenericsFromChainedNodes,
             GetParameterFromChainedNodes,
         )
@@ -78,7 +79,7 @@ class Function(VHDLModel_Function, DOMMixin):
         parameters = GetParameterFromChainedNodes(nodes.Get_Interface_Declaration_Chain(functionNode))
 
         returnType = nodes.Get_Return_Type_Mark(functionNode)
-        returnTypeName = GetNameOfNode(returnType)
+        returnTypeName = GetName(returnType)
         returnTypeSymbol = SimpleSubtypeSymbol(returnType, returnTypeName)
 
         return cls(functionNode, functionName, returnTypeSymbol, generics, parameters, documentation)

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -83,6 +83,14 @@ class ContextReferenceSymbol(VHDLModel_ContextReferenceSymbol, DOMMixin):
 
 
 @export
+class PackageMemberReferenceSymbol(VHDLModel_PackageMembersReferenceSymbol, DOMMixin):
+    @InheritDocString(VHDLModel_PackageMembersReferenceSymbol)
+    def __init__(self, identifierNode: Iir, name: Name):
+        super().__init__(name)
+        DOMMixin.__init__(self, identifierNode)
+
+
+@export
 class EntityInstantiationSymbol(VHDLModel_EntityInstantiationSymbol, DOMMixin):
     @InheritDocString(VHDLModel_EntityInstantiationSymbol)
     def __init__(self, identifierNode: Iir, name: Name):

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -39,7 +39,6 @@ from pyVHDLModel.Base import ExpressionUnion
 from pyVHDLModel.Symbol import LibraryReferenceSymbol as VHDLModel_LibraryReferenceSymbol
 from pyVHDLModel.Symbol import PackageReferenceSymbol as VHDLModel_PackageReferenceSymbol
 from pyVHDLModel.Symbol import PackageMembersReferenceSymbol as VHDLModel_PackageMembersReferenceSymbol
-from pyVHDLModel.Symbol import AllPackageMembersReferenceSymbol as VHDLModel_AllPackageMembersReferenceSymbol
 from pyVHDLModel.Symbol import ContextReferenceSymbol as VHDLModel_ContextReferenceSymbol
 from pyVHDLModel.Symbol import EntitySymbol as VHDLModel_EntitySymbol
 from pyVHDLModel.Symbol import ArchitectureSymbol as VHDLModel_ArchitectureSymbol

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -144,16 +144,15 @@ class PackageSymbol(VHDLModel_PackageSymbol, DOMMixin):
 
 @export
 class SimpleSubtypeSymbol(VHDLModel_SimpleSubtypeSymbol, DOMMixin):
-    def __init__(self, node: Iir, subtypeName: str):
-        if isinstance(subtypeName, (List, Iterator)):
-            subtypeName = ".".join(subtypeName)
-
+    @InheritDocString(VHDLModel_SimpleSubtypeSymbol)
+    def __init__(self, node: Iir, subtypeName: Name):
         super().__init__(subtypeName)
         DOMMixin.__init__(self, node)
 
 
 @export
 class ConstrainedScalarSubtypeSymbol(VHDLModel_ConstrainedScalarSubtypeSymbol, DOMMixin):
+    @InheritDocString(VHDLModel_ConstrainedScalarSubtypeSymbol)
     def __init__(self, node: Iir, subtypeName: Name, rng: Range = None):
         super().__init__(subtypeName)  # , rng)  # XXX: hacked
         DOMMixin.__init__(self, node)
@@ -165,6 +164,7 @@ class ConstrainedScalarSubtypeSymbol(VHDLModel_ConstrainedScalarSubtypeSymbol, D
 
 @export
 class ConstrainedCompositeSubtypeSymbol(VHDLModel_ConstrainedCompositeSubtypeSymbol, DOMMixin):
+    @InheritDocString(VHDLModel_ConstrainedCompositeSubtypeSymbol)
     def __init__(self, node: Iir, subtypeName: Name, constraints: List = None):
         super().__init__(subtypeName)  # , constraints)  # XXX: hacked
         DOMMixin.__init__(self, node)
@@ -176,6 +176,7 @@ class ConstrainedCompositeSubtypeSymbol(VHDLModel_ConstrainedCompositeSubtypeSym
 
 @export
 class SimpleObjectOrFunctionCallSymbol(VHDLModel_SimpleObjectOrFunctionCallSymbol, DOMMixin):
+    @InheritDocString(VHDLModel_SimpleObjectOrFunctionCallSymbol)
     def __init__(self, node: Iir, name: Name):
         super().__init__(name)
         DOMMixin.__init__(self, node)
@@ -191,6 +192,7 @@ class SimpleObjectOrFunctionCallSymbol(VHDLModel_SimpleObjectOrFunctionCallSymbo
 
 @export
 class IndexedObjectOrFunctionCallSymbol(VHDLModel_IndexedObjectOrFunctionCallSymbol, DOMMixin):
+    @InheritDocString(VHDLModel_IndexedObjectOrFunctionCallSymbol)
     def __init__(self, node: Iir, name: Name):
         super().__init__(name)
         DOMMixin.__init__(self, node)

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -61,88 +61,72 @@ from pyGHDL.dom.Range import Range
 @export
 class LibraryReferenceSymbol(VHDLModel_LibraryReferenceSymbol, DOMMixin):
     @InheritDocString(VHDLModel_LibraryReferenceSymbol)
-    def __init__(self, identifierNode: Iir, identifier: str):
-        super().__init__(identifier)
+    def __init__(self, identifierNode: Iir, name: Name):
+        super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
 
 @export
 class PackageReferenceSymbol(VHDLModel_PackageReferenceSymbol, DOMMixin):
     @InheritDocString(VHDLModel_PackageReferenceSymbol)
-    def __init__(self, identifierNode: Iir, identifier: str, prefix: LibraryReferenceSymbol):
-        super().__init__(identifier, prefix)
-        DOMMixin.__init__(self, identifierNode)
-
-
-@export
-class PackageMembersReferenceSymbol(VHDLModel_PackageMembersReferenceSymbol, DOMMixin):
-    @InheritDocString(VHDLModel_PackageMembersReferenceSymbol)
-    def __init__(self, identifierNode: Iir, identifier: str, prefix: PackageReferenceSymbol):
-        super().__init__(identifier, prefix)
-        DOMMixin.__init__(self, identifierNode)
-
-
-@export
-class AllPackageMembersReferenceSymbol(VHDLModel_AllPackageMembersReferenceSymbol, DOMMixin):
-    @InheritDocString(VHDLModel_AllPackageMembersReferenceSymbol)
-    def __init__(self, identifierNode: Iir, prefix: PackageReferenceSymbol):
-        super().__init__(prefix)
+    def __init__(self, identifierNode: Iir, name: Name):
+        super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
 
 @export
 class ContextReferenceSymbol(VHDLModel_ContextReferenceSymbol, DOMMixin):
     @InheritDocString(VHDLModel_ContextReferenceSymbol)
-    def __init__(self, identifierNode: Iir, identifier: str, prefix: LibraryReferenceSymbol):
-        super().__init__(identifier, prefix)
+    def __init__(self, identifierNode: Iir, name: Name):
+        super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
 
 @export
 class EntityInstantiationSymbol(VHDLModel_EntityInstantiationSymbol, DOMMixin):
     @InheritDocString(VHDLModel_EntityInstantiationSymbol)
-    def __init__(self, identifierNode: Iir, identifier: str, prefix: LibraryReferenceSymbol):
-        super().__init__(identifier, prefix)
+    def __init__(self, identifierNode: Iir, name: Name):
+        super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
 
 @export
 class ComponentInstantiationSymbol(VHDLModel_ComponentInstantiationSymbol, DOMMixin):
     @InheritDocString(VHDLModel_ComponentInstantiationSymbol)
-    def __init__(self, identifierNode: Iir, identifier: str):
-        super().__init__(identifier)
+    def __init__(self, identifierNode: Iir, name: Name):
+        super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
 
 @export
 class ConfigurationInstantiationSymbol(VHDLModel_ConfigurationInstantiationSymbol, DOMMixin):
     @InheritDocString(VHDLModel_ConfigurationInstantiationSymbol)
-    def __init__(self, identifierNode: Iir, identifier: str):
-        super().__init__(identifier)
+    def __init__(self, identifierNode: Iir, name: Name):
+        super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
 
 @export
 class EntitySymbol(VHDLModel_EntitySymbol, DOMMixin):
     @InheritDocString(VHDLModel_EntitySymbol)
-    def __init__(self, identifierNode: Iir, identifier: str):
-        super().__init__(identifier)
+    def __init__(self, identifierNode: Iir, name: Name):
+        super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
 
 @export
 class ArchitectureSymbol(VHDLModel_ArchitectureSymbol, DOMMixin):
     @InheritDocString(VHDLModel_ArchitectureSymbol)
-    def __init__(self, identifierNode: Iir, identifier: str, prefix: EntitySymbol):
-        super().__init__(identifier, prefix)
+    def __init__(self, identifierNode: Iir, name: Name):
+        super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
 
 @export
 class PackageSymbol(VHDLModel_PackageSymbol, DOMMixin):
     @InheritDocString(VHDLModel_PackageSymbol)
-    def __init__(self, identifierNode: Iir, identifier: str):
-        super().__init__(identifier)
+    def __init__(self, identifierNode: Iir, name: Name):
+        super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
 
@@ -184,29 +168,29 @@ class ConstrainedCompositeSubtypeSymbol(VHDLModel_ConstrainedCompositeSubtypeSym
 
 @export
 class SimpleObjectOrFunctionCallSymbol(VHDLModel_SimpleObjectOrFunctionCallSymbol, DOMMixin):
-    def __init__(self, node: Iir, identifier: str):
-        super().__init__(identifier)
+    def __init__(self, node: Iir, name: Name):
+        super().__init__(name)
         DOMMixin.__init__(self, node)
 
     @classmethod
     def parse(cls, node: Iir):
-        from pyGHDL.dom._Translate import GetNameFromNode
+        from pyGHDL.dom._Translate import GetName
 
-        name = GetNameFromNode(node)
+        name = GetName(node)
 
-        return cls(node, str(name))  # XXX: hacked
+        return cls(node, name)
 
 
 @export
 class IndexedObjectOrFunctionCallSymbol(VHDLModel_IndexedObjectOrFunctionCallSymbol, DOMMixin):
-    def __init__(self, node: Iir, prefix: Name, indices: Iterable[ExpressionUnion]):
-        super().__init__(prefix, indices)
+    def __init__(self, node: Iir, name: Name):
+        super().__init__(name)
         DOMMixin.__init__(self, node)
 
     @classmethod
     def parse(cls, node: Iir):
-        from pyGHDL.dom._Translate import GetNameFromNode
+        from pyGHDL.dom._Translate import GetName
 
-        name = GetNameFromNode(node)
+        name = GetName(node)
 
-        return cls(node, name, [])
+        return cls(node, name)

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -38,7 +38,8 @@ from pyVHDLModel import Name
 from pyVHDLModel.Base import ExpressionUnion
 from pyVHDLModel.Symbol import LibraryReferenceSymbol as VHDLModel_LibraryReferenceSymbol
 from pyVHDLModel.Symbol import PackageReferenceSymbol as VHDLModel_PackageReferenceSymbol
-from pyVHDLModel.Symbol import PackageMembersReferenceSymbol as VHDLModel_PackageMembersReferenceSymbol
+from pyVHDLModel.Symbol import PackageMemberReferenceSymbol as VHDLModel_PackageMemberReferenceSymbol
+from pyVHDLModel.Symbol import AllPackageMembersReferenceSymbol as VHDLModel_AllPackageMembersReferenceSymbol
 from pyVHDLModel.Symbol import ContextReferenceSymbol as VHDLModel_ContextReferenceSymbol
 from pyVHDLModel.Symbol import EntitySymbol as VHDLModel_EntitySymbol
 from pyVHDLModel.Symbol import ArchitectureSymbol as VHDLModel_ArchitectureSymbol
@@ -82,8 +83,16 @@ class ContextReferenceSymbol(VHDLModel_ContextReferenceSymbol, DOMMixin):
 
 
 @export
-class PackageMemberReferenceSymbol(VHDLModel_PackageMembersReferenceSymbol, DOMMixin):
-    @InheritDocString(VHDLModel_PackageMembersReferenceSymbol)
+class PackageMemberReferenceSymbol(VHDLModel_PackageMemberReferenceSymbol, DOMMixin):
+    @InheritDocString(VHDLModel_PackageMemberReferenceSymbol)
+    def __init__(self, identifierNode: Iir, name: Name):
+        super().__init__(name)
+        DOMMixin.__init__(self, identifierNode)
+
+
+@export
+class AllPackageMembersReferenceSymbol(VHDLModel_AllPackageMembersReferenceSymbol, DOMMixin):
+    @InheritDocString(VHDLModel_AllPackageMembersReferenceSymbol)
     def __init__(self, identifierNode: Iir, name: Name):
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)

--- a/pyGHDL/dom/Type.py
+++ b/pyGHDL/dom/Type.py
@@ -314,7 +314,9 @@ class FileType(VHDLModel_FileType, DOMMixin):
 
         designatedSubtypeMark = nodes.Get_File_Type_Mark(typeDefinitionNode)
         designatedSubtypeName = GetNameOfNode(designatedSubtypeMark)
-        designatedSubtype = SimpleSubtypeSymbol(typeDefinitionNode, SimpleName(designatedSubtypeMark, designatedSubtypeName))
+        designatedSubtype = SimpleSubtypeSymbol(
+            typeDefinitionNode, SimpleName(designatedSubtypeMark, designatedSubtypeName)
+        )
 
         return cls(typeDefinitionNode, typeName, designatedSubtype)
 

--- a/pyGHDL/dom/Type.py
+++ b/pyGHDL/dom/Type.py
@@ -314,7 +314,7 @@ class FileType(VHDLModel_FileType, DOMMixin):
 
         designatedSubtypeMark = nodes.Get_File_Type_Mark(typeDefinitionNode)
         designatedSubtypeName = GetNameOfNode(designatedSubtypeMark)
-        designatedSubtype = SimpleSubtypeSymbol(typeDefinitionNode, SimpleName(designatedSubtypeName))
+        designatedSubtype = SimpleSubtypeSymbol(typeDefinitionNode, SimpleName(designatedSubtypeMark, designatedSubtypeName))
 
         return cls(typeDefinitionNode, typeName, designatedSubtype)
 

--- a/pyGHDL/dom/Type.py
+++ b/pyGHDL/dom/Type.py
@@ -114,7 +114,7 @@ class PhysicalType(VHDLModel_PhysicalType, DOMMixin):
     @classmethod
     def parse(cls, typeName: str, typeDefinitionNode: Iir) -> "PhysicalType":
         from pyGHDL.dom._Utils import GetIirKindOfNode, GetNameOfNode
-        from pyGHDL.dom._Translate import GetRangeFromNode, GetNameFromNode
+        from pyGHDL.dom._Translate import GetRangeFromNode, GetName
 
         rangeConstraint = nodes.Get_Range_Constraint(typeDefinitionNode)
         rangeKind = GetIirKindOfNode(rangeConstraint)
@@ -124,7 +124,7 @@ class PhysicalType(VHDLModel_PhysicalType, DOMMixin):
             nodes.Iir_Kind.Attribute_Name,
             nodes.Iir_Kind.Parenthesis_Name,
         ):
-            rng = GetNameFromNode(rangeConstraint)
+            rng = GetName(rangeConstraint)
         else:
             pos = Position.parse(typeDefinitionNode)
             raise DOMException(f"Unknown range kind '{rangeKind.name}' in physical type definition at line {pos.Line}.")

--- a/pyGHDL/dom/Type.py
+++ b/pyGHDL/dom/Type.py
@@ -32,6 +32,7 @@
 # ============================================================================
 from typing import List, Union, Iterator, Tuple, Iterable
 
+from pyGHDL.dom.Names import SimpleName
 from pyTooling.Decorators import export
 
 from pyVHDLModel.Name import Name
@@ -313,7 +314,7 @@ class FileType(VHDLModel_FileType, DOMMixin):
 
         designatedSubtypeMark = nodes.Get_File_Type_Mark(typeDefinitionNode)
         designatedSubtypeName = GetNameOfNode(designatedSubtypeMark)
-        designatedSubtype = SimpleSubtypeSymbol(typeDefinitionNode, designatedSubtypeName)
+        designatedSubtype = SimpleSubtypeSymbol(typeDefinitionNode, SimpleName(designatedSubtypeName))
 
         return cls(typeDefinitionNode, typeName, designatedSubtype)
 

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -322,7 +322,7 @@ def GetSubtypeIndicationFromIndicationNode(subtypeIndicationNode: Iir, entity: s
 @export
 def GetSimpleTypeFromNode(subtypeIndicationNode: Iir) -> SimpleSubtypeSymbol:
     subtypeName = GetName(subtypeIndicationNode)
-    return SimpleSubtypeSymbol(subtypeIndicationNode, str(subtypeName))  # XXX: hacked
+    return SimpleSubtypeSymbol(subtypeIndicationNode, subtypeName)
 
 
 @export
@@ -340,7 +340,7 @@ def GetScalarConstrainedSubtypeFromNode(
         r = GetRangeFromNode(rangeConstraint)
     # todo: Get actual range from AttributeName node?
 
-    return ConstrainedScalarSubtypeSymbol(subtypeIndicationNode, str(simpleTypeMark), r)  # XXX: hacked
+    return ConstrainedScalarSubtypeSymbol(subtypeIndicationNode, simpleTypeMark, r)
 
 
 @export

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -166,26 +166,25 @@ from pyGHDL.dom.PSL import DefaultClock
 
 
 @export
-def GetNameFromNode(node: Iir) -> Name:
+def GetName(node: Iir) -> Name:
     kind = GetIirKindOfNode(node)
     if kind == nodes.Iir_Kind.Simple_Name:
         name = GetNameOfNode(node)
         return SimpleName(node, name)
     elif kind == nodes.Iir_Kind.Selected_Name:
         name = GetNameOfNode(node)
-        prefixName = GetNameFromNode(nodes.Get_Prefix(node))
+        prefixName = GetName(nodes.Get_Prefix(node))
         return SelectedName(node, name, prefixName)
+    elif kind == nodes.Iir_Kind.Parenthesis_Name:
+        prefixName = GetName(nodes.Get_Prefix(node))
+        associations = GetAssociations(node)
+        return ParenthesisName(node, prefixName, associations)
     elif kind == nodes.Iir_Kind.Attribute_Name:
         name = GetNameOfNode(node)
-        prefixName = GetNameFromNode(nodes.Get_Prefix(node))
+        prefixName = GetName(nodes.Get_Prefix(node))
         return AttributeName(node, name, prefixName)
-    elif kind == nodes.Iir_Kind.Parenthesis_Name:
-        prefixName = GetNameFromNode(nodes.Get_Prefix(node))
-        associations = GetAssociations(node)
-
-        return ParenthesisName(node, prefixName, associations)
     elif kind == nodes.Iir_Kind.Selected_By_All_Name:
-        prefixName = GetNameFromNode(nodes.Get_Prefix(node))
+        prefixName = GetName(nodes.Get_Prefix(node))
         return AllName(node, prefixName)
     else:
         raise DOMException(f"Unknown name kind '{kind.name}'")
@@ -227,7 +226,7 @@ def GetArrayConstraintsFromSubtypeIndication(
             nodes.Iir_Kind.Selected_Name,
             nodes.Iir_Kind.Attribute_Name,
         ):
-            constraints.append(GetNameFromNode(constraint))
+            constraints.append(GetName(constraint))
         else:
             position = Position.parse(constraint)
             raise DOMException(
@@ -277,7 +276,7 @@ def GetAnonymousTypeFromNode(node: Iir) -> BaseType:
         return IntegerType(node, typeName, r)
 
     elif kind in (nodes.Iir_Kind.Attribute_Name, nodes.Iir_Kind.Parenthesis_Name):
-        n = GetNameFromNode(typeDefinition)
+        n = GetName(typeDefinition)
 
         return IntegerType(node, typeName, n)
     elif kind == nodes.Iir_Kind.Physical_Type_Definition:
@@ -322,7 +321,7 @@ def GetSubtypeIndicationFromIndicationNode(subtypeIndicationNode: Iir, entity: s
 
 @export
 def GetSimpleTypeFromNode(subtypeIndicationNode: Iir) -> SimpleSubtypeSymbol:
-    subtypeName = GetNameFromNode(subtypeIndicationNode)
+    subtypeName = GetName(subtypeIndicationNode)
     return SimpleSubtypeSymbol(subtypeIndicationNode, str(subtypeName))  # XXX: hacked
 
 
@@ -353,7 +352,7 @@ def GetCompositeConstrainedSubtypeFromNode(
     simpleTypeMark = SimpleName(typeMark, typeMarkName)
 
     constraints = GetArrayConstraintsFromSubtypeIndication(subtypeIndicationNode)
-    return ConstrainedCompositeSubtypeSymbol(subtypeIndicationNode, str(simpleTypeMark), constraints)  # XXX: hacked
+    return ConstrainedCompositeSubtypeSymbol(subtypeIndicationNode, simpleTypeMark, constraints)
 
 
 @export
@@ -609,7 +608,7 @@ def GetMapAspect(mapAspect: Iir, cls: Type, entity: str) -> Generator[Associatio
             if formalNode is nodes.Null_Iir:
                 formal = None
             else:
-                formal = GetNameFromNode(formalNode)
+                formal = GetName(formalNode)
 
             actual = GetExpressionFromNode(nodes.Get_Actual(generic))
 
@@ -619,7 +618,7 @@ def GetMapAspect(mapAspect: Iir, cls: Type, entity: str) -> Generator[Associatio
             if formalNode is nodes.Null_Iir:
                 formal = None
             else:
-                formal = GetNameFromNode(formalNode)
+                formal = GetName(formalNode)
 
             yield cls(generic, OpenName(generic), formal)
         else:

--- a/pyGHDL/dom/_Utils.py
+++ b/pyGHDL/dom/_Utils.py
@@ -35,23 +35,15 @@ from typing import Union
 from pyTooling.Decorators import export
 
 from pyVHDLModel.Base import Mode
+from pyVHDLModel.Name import Name
+from pyVHDLModel.Symbol import PackageMembersReferenceSymbol, AllPackageMembersReferenceSymbol
 
 from pyGHDL.libghdl import LibGHDLException, name_table, errorout_memory, files_map, file_comments
 from pyGHDL.libghdl._types import Iir
 from pyGHDL.libghdl.vhdl import nodes, utils
 from pyGHDL.libghdl.vhdl.nodes import Null_Iir
 from pyGHDL.dom import DOMException, Position
-from pyGHDL.dom.Symbol import (
-    LibraryReferenceSymbol,
-    PackageReferenceSymbol,
-    PackageMembersReferenceSymbol,
-    AllPackageMembersReferenceSymbol,
-    ContextReferenceSymbol,
-    EntityInstantiationSymbol,
-    ComponentInstantiationSymbol,
-    ConfigurationInstantiationSymbol,
-)
-
+from pyGHDL.dom.Names import SelectedName, AllName, SimpleName
 
 __MODE_TRANSLATION = {
     nodes.Iir_Mode.In_Mode: Mode.In,
@@ -172,35 +164,12 @@ def GetPackageSymbol(node: Iir) -> PackageReferenceSymbol:
 
 def GetPackageMemberSymbol(
     node: Iir,
-) -> Union[PackageReferenceSymbol, PackageMembersReferenceSymbol, AllPackageMembersReferenceSymbol]:
-    kind = GetIirKindOfNode(node)
-    prefixName = GetPackageSymbol(nodes.Get_Prefix(node))
-    if kind == nodes.Iir_Kind.Selected_Name:
-        name = GetNameOfNode(node)
-        return PackageMembersReferenceSymbol(node, name, prefixName)
-    elif kind == nodes.Iir_Kind.Selected_By_All_Name:
-        prefixName = GetPackageSymbol(nodes.Get_Prefix(node))
-        return AllPackageMembersReferenceSymbol(node, prefixName)
-    else:
-        raise DOMException(f"{kind.name} at {Position.parse(node)}")
+) -> Union[PackageMembersReferenceSymbol, AllPackageMembersReferenceSymbol]:
+    from pyGHDL.dom._Translate import GetName
 
-
-def GetContextSymbol(node: Iir) -> ContextReferenceSymbol:
-    kind = GetIirKindOfNode(node)
-    if kind == nodes.Iir_Kind.Selected_Name:
-        name = GetNameOfNode(node)
-        prefixName = GetLibrarySymbol(nodes.Get_Prefix(node))
-        return ContextReferenceSymbol(node, name, prefixName)
-    else:
-        raise DOMException(f"{kind.name} at {Position.parse(node)}")
-
-
-def GetEntityInstantiationSymbol(node: Iir) -> EntityInstantiationSymbol:
-    kind = GetIirKindOfNode(node)
-    if kind == nodes.Iir_Kind.Selected_Name:
-        name = GetNameOfNode(node)
-        prefixName = GetLibrarySymbol(nodes.Get_Prefix(node))
-        return EntityInstantiationSymbol(node, name, prefixName)
+    name = GetName(node)
+    if isinstance(name, AllName):
+        return AllPackageMembersReferenceSymbol(name)
     else:
         raise DOMException(f"{kind.name} at {Position.parse(node)}")
 

--- a/pyGHDL/dom/_Utils.py
+++ b/pyGHDL/dom/_Utils.py
@@ -30,20 +30,15 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
-from typing import Union
-
 from pyTooling.Decorators import export
 
 from pyVHDLModel.Base import Mode
-from pyVHDLModel.Name import Name
-from pyVHDLModel.Symbol import PackageMembersReferenceSymbol, AllPackageMembersReferenceSymbol
 
 from pyGHDL.libghdl import LibGHDLException, name_table, errorout_memory, files_map, file_comments
 from pyGHDL.libghdl._types import Iir
 from pyGHDL.libghdl.vhdl import nodes, utils
 from pyGHDL.libghdl.vhdl.nodes import Null_Iir
-from pyGHDL.dom import DOMException, Position
-from pyGHDL.dom.Names import SelectedName, AllName, SimpleName
+from pyGHDL.dom import DOMException
 
 __MODE_TRANSLATION = {
     nodes.Iir_Mode.In_Mode: Mode.In,
@@ -139,54 +134,3 @@ def GetModeOfNode(node: Iir) -> Mode:
         return __MODE_TRANSLATION[nodes.Get_Mode(node)]
     except KeyError as ex:
         raise DOMException(f"Unknown mode '{ex.args[0]}'.") from ex
-
-
-def GetLibrarySymbol(node: Iir) -> LibraryReferenceSymbol:
-    kind = GetIirKindOfNode(node)
-    if kind == nodes.Iir_Kind.Simple_Name:
-        name = GetNameOfNode(node)
-        return LibraryReferenceSymbol(node, name)
-    else:
-        raise DOMException(f"{kind} at {Position.parse(node)}")
-
-
-def GetPackageSymbol(node: Iir) -> PackageReferenceSymbol:
-    kind = GetIirKindOfNode(node)
-    name = GetNameOfNode(node)
-    if kind == nodes.Iir_Kind.Selected_Name:
-        prefixName = GetLibrarySymbol(nodes.Get_Prefix(node))
-        return PackageReferenceSymbol(node, name, prefixName)
-    elif kind == nodes.Iir_Kind.Simple_Name:
-        return PackageReferenceSymbol(node, name, None)
-    else:
-        raise DOMException(f"{kind.name} at {Position.parse(node)}")
-
-
-def GetPackageMemberSymbol(
-    node: Iir,
-) -> Union[PackageMembersReferenceSymbol, AllPackageMembersReferenceSymbol]:
-    from pyGHDL.dom._Translate import GetName
-
-    name = GetName(node)
-    if isinstance(name, AllName):
-        return AllPackageMembersReferenceSymbol(name)
-    else:
-        raise DOMException(f"{kind.name} at {Position.parse(node)}")
-
-
-def GetComponentInstantiationSymbol(node: Iir) -> ComponentInstantiationSymbol:
-    kind = GetIirKindOfNode(node)
-    if kind == nodes.Iir_Kind.Simple_Name:
-        name = GetNameOfNode(node)
-        return ComponentInstantiationSymbol(node, name)
-    else:
-        raise DOMException(f"{kind.name} at {Position.parse(node)}")
-
-
-def GetConfigurationInstantiationSymbol(node: Iir) -> ConfigurationInstantiationSymbol:
-    kind = GetIirKindOfNode(node)
-    if kind == nodes.Iir_Kind.Simple_Name:
-        name = GetNameOfNode(node)
-        return ConfigurationInstantiationSymbol(node, name)
-    else:
-        raise DOMException(f"{kind.name} at {Position.parse(node)}")

--- a/pyGHDL/dom/formatting/GraphML.py
+++ b/pyGHDL/dom/formatting/GraphML.py
@@ -91,7 +91,7 @@ class DependencyGraphFormatter:
 
                 for vertex in vertices:
                     if vertex["kind"] is DependencyGraphVertexKind.Architecture:
-                        value = f"{vertex.Value.Entity.Identifier}({vertex.Value.Identifier})"
+                        value = f"{vertex.Value.Entity.Name.Identifier}({vertex.Value.Identifier})"
                     elif vertex["kind"] is DependencyGraphVertexKind.Document:
                         value = f"{vertex.ID}"
                     else:

--- a/pyGHDL/dom/requirements.txt
+++ b/pyGHDL/dom/requirements.txt
@@ -1,4 +1,4 @@
 -r ../libghdl/requirements.txt
 
-pyVHDLModel==0.24.1
+pyVHDLModel==0.25.0
 #https://github.com/VHDL/pyVHDLModel/archive/dev.zip#pyVHDLModel

--- a/pyGHDL/dom/requirements.txt
+++ b/pyGHDL/dom/requirements.txt
@@ -1,4 +1,4 @@
 -r ../libghdl/requirements.txt
 
-pyVHDLModel==0.25.0
+pyVHDLModel==0.25.1
 #https://github.com/VHDL/pyVHDLModel/archive/dev.zip#pyVHDLModel

--- a/testsuite/pyunit/dom/Expressions.py
+++ b/testsuite/pyunit/dom/Expressions.py
@@ -84,9 +84,7 @@ class Expressions(TestCase):
         return default
 
     def test_NotExpression(self):
-        filename: Path = self._root / "{className}_{funcName}.vhdl".format(
-            className=self.__class__.__name__, funcName= currentframe().f_code.co_name[5:]
-        )
+        filename: Path = self._root / f"{self.__class__.__name__}_{currentframe().f_code.co_name[5:]}.vhdl"
 
         # Define test data
         constantDeclartion = "constant c0 : boolean := not True;"

--- a/testsuite/pyunit/dom/Expressions.py
+++ b/testsuite/pyunit/dom/Expressions.py
@@ -34,7 +34,7 @@ import ctypes
 from inspect import currentframe
 from pathlib import Path
 from textwrap import dedent
-from typing import TypeVar, Dict
+from typing import TypeVar, Dict, cast
 from unittest import TestCase
 
 
@@ -89,7 +89,7 @@ class Expressions(TestCase):
         )
 
         # Define test data
-        constantDeclartion = "constant c0 : boolean := not true;"
+        constantDeclartion = "constant c0 : boolean := not True;"
 
         # Parse in-memory
         default: Expression = self.parse(filename, constantDeclartion)
@@ -97,7 +97,7 @@ class Expressions(TestCase):
         # Start checks
         self.assertIsInstance(default, InverseExpression)
         self.assertIsInstance(default.Operand, SimpleObjectOrFunctionCallSymbol)
-        self.assertEqual("true", str(default.Operand))  # .SymbolName))  # XXX: hacked
+        self.assertEqual("True", cast(SimpleObjectOrFunctionCallSymbol, default.Operand).Name.Identifier)
 
     # def test_AbsExpression(self):
     #     filename: Path = self._root / "{className}_{funcName}.vhdl".format(

--- a/testsuite/requirements.txt
+++ b/testsuite/requirements.txt
@@ -4,4 +4,4 @@ pytest>=7.3.0
 pytest-cov>=2.10.1
 
 # Coverage collection
-Coverage>=5.3
+Coverage>=7.2


### PR DESCRIPTION
# Changes

* The translation process from Iir to DOM now generates `***Symbol` instances, which are wrapping `***Name` instances. This feature was reintroduced in pyVHDLModel v0.25.0 after it was remove to simplify the handling of symbols and names. But VHDL/pyVHDLModel#70 demonstrated, that the former complexity was needed.
* Renamed `GetNameFromNode` to `GetName`. This helper function walks a linked list of names and translates them to a chain of `***Name` instances.
* Removed `Get***Symbol` helper functions.
* Bumped dependencies.

# Relates Issues

* VHDL/pyVHDLModel#70

# Related PRs

* #2308
* #2408 