### PR TITLE
libghw: Speed up ghw_read_cycle_cont without null-type signals

### DIFF
--- a/ghw/libghw.h
+++ b/ghw/libghw.h
@@ -384,6 +384,8 @@ struct ghw_handler
   char *skip_sigs;
   int flag_full_names;
   struct ghw_sig *sigs;
+  /* 1: sigs does not contain any signals with type = NULL and index > 0 */
+  int sigs_no_null;
 
   /* Hierarchy.  */
   struct ghw_hie *hie;


### PR DESCRIPTION
**Description** 

This PR adds a flag if all the signals in the `h->sigs` array (other than the entry with index 0) have a non-NULL type.
In that case, the linear search in `ghw_read_hie` can be replaced by a simple addition.
This seems to be the regular case and provides a massive speedup (about 6x to 20x+ in a quick test) in gtkwave.
I've also added some checks for out-of-bounds accesses.

**Context**
I hope that this is the correct place to put these changes to libghw.
Otherwise, I can instead submit them to gtkwave first.

This PR is similar to the patch from #2548, in which the addition is used unconditionally.
Here's that patch without the white space changes: [output.diff.zip](https://github.com/ghdl/ghdl/files/13929182/output.diff.zip)
I'm not sure if it's possible to have a case where a non-NULL type signal exists, so I decided to add the flag to avoid breaking that case.

For the ghw file from https://github.com/gtkwave/gtkwave/issues/280#issuecomment-1791391127, the load time on my machine is 20s with these changes. Without them, I stopped it after 6min.

Closes #2548 

**Varia**

On a somewhat unrelated note: The indentation in these files was a mix of tabs and spaces. Is that intended? It certainly made it quite difficult to edit the code for me (using VS Code or Sublime Text)...