### PR TITLE
VPI enhancements

### DIFF
--- a/src/grt/grt-callbacks.adb
+++ b/src/grt/grt-callbacks.adb
@@ -78,6 +78,37 @@ package body Grt.Callbacks is
       end if;
    end Register_Callback_At;
 
+   -- The handle is freed if it is found in the list.
+   procedure Unregister_Callback_At
+     (List : in out Callback_Time_List;
+      Handle : in out Callback_Handle)
+   is
+      C : Callback_Handle;
+   begin
+      if List.First = null or Handle = null then
+         return;
+      end if;
+      if List.First = Handle then
+         List.First := Handle.Next;
+         Free_Handle(Handle);
+         Handle := null;
+      else
+         C := List.First;
+         loop
+            if C.Next = Handle then
+               C.Next := Handle.Next;
+               Free_Handle(Handle);
+               Handle := null;
+               exit;
+            else
+               C := C.Next;
+               exit when C = null;
+            end if;
+         end loop;
+      end if;
+      pragma Assert (Handle = null);
+   end Unregister_Callback_At;
+
    procedure Call_Time_Callbacks (List : in out Callback_Time_List)
    is
       C : Callback_Handle;

--- a/src/grt/grt-callbacks.ads
+++ b/src/grt/grt-callbacks.ads
@@ -56,6 +56,11 @@ package Grt.Callbacks is
       Proc : Callback_Acc;
       Arg : System.Address := System.Null_Address);
 
+   -- The handle is freed if it is found in the list.
+   procedure Unregister_Callback_At
+     (List : in out Callback_Time_List;
+      Handle : in out Callback_Handle);
+
    type Callback_Mode is (Timed, Repeat, Oneshot);
    subtype Callback_Non_Timed_Mode is Callback_Mode range Repeat .. Oneshot;
 

--- a/src/grt/grt-cvpi.c
+++ b/src/grt/grt-cvpi.c
@@ -182,3 +182,28 @@ vpi_control (int op, ...)
 
   return res;
 }
+
+/* Increment a pointer to struct s_vpi_vecval.  This is a work-round
+ * for undefined reference problems with "ghdl -e" when trying to use
+ * Interfaces.C.Pointers.
+ */
+
+void Increment_p_vpi_vecval (p_vpi_vecval *ppv) { (*ppv)++; }
+
+/* Call vpi_get_value() with some temporary vector space, then
+ * make a VPI callback with the data.
+ */
+
+void vpi_get_value_vec_helper (p_cb_data cb, int len)
+{
+    p_vpi_value         vp;
+    p_vpi_vecval        save_vec;
+    struct t_vpi_vecval space[len];
+
+    vp = cb->value;
+    save_vec = vp->value.vector;
+    vp->value.vector = space;
+    vpi_get_value (cb->obj, vp);
+    (*cb->cb_rtn)(cb);
+    vp->value.vector = save_vec;
+}

--- a/src/grt/grt-options.adb
+++ b/src/grt/grt-options.adb
@@ -60,6 +60,13 @@ package body Grt.Options is
       Time_Phys_To_Real := 1.0 / Time_Real_To_Phys;
    end Set_Time_Resolution;
 
+   function Time_Scale_Unit return Long_Float is
+      Units : constant array (Natural_Time_Scale) of Long_Float :=
+         ( 1.0, 1.0e-3, 1.0e-6, 1.0e-9, 1.0e-12, 1.0e-15 );
+   begin
+      return Units (Options.Time_Resolution_Scale);
+   end Time_Scale_Unit;
+
    procedure Help
    is
       use Grt.Astdio;

--- a/src/grt/grt-options.ads
+++ b/src/grt/grt-options.ads
@@ -71,6 +71,9 @@ package Grt.Options is
    --  Set Time_Resolution_Scale from Flag_String.
    procedure Set_Time_Resolution;
 
+   --  Return the time scale unit.
+   function Time_Scale_Unit return Long_Float;
+
    --  Display options help.
    --  Should not be called directly.
    procedure Help;

--- a/src/grt/grt-vpi.adb
+++ b/src/grt/grt-vpi.adb
@@ -355,7 +355,7 @@ package body Grt.Vpi is
       Res : Std_Time;
    begin
       case V.mType is
-         when vpiSCaledRealTime =>
+         when vpiScaledRealTime =>
             Res := Std_Time (Unsigned_64 (V.mReal / Time_Scale_Unit));
          when vpiSimTime =>
             Res := Std_Time (Unsigned_64 (V.mHigh) * 2 ** 32);
@@ -1173,7 +1173,7 @@ package body Grt.Vpi is
       Len, Chunks, Bits, Base : Ghdl_Index_Type;
       A, Aall, B, Ball : Unsigned_32;
       Pointer : p_vpi_vecval;
-    begin
+   begin
       Info := Get_Value_Obj (Obj);
 
       case Info.Vtype is
@@ -1300,7 +1300,7 @@ package body Grt.Vpi is
          when vpiStringVal =>   dbgPut_Line ("vpi_get_value: vpiStringVal");
          when vpiTimeVal =>     dbgPut_Line ("vpi_get_value: vpiTimeVal");
          when vpiVectorVal =>
-	    Vpi_Get_Value_Vecval (Expr.Ref, Value.Vector);
+            Vpi_Get_Value_Vecval (Expr.Ref, Value.Vector);
          when vpiStrengthVal => dbgPut_Line ("vpi_get_value: vpiStrengthVal");
          when others =>         dbgPut_Line ("vpi_get_value: unknown mFormat");
       end case;
@@ -1509,8 +1509,8 @@ package body Grt.Vpi is
                   Vec (Base + J) := 'X';
                end if;
             end if;
-           Va := Shift_Right_Arithmetic (Va, 1);
-           Vb := Shift_Right_Arithmetic (Vb, 1);
+            Va := Shift_Right_Arithmetic (Va, 1);
+            Vb := Shift_Right_Arithmetic (Vb, 1);
          end loop;
          Base := Base + Bits;
          Increment_p_vpi_vecval (Pointer);
@@ -1799,7 +1799,7 @@ package body Grt.Vpi is
          Hand.Cb_Refcnt := Hand.Cb_Refcnt + 1;
          if Hand.Cb.Value /= null then
             -- Supply value before call.  May need to allocate vector space.
-            if (Hand.Cb.Value.format = vpiVectorVal) then
+            if (Hand.Cb.Value.Format = vpiVectorVal) then
                -- Storage for the vector must be allocated first.
                declare
                   Len : Integer;
@@ -1876,11 +1876,11 @@ package body Grt.Vpi is
 
       if Res.Cb.Time /= null then
          Res.Cb.Time := new s_vpi_time;
-         Res.Cb.Time.All := Data.Time.All;
+         Res.Cb.Time.all := Data.Time.all;
       end if;
       if Res.Cb.Value /= null then
          Res.Cb.Value := new s_vpi_value (Data.Value.Format);
-         Res.Cb.Value.All := Data.Value.All;
+         Res.Cb.Value.all := Data.Value.all;
       end if;
 
       case Data.Reason is

--- a/src/grt/grt-vpi.adb
+++ b/src/grt/grt-vpi.adb
@@ -1803,15 +1803,20 @@ package body Grt.Vpi is
            |  cbReadWriteSynch
            |  cbReadOnlySynch =>
             Delete_Callback (Ref.Cb_Handle);
-            Ref.Cb_Refcnt := Ref.Cb_Refcnt - 1;
-            if Ref.Cb_Refcnt > 0 then
-               --  Do not free REF.
-               Ref_Copy := null;
-            end if;
+         when cbAfterDelay =>
+            Unregister_Callback_At (Cb_After_Delay, Ref.Cb_Handle);
          when others =>
             Res := 0;
             Ref_Copy := null;
       end case;
+
+      if Res > 0 then
+         Ref.Cb_Refcnt := Ref.Cb_Refcnt - 1;
+         if Ref.Cb_Refcnt > 0 then
+            --  Do not free REF.
+            Ref_Copy := null;
+         end if;
+      end if;
 
       if Flag_Trace then
          if Ref_Copy = null then

--- a/src/grt/grt-vpi.adb
+++ b/src/grt/grt-vpi.adb
@@ -218,6 +218,8 @@ package body Grt.Vpi is
             Trace ("vpiNetArray");
          when vpiPort =>
             Trace ("vpiPort");
+         when vpiDirection =>
+            Trace ("vpiDirection");
          when vpiParameter =>
             Trace ("vpiParameter");
          when vpiScope =>
@@ -557,8 +559,16 @@ package body Grt.Vpi is
             | VhpiForGenerateK
             | VhpiCompInstStmtK =>
             return vpiModule;
-         when VhpiPortDeclK
-            | VhpiSigDeclK =>
+         when VhpiPortDeclK =>
+            declare
+               Info : Verilog_Wire_Info;
+            begin
+               Get_Verilog_Wire (Res, Info);
+               if Info.Vtype /= Vcd_Bad then
+                  return vpiPort;
+               end if;
+            end;
+         when VhpiSigDeclK =>
             declare
                Info : Verilog_Wire_Info;
             begin
@@ -646,7 +656,7 @@ package body Grt.Vpi is
    -- vpiHandle  vpi_scan(vpiHandle iter)
    -- Scan the Verilog HDL hierarchy for objects with a one-to-many
    -- relationship.
-   -- see IEEE 1364-2001, chapter 27.36, page 709
+   -- see IEEE Std 1800-2017, chapter 38.40, page 1109
    function Vpi_Scan_Internal (Iter: vpiHandle) return vpiHandle
    is
       Res : VhpiHandleT;
@@ -735,7 +745,7 @@ package body Grt.Vpi is
 
    ------------------------------------------------------------------------
    -- char *vpi_get_str(int property, vpiHandle ref)
-   -- see IEEE 1364-2001, page xxx
+   -- see IEEE Std 1800-2017, page 1061
    Tmpstring2 : String (1 .. 1024);
    function Vpi_Get_Str_Internal (Property : Integer; Ref : vpiHandle)
                                  return Ghdl_C_String
@@ -743,6 +753,75 @@ package body Grt.Vpi is
       Prop : VhpiStrPropertyT;
       Len : Natural;
       Res : Ghdl_C_String;
+
+      procedure Copy_VpiType_CString is
+         R : String renames Tmpstring2;
+         procedure Add (C : Character) is
+         begin
+            Len := Len + 1;
+            if Len <= R'Last then
+               R (Len) := C;
+            end if;
+         end Add;
+
+         procedure Add (Str : String) is
+         begin
+            for I in Str'Range loop
+               Add (Str (I));
+            end loop;
+         end Add;
+
+      begin
+         Len := 0;
+         case Vhpi_Handle_To_Vpi_Prop(Ref.Ref) is
+            when vpiUndefined =>
+               Add ("vpiUndefined");
+            when vpiType =>
+               Add ("vpiType");
+            when vpiName =>
+               Add ("vpiName");
+            when vpiFullName =>
+               Add ("vpiFullName");
+            when vpiSize =>
+               Add ("vpiSize");
+            when vpiTimePrecision =>
+               Add ("vpiTimePrecision");
+            when vpiScalar =>
+               Add ("vpiScalar");
+            when vpiVector =>
+               Add ("vpiVector");
+            when vpiModule =>
+               Add ("vpiModule");
+            when vpiDefFile =>
+               Add ("vpiDefFile");
+            when vpiNet =>
+               Add ("vpiNet");
+            when vpiPort =>
+               Add ("vpiPort");
+            when vpiDirection =>
+               Add ("vpiDirection");
+            when vpiParameter =>
+               Add ("vpiParameter");
+            when vpiScope =>
+               Add ("vpiScope");
+            when vpiInternalScope =>
+               Add ("vpiInternalScope");
+            when vpiLeftRange =>
+               Add ("vpiLeftRange");
+            when vpiRightRange =>
+               Add ("vpiRightRange");
+            when vpiStop =>
+               Add ("vpiStop");
+            when vpiFinish =>
+               Add ("vpiFinish");
+            when vpiReset =>
+               Add ("vpiReset");
+            when others =>
+               return;
+         end case;
+         R (Len + 1) := NUL;
+      end Copy_VpiType_CString;
+
    begin
       if Ref = null then
          return null;
@@ -753,9 +832,15 @@ package body Grt.Vpi is
             Prop := VhpiFullNameP;
          when vpiName =>
             Prop := VhpiNameP;
+         when vpiDefFile =>
+            Prop := VhpiFileNameP;
          when vpiType =>
-            Tmpstring2 (1 .. 4) := "???" & NUL;
-            return To_Ghdl_C_String (Tmpstring2'Address);
+            Copy_VpiType_CString;
+            if Len = 0 then
+               return null;
+            else
+               return To_Ghdl_C_String (Tmpstring2'Address);
+            end if;
          when others =>
             dbgPut_Line ("vpi_get_str: unhandled property");
             return null;

--- a/src/grt/grt-vpi.ads
+++ b/src/grt/grt-vpi.ads
@@ -20,6 +20,7 @@
 
 with System; use System;
 with Interfaces; use Interfaces;
+-- with Interfaces.C.Pointers;
 with Ada.Unchecked_Conversion;
 with Grt.Types; use Grt.Types;
 with Grt.Avhpi; use Grt.Avhpi;
@@ -146,6 +147,16 @@ package Grt.Vpi is
    pragma Convention (C, s_vpi_time);
    type p_vpi_time is access s_vpi_time;
 
+   type s_vpi_vecval is record
+      aval : Unsigned_32; -- PLI_INT32 in the standard, but a bit mask
+      bval : Unsigned_32;
+   end record;
+   pragma Convention (C, s_vpi_vecval);
+   type p_vpi_vecval is access s_vpi_vecval; -- Should be array
+
+   procedure Increment_p_vpi_vecval (Ptr : in out p_vpi_vecval);
+   pragma Import (C, Increment_p_vpi_vecval, "Increment_p_vpi_vecval");
+
    -- typedef struct t_vpi_value
    -- { int format;
    --   union
@@ -174,7 +185,8 @@ package Grt.Vpi is
          when vpiRealVal=>
             Real_M : Ghdl_F64;
             --when vpiTimeVal=>     mTime:     p_vpi_time;
-            --when vpiVectorVal=>   mVector:   p_vpi_vecval;
+         when vpiVectorVal=>
+            Vector: p_vpi_vecval;
             --when vpiStrengthVal=> mStrength: p_vpi_strengthval;
          when others =>
             null;
@@ -238,6 +250,11 @@ package Grt.Vpi is
    -- void  vpi_get_value(vpiHandle expr, p_vpi_value value);
    procedure vpi_get_value (Expr : vpiHandle; Value : p_vpi_value);
    pragma Export (C, vpi_get_value, "vpi_get_value");
+
+   -- Ugly, but C can do allocation on the fly with an auto.  Ada???
+   -- void  vpi_vec_callback_helper (p_cb_data cb, int Len);
+   procedure vpi_vec_callback_helper (cb : p_cb_data; Len : Integer);
+   pragma Import (C, vpi_vec_callback_helper, "vpi_get_value_vec_helper");
 
    -- void  vpi_get_time(vpiHandle obj, s_vpi_time*t);
    procedure vpi_get_time (Obj: vpiHandle; Time: p_vpi_time);

--- a/src/grt/grt-vpi.ads
+++ b/src/grt/grt-vpi.ads
@@ -101,7 +101,9 @@ package Grt.Vpi is
    vpiSuppressVal:   constant Integer := 13;
 
    -- codes for type tag of vpi_time structure
-   vpiSimTime:       constant Integer :=  2;
+   vpiScaledRealTime   : constant Integer :=  1;
+   vpiSimTime          : constant Integer :=  2;
+   vpiSuppressTime     : constant Integer :=  3;
 
    -- codes for the reason tag of cb_data structure
    cbValueChange       : constant := 1;

--- a/testsuite/vpi/vpi006/mydesign.vhdl
+++ b/testsuite/vpi/vpi006/mydesign.vhdl
@@ -1,0 +1,15 @@
+library ieee ;
+use ieee.std_logic_1164.all;
+
+entity myentity is
+  port (
+    in1: in bit_vector(1 downto 0);
+    out1: out bit_vector(2 downto 0);
+    inout1: inout bit_vector(3 downto 0);
+    inout2: buffer bit_vector(1 to 3)
+    );
+end myentity;
+
+architecture arch of myentity is
+begin
+end arch;

--- a/testsuite/vpi/vpi006/testsuite.sh
+++ b/testsuite/vpi/vpi006/testsuite.sh
@@ -1,0 +1,24 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+analyze mydesign.vhdl
+elab myentity
+
+if c_compiler_is_available && ghdl_has_feature myentity vpi; then
+  $GHDL --vpi-compile -v $CC -c vpi1.c
+  $GHDL --vpi-link -v $CC -o vpi1.vpi vpi1.o
+
+  add_vpi_path
+
+  simulate myentity --vpi=./vpi1.vpi | tee myentity.out
+  if grep -q Error myentity.out; then
+      echo "Error in output"
+      exit 1;
+  fi
+
+  rm -f vpi1.vpi vpi1.o
+fi
+clean
+
+echo "Test successful"

--- a/testsuite/vpi/vpi006/vpi1.c
+++ b/testsuite/vpi/vpi006/vpi1.c
@@ -1,0 +1,84 @@
+#include <stdio.h>
+#include <vpi_user.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const struct {
+  const char *name;
+  PLI_INT32   direction, size;
+} expected[] = {{ "in1", vpiInput, 2},
+                { "out1", vpiOutput, 3},
+                { "inout1", vpiInout, 4},
+                { "inout2", vpiNoDirection, 3}, // !
+                { NULL, }
+};
+
+PLI_INT32
+vpi_proc (s_cb_data *cb)
+{
+  vpiHandle      iter, top, item;
+  PLI_INT32      direction, size;
+  char          *name;
+  int            i;
+
+  /* Find the (unique?) top-level module and the one inside it. */
+
+  iter = vpi_iterate(vpiModule, NULL);
+  top = vpi_scan(iter);
+  vpi_free_object(iter);
+  vpi_printf("Top %s\n", vpi_get_str(vpiName, top));
+
+  /* Get the ports. */
+
+  iter = vpi_iterate(vpiPort, top);
+  i = 0;
+  while ((item = vpi_scan(iter))) {
+    direction = vpi_get(vpiDirection, item);
+    name = vpi_get_str(vpiName, item);
+    size = vpi_get(vpiSize, item);
+
+    vpi_printf("Port %s direction %d size %d, type %d\n",
+               name, direction, size, vpi_get(vpiType, item));
+
+    if (!expected[i].name) {
+        vpi_printf("Error: found extra port %s.\n", name);
+        exit(1);
+    }
+
+    if (strcmp(name, expected[i].name)) {
+      vpi_printf("Error: found port %s but expected %s.\n",
+                 name, expected[i].name);
+    }
+    if (direction != expected[i].direction) {
+      vpi_printf("Error: found port %s direction %d but expected %d.\n",
+                 name, direction, expected[i].direction);
+    }
+    if (size != expected[i].size) {
+      vpi_printf("Error: found port %s size %d but expected %d.\n",
+                 name, size, expected[i].size);
+    }
+    ++i;
+  }
+
+  if (expected[i].name)
+    vpi_printf("Error: missing port %s.\n", expected[i].name);
+  return 0;
+}
+
+void my_handle_register()
+{
+  s_cb_data cb;
+  printf ("Hello world\n");
+
+  cb.reason = cbEndOfCompile;
+  cb.cb_rtn = &vpi_proc;
+  cb.user_data = NULL;
+  if (vpi_register_cb (&cb) == NULL)
+    vpi_printf ("Error: Cannot register EndOfCompile call back\n");
+}
+
+void (*vlog_startup_routines[]) () =
+{
+  my_handle_register,
+  0
+};

--- a/testsuite/vpi/vpi007/mydesign.vhdl
+++ b/testsuite/vpi/vpi007/mydesign.vhdl
@@ -1,0 +1,17 @@
+library ieee ;
+use ieee.std_logic_1164.all;
+
+entity myentity is
+  port (
+    out1 : out integer := 0
+    );
+end myentity;
+
+architecture arch of myentity is
+begin
+  process
+  begin
+    wait for 1 ms;
+    out1 <= 17;
+  end process;
+end arch;

--- a/testsuite/vpi/vpi007/testsuite.sh
+++ b/testsuite/vpi/vpi007/testsuite.sh
@@ -1,0 +1,24 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+analyze mydesign.vhdl
+elab myentity
+
+if c_compiler_is_available && ghdl_has_feature myentity vpi; then
+  $GHDL --vpi-compile -v $CC -c vpi1.c
+  $GHDL --vpi-link -v $CC -o vpi1.vpi vpi1.o
+
+  add_vpi_path
+
+  simulate myentity --vpi=./vpi1.vpi | tee myentity.out
+  if grep -q Error myentity.out; then
+      echo "Error in output"
+      exit 1;
+  fi
+
+  rm -f vpi1.vpi vpi1.o
+fi
+clean
+
+echo "Test successful"

--- a/testsuite/vpi/vpi007/vpi1.c
+++ b/testsuite/vpi/vpi007/vpi1.c
@@ -1,0 +1,63 @@
+#include <stdio.h>
+#include <vpi_user.h>
+#include <stdlib.h>
+#include <string.h>
+
+PLI_INT32
+vpi_proc2 (s_cb_data *cb)
+{
+  if (cb->value->format != vpiIntVal || cb->value->value.integer != 17) {
+    vpi_printf ("Error: unexpected data in callback: %d/%d\n",
+                cb->value->format, cb->value->value.integer);
+  }
+  if (cb->time->type != vpiScaledRealTime || cb->time->real != 1e-3) {
+    vpi_printf ("Error: unexpected time in callback: %d at %g\n",
+                cb->value->value.integer, cb->time->real);
+  }
+  return 0;
+}
+
+PLI_INT32
+vpi_proc1 (s_cb_data *cb)
+{
+  const char  port_name[] = "myentity.out1";
+  s_vpi_time  time;
+  s_vpi_value val;
+  s_cb_data   ncb;
+  vpiHandle   port;
+
+  port = vpi_handle_by_name ((char *)port_name, NULL);
+  if (port == NULL) {
+    vpi_printf ("Error: no port %s.\n", port_name);
+    return 0;
+  }
+
+  time.type = vpiScaledRealTime;
+  val.format = vpiIntVal;
+  ncb.reason = cbValueChange;
+  ncb.obj = port;
+  ncb.time = &time;
+  ncb.value = &val;
+  ncb.cb_rtn = &vpi_proc2;
+  if (vpi_register_cb (&ncb) == NULL)
+    vpi_printf ("Error: Cannot register cbValueChange call back\n");
+  return 0;
+}
+
+void my_handle_register()
+{
+  s_cb_data cb;
+  printf ("Hello world\n");
+
+  cb.reason = cbEndOfCompile;
+  cb.cb_rtn = &vpi_proc1;
+  cb.user_data = NULL;
+  if (vpi_register_cb (&cb) == NULL)
+    vpi_printf ("Error: Cannot register EndOfCompile call back\n");
+}
+
+void (*vlog_startup_routines[]) () =
+{
+  my_handle_register,
+  0
+};

--- a/testsuite/vpi/vpi008/mydesign.vhdl
+++ b/testsuite/vpi/vpi008/mydesign.vhdl
@@ -1,0 +1,12 @@
+library ieee ;
+use ieee.std_logic_1164.all;
+
+entity myentity is
+  port (
+    inout1: inout std_logic_vector(9 downto 1) := "10ZWLH-UX"
+    );
+end myentity;
+
+architecture arch of myentity is
+begin
+end arch;

--- a/testsuite/vpi/vpi008/testsuite.sh
+++ b/testsuite/vpi/vpi008/testsuite.sh
@@ -1,0 +1,24 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+analyze mydesign.vhdl
+elab myentity
+
+if c_compiler_is_available && ghdl_has_feature myentity vpi; then
+  $GHDL --vpi-compile -v $CC -c vpi1.c
+  $GHDL --vpi-link -v $CC -o vpi1.vpi vpi1.o
+
+  add_vpi_path
+
+  simulate myentity --vpi=./vpi1.vpi | tee myentity.out
+  if grep -q Error myentity.out; then
+      echo "Error in output"
+      exit 1;
+  fi
+
+  rm -f vpi1.vpi vpi1.o
+fi
+clean
+
+echo "Test successful"

--- a/testsuite/vpi/vpi008/vpi1.c
+++ b/testsuite/vpi/vpi008/vpi1.c
@@ -1,0 +1,117 @@
+/* Test for vpiVectorVal. */
+
+#include <stdio.h>
+#include <vpi_user.h>
+#include <stdlib.h>
+#include <string.h>
+
+static s_vpi_time   when; // Structures are re-used.
+static s_cb_data    cb;
+static s_vpi_vecval vec;
+static s_vpi_value  val;
+static vpiHandle    port;
+static char         buf[10];
+
+static void vec_to_text (s_vpi_vecval *vp, char *bp)
+{
+  int i;
+
+  for (i = 0; i < 9; ++i) {
+    if (vp->bval & 1)
+      bp[i] = (vp->aval & 1) ? 'X' : 'Z';
+    else
+      bp[i] = '0' + (vp->aval & 1);
+    vp->aval >>= 1;
+    vp->bval >>= 1;
+  }
+  bp[i] = '\0';
+}
+
+static PLI_INT32
+vpi_proc3 (s_cb_data *pcb)
+{
+  vpi_printf ("Error: Cancelled callback called.\n");
+  return 0;
+}
+
+static PLI_INT32
+vpi_proc2 (s_cb_data *pcb)
+{
+  vpiHandle h1, h2, h3;
+
+  vpi_get_value (port, &val);
+  vpi_printf ("Got %#x %#x\n", vec.aval, vec.bval);
+  vec_to_text (&vec, buf);
+  vpi_printf ("Translation of round-trip Verilog \"1X0Z1X0Z0\": %s\n", buf);
+  if (strcmp(buf, "1X0Z1X0Z0")) {
+    vpi_printf ("Error: Got %s but expected \"1X0Z1X0Z0\" for round trip.\n",
+                buf);
+  }
+
+  /* Test callback cancellation. */
+
+  cb.cb_rtn = &vpi_proc3;
+  h1 = vpi_register_cb (&cb);
+  when.low = 1200;
+  h3 = vpi_register_cb (&cb);
+  when.low = 1100;
+  h2 = vpi_register_cb (&cb);
+  if (h1 == NULL || h2 == NULL || h3 == NULL)
+    vpi_printf ("Error: Cannot register extra AfterDelay call backs.\n");
+  vpi_remove_cb (h3);
+  vpi_remove_cb (h2);
+  vpi_remove_cb (h1);
+  return 0;
+}
+
+static PLI_INT32
+vpi_proc1 (s_cb_data *pcb)
+{
+  const char   port_name[] = "myentity.inout1";
+
+  port = vpi_handle_by_name ((char *)port_name, NULL);
+  if (port == NULL) {
+    vpi_printf ("Error: no port %s.\n", port_name);
+    return 0;
+  }
+ 
+  val.format = vpiVectorVal;
+  val.value.vector = &vec;
+  vpi_get_value (port, &val);
+  vpi_printf ("Got %#x %#x\n", vec.aval, vec.bval);
+  vec_to_text (&vec, buf);
+  vpi_printf ("Translation of VHDL \"10ZWLH-UX\": %s\n", buf);
+  if (strcmp(buf, "10ZX01XXX")) {
+    vpi_printf ("Error: Got %s but expected \"10ZX01XXX\" for translation of "
+                "VHDL \"10ZWLH-UX\"\n", buf);
+  }
+
+  vec.aval = 0x33;
+  vec.bval = 0xaa;
+  vpi_put_value (port, &val, NULL, vpiNoDelay); // Effect is not immediate.
+  cb.cb_rtn = &vpi_proc2;
+  if (vpi_register_cb (&cb) == NULL)
+    vpi_printf ("Error: Cannot re-register AfterDelay call back\n");
+  return 0;
+}
+
+void my_handle_register()
+{
+  printf ("Hello world\n");
+
+  when.type = vpiSimTime;
+  when.low = 1000;
+  when.high = 0;
+  cb.reason = cbAfterDelay;
+  cb.time = &when;
+  cb.cb_rtn = &vpi_proc1;
+  cb.user_data = NULL;
+  if (vpi_register_cb (&cb) == NULL)
+    vpi_printf ("Error: Cannot register AfterDelay call back\n");
+}
+
+void (*vlog_startup_routines[]) () =
+{
+  my_handle_register,
+  0
+};


### PR DESCRIPTION
Implement some additional parts of VPI: vpiVectorVal, vpiScaledRealTime and vpiSuppressTime; setting time and value in value change callbacks; and handle cbAfterDelay in vpi_remove_cb().  Tests included. It also includes PR #2648: "Partial merge of #762: VPI: Adding vpiPort detection (Corrects regression introduced by #753)" as these changes work together.

The use case is integration with Ngspice: with these changes a shared library built by GHDL can define the behaviour of a circuit element in a mixed-signal simulation.