### PR TITLE
Modifies uninstall for Uninstall leaves files on disk #2316

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -551,7 +551,9 @@ uninstall.libghdl:
 	$(RM) $(DESTDIR)$(libdir)/$(libghdl_name)
 	$(RM) $(DESTDIR)$(libdir)/libghdl.a
 	$(RM) $(DESTDIR)$(libdir)/libghdl.link
+	$(RM) $(DESTDIR)$(libdir)/libghdl$(SOEXT)
 	$(RM) $(DESTDIR)$(libdir)/libghw.dll
+	$(RM) $(DESTDIR)$(libdir)/libghw$(SOEXT)
 	$(RM) $(incdirsuffix)/ghdl/synth.h
 	$(RM) $(incdirsuffix)/ghdl/synth_gates.h
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -549,6 +549,11 @@ copy.libghdl.deps.so:
 
 uninstall.libghdl:
 	$(RM) $(DESTDIR)$(libdir)/$(libghdl_name)
+	$(RM) $(DESTDIR)$(libdir)/libghdl.a
+	$(RM) $(DESTDIR)$(libdir)/libghdl.link
+	$(RM) $(DESTDIR)$(libdir)/libghw.dll
+	$(RM) $(incdirsuffix)/ghdl/synth.h
+	$(RM) $(incdirsuffix)/ghdl/synth_gates.h
 
 ################ ghwdump #################################################
 


### PR DESCRIPTION
**Description**

Modifies Makefile.in to properly remove all files. Modification was added to uninstall.libghdl as it is what I currently beelive is the most suitable location.

This allows for a complete uninstall without leaving any files behind to close #2316


