### PR TITLE
Display the list of all drivers of a signal in case an unresolved signal has multiple drivers.

### DIFF
--- a/src/grt/grt-processes.adb
+++ b/src/grt/grt-processes.adb
@@ -36,7 +36,6 @@ with Grt.Disp_Signals;
 with Grt.Stats;
 with Grt.Threads; use Grt.Threads;
 pragma Elaborate_All (Grt.Table);
-with Grt.Stdio;
 with Grt.Analog_Solver;
 
 package body Grt.Processes is

--- a/src/grt/grt-processes.ads
+++ b/src/grt/grt-processes.ads
@@ -28,6 +28,7 @@ with Grt.Vhdl_Types; use Grt.Vhdl_Types;
 with Grt.Signals; use Grt.Signals;
 with Grt.Rtis; use Grt.Rtis;
 with Grt.Rtis_Addr;
+with Grt.Stdio;
 
 package Grt.Processes is
    pragma Suppress (All_Checks);
@@ -103,6 +104,8 @@ package Grt.Processes is
    --  Total number of resumed processes.
    function Get_Nbr_Resumed_Processes return Long_Long_Integer;
 
+   -- Display the name of a process.
+   procedure Disp_Process_Name (Stream : Grt.Stdio.FILEs; Proc : Process_Acc);
 
    --  Instance is the parameter of the process procedure.
    --  This is in fact a fully opaque type whose content is private to the

--- a/src/grt/grt-signals.adb
+++ b/src/grt/grt-signals.adb
@@ -318,31 +318,46 @@ package body Grt.Signals is
          Disconnect_Time => Bad_Time);
    end Ghdl_Signal_Create_Resolution;
 
-   procedure Check_New_Source (Sig : Ghdl_Signal_Ptr)
-   is
-      use Grt.Stdio;
-      use Grt.Astdio;
+   procedure Display_Signal_And_Sources (Sig : in Ghdl_Signal_Ptr) is
    begin
-      if Sig.S.Nbr_Drivers + Sig.Nbr_Ports > 0 then
+      Grt.Astdio.Put(Grt.Stdio.Stderr, "Signal ");
+      Disp_Signals.Put_Signal_Name(Grt.Stdio.Stderr, Sig);
+      Grt.Astdio.Put(Grt.Stdio.Stderr, " is driven by :");
+      Grt.Astdio.New_Line(Grt.Stdio.Stderr);
+      if Sig.S.Nbr_Drivers /= 0
+      then
+         for I in 0 .. Sig.S.Nbr_Drivers - 1
+         loop
+            Grt.Processes.Disp_Process_Name(Grt.Stdio.Stderr, Sig.S.Drivers.all(I).Proc);
+            Grt.Astdio.New_Line(Grt.Stdio.Stderr);
+         end loop;
+      end if;
+      if Sig.Nbr_Ports /= 0
+      then
+         Grt.Astdio.Put(Grt.Stdio.Stderr, "At least one port.");
+         Grt.Astdio.New_Line(Grt.Stdio.Stderr);
+      end if;
+   end Display_Signal_And_Sources;
+
+   procedure Check_Number_Of_Sources (Sig : in Ghdl_Signal_Ptr) is
+   begin
+      if Sig.S.Nbr_Drivers + Sig.Nbr_Ports > 1 then
          if Sig.S.Resolv = null then
             --  LRM 4.3.1.2 Signal Declaration
             --  It is an error if, after the elaboration of a description, a
             --  signal has multiple sources and it is not a resolved signal.
-            Put (stderr, "for signal: ");
-            Disp_Signals.Put_Signal_Name (stderr, Sig);
-            New_Line (stderr);
-            Error ("several sources for unresolved signal");
+            Display_Signal_And_Sources(Sig);
+            Error("several sources for unresolved signal");
          elsif Sig.S.Mode_Sig = Mode_Buffer and False then
             --  LRM 1.1.1.2  Ports
             --  A BUFFER port may have at most one source.
-
             --  FIXME: this is not true with VHDL-02.
             --  With VHDL-87/93, should also check that: any actual associated
             --  with a formal buffer port may have at most one source.
-            Error ("buffer port which more than one source");
+            Error("buffer port which more than one source");
          end if;
       end if;
-   end Check_New_Source;
+   end Check_Number_Of_Sources;
 
    --  Return True iff signal SIGN has a driver for PROC.
    function Has_Driver (Sign : Ghdl_Signal_Ptr; Proc : Process_Acc)
@@ -378,8 +393,6 @@ package body Grt.Signals is
                         / System.Storage_Unit);
       end Size;
    begin
-      Check_New_Source (Sign);
-
       if Sign.S.Nbr_Drivers = 0 then
          Sign.S.Drivers := Malloc (Size (1));
          Sign.S.Nbr_Drivers := 1;
@@ -391,6 +404,7 @@ package body Grt.Signals is
         (First_Trans => Trans,
          Last_Trans => Trans,
          Proc => Proc);
+      Check_Number_Of_Sources(Sign);
    end Ghdl_Signal_Add_Driver;
 
    procedure Ghdl_Process_Add_Driver (Sign : Ghdl_Signal_Ptr)
@@ -529,8 +543,8 @@ package body Grt.Signals is
                                      Src : Ghdl_Signal_Ptr)
    is
    begin
-      Check_New_Source (Targ);
       Append_Port (Targ, Src);
+      Check_Number_Of_Sources(Targ);
    end Ghdl_Signal_Add_Source;
 
    procedure Ghdl_Signal_Set_Disconnect (Sign : Ghdl_Signal_Ptr;

--- a/src/grt/grt-signals.adb
+++ b/src/grt/grt-signals.adb
@@ -320,22 +320,22 @@ package body Grt.Signals is
 
    procedure Display_Signal_And_Sources (Sig : in Ghdl_Signal_Ptr) is
    begin
-      Grt.Astdio.Put(Grt.Stdio.Stderr, "Signal ");
-      Disp_Signals.Put_Signal_Name(Grt.Stdio.Stderr, Sig);
-      Grt.Astdio.Put(Grt.Stdio.Stderr, " is driven by :");
-      Grt.Astdio.New_Line(Grt.Stdio.Stderr);
-      if Sig.S.Nbr_Drivers /= 0
-      then
+      Grt.Astdio.Put(Grt.Stdio.stderr, "Signal ");
+      Disp_Signals.Put_Signal_Name(Grt.Stdio.stderr, Sig);
+      Grt.Astdio.Put(Grt.Stdio.stderr, " is driven by :");
+      Grt.Astdio.New_Line(Grt.Stdio.stderr);
+      if Sig.S.Nbr_Drivers /= 0 then
          for I in 0 .. Sig.S.Nbr_Drivers - 1
          loop
-            Grt.Processes.Disp_Process_Name(Grt.Stdio.Stderr, Sig.S.Drivers.all(I).Proc);
-            Grt.Astdio.New_Line(Grt.Stdio.Stderr);
+            Grt.Processes.Disp_Process_Name(
+              Grt.Stdio.stderr,
+              Sig.S.Drivers.all(I).Proc);
+            Grt.Astdio.New_Line(Grt.Stdio.stderr);
          end loop;
       end if;
-      if Sig.Nbr_Ports /= 0
-      then
-         Grt.Astdio.Put(Grt.Stdio.Stderr, "At least one port.");
-         Grt.Astdio.New_Line(Grt.Stdio.Stderr);
+      if Sig.Nbr_Ports /= 0 then
+         Grt.Astdio.Put(Grt.Stdio.stderr, "At least one port.");
+         Grt.Astdio.New_Line(Grt.Stdio.stderr);
       end if;
    end Display_Signal_And_Sources;
 


### PR DESCRIPTION
Whenever a source is added to a signal, check the number of sources after adding it. Upon detecting the presence of multiple drivers, display the drivers. Port sources are not displayed because I could not figure out how to exercise this path, though I report their presence if found.

This is an enhancement, and is not related to an issue.