### PR TITLE
libghw - Add checks to prevent memory access issues when opening ghd files

### DIFF
--- a/ghw/libghw.h
+++ b/ghw/libghw.h
@@ -176,7 +176,7 @@ struct ghw_type_enum
   const char *name;
 
   enum ghw_wkt_type wkt;
-  unsigned int nbr;
+  uint32_t nbr;
   const char **lits;
 };
 
@@ -367,20 +367,20 @@ struct ghw_handler
 
   /* String table.  */
   /* Number of strings.  */
-  unsigned nbr_str;
+  uint32_t nbr_str;
   /* Size of the strings (without nul).  */
-  unsigned str_size;
+  uint32_t str_size;
   /* String table.  */
   char **str_table;
   /* Array containing strings.  */
   char *str_content;
 
   /* Type table.  */
-  unsigned nbr_types;
+  uint32_t nbr_types;
   union ghw_type **types;
 
   /* Non-composite (or basic) signals.  */
-  unsigned nbr_sigs;
+  uint32_t nbr_sigs;
   char *skip_sigs;
   int flag_full_names;
   struct ghw_sig *sigs;


### PR DESCRIPTION
This MR adds checks to prevent memory access issues when opening ghw files. The type of fixed issues include:
-  Out-of-bounds accesses in arrays (with the array size and index read from the ghw file).
-  Casts to union members without checking the type.
-  Continued program execution after an error condition.
-  Overflows/underflows on malloc size variables.

I've added a function `ghw_error_exit_line` that's called when an invalid value is detected. I've chosen to call `exit(1)` in that case, after printing the . The original code had calls to `abort()` in some cases, I can also change it to do call `abort()`, if you prefer.

Note: codacy fails, but I did not change those lines.