### PR TITLE
update for GCC 14

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -299,9 +299,9 @@ copy-sources.gcc: version.ads scripts/gcc/Make-lang.in
 	 6 | 6.*)  	    gcc_ortho_lang=ortho-lang-6.c ;; \
 	 7.*)      	    gcc_ortho_lang=ortho-lang-7.c ;; \
 	 8.*)      	    gcc_ortho_lang=ortho-lang-8.c ;; \
-	 9.* | 10.* | 11.* | 12.* | 13.*) gcc_ortho_lang=ortho-lang-9.c ;; \
+	 9.* | 10.* | 11.* | 12.* | 13.* | 14.*) gcc_ortho_lang=ortho-lang-9.c ;; \
 	 *) echo "Mismatch gcc version from $(gcc_src_dir)"; \
-	    echo "Need gcc version 4.9.x, 5.x to 12.x"; \
+	    echo "Need gcc version 4.9.x, 5.x to 14.x"; \
 	    exit 1 ;; \
 	esac; \
 	$(CP) -p $(srcdir)/src/ortho/gcc/$$gcc_ortho_lang \
@@ -316,7 +316,7 @@ copy-sources.gcc: version.ads scripts/gcc/Make-lang.in
 #	For gcc 12.x, use .cc extension
 	base_ver=`cat $(gcc_src_dir)/gcc/BASE-VER`; \
 	case $$base_ver in \
-	12.* | 13.*) for f in $(gcc_vhdl_dir)/*.c; do mv $$f $${f}c; done; \
+	12.* | 13.* | 14.*) for f in $(gcc_vhdl_dir)/*.c; do mv $$f $${f}c; done; \
 	  sed -e 's/ortho-lang.c/ortho-lang.cc/' \
 	    < $(srcdir)/scripts/gcc/config-lang.in \
 	    > $(gcc_vhdl_dir)/config-lang.in ;; \


### PR DESCRIPTION
**Description**
update Makefile to accept GCC 14, which is the system compiler in Fedora 40

But
````
touch gcc/vhdl/lang.opt.urls
````
workaround is still required to overcome
````
...
make[2]: *** No rule to make target '../../gcc/vhdl/lang.opt.urls', needed by 's-options'.  Stop.
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/builddir/build/BUILD/gcc-14.0.1-20240208/obj-ppc64le-fedora_ghdl-linux/gcc'
make[1]: *** [Makefile:4678: all-gcc] Error 2
make[1]: *** Waiting for unfinished jobs....

````

Seems the `vhdl` backend in GCC will need a little update in the buildsystem to not require the missing file. I believe there is a way, because not all existing backends provide the `lang.opt.urls` file.