### PR TITLE
Fix #1930: Vhdl Identifier Length Cap

### DIFF
--- a/src/vhdl/translate/trans.adb
+++ b/src/vhdl/translate/trans.adb
@@ -14,6 +14,7 @@
 --  You should have received a copy of the GNU General Public License
 --  along with this program.  If not, see <gnu.org/licenses>.
 
+with Ada.Strings.Unbounded;
 with Name_Table; -- use Name_Table;
 with Vhdl.Nodes_Priv;
 with Tables;
@@ -180,9 +181,11 @@ package body Trans is
    end Subprgs;
 
    package body Chap10 is
+      use Ada.Strings.Unbounded;
+
       --  Identifiers.
       --  The following functions are helpers to create ortho identifiers.
-      Identifier_Buffer : String (1 .. 4096);
+      Identifier_Buffer : Unbounded_String;
       Identifier_Len    : Natural := 0;
       Identifier_Start  : Natural := 1;
 
@@ -732,7 +735,7 @@ package body Trans is
 
       procedure Add_String (Len : in out Natural; Str : String) is
       begin
-         Identifier_Buffer (Len + 1 .. Len + Str'Length) := Str;
+         Insert (Identifier_Buffer, Len + 1, Str);
          Len := Len + Str'Length;
       end Add_String;
 
@@ -923,9 +926,9 @@ package body Trans is
          --Identifier_Buffer (L + Str'Length + 1) := Nul;
          if Is_Local then
             return Get_Identifier
-              (Identifier_Buffer (Identifier_Start .. L));
+              (Slice (Identifier_Buffer, Identifier_Start, L));
          else
-            return Get_Identifier (Identifier_Buffer (1 .. L));
+            return Get_Identifier (Slice (Identifier_Buffer, 1, L));
          end if;
       end Create_Id;
 
@@ -957,7 +960,7 @@ package body Trans is
             Add_Nat (Len, Natural (Val));
          end if;
          Add_String (Len, Str);
-         return Get_Identifier (Identifier_Buffer (1 .. Len));
+         return Get_Identifier (Slice (Identifier_Buffer, 1, Len));
       end Create_Identifier;
 
       function Create_Identifier (Str : String)
@@ -967,13 +970,14 @@ package body Trans is
       begin
          Len := Identifier_Len;
          Add_String (Len, Str);
-         return Get_Identifier (Identifier_Buffer (1 .. Len));
+         return Get_Identifier (Slice (Identifier_Buffer, 1, Len));
       end Create_Identifier;
 
       function Create_Identifier return O_Ident
       is
       begin
-         return Get_Identifier (Identifier_Buffer (1 .. Identifier_Len - 2));
+         return
+            Get_Identifier (Slice (Identifier_Buffer, 1, Identifier_Len - 2));
       end Create_Identifier;
 
       function Create_Elab_Identifier (Kind : Elab_Kind) return O_Ident is
@@ -996,7 +1000,8 @@ package body Trans is
          else
             Start := 1;
          end if;
-         return (Id => Get_Identifier (Identifier_Buffer (Start .. L)));
+         return (Id =>
+                 Get_Identifier (Slice (Identifier_Buffer, Start, L)));
       end Create_Var_Identifier_From_Buffer;
 
       function Create_Var_Identifier (Id : Iir)

--- a/src/vhdl/translate/trans.adb
+++ b/src/vhdl/translate/trans.adb
@@ -14,7 +14,7 @@
 --  You should have received a copy of the GNU General Public License
 --  along with this program.  If not, see <gnu.org/licenses>.
 
-with Ada.Strings.Unbounded;
+with Grt.Vstrings;
 with Name_Table; -- use Name_Table;
 with Vhdl.Nodes_Priv;
 with Tables;
@@ -181,11 +181,11 @@ package body Trans is
    end Subprgs;
 
    package body Chap10 is
-      use Ada.Strings.Unbounded;
+      use Grt.Vstrings;
 
       --  Identifiers.
       --  The following functions are helpers to create ortho identifiers.
-      Identifier_Buffer : Unbounded_String;
+      Identifier_Buffer : Vstring;
       Identifier_Len    : Natural := 0;
       Identifier_Start  : Natural := 1;
 
@@ -735,7 +735,7 @@ package body Trans is
 
       procedure Add_String (Len : in out Natural; Str : String) is
       begin
-         Insert (Identifier_Buffer, Len + 1, Str);
+         Append (Identifier_Buffer, Str);
          Len := Len + Str'Length;
       end Add_String;
 
@@ -926,9 +926,9 @@ package body Trans is
          --Identifier_Buffer (L + Str'Length + 1) := Nul;
          if Is_Local then
             return Get_Identifier
-              (Slice (Identifier_Buffer, Identifier_Start, L));
+               (Get_C_String (Identifier_Buffer) (Identifier_Start .. L));
          else
-            return Get_Identifier (Slice (Identifier_Buffer, 1, L));
+            return Get_Identifier (Get_C_String (Identifier_Buffer) (1 .. L));
          end if;
       end Create_Id;
 
@@ -960,7 +960,7 @@ package body Trans is
             Add_Nat (Len, Natural (Val));
          end if;
          Add_String (Len, Str);
-         return Get_Identifier (Slice (Identifier_Buffer, 1, Len));
+         return Get_Identifier (Get_C_String (Identifier_Buffer) (1 .. Len));
       end Create_Identifier;
 
       function Create_Identifier (Str : String)
@@ -970,14 +970,14 @@ package body Trans is
       begin
          Len := Identifier_Len;
          Add_String (Len, Str);
-         return Get_Identifier (Slice (Identifier_Buffer, 1, Len));
+         return Get_Identifier (Get_C_String (Identifier_Buffer) (1 .. Len));
       end Create_Identifier;
 
       function Create_Identifier return O_Ident
       is
       begin
-         return
-            Get_Identifier (Slice (Identifier_Buffer, 1, Identifier_Len - 2));
+         return Get_Identifier
+            (Get_C_String (Identifier_Buffer) ( 1 .. Identifier_Len - 2));
       end Create_Identifier;
 
       function Create_Elab_Identifier (Kind : Elab_Kind) return O_Ident is
@@ -1000,8 +1000,8 @@ package body Trans is
          else
             Start := 1;
          end if;
-         return (Id =>
-                 Get_Identifier (Slice (Identifier_Buffer, Start, L)));
+         return (Id => Get_Identifier
+                       (Get_C_String (Identifier_Buffer) (Start .. L)));
       end Create_Var_Identifier_From_Buffer;
 
       function Create_Var_Identifier (Id : Iir)

--- a/src/vhdl/vhdl-scanner.adb
+++ b/src/vhdl/vhdl-scanner.adb
@@ -14,7 +14,7 @@
 --  You should have received a copy of the GNU General Public License
 --  along with this program.  If not, see <gnu.org/licenses>.
 with Ada.Characters.Latin_1; use Ada.Characters.Latin_1;
-with Ada.Strings.Unbounded;
+with Grt.Vstrings;
 with Errorout; use Errorout;
 with Name_Table;
 with Files_Map; use Files_Map;
@@ -1004,7 +1004,7 @@ package body Vhdl.Scanner is
    -- character for a basic identifier.
    procedure Scan_Identifier (Allow_PSL : Boolean)
    is
-      use Ada.Strings.Unbounded;
+      use Grt.Vstrings;
       use Name_Table;
       --  Local copy for speed-up.
       Source : constant File_Buffer_Acc := Current_Context.Source;
@@ -1013,7 +1013,7 @@ package body Vhdl.Scanner is
       --  Current and next character.
       C : Character;
 
-      Buffer : Unbounded_String;
+      Buffer : Vstring;
       Len : Natural;
    begin
       -- This is an identifier or a key word.
@@ -1124,8 +1124,8 @@ package body Vhdl.Scanner is
                --  with the same meaning.
                declare
                   Base : Nat32;
-                  Cl : constant Character := Element (Buffer, Len);
-                  Cf : constant Character := Element (Buffer, 1);
+                  Cl : constant Character := Get_C_String (Buffer) (Len);
+                  Cf : constant Character := Get_C_String (Buffer) (1);
                begin
                   Current_Context.Bit_Str_Base := Cl;
                   if Cl = 'b' then
@@ -1166,7 +1166,7 @@ package body Vhdl.Scanner is
             --  quote marks, there are invalid character (in the 128-160
             --  range).
             if C = Character'Val (16#80#)
-              and then Element (Buffer, Len) = Character'Val (16#e2#)
+              and then Get_C_String (Buffer) (Len) = Character'Val (16#e2#)
               and then (Source (Pos + 1) = Character'Val (16#98#)
                           or else Source (Pos + 1) = Character'Val (16#99#))
             then
@@ -1214,7 +1214,8 @@ package body Vhdl.Scanner is
       end case;
 
       -- Hash it.
-      Current_Context.Identifier := Get_Identifier (Slice (Buffer, 1, Len));
+      Current_Context.Identifier := Get_Identifier
+         (Get_C_String (Buffer) (1 .. Len));
       Current_Token := Tok_Identifier;
    end Scan_Identifier;
 
@@ -1462,9 +1463,9 @@ package body Vhdl.Scanner is
    --  backslashes, doubling backslashes inside).
    procedure Scan_Extended_Identifier
    is
-      use Ada.Strings.Unbounded;
+      use Grt.Vstrings;
       use Name_Table;
-      Buffer : Unbounded_String;
+      Buffer : Vstring;
       Len : Natural;
       C : Character;
    begin
@@ -1473,7 +1474,7 @@ package body Vhdl.Scanner is
       --  identifier.
       --  GHDL: This is satisfied by storing '\' in the name table.
       Len := 1;
-      Buffer := To_Unbounded_String("\");
+      Append (Buffer, "\");
       loop
          --  Next character.
          Pos := Pos + 1;
@@ -1543,7 +1544,8 @@ package body Vhdl.Scanner is
       end case;
 
       -- Hash it.
-      Current_Context.Identifier := Get_Identifier (Slice (Buffer, 1, Len));
+      Current_Context.Identifier := Get_Identifier
+         (Get_C_String (Buffer) (1 .. Len));
       Current_Token := Tok_Identifier;
    end Scan_Extended_Identifier;
 
@@ -1688,9 +1690,9 @@ package body Vhdl.Scanner is
    --  allowed.
    procedure Scan_Comment_Identifier (Id : out Name_Id; Create : Boolean)
    is
-      use Ada.Strings.Unbounded;
+      use Grt.Vstrings;
       use Name_Table;
-      Buffer : Unbounded_String;
+      Buffer : Vstring;
       Len : Natural;
       C : Character;
    begin
@@ -1731,9 +1733,9 @@ package body Vhdl.Scanner is
       end if;
 
       if Create then
-         Id := Get_Identifier (Slice (Buffer, 1, Len));
+         Id := Get_Identifier (Get_C_String (Buffer) (1 .. Len));
       else
-         Id := Get_Identifier_No_Create (Slice (Buffer, 1, Len));
+         Id := Get_Identifier_No_Create (Get_C_String (Buffer) (1 .. Len));
       end if;
    end Scan_Comment_Identifier;
 

--- a/src/vhdl/vhdl-scanner.ads
+++ b/src/vhdl/vhdl-scanner.ads
@@ -25,9 +25,6 @@ package Vhdl.Scanner is
    -- It can be replaced by a function call.
    Current_Token: Token_Type := Tok_Invalid;
 
-   --  Maximal length for identifiers.
-   Max_Name_Length : constant Natural := 1024;
-
    -- Simply set current_token to tok_invalid.
    procedure Invalidate_Current_Token;
    pragma Inline (Invalidate_Current_Token);


### PR DESCRIPTION
Handles/Fixes #1930 

Changes the scanning functions from fixed size strings to Unbounded_Strings as the LRM does allow for arbritrary identifier lengths rather than the current 1K/4K cap and does not meet standard that way.

Only the strings and their access have been changed, any code around it (such as keeping track of the Length of the string) has remained unmodified for now.

Since this change from fixed size strings to unbounded ones can have a bigger impact on performance, memory and so on I would highly appreciate taking a closer look before merging as this is my first contribution and Ada is not my strong suit.

The unlimited length works on my end, but it would be great if somebody could countercheck with a bigger project and see if everything works just fine.