### PR TITLE
allow redefining the ar executable

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -17,6 +17,7 @@ CC=@CC@
 CFLAGS=@CFLAGS@
 CXX=@CXX@
 CXXFLAGS=@CXXFLAGS@
+AR=@AR@
 build=@build@
 srcdir=@srcdir@
 abs_srcdir=@abs_srcdir@
@@ -481,7 +482,7 @@ libghdl.a: lib/$(libghdl_name)
 #	Also create a static library
 	sed -e '1,/--  BEGIN/d' -e '/--  END/,$$d' -e 's/^   --   //' < b~libghdl.adb > libghdl.bind
 	$(RM) -f $@
-	ar rc $@ b~libghdl.o $(LIBGHDL_GRT_OBJS) `sed -e /^-/d < libghdl.bind`
+	$(AR) rc $@ b~libghdl.o $(LIBGHDL_GRT_OBJS) `sed -e /^-/d < libghdl.bind`
 	grep adalib libghdl.bind | sed -e 's/^-L//' -e 's@adalib/@adalib/libgnat.a@' > libghdl.link
 
 $(srcdir)/src/synth/include/synth_gates.h: $(srcdir)/src/synth/netlists.ads $(srcdir)/src/synth/netlists-gates.ads

--- a/configure
+++ b/configure
@@ -27,6 +27,7 @@ backend=mcode
 backend_version="none"
 CC=${CC:-gcc}
 CXX=${CXX:-clang++}
+AR=${AR:-ar}
 CFLAGS=${CFLAGS:--g}
 CXXFLAGS=${CXXFLAGS:--g}
 GNATMAKE=${GNATMAKE:-gnatmake}
@@ -60,7 +61,7 @@ PIC_FLAGS=-fPIC
 show_help=no
 progname=$0
 
-subst_vars="CC CXX GNATMAKE ADA_FLAGS MAKE CFLAGS CXXFLAGS LDFLAGS build
+subst_vars="CC CXX AR GNATMAKE ADA_FLAGS MAKE CFLAGS CXXFLAGS LDFLAGS build
 srcdir abs_srcdir prefix backend backend_version libdirsuffix libghdldirsuffix
 incdirsuffix gcc_src_dir llvm_config llvm_be backtrace_lib
 build_mode EXEEXT SOEXT PIC_FLAGS default_pic enable_werror enable_checks


### PR DESCRIPTION
Archiver on most UNIX-like systems is bound to the GCC distribution we need do allow AR to be configured to prevent leaking of other "ar" executables from path and pick the correct verion from (mostly) GCC.
This is very helpful for downstream packagers of GHDL to ensure correct compilation.

