### PR TITLE
Remove replacement characters since VHDL 2008

### DIFF
--- a/src/vhdl/vhdl-scanner.adb
+++ b/src/vhdl/vhdl-scanner.adb
@@ -2309,6 +2309,11 @@ package body Vhdl.Scanner is
                   Current_Token := Tok_Not_Equal;
                   Pos := Pos + 1;
                else
+                  if Vhdl_Std >= Vhdl_08 then
+                     Error_Msg_Scan
+                       ("'!' not allowed since vhdl 2008"
+                         & "(was replacement character for '|')");
+                  end if;
                   --  LRM93 13.10
                   --  A vertical line (|) can be replaced by an exclamation
                   --  mark (!) where used as a delimiter.

--- a/src/vhdl/vhdl-scanner.adb
+++ b/src/vhdl/vhdl-scanner.adb
@@ -475,6 +475,10 @@ package body Vhdl.Scanner is
       --  String delimiter.
       Mark := Source (Pos);
       pragma Assert (Mark = '"' or else Mark = '%');
+      if (Vhdl_Std >= Vhdl_08 and then Mark = '%') then
+         Error_Msg_Scan
+            ("'%' not allowed in vhdl 2008 (was replacement character)");
+      end if;
 
       Pos := Pos + 1;
       Length := 0;
@@ -585,6 +589,11 @@ package body Vhdl.Scanner is
       Has_Invalid : Boolean;
    begin
       pragma Assert (Mark = '"' or else Mark = '%');
+      if (Vhdl_Std >= Vhdl_08 and then Mark = '%') then
+         Error_Msg_Scan
+            ("'%' not allowed in vhdl 2008 (was replacement character)");
+      end if;
+
       Pos := Pos + 1;
       Length := 0;
       Has_Invalid := False;
@@ -773,7 +782,12 @@ package body Vhdl.Scanner is
          end loop;
       end Add_One_To_Carries;
    begin
-      pragma Assert (Source (Pos) = '"' or Source (Pos) = '%');
+      pragma Assert (Source (Pos) = '"' or else Source (Pos) = '%');
+      if (Vhdl_Std >= Vhdl_08 and then Source (Pos) = '%') then
+         Error_Msg_Scan
+            ("'%' not allowed in vhdl 2008 (was replacement character)");
+      end if;
+
       Pos := Pos + 1;
       Length := 0;
       Id := Create_String8;
@@ -2478,11 +2492,6 @@ package body Vhdl.Scanner is
             Scan_String;
             return;
          when '%' =>
-            if Vhdl_Std >= Vhdl_08 then
-               Error_Msg_Scan
-                 ("'%%' not allowed in vhdl 2008 (was replacement character)");
-               --  Continue as a string.
-            end if;
             Scan_String;
             return;
          when '[' =>

--- a/src/vhdl/vhdl-scanner.adb
+++ b/src/vhdl/vhdl-scanner.adb
@@ -477,7 +477,7 @@ package body Vhdl.Scanner is
       pragma Assert (Mark = '"' or else Mark = '%');
       if (Vhdl_Std >= Vhdl_08 and then Mark = '%') then
          Error_Msg_Scan
-            ("'%' not allowed in vhdl 2008 (was replacement character)");
+            ("'%%' not allowed in vhdl 2008 (was replacement character)");
       end if;
 
       Pos := Pos + 1;
@@ -590,8 +590,9 @@ package body Vhdl.Scanner is
    begin
       pragma Assert (Mark = '"' or else Mark = '%');
       if (Vhdl_Std >= Vhdl_08 and then Mark = '%') then
+
          Error_Msg_Scan
-            ("'%' not allowed in vhdl 2008 (was replacement character)");
+            ("'%%' not allowed in vhdl 2008 (was replacement character)");
       end if;
 
       Pos := Pos + 1;
@@ -785,7 +786,7 @@ package body Vhdl.Scanner is
       pragma Assert (Source (Pos) = '"' or else Source (Pos) = '%');
       if (Vhdl_Std >= Vhdl_08 and then Source (Pos) = '%') then
          Error_Msg_Scan
-            ("'%' not allowed in vhdl 2008 (was replacement character)");
+            ("'%%' not allowed in vhdl 2008 (was replacement character)");
       end if;
 
       Pos := Pos + 1;


### PR DESCRIPTION
After I had read the VHDL 93 LRM, I noticed the replacement characters were not supported anymore since VHDL 2008. Didn't know that!
So here are some minor fixes in the code to add a better support.

Changes:
- prevent from using '!' as a '|'
- update pragma for replacement char "%"

@tgingold I think we should also add a pragma for the use of colon ':' in string litteral but I dont know how you want to proceed. Feel free to edit this PR or give me some insights...