### PR TITLE
pyproject.toml: Specify pyTooling<5.0, fixes ghdl/ghdl#2589

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "pyTooling >= 4.0.1",
+    "pyTooling >= 4.0.1, <5.0",
     "setuptools >= 62.3.3",
     "wheel >= 0.38.1"
 ]


### PR DESCRIPTION
Since pyTooling 6.0.0 was released, attempting to install pyGHDL via `pip install .` fails with the following exception: "Multiple .egg-info directories found".

This corrects the problem.