### PR TITLE
Fix a crash when called with incorrectly formatted "--fst" cmdline option

### DIFF
--- a/src/simul/simul-fst.adb
+++ b/src/simul/simul-fst.adb
@@ -209,7 +209,7 @@ package body Simul.Fst is
          return False;
       end if;
 
-      if Opt (F + 5) = '=' then
+      if Opt'Length > 5 and then Opt (F + 5) = '=' then
          if Fst_Filename /= null then
             Free (Fst_Filename);
          end if;


### PR DESCRIPTION
Hi,

I noticed that ghdl crashed when called with an incorrectly formatted "--fst" cmdline option (e.g. without "=" between the option and the filename). The reported error was "CONSTRAINT_ERROR : simul-fst.adb:212 index check failed". This commit fixes this small problem.

BR,

Stanislav