### PR TITLE
 Add support for ecp5um to vendors\compile-lattice script #2588 

### DIFF
--- a/scripts/vendors/compile-lattice.ps1
+++ b/scripts/vendors/compile-lattice.ps1
@@ -28,7 +28,7 @@
 #   (1) creates a subdirectory in the current working directory
 #   (2) compiles all Lattice Diamond simulation libraries and packages
 #       o Lattice device libraries:
-#         - EC, ECP, ECP2, ECP3, ECP5U
+#         - EC, ECP, ECP2, ECP3, ECP5
 #         - LPTM, LPTM2
 #         - MachXO, MachXO2, MachXO3L, MachXO3D
 #         - SC, SCM
@@ -50,8 +50,8 @@ param(
 	[switch]$ecp2 =       $false,
 	# Compile the Lattice ECP3 device libraries
 	[switch]$ecp3 =       $false,
-	# Compile the Lattice ECP5U device libraries
-	[switch]$ecp5u =      $false,
+	# Compile the Lattice ECP5 device libraries
+	[switch]$ecp5 =      $false,
 
 	# Compile the Lattice LPTM device libraries
 	[switch]$lptm =       $false,
@@ -115,7 +115,7 @@ Import-Module $PSScriptRoot\shared.psm1 -Verbose:$false -ArgumentList @("Lattice
 
 # Display help if no command was selected
 $Help = $Help -or (-not ($All -or
-                    ($ec -or $ecp -or $ecp2 -or $ecp3 -or $ecp5u) -or
+                    ($ec -or $ecp -or $ecp2 -or $ecp3 -or $ecp5) -or
                     ($lptm -or $lptm2) -or
                     ($MachXO -or $MachXO2 -or $MachXO3L -or $MachXO3D) -or
                     ($sc -or $scm) -or
@@ -131,7 +131,7 @@ if ($All)
 	$ecp =      $true
 	$ecp2 =     $true
 	$ecp3 =     $true
-	$ecp5u =    $true
+	$ecp5 =    $true
 	$lptm =     $true
 	$lptm2 =    $true
 	$MachXO =   $true
@@ -276,7 +276,7 @@ if ((-not $StopCompiling) -and $ecp3)
 
 # Lattice ECP5U library
 # ==============================================================================
-if ((-not $StopCompiling) -and $ecp5u)
+if ((-not $StopCompiling) -and $ecp5)
 {	$Library = "ecp5u"
 	$SourceFiles = $FileLists[$Library] | % { "$SourceDirectory\$Library\src\$_" }
 

--- a/scripts/vendors/compile-lattice.ps1
+++ b/scripts/vendors/compile-lattice.ps1
@@ -284,6 +284,18 @@ if ((-not $StopCompiling) -and $ecp5)
 	$StopCompiling = $HaltOnError -and ($ErrorCount -ne 0)
 }
 
+# Lattice ECP5UM library
+# ==============================================================================
+if ((-not $StopCompiling) -and $ecp5)
+{	$Library = "ecp5u"
+	$SourceFiles = $FileLists[$Library] | % { "$SourceDirectory\$Library\src\$_" }
+  
+  # rename library to get extra directory for ecp5um (libs are the same as for ecp5u)
+  $Library = "ecp5um" 
+	$ErrorCount += Start-PackageCompilation $GHDLBinary $Analyze_Parameters $DestinationDirectory $Library $VHDLVersion $SourceFiles $SuppressWarnings $HaltOnError -Verbose:$EnableVerbose -Debug:$EnableDebug
+	$StopCompiling = $HaltOnError -and ($ErrorCount -ne 0)
+}
+
 # Lattice LPTM library
 # ==============================================================================
 if ((-not $StopCompiling) -and $lptm)


### PR DESCRIPTION
**Description**
fix #2588 

Implemenation: 
`ecp5u` and `ecp5um` share the same lib. As GHDL looks for paths the `ecp5u` lib is duplicated to `ecp5um` directory and  the .cf file gets `ecp5um` name. To keep things simple, if `ecp5` is selected, both `ecp5u` and `ecp5um` libs are created.

I made and checked the changes for the .ps1 compile-lattice script:
```
C:\GHDL_3_0\lib\ghdl\vendors> .\compile-lattice.ps1 -ecp5
Calling Get-Command ...
Creating vendor directory: 'C:\GHDL_3_0\lib\ghdl\vendors\lattice'.
Compiling library 'ecp5u' ...
Compiling library 'ecp5um' ...
--------------------------------------------------------------------------------
Compiling Lattice libraries [SUCCESSFUL]
```

The following code does not cause errors anymore:  
```vhdl
library ecp5um;
use ecp5um.components.all;
```
The same changes for the .sh script are missing as I don´t have a setup for testing yet.