### PR TITLE
pyGHDL changes from 'simplify-pipeline' branch.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ grt-backtraces-impl.ads
 grt-files
 grt-files.in
 grt.lst
-lib/
+#/lib/
 libghdl-*.so
 libghdl.a
 libghdl.bind
@@ -71,8 +71,11 @@ __pycache__/
 *.py[cod]
 
 # Python installation packages
-dist/
-pyGHDL.egg-info/
+/pyGHDL/lib/**/*
+/pyGHDL/lib/**/*.*
+!/pyGHDL/lib/__init__.py
+/dist/*.whl
+/pyGHDL.egg-info/
 
 # Coverage.py
 .coverage
@@ -80,10 +83,10 @@ pyGHDL.egg-info/
 coverage.xml
 
 # Sphinx
-doc/_build/
-doc/_theme/
-doc/pyGHDL/**/*.*
-!doc/pyGHDL/index.rst
+/doc/_build/
+/doc/_theme/
+/doc/pyGHDL/**/*.*
+!/doc/pyGHDL/index.rst
 
 # IntelliJ project files
 /.idea/workspace.xml

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -68,12 +68,12 @@ pygments_style = 'manni'
 # ==============================================================================
 # Restructured Text settings
 # ==============================================================================
-prologPath = "prolog.inc"
+prologPath = Path("prolog.inc")
 try:
-    with open(prologPath, "r") as prologFile:
-        rst_prolog = prologFile.read()
+    with prologPath.open("r", encoding="utf-8") as fileHandle:
+        rst_prolog = fileHandle.read()
 except Exception as ex:
-    print(f"[ERROR:] While reading '{prologPath!s}'.")
+    print(f"[ERROR:] While reading '{prologPath}'.")
     print(ex)
     rst_prolog = ""
 
@@ -190,13 +190,13 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     # BuildTheDocs extensions
-    'btd.sphinx.autoprogram',
+#    'btd.sphinx.autoprogram',
     # Other extensions
     'exec',
     'myst_parser',
-    'sphinx_fontawesome',
+    # 'sphinx_fontawesome',
     'sphinx_autodoc_typehints',
-    'autoapi.sphinx',
+#    'autoapi.sphinx',
 ]
 
 

--- a/doc/helpers.py
+++ b/doc/helpers.py
@@ -19,14 +19,14 @@ def getJSON(tag='all'):
    return d
 
 #
-# Print two versions of each shield. Onee for 'html' (`image::`) and one for 'latex' (`replace::`)
+# Print two versions of each shield. One for 'html' (`image::`) and one for 'latex' (`replace::`)
 #
 
 def printShieldSrc(label, alt, img, target, latex=False):
    if latex:
       if label[-6:] == '/total':
          label = label[:-6]
-      idx = re.compile('[\W_]+').sub('', label)
+      idx = re.compile(r"[\W_]+").sub('', label)
       print(f"""
 .. |l{idx}| replace:: `{label}`_
 .. _{label}: {target}

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -27,4 +27,4 @@ GHDL
 .. include:: toc.rst
 
 .. include:: ../NEWS.md
-  :parser: myst_parser.sphinx_
+   :parser: myst_parser.sphinx_

--- a/doc/prolog.inc
+++ b/doc/prolog.inc
@@ -9,9 +9,50 @@
 
    <br />
 
+.. # define horizontal line for HTML
 .. |hr| raw:: html
 
    <hr />
+
+.. # define additional CSS based styles and ReST roles for HTML
+.. raw:: html
+
+   <style type="text/css">
+     span.bolditalic {font-weight: bold; font-style: italic; }
+     span.underline {text-decoration: underline; }
+     span.strike {text-decoration: line-through; }
+     span.xlarge {font-size: x-large; }
+     span.colorred {color: #CC0000; }
+     span.colorgreen {color: #009933; }
+     span.colorblue {color: #0066FF; }
+     span.colorpurple {color: #9900CC; }
+   </style>
+
+.. role:: bolditalic
+   :class: bolditalic
+
+.. role:: underline
+   :class: underline
+
+.. role:: strike
+   :class: strike
+
+.. role:: xlarge
+   :class: xlarge
+
+.. role:: red
+   :class: colorred
+.. role:: green
+   :class: colorgreen
+.. role:: blue
+   :class: colorblue
+.. role:: purple
+   :class: colorpurple
+
+.. role:: deletion
+   :class: colorred strike
+.. role:: addition
+   :class: colorgreen
 
 .. role:: pycode(code)
    :language: python

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,16 +1,15 @@
 -r ../pyGHDL/requirements.txt
 
-sphinx
-python-dateutil>=2.8.2
+sphinx ~= 8.0
+python-dateutil ~= 2.8
 
 # Sphinx Extenstions
-autoapi>=2.0.1
-myst-parser
-sphinx_fontawesome>=0.0.6
-sphinx_autodoc_typehints>=1.19.5
+autoapi ~= 2.0
+myst-parser ~= 4.0
+sphinx_autodoc_typehints ~= 2.3
 
 # Theme
 furo
 
 # BuildTheDocs Extensions (mostly patched Sphinx extensions)
-btd.sphinx.autoprogram>=0.1.7.post1
+#btd.sphinx.autoprogram>=0.1.7.post1

--- a/doc/using/CommandReference.rst
+++ b/doc/using/CommandReference.rst
@@ -21,7 +21,7 @@ There are a few GHDL commands which are seldom useful.
 .. index:: cmd help
 
 Help [``-h``]
------------------
+-------------
 
 .. option:: --help, -h
 
@@ -36,7 +36,7 @@ switch, then options for that second command are displayed::
 .. index:: cmd help-options
 
 Help [``--help-options``]
------------------
+-------------------------
 
 .. option:: --help-options,
 
@@ -48,7 +48,7 @@ analysis options.
 .. index:: cmd help-warnings
 
 Help [``--help-warnings``]
------------------
+--------------------------
 
 .. option:: --help-warnings,
 
@@ -60,7 +60,7 @@ and those which are enabled by default.
 .. index:: cmd display configuration
 
 Display config [``--disp-config``]
---------------------------------------
+----------------------------------
 
 .. option:: --disp-config <[options]>
 
@@ -70,7 +70,7 @@ Display the program paths and options used by GHDL. This may be useful to track 
 .. index:: display ``std.standard``
 
 Display standard [``--disp-standard``]
-------------------------------------------
+--------------------------------------
 
 .. option:: --disp-standard <[options]>
 
@@ -79,7 +79,7 @@ Display the ``std.standard`` package.
 .. index:: cmd version
 
 Version [``--version``]
----------------------------
+-----------------------
 
 .. option:: --version, -v
 
@@ -94,7 +94,7 @@ These are not analyzed, therefore, they work even if a file has semantic errors.
 .. index:: cmd file format
 
 Format [``fmt``]
------------------------
+----------------
 
 .. option:: fmt <file>
 
@@ -104,7 +104,7 @@ Format on the standard output the input file.
 .. index:: vhdl to html
 
 Pretty print [``--pp-html``]
---------------------------------
+----------------------------
 
 .. option:: --pp-html <[options] file...>
 
@@ -115,7 +115,7 @@ The style of the html file can be modified with the :option:`--format` option.
 .. index:: cmd file find
 
 Find [``-f``]
------------------
+-------------
 
 .. option:: -f <file...>
 
@@ -125,7 +125,7 @@ Design units marked with two stars are candidates to be at the apex of a design 
 .. index:: cmd file chop
 
 Chop [``--chop``]
----------------------
+-----------------
 
 .. option:: --chop <files...>
 
@@ -148,7 +148,7 @@ The size of the executable is reduced too.
 .. index:: cmd file lines
 
 Lines [``--lines``]
------------------------
+-------------------
 
 .. option:: --lines <files...>
 
@@ -202,7 +202,7 @@ GCC/LLVM only commands
 .. index:: cmd GCC/LLVM binding
 
 Bind [``--bind``]
----------------------
+-----------------
 
 .. option:: --bind <[options] [library.]top_unit [arch]>
 
@@ -220,7 +220,7 @@ This command should be used only when the main entry point is not GHDL.
 .. index:: cmd GCC/LLVM linking
 
 Link [``--link``]
----------------------
+-----------------
 
 .. option:: --link <[options] [library.]top_unit [arch]>
 

--- a/pyGHDL/__init__.py
+++ b/pyGHDL/__init__.py
@@ -56,11 +56,26 @@ __copyright__ = "2002-2024, Tristan Gingold and contributors"
 __license__ = "GNU General Public License v2"
 __keywords__ = ["vhdl", "parser", "compiler", "simulator", "ghdl"]
 
+from sys import version_info
+from typing import List
+
 from pyTooling.Decorators import export
 
 
 @export
 class GHDLBaseException(Exception):
+    # WORKAROUND: for Python <3.11
+    # Implementing a dummy method for Python versions before
+    if version_info < (3, 11):  # pragma: no cover
+        __notes__: List[str]
+
+        def __init__(self, *args):
+            super().__init__(*args)
+            self.__notes__ = []
+
+        def add_note(self, message: str) -> None:
+            self.__notes__.append(message)
+
     @property
     def message(self) -> str:
         return str(self)

--- a/pyGHDL/cli/requirements.txt
+++ b/pyGHDL/cli/requirements.txt
@@ -1,4 +1,3 @@
 -r ../dom/requirements.txt
 
-pyTooling>=4.0.1, <5.0
-pyAttributes>=2.3.2
+pyTooling[terminal] ~= 8.0

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -245,7 +245,7 @@ class ProcessStatement(VHDLModel_ProcessStatement, DOMMixin):
 
 
 @export
-class IfGenerateBranch(VHDLModel_IfGenerateBranch):
+class IfGenerateBranch(VHDLModel_IfGenerateBranch, DOMMixin):
     def __init__(
         self,
         branchNode: Iir,
@@ -282,7 +282,7 @@ class IfGenerateBranch(VHDLModel_IfGenerateBranch):
 
 
 @export
-class ElsifGenerateBranch(VHDLModel_ElsifGenerateBranch):
+class ElsifGenerateBranch(VHDLModel_ElsifGenerateBranch, DOMMixin):
     def __init__(
         self,
         branchNode: Iir,
@@ -319,7 +319,7 @@ class ElsifGenerateBranch(VHDLModel_ElsifGenerateBranch):
 
 
 @export
-class ElseGenerateBranch(VHDLModel_ElseGenerateBranch):
+class ElseGenerateBranch(VHDLModel_ElseGenerateBranch, DOMMixin):
     def __init__(
         self,
         branchNode: Iir,

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -45,7 +45,7 @@ from pyTooling.Decorators import export
 
 from pyVHDLModel.Symbol import Symbol
 from pyVHDLModel.Instantiation import PackageInstantiation as VHDLModel_PackageInstantiation
-from pyVHDLModel.Interface import GenericInterfaceItem, PortInterfaceItem
+from pyVHDLModel.Interface import GenericInterfaceItemMixin, PortInterfaceItemMixin
 from pyVHDLModel.Concurrent import ConcurrentStatement
 from pyVHDLModel.DesignUnit import Context as VHDLModel_Context
 from pyVHDLModel.DesignUnit import Package as VHDLModel_Package
@@ -129,8 +129,8 @@ class Entity(VHDLModel_Entity, DOMMixin):
         node: Iir,
         identifier: str,
         contextItems: Iterable[VHDLModel_ContextUnion] = None,
-        genericItems: Iterable[GenericInterfaceItem] = None,
-        portItems: Iterable[PortInterfaceItem] = None,
+        genericItems: Iterable[GenericInterfaceItemMixin] = None,
+        portItems: Iterable[PortInterfaceItemMixin] = None,
         declaredItems: Iterable = None,
         statements: Iterable["ConcurrentStatement"] = None,
         documentation: str = None,
@@ -193,8 +193,8 @@ class Component(VHDLModel_Component, DOMMixin):
         self,
         node: Iir,
         identifier: str,
-        genericItems: Iterable[GenericInterfaceItem] = None,
-        portItems: Iterable[PortInterfaceItem] = None,
+        genericItems: Iterable[GenericInterfaceItemMixin] = None,
+        portItems: Iterable[PortInterfaceItemMixin] = None,
         documentation: str = None,
     ):
         super().__init__(identifier, genericItems, portItems, documentation)
@@ -217,7 +217,7 @@ class Package(VHDLModel_Package, DOMMixin):
         node: Iir,
         identifier: str,
         contextItems: Iterable[VHDLModel_ContextUnion] = None,
-        genericItems: Iterable[GenericInterfaceItem] = None,
+        genericItems: Iterable[GenericInterfaceItemMixin] = None,
         declaredItems: Iterable = None,
         documentation: str = None,
     ):

--- a/pyGHDL/dom/Expression.py
+++ b/pyGHDL/dom/Expression.py
@@ -33,6 +33,7 @@
 from typing import List, Union
 
 from pyTooling.Decorators import export
+from pyTooling.MetaClasses import ExtendedType
 
 from pyVHDLModel.Base import ExpressionUnion
 from pyVHDLModel.Symbol import Symbol
@@ -103,7 +104,7 @@ from pyGHDL.dom.Aggregates import (
 )
 
 
-class _ParseUnaryExpressionMixin:
+class _ParseUnaryExpressionMixin(metaclass=ExtendedType, mixin=True):
     @classmethod
     def parse(cls, node: Iir) -> VHDLModel_UnaryExpression:
         from pyGHDL.dom._Translate import GetExpressionFromNode
@@ -112,7 +113,7 @@ class _ParseUnaryExpressionMixin:
         return cls(node, operand)
 
 
-class _ParseBinaryExpressionMixin:
+class _ParseBinaryExpressionMixin(metaclass=ExtendedType, mixin=True):
     @classmethod
     def parse(cls, node: Iir) -> VHDLModel_BinaryExpression:
         from pyGHDL.dom._Translate import GetExpressionFromNode

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -38,7 +38,7 @@
 import ctypes
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional as Nullable
 
 from pyGHDL.dom.Names import SimpleName
 from pyTooling.Decorators import export, InheritDocString
@@ -49,7 +49,6 @@ from pyVHDLModel import Library as VHDLModel_Library
 from pyVHDLModel import Document as VHDLModel_Document
 
 from pyGHDL.libghdl import (
-    ENCODING,
     initialize as libghdl_initialize,
     finalize as libghdl_finalize,
     set_option as libghdl_set_option,
@@ -86,9 +85,15 @@ from pyGHDL.dom.PSL import VerificationUnit, VerificationProperty, VerificationM
 
 @export
 class Design(VHDLModel_Design):
+    _loadDefaultLibraryTime: Nullable[float]
+    _analyzeTime: Nullable[float]
+
     @InheritDocString(VHDLModel_Design)
     def __init__(self, name: str = None):
         super().__init__(name)
+
+        self._loadDefaultLibraryTime = None
+        self._analyzeTime = None
 
         self.__ghdl_init()
 

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -63,7 +63,7 @@ from pyGHDL.dom.Concurrent import WaveformElement, ParameterAssociationItem  # T
 
 
 @export
-class IfBranch(VHDLModel_IfBranch):
+class IfBranch(VHDLModel_IfBranch, DOMMixin):
     def __init__(
         self,
         branchNode: Iir,
@@ -88,7 +88,7 @@ class IfBranch(VHDLModel_IfBranch):
 
 
 @export
-class ElsifBranch(VHDLModel_ElsifBranch):
+class ElsifBranch(VHDLModel_ElsifBranch, DOMMixin):
     def __init__(
         self,
         branchNode: Iir,
@@ -113,7 +113,7 @@ class ElsifBranch(VHDLModel_ElsifBranch):
 
 
 @export
-class ElseBranch(VHDLModel_ElseBranch):
+class ElseBranch(VHDLModel_ElseBranch, DOMMixin):
     def __init__(
         self,
         branchNode: Iir,

--- a/pyGHDL/dom/Subprogram.py
+++ b/pyGHDL/dom/Subprogram.py
@@ -35,7 +35,7 @@ from typing import List
 from pyTooling.Decorators import export
 
 from pyVHDLModel.Symbol import Symbol
-from pyVHDLModel.Interface import GenericInterfaceItem, ParameterInterfaceItem
+from pyVHDLModel.Interface import GenericInterfaceItemMixin, ParameterInterfaceItemMixin
 from pyVHDLModel.Subprogram import Procedure as VHDLModel_Procedure, Function as VHDLModel_Function
 
 from pyGHDL.libghdl._types import Iir
@@ -52,8 +52,8 @@ class Function(VHDLModel_Function, DOMMixin):
         node: Iir,
         functionName: str,
         returnType: Symbol,
-        genericItems: List[GenericInterfaceItem] = None,
-        parameterItems: List[ParameterInterfaceItem] = None,
+        genericItems: List[GenericInterfaceItemMixin] = None,
+        parameterItems: List[ParameterInterfaceItemMixin] = None,
         documentation: str = None,
     ):
         super().__init__(functionName, documentation)
@@ -91,8 +91,8 @@ class Procedure(VHDLModel_Procedure, DOMMixin):
         self,
         node: Iir,
         procedureName: str,
-        genericItems: List[GenericInterfaceItem] = None,
-        parameterItems: List[ParameterInterfaceItem] = None,
+        genericItems: List[GenericInterfaceItemMixin] = None,
+        parameterItems: List[ParameterInterfaceItemMixin] = None,
         documentation: str = None,
     ):
         super().__init__(procedureName, documentation)

--- a/pyGHDL/dom/Type.py
+++ b/pyGHDL/dom/Type.py
@@ -323,6 +323,6 @@ class FileType(VHDLModel_FileType, DOMMixin):
 
 @export
 class Subtype(VHDLModel_Subtype, DOMMixin):
-    def __init__(self, node: Iir, subtypeName: str):
-        super().__init__(subtypeName)
+    def __init__(self, node: Iir, subtypeName: str, symbol: Symbol):
+        super().__init__(subtypeName, symbol)
         DOMMixin.__init__(self, node)

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -38,7 +38,7 @@ from pyVHDLModel import Name
 from pyVHDLModel.Base import ModelEntity, Direction, ExpressionUnion
 from pyVHDLModel.Symbol import Symbol
 from pyVHDLModel.Association import AssociationItem
-from pyVHDLModel.Interface import GenericInterfaceItem, PortInterfaceItem, ParameterInterfaceItem
+from pyVHDLModel.Interface import GenericInterfaceItemMixin, PortInterfaceItemMixin, ParameterInterfaceItemMixin
 from pyVHDLModel.Type import BaseType
 from pyVHDLModel.Sequential import SequentialStatement
 from pyVHDLModel.Concurrent import ConcurrentStatement
@@ -358,8 +358,9 @@ def GetCompositeConstrainedSubtypeFromNode(
 @export
 def GetSubtypeFromNode(subtypeNode: Iir) -> Symbol:
     subtypeName = GetNameOfNode(subtypeNode)
+    symbol = GetSubtypeIndicationFromNode(subtypeNode, "subtype", subtypeName)
 
-    return Subtype(subtypeNode, subtypeName)
+    return Subtype(subtypeNode, subtypeName, symbol)
 
 
 @export
@@ -448,7 +449,7 @@ def GetExpressionFromNode(node: Iir) -> ExpressionUnion:
 @export
 def GetGenericsFromChainedNodes(
     nodeChain: Iir,
-) -> Generator[GenericInterfaceItem, None, None]:
+) -> Generator[GenericInterfaceItemMixin, None, None]:
     from pyGHDL.dom.InterfaceItem import (
         GenericTypeInterfaceItem,
         GenericPackageInterfaceItem,
@@ -507,7 +508,7 @@ def GetGenericsFromChainedNodes(
 @export
 def GetPortsFromChainedNodes(
     nodeChain: Iir,
-) -> Generator[PortInterfaceItem, None, None]:
+) -> Generator[PortInterfaceItemMixin, None, None]:
     furtherIdentifiers = []
     port = nodeChain
     while port != nodes.Null_Iir:
@@ -548,7 +549,7 @@ def GetPortsFromChainedNodes(
 @export
 def GetParameterFromChainedNodes(
     nodeChain: Iir,
-) -> Generator[ParameterInterfaceItem, None, None]:
+) -> Generator[ParameterInterfaceItemMixin, None, None]:
     identifiers = []
     parameter = nodeChain
     while parameter != nodes.Null_Iir:

--- a/pyGHDL/dom/__init__.py
+++ b/pyGHDL/dom/__init__.py
@@ -34,6 +34,7 @@ Document object model (DOM) for :mod:`pyGHDL.libghdl` based on :doc:`pyVHDLModel
 from pathlib import Path
 
 from pyTooling.Decorators import export
+from pyTooling.MetaClasses import ExtendedType
 
 from pyGHDL import GHDLBaseException
 from pyGHDL.libghdl import files_map, name_table
@@ -86,7 +87,7 @@ class Position:
 
 
 @export
-class DOMMixin:
+class DOMMixin(metaclass=ExtendedType, mixin=True):
     _iirNode: Iir
     _position: Position = None
 

--- a/pyGHDL/dom/formatting/prettyprint.py
+++ b/pyGHDL/dom/formatting/prettyprint.py
@@ -35,7 +35,7 @@ from typing import List, Union
 from pyTooling.Decorators import export
 
 from pyVHDLModel.Base import NamedEntityMixin
-from pyVHDLModel.Interface import GenericInterfaceItem, PortInterfaceItem
+from pyVHDLModel.Interface import GenericInterfaceItemMixin, PortInterfaceItemMixin
 from pyVHDLModel.Subprogram import Function
 from pyVHDLModel.Object import BaseConstant, WithDefaultExpressionMixin
 from pyVHDLModel.Type import BaseType, FullType
@@ -319,7 +319,9 @@ class PrettyPrint:
 
         return buffer
 
-    def formatGeneric(self, generic: Union[NamedEntityMixin, GenericInterfaceItem], level: int = 0) -> StringBuffer:
+    def formatGeneric(
+        self, generic: Union[NamedEntityMixin, GenericInterfaceItemMixin], level: int = 0
+    ) -> StringBuffer:
         if isinstance(generic, GenericConstantInterfaceItem):
             return self.formatGenericConstant(generic, level)
         elif isinstance(generic, GenericTypeInterfaceItem):
@@ -329,7 +331,7 @@ class PrettyPrint:
                 f"Unhandled generic kind '{generic.__class__.__name__}' for generic '{generic.Identifiers[0]}'."
             )
 
-    def formatPort(self, port: Union[NamedEntityMixin, PortInterfaceItem], level: int = 0) -> StringBuffer:
+    def formatPort(self, port: Union[NamedEntityMixin, PortInterfaceItemMixin], level: int = 0) -> StringBuffer:
         if isinstance(port, PortSignalInterfaceItem):
             return self.formatPortSignal(port, level)
         else:

--- a/pyGHDL/dom/requirements.txt
+++ b/pyGHDL/dom/requirements.txt
@@ -1,4 +1,4 @@
 -r ../libghdl/requirements.txt
 
-pyVHDLModel==0.25.1
+pyVHDLModel ~= 0.29.0
 #https://github.com/VHDL/pyVHDLModel/archive/dev.zip#pyVHDLModel

--- a/pyGHDL/libghdl/errorout_memory.py
+++ b/pyGHDL/libghdl/errorout_memory.py
@@ -95,7 +95,7 @@ def Get_Nbr_Messages() -> ErrorIndex:
 
     :return: Number of messages available.
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -112,7 +112,7 @@ def Get_Error_Record(Idx: ErrorIndex) -> Error_Message:
 # @export
 @BindToLibGHDL("errorout__memory__get_error_message_addr")
 def _Get_Error_Message(Idx: ErrorIndex) -> c_char_p:
-    return ""
+    return ""  # pragma: no cover
 
 
 @export

--- a/pyGHDL/libghdl/file_comments.py
+++ b/pyGHDL/libghdl/file_comments.py
@@ -61,7 +61,7 @@ def Find_First_Comment(File: SourceFileEntry, N: c_uint32) -> Comment_Index:
     :param File: Source file for node
     :return:     The first comment index, or No_Comment_Index if none.
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export

--- a/pyGHDL/libghdl/files_map.py
+++ b/pyGHDL/libghdl/files_map.py
@@ -59,7 +59,7 @@ def Location_To_File(Location: LocationType) -> SourceFileEntry:
     :param Location: Location
     :return:         Source file. Return ``No_Source_File_Entry`` if location is incorrect.
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -72,7 +72,7 @@ def Location_File_To_Pos(Location: LocationType, File: SourceFileEntry) -> int:
     :param File:     Source file
     :return:         Offset
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -85,7 +85,7 @@ def Location_File_To_Line(Location: LocationType, File: SourceFileEntry) -> int:
     :param File:     Source file
     :return:         Line number
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -99,7 +99,7 @@ def Location_File_Line_To_Offset(Location: LocationType, File: SourceFileEntry, 
     :param Line:     Line number
     :return:         Offset
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -114,7 +114,7 @@ def Location_File_Line_To_Col(Location: LocationType, File: SourceFileEntry, Lin
     :param Line:     Line number
     :return:         logical column (horizontal tabs are expanded)
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -125,7 +125,7 @@ def File_To_Location(File: SourceFileEntry) -> LocationType:
     :param File: Source file
     :return:     Location.
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -138,7 +138,7 @@ def File_Pos_To_Location(File: SourceFileEntry, Pos: int) -> LocationType:
     :param Pos:  Offset in the file
     :return:     Location.
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -151,7 +151,7 @@ def File_Line_To_Position(File: SourceFileEntry, Line: int) -> int:
     :param Line: Line number
     :return:     Return ``Source_Ptr_Bad`` in case of error (:obj:`Line` out of bounds).
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -163,7 +163,7 @@ def Get_File_Name(File: SourceFileEntry) -> NameId:
     :param File: Source file to get the filename from.
     :return:     NameId for the filename.
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -175,7 +175,7 @@ def Get_Directory_Name(File: SourceFileEntry) -> NameId:
     :param File: Source file to get the directory name from.
     :return:     NameId for the directory.
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -187,7 +187,7 @@ def Get_File_Buffer(File: SourceFileEntry) -> bytes:
     :param File: Source file to get the buffer from.
     :return:     Type: ``File_Buffer_Ptr``
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -199,7 +199,7 @@ def Get_File_Length(File: SourceFileEntry) -> int:
     :param File: Source file
     :return:     Type: ``Source_Ptr``
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -213,7 +213,7 @@ def Set_File_Length(File: SourceFileEntry, Length: int) -> None:
     :param File:   Source file
     :param Length: Length for the file. Type: ``Source_Ptr``
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -250,7 +250,7 @@ def Read_Source_File(Directory: NameId, Name: NameId) -> SourceFileEntry:
     :param Name:      File name
     :return:          Return ``No_Source_File_Entry``, if the file does not exist.
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -266,7 +266,7 @@ def Reserve_Source_File(Directory: NameId, Name: NameId, Length: int) -> SourceF
     :param Length:    Length to reserve. Type: ``Source_Ptr``
     :return:          SourceFile
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -303,4 +303,4 @@ def Get_Last_Source_File_Entry() -> SourceFileEntry:
 
     :return: Last SourceFileEntry. Type: ``SourceFileEntry``
     """
-    return 0
+    return 0  # pragma: no cover

--- a/pyGHDL/libghdl/files_map_editor.py
+++ b/pyGHDL/libghdl/files_map_editor.py
@@ -63,7 +63,7 @@ def _Replace_Text(
     :param Text_Length:  Type: ``Source_Ptr``
     :return:             Return True in case of success, False in case of failure (the gap is too small).
     """
-    return False
+    return False  # pragma: no cover
 
 
 @export

--- a/pyGHDL/libghdl/libraries.py
+++ b/pyGHDL/libghdl/libraries.py
@@ -80,7 +80,7 @@ def Get_Libraries_Chain() -> Iir_Library_Declaration:
 
     :return: undocumented
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -125,7 +125,7 @@ def Find_Entity_For_Component(Name: NameId) -> Iir_Design_Unit:
     :param Name: Entity name to search for.
     :return:     undocumented
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -137,7 +137,7 @@ def Get_Library_No_Create(Ident: NameId) -> Iir_Library_Declaration:
     :param Ident: Library to look for.
     :return:      Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` if it doesn't exist.
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -150,7 +150,7 @@ def Get_Library(Ident: NameId, Loc: LocationType, Force: bool) -> Iir_Library_De
     :param Loc: Location in case of errors.
     :return:      Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` if it doesn't exist.
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -163,7 +163,7 @@ def Find_Primary_Unit(Library: Iir_Library_Declaration, Name: NameId) -> Iir_Des
     :param Name:    Primary unit to search for.
     :return:        undocumented
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -174,4 +174,3 @@ def Load_Work_Library(Empty: bool) -> None:
 
     :param Empty: If set, just create it.
     """
-    return

--- a/pyGHDL/libghdl/name_table.py
+++ b/pyGHDL/libghdl/name_table.py
@@ -54,14 +54,14 @@ def Get_Name_Length(Id: NameId) -> int:
     :param Id: NameId for the identifier to query.
     :return:   Length of the identifier.
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 # @export
 @BindToLibGHDL("name_table__get_name_ptr")
 def _Get_Name_Ptr(Id: NameId) -> c_char_p:
     """"""
-    return ""
+    return ""  # pragma: no cover
 
 
 @export
@@ -81,7 +81,7 @@ def Get_Name_Ptr(Id: NameId) -> str:
 @BindToLibGHDL("name_table__get_character")
 def _Get_Character(Id: NameId) -> c_char:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -103,7 +103,7 @@ def Get_Character(Id: NameId) -> str:
 @BindToLibGHDL("name_table__get_identifier_with_len")
 def _Get_Identifier(string: c_char_p, length: int) -> NameId:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export

--- a/pyGHDL/libghdl/requirements.txt
+++ b/pyGHDL/libghdl/requirements.txt
@@ -1,1 +1,1 @@
-pyTooling>=4.0.1, <5.0
+pyTooling[terminal] ~= 8.0

--- a/pyGHDL/libghdl/str_table.py
+++ b/pyGHDL/libghdl/str_table.py
@@ -45,7 +45,7 @@ from pyGHDL.libghdl._decorator import BindToLibGHDL
 @BindToLibGHDL("str_table__string8_address")
 def _String8_Address(Id: String8Id) -> c_char_p:
     """"""
-    return ""
+    return ""  # pragma: no cover
 
 
 @export

--- a/pyGHDL/libghdl/vhdl/flists.py
+++ b/pyGHDL/libghdl/vhdl/flists.py
@@ -56,7 +56,7 @@ def Flast(FList: int) -> int:
     :param FList: List to query.
     :return:      Index of the last element in the list.
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -68,7 +68,7 @@ def Length(FList: int) -> int:
     :param FList: List to query.
     :return:      Number of elements in the list.
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -82,4 +82,4 @@ def Get_Nth_Element(FList: int, N: int) -> int:
     :param FList: List to query.
     :return:      Type: ``El_Type``
     """
-    return 0
+    return 0  # pragma: no cover

--- a/pyGHDL/libghdl/vhdl/formatters.py
+++ b/pyGHDL/libghdl/vhdl/formatters.py
@@ -36,7 +36,6 @@ from ctypes import c_void_p
 
 from pyTooling.Decorators import export
 
-from pyGHDL.libghdl import libghdl
 from pyGHDL.libghdl._decorator import BindToLibGHDL
 
 

--- a/pyGHDL/libghdl/vhdl/lists.py
+++ b/pyGHDL/libghdl/vhdl/lists.py
@@ -125,7 +125,7 @@ def Get_Nbr_Elements(List: int) -> int:
     :param List: The list to use.
     :return:     Number of list elements.
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -136,7 +136,7 @@ def Create_Iir_List() -> int:
 
     :return: undocumented; Type: ``List_Type``
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export

--- a/pyGHDL/libghdl/vhdl/nodes.py
+++ b/pyGHDL/libghdl/vhdl/nodes.py
@@ -2029,21 +2029,21 @@ class Iir_Predefined(IntEnum):
 @BindToLibGHDL("vhdl__nodes__get_kind")
 def Get_Kind(node: Iir) -> IirKind:
     """Get node kind."""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
 @BindToLibGHDL("vhdl__nodes__get_location")
 def Get_Location(node: Iir) -> LocationType:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
 @BindToLibGHDL("vhdl__nodes__get_first_design_unit")
 def Get_First_Design_Unit(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2056,7 +2056,7 @@ def Set_First_Design_Unit(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_last_design_unit")
 def Get_Last_Design_Unit(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2069,7 +2069,7 @@ def Set_Last_Design_Unit(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_library_declaration")
 def Get_Library_Declaration(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2082,7 +2082,7 @@ def Set_Library_Declaration(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_file_checksum")
 def Get_File_Checksum(obj: Iir) -> FileChecksumId:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2095,7 +2095,7 @@ def Set_File_Checksum(obj: Iir, value: FileChecksumId) -> None:
 @BindToLibGHDL("vhdl__nodes__get_analysis_time_stamp")
 def Get_Analysis_Time_Stamp(obj: Iir) -> TimeStampId:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2108,7 +2108,7 @@ def Set_Analysis_Time_Stamp(obj: Iir, value: TimeStampId) -> None:
 @BindToLibGHDL("vhdl__nodes__get_design_file_source")
 def Get_Design_File_Source(obj: Iir) -> SourceFileEntry:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2121,7 +2121,7 @@ def Set_Design_File_Source(obj: Iir, value: SourceFileEntry) -> None:
 @BindToLibGHDL("vhdl__nodes__get_library")
 def Get_Library(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2134,7 +2134,7 @@ def Set_Library(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_design_file_filename")
 def Get_Design_File_Filename(obj: Iir) -> NameId:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2147,7 +2147,7 @@ def Set_Design_File_Filename(obj: Iir, value: NameId) -> None:
 @BindToLibGHDL("vhdl__nodes__get_design_file_directory")
 def Get_Design_File_Directory(obj: Iir) -> NameId:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2160,7 +2160,7 @@ def Set_Design_File_Directory(obj: Iir, value: NameId) -> None:
 @BindToLibGHDL("vhdl__nodes__get_design_file")
 def Get_Design_File(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2173,7 +2173,7 @@ def Set_Design_File(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_design_file_chain")
 def Get_Design_File_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2186,7 +2186,7 @@ def Set_Design_File_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_library_directory")
 def Get_Library_Directory(obj: Iir) -> NameId:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2199,7 +2199,7 @@ def Set_Library_Directory(obj: Iir, value: NameId) -> None:
 @BindToLibGHDL("vhdl__nodes__get_date")
 def Get_Date(obj: Iir) -> DateType:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2212,7 +2212,7 @@ def Set_Date(obj: Iir, value: DateType) -> None:
 @BindToLibGHDL("vhdl__nodes__get_context_items")
 def Get_Context_Items(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2225,7 +2225,7 @@ def Set_Context_Items(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_dependence_list")
 def Get_Dependence_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2238,7 +2238,7 @@ def Set_Dependence_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_analysis_checks_list")
 def Get_Analysis_Checks_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2251,7 +2251,7 @@ def Set_Analysis_Checks_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_date_state")
 def Get_Date_State(obj: Iir) -> DateStateType:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2264,7 +2264,7 @@ def Set_Date_State(obj: Iir, value: DateStateType) -> None:
 @BindToLibGHDL("vhdl__nodes__get_guarded_target_state")
 def Get_Guarded_Target_State(obj: Iir) -> TriStateType:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2277,7 +2277,7 @@ def Set_Guarded_Target_State(obj: Iir, value: TriStateType) -> None:
 @BindToLibGHDL("vhdl__nodes__get_library_unit")
 def Get_Library_Unit(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2290,7 +2290,7 @@ def Set_Library_Unit(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_hash_chain")
 def Get_Hash_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2303,7 +2303,7 @@ def Set_Hash_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_design_unit_source_pos")
 def Get_Design_Unit_Source_Pos(obj: Iir) -> SourcePtr:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2316,7 +2316,7 @@ def Set_Design_Unit_Source_Pos(obj: Iir, value: SourcePtr) -> None:
 @BindToLibGHDL("vhdl__nodes__get_design_unit_source_line")
 def Get_Design_Unit_Source_Line(obj: Iir) -> Int32:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2329,7 +2329,7 @@ def Set_Design_Unit_Source_Line(obj: Iir, value: Int32) -> None:
 @BindToLibGHDL("vhdl__nodes__get_design_unit_source_col")
 def Get_Design_Unit_Source_Col(obj: Iir) -> Int32:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2342,7 +2342,7 @@ def Set_Design_Unit_Source_Col(obj: Iir, value: Int32) -> None:
 @BindToLibGHDL("vhdl__nodes__get_value")
 def Get_Value(obj: Iir) -> Int64:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2355,7 +2355,7 @@ def Set_Value(obj: Iir, value: Int64) -> None:
 @BindToLibGHDL("vhdl__nodes__get_enum_pos")
 def Get_Enum_Pos(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2368,7 +2368,7 @@ def Set_Enum_Pos(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_physical_literal")
 def Get_Physical_Literal(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2381,7 +2381,7 @@ def Set_Physical_Literal(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_fp_value")
 def Get_Fp_Value(obj: Iir) -> Fp64:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2394,7 +2394,7 @@ def Set_Fp_Value(obj: Iir, value: Fp64) -> None:
 @BindToLibGHDL("vhdl__nodes__get_simple_aggregate_list")
 def Get_Simple_Aggregate_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2407,7 +2407,7 @@ def Set_Simple_Aggregate_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_string8_id")
 def Get_String8_Id(obj: Iir) -> String8Id:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2420,7 +2420,7 @@ def Set_String8_Id(obj: Iir, value: String8Id) -> None:
 @BindToLibGHDL("vhdl__nodes__get_string_length")
 def Get_String_Length(obj: Iir) -> Int32:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2433,7 +2433,7 @@ def Set_String_Length(obj: Iir, value: Int32) -> None:
 @BindToLibGHDL("vhdl__nodes__get_bit_string_base")
 def Get_Bit_String_Base(obj: Iir) -> NumberBaseType:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2446,7 +2446,7 @@ def Set_Bit_String_Base(obj: Iir, value: NumberBaseType) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_signed")
 def Get_Has_Signed(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2459,7 +2459,7 @@ def Set_Has_Signed(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_sign")
 def Get_Has_Sign(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2472,7 +2472,7 @@ def Set_Has_Sign(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_length")
 def Get_Has_Length(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2485,7 +2485,7 @@ def Set_Has_Length(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_literal_length")
 def Get_Literal_Length(obj: Iir) -> Int32:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2498,7 +2498,7 @@ def Set_Literal_Length(obj: Iir, value: Int32) -> None:
 @BindToLibGHDL("vhdl__nodes__get_literal_origin")
 def Get_Literal_Origin(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2511,7 +2511,7 @@ def Set_Literal_Origin(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_range_origin")
 def Get_Range_Origin(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2524,7 +2524,7 @@ def Set_Range_Origin(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_literal_subtype")
 def Get_Literal_Subtype(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2537,7 +2537,7 @@ def Set_Literal_Subtype(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_allocator_subtype")
 def Get_Allocator_Subtype(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2550,7 +2550,7 @@ def Set_Allocator_Subtype(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_entity_class")
 def Get_Entity_Class(obj: Iir) -> Tok:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2563,7 +2563,7 @@ def Set_Entity_Class(obj: Iir, value: Tok) -> None:
 @BindToLibGHDL("vhdl__nodes__get_entity_name_list")
 def Get_Entity_Name_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2576,7 +2576,7 @@ def Set_Entity_Name_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_attribute_designator")
 def Get_Attribute_Designator(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2589,7 +2589,7 @@ def Set_Attribute_Designator(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_attribute_specification_chain")
 def Get_Attribute_Specification_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2602,7 +2602,7 @@ def Set_Attribute_Specification_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_attribute_specification")
 def Get_Attribute_Specification(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2615,7 +2615,7 @@ def Set_Attribute_Specification(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_static_attribute_flag")
 def Get_Static_Attribute_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2628,7 +2628,7 @@ def Set_Static_Attribute_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_signal_list")
 def Get_Signal_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2641,7 +2641,7 @@ def Set_Signal_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_quantity_list")
 def Get_Quantity_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2654,7 +2654,7 @@ def Set_Quantity_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_designated_entity")
 def Get_Designated_Entity(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2667,7 +2667,7 @@ def Set_Designated_Entity(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_formal")
 def Get_Formal(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2680,7 +2680,7 @@ def Set_Formal(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_actual")
 def Get_Actual(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2693,7 +2693,7 @@ def Set_Actual(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_open_actual")
 def Get_Open_Actual(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2706,7 +2706,7 @@ def Set_Open_Actual(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_actual_conversion")
 def Get_Actual_Conversion(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2719,7 +2719,7 @@ def Set_Actual_Conversion(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_formal_conversion")
 def Get_Formal_Conversion(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2732,7 +2732,7 @@ def Set_Formal_Conversion(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_whole_association_flag")
 def Get_Whole_Association_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2745,7 +2745,7 @@ def Set_Whole_Association_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_collapse_signal_flag")
 def Get_Collapse_Signal_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2758,7 +2758,7 @@ def Set_Collapse_Signal_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_artificial_flag")
 def Get_Artificial_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2771,7 +2771,7 @@ def Set_Artificial_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_open_flag")
 def Get_Open_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2784,7 +2784,7 @@ def Set_Open_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_after_drivers_flag")
 def Get_After_Drivers_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2797,7 +2797,7 @@ def Set_After_Drivers_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_we_value")
 def Get_We_Value(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2810,7 +2810,7 @@ def Set_We_Value(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_time")
 def Get_Time(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2823,7 +2823,7 @@ def Set_Time(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_associated_expr")
 def Get_Associated_Expr(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2836,7 +2836,7 @@ def Set_Associated_Expr(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_associated_block")
 def Get_Associated_Block(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2849,7 +2849,7 @@ def Set_Associated_Block(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_associated_chain")
 def Get_Associated_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2862,7 +2862,7 @@ def Set_Associated_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_choice_name")
 def Get_Choice_Name(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2875,7 +2875,7 @@ def Set_Choice_Name(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_choice_expression")
 def Get_Choice_Expression(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2888,7 +2888,7 @@ def Set_Choice_Expression(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_choice_range")
 def Get_Choice_Range(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2901,7 +2901,7 @@ def Set_Choice_Range(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_same_alternative_flag")
 def Get_Same_Alternative_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2914,7 +2914,7 @@ def Set_Same_Alternative_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_element_type_flag")
 def Get_Element_Type_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2927,7 +2927,7 @@ def Set_Element_Type_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_architecture")
 def Get_Architecture(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2940,7 +2940,7 @@ def Set_Architecture(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_block_specification")
 def Get_Block_Specification(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2953,7 +2953,7 @@ def Set_Block_Specification(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_prev_block_configuration")
 def Get_Prev_Block_Configuration(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2966,7 +2966,7 @@ def Set_Prev_Block_Configuration(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_configuration_item_chain")
 def Get_Configuration_Item_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2979,7 +2979,7 @@ def Set_Configuration_Item_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_attribute_value_chain")
 def Get_Attribute_Value_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -2992,7 +2992,7 @@ def Set_Attribute_Value_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_spec_chain")
 def Get_Spec_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3005,7 +3005,7 @@ def Set_Spec_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_value_chain")
 def Get_Value_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3018,7 +3018,7 @@ def Set_Value_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_attribute_value_spec_chain")
 def Get_Attribute_Value_Spec_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3031,7 +3031,7 @@ def Set_Attribute_Value_Spec_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_entity_name")
 def Get_Entity_Name(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3044,7 +3044,7 @@ def Set_Entity_Name(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_package")
 def Get_Package(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3057,7 +3057,7 @@ def Set_Package(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_package_body")
 def Get_Package_Body(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3070,7 +3070,7 @@ def Set_Package_Body(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_instance_package_body")
 def Get_Instance_Package_Body(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3083,7 +3083,7 @@ def Set_Instance_Package_Body(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_owned_instance_package_body")
 def Get_Owned_Instance_Package_Body(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3096,7 +3096,7 @@ def Set_Owned_Instance_Package_Body(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_need_body")
 def Get_Need_Body(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3109,7 +3109,7 @@ def Set_Need_Body(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_immediate_body_flag")
 def Get_Immediate_Body_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3122,7 +3122,7 @@ def Set_Immediate_Body_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_macro_expand_flag")
 def Get_Macro_Expand_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3135,7 +3135,7 @@ def Set_Macro_Expand_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_need_instance_bodies")
 def Get_Need_Instance_Bodies(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3148,7 +3148,7 @@ def Set_Need_Instance_Bodies(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_hierarchical_name")
 def Get_Hierarchical_Name(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3161,7 +3161,7 @@ def Set_Hierarchical_Name(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_vunit_item_chain")
 def Get_Vunit_Item_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3174,7 +3174,7 @@ def Set_Vunit_Item_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_bound_vunit_chain")
 def Get_Bound_Vunit_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3187,7 +3187,7 @@ def Set_Bound_Vunit_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_verification_block_configuration")
 def Get_Verification_Block_Configuration(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3200,7 +3200,7 @@ def Set_Verification_Block_Configuration(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_block_configuration")
 def Get_Block_Configuration(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3213,7 +3213,7 @@ def Set_Block_Configuration(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_concurrent_statement_chain")
 def Get_Concurrent_Statement_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3226,7 +3226,7 @@ def Set_Concurrent_Statement_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_chain")
 def Get_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3239,7 +3239,7 @@ def Set_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_port_chain")
 def Get_Port_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3252,7 +3252,7 @@ def Set_Port_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_generic_chain")
 def Get_Generic_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3265,7 +3265,7 @@ def Set_Generic_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_type")
 def Get_Type(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3278,7 +3278,7 @@ def Set_Type(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_subtype_indication")
 def Get_Subtype_Indication(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3291,7 +3291,7 @@ def Set_Subtype_Indication(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_discrete_range")
 def Get_Discrete_Range(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3304,7 +3304,7 @@ def Set_Discrete_Range(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_type_definition")
 def Get_Type_Definition(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3317,7 +3317,7 @@ def Set_Type_Definition(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_subtype_definition")
 def Get_Subtype_Definition(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3330,7 +3330,7 @@ def Set_Subtype_Definition(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_incomplete_type_declaration")
 def Get_Incomplete_Type_Declaration(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3343,7 +3343,7 @@ def Set_Incomplete_Type_Declaration(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_interface_type_subprograms")
 def Get_Interface_Type_Subprograms(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3356,7 +3356,7 @@ def Set_Interface_Type_Subprograms(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_interface_type_definition")
 def Get_Interface_Type_Definition(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3369,7 +3369,7 @@ def Set_Interface_Type_Definition(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_nature_definition")
 def Get_Nature_Definition(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3382,7 +3382,7 @@ def Set_Nature_Definition(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_nature")
 def Get_Nature(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3395,7 +3395,7 @@ def Set_Nature(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_subnature_indication")
 def Get_Subnature_Indication(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3408,7 +3408,7 @@ def Set_Subnature_Indication(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_reference_terminal_flag")
 def Get_Reference_Terminal_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3421,7 +3421,7 @@ def Set_Reference_Terminal_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_mode")
 def Get_Mode(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3434,7 +3434,7 @@ def Set_Mode(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_guarded_signal_flag")
 def Get_Guarded_Signal_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3447,7 +3447,7 @@ def Set_Guarded_Signal_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_signal_kind")
 def Get_Signal_Kind(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3460,7 +3460,7 @@ def Set_Signal_Kind(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_base_name")
 def Get_Base_Name(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3473,7 +3473,7 @@ def Set_Base_Name(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_interface_declaration_chain")
 def Get_Interface_Declaration_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3486,7 +3486,7 @@ def Set_Interface_Declaration_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_default_subprogram")
 def Get_Default_Subprogram(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3499,7 +3499,7 @@ def Set_Default_Subprogram(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_associated_subprogram")
 def Get_Associated_Subprogram(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3512,7 +3512,7 @@ def Set_Associated_Subprogram(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_subprogram_specification")
 def Get_Subprogram_Specification(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3525,7 +3525,7 @@ def Set_Subprogram_Specification(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_sequential_statement_chain")
 def Get_Sequential_Statement_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3538,7 +3538,7 @@ def Set_Sequential_Statement_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_simultaneous_statement_chain")
 def Get_Simultaneous_Statement_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3551,7 +3551,7 @@ def Set_Simultaneous_Statement_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_subprogram_body")
 def Get_Subprogram_Body(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3564,7 +3564,7 @@ def Set_Subprogram_Body(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_overload_number")
 def Get_Overload_Number(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3577,7 +3577,7 @@ def Set_Overload_Number(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_subprogram_depth")
 def Get_Subprogram_Depth(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3590,7 +3590,7 @@ def Set_Subprogram_Depth(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_subprogram_hash")
 def Get_Subprogram_Hash(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3603,7 +3603,7 @@ def Set_Subprogram_Hash(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_impure_depth")
 def Get_Impure_Depth(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3616,7 +3616,7 @@ def Set_Impure_Depth(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_return_type")
 def Get_Return_Type(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3629,7 +3629,7 @@ def Set_Return_Type(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_implicit_definition")
 def Get_Implicit_Definition(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3642,7 +3642,7 @@ def Set_Implicit_Definition(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_uninstantiated_subprogram_name")
 def Get_Uninstantiated_Subprogram_Name(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3655,7 +3655,7 @@ def Set_Uninstantiated_Subprogram_Name(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_default_value")
 def Get_Default_Value(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3668,7 +3668,7 @@ def Set_Default_Value(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_mode_view_indication")
 def Get_Mode_View_Indication(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3681,7 +3681,7 @@ def Set_Mode_View_Indication(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_deferred_declaration")
 def Get_Deferred_Declaration(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3694,7 +3694,7 @@ def Set_Deferred_Declaration(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_deferred_declaration_flag")
 def Get_Deferred_Declaration_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3707,7 +3707,7 @@ def Set_Deferred_Declaration_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_shared_flag")
 def Get_Shared_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3720,7 +3720,7 @@ def Set_Shared_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_design_unit")
 def Get_Design_Unit(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3733,7 +3733,7 @@ def Set_Design_Unit(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_block_statement")
 def Get_Block_Statement(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3746,7 +3746,7 @@ def Set_Block_Statement(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_signal_driver")
 def Get_Signal_Driver(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3759,7 +3759,7 @@ def Set_Signal_Driver(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_declaration_chain")
 def Get_Declaration_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3772,7 +3772,7 @@ def Set_Declaration_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_file_logical_name")
 def Get_File_Logical_Name(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3785,7 +3785,7 @@ def Set_File_Logical_Name(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_file_open_kind")
 def Get_File_Open_Kind(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3798,7 +3798,7 @@ def Set_File_Open_Kind(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_element_position")
 def Get_Element_Position(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3811,7 +3811,7 @@ def Set_Element_Position(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_use_clause_chain")
 def Get_Use_Clause_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3824,7 +3824,7 @@ def Set_Use_Clause_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_context_reference_chain")
 def Get_Context_Reference_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3837,7 +3837,7 @@ def Set_Context_Reference_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_inherit_spec_chain")
 def Get_Inherit_Spec_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3850,7 +3850,7 @@ def Set_Inherit_Spec_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_selected_name")
 def Get_Selected_Name(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3863,7 +3863,7 @@ def Set_Selected_Name(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_mode_view_name")
 def Get_Mode_View_Name(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3876,7 +3876,7 @@ def Set_Mode_View_Name(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_type_declarator")
 def Get_Type_Declarator(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3889,7 +3889,7 @@ def Set_Type_Declarator(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_complete_type_definition")
 def Get_Complete_Type_Definition(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3902,7 +3902,7 @@ def Set_Complete_Type_Definition(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_incomplete_type_ref_chain")
 def Get_Incomplete_Type_Ref_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3915,7 +3915,7 @@ def Set_Incomplete_Type_Ref_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_associated_type")
 def Get_Associated_Type(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3928,7 +3928,7 @@ def Set_Associated_Type(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_enumeration_literal_list")
 def Get_Enumeration_Literal_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3941,7 +3941,7 @@ def Set_Enumeration_Literal_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_entity_class_entry_chain")
 def Get_Entity_Class_Entry_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3954,7 +3954,7 @@ def Set_Entity_Class_Entry_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_group_constituent_list")
 def Get_Group_Constituent_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3967,7 +3967,7 @@ def Set_Group_Constituent_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_unit_chain")
 def Get_Unit_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3980,7 +3980,7 @@ def Set_Unit_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_primary_unit")
 def Get_Primary_Unit(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -3993,7 +3993,7 @@ def Set_Primary_Unit(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_identifier")
 def Get_Identifier(obj: Iir) -> NameId:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4006,7 +4006,7 @@ def Set_Identifier(obj: Iir, value: NameId) -> None:
 @BindToLibGHDL("vhdl__nodes__get_label")
 def Get_Label(obj: Iir) -> NameId:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4019,7 +4019,7 @@ def Set_Label(obj: Iir, value: NameId) -> None:
 @BindToLibGHDL("vhdl__nodes__get_return_identifier")
 def Get_Return_Identifier(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4032,7 +4032,7 @@ def Set_Return_Identifier(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_visible_flag")
 def Get_Visible_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4045,7 +4045,7 @@ def Set_Visible_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_range_constraint")
 def Get_Range_Constraint(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4058,7 +4058,7 @@ def Set_Range_Constraint(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_direction")
 def Get_Direction(obj: Iir) -> DirectionType:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4071,7 +4071,7 @@ def Set_Direction(obj: Iir, value: DirectionType) -> None:
 @BindToLibGHDL("vhdl__nodes__get_left_limit")
 def Get_Left_Limit(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4084,7 +4084,7 @@ def Set_Left_Limit(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_right_limit")
 def Get_Right_Limit(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4097,7 +4097,7 @@ def Set_Right_Limit(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_left_limit_expr")
 def Get_Left_Limit_Expr(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4110,7 +4110,7 @@ def Set_Left_Limit_Expr(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_right_limit_expr")
 def Get_Right_Limit_Expr(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4123,7 +4123,7 @@ def Set_Right_Limit_Expr(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_parent_type")
 def Get_Parent_Type(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4136,7 +4136,7 @@ def Set_Parent_Type(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_simple_nature")
 def Get_Simple_Nature(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4149,7 +4149,7 @@ def Set_Simple_Nature(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_base_nature")
 def Get_Base_Nature(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4162,7 +4162,7 @@ def Set_Base_Nature(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_resolution_indication")
 def Get_Resolution_Indication(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4175,7 +4175,7 @@ def Set_Resolution_Indication(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_record_element_resolution_chain")
 def Get_Record_Element_Resolution_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4188,7 +4188,7 @@ def Set_Record_Element_Resolution_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_tolerance")
 def Get_Tolerance(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4201,7 +4201,7 @@ def Set_Tolerance(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_plus_terminal_name")
 def Get_Plus_Terminal_Name(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4214,7 +4214,7 @@ def Set_Plus_Terminal_Name(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_minus_terminal_name")
 def Get_Minus_Terminal_Name(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4227,7 +4227,7 @@ def Set_Minus_Terminal_Name(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_plus_terminal")
 def Get_Plus_Terminal(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4240,7 +4240,7 @@ def Set_Plus_Terminal(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_minus_terminal")
 def Get_Minus_Terminal(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4253,7 +4253,7 @@ def Set_Minus_Terminal(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_magnitude_expression")
 def Get_Magnitude_Expression(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4266,7 +4266,7 @@ def Set_Magnitude_Expression(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_phase_expression")
 def Get_Phase_Expression(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4279,7 +4279,7 @@ def Set_Phase_Expression(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_power_expression")
 def Get_Power_Expression(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4292,7 +4292,7 @@ def Set_Power_Expression(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_simultaneous_left")
 def Get_Simultaneous_Left(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4305,7 +4305,7 @@ def Set_Simultaneous_Left(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_simultaneous_right")
 def Get_Simultaneous_Right(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4318,7 +4318,7 @@ def Set_Simultaneous_Right(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_text_file_flag")
 def Get_Text_File_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4331,7 +4331,7 @@ def Set_Text_File_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_only_characters_flag")
 def Get_Only_Characters_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4344,7 +4344,7 @@ def Set_Only_Characters_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_is_character_type")
 def Get_Is_Character_Type(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4357,7 +4357,7 @@ def Set_Is_Character_Type(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_nature_staticness")
 def Get_Nature_Staticness(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4370,7 +4370,7 @@ def Set_Nature_Staticness(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_type_staticness")
 def Get_Type_Staticness(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4383,7 +4383,7 @@ def Set_Type_Staticness(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_constraint_state")
 def Get_Constraint_State(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4396,7 +4396,7 @@ def Set_Constraint_State(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_index_subtype_list")
 def Get_Index_Subtype_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4409,7 +4409,7 @@ def Set_Index_Subtype_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_index_subtype_definition_list")
 def Get_Index_Subtype_Definition_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4422,7 +4422,7 @@ def Set_Index_Subtype_Definition_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_element_subtype_indication")
 def Get_Element_Subtype_Indication(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4435,7 +4435,7 @@ def Set_Element_Subtype_Indication(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_element_subtype")
 def Get_Element_Subtype(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4448,7 +4448,7 @@ def Set_Element_Subtype(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_element_subnature_indication")
 def Get_Element_Subnature_Indication(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4461,7 +4461,7 @@ def Set_Element_Subnature_Indication(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_element_subnature")
 def Get_Element_Subnature(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4474,7 +4474,7 @@ def Set_Element_Subnature(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_index_constraint_list")
 def Get_Index_Constraint_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4487,7 +4487,7 @@ def Set_Index_Constraint_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_array_element_constraint")
 def Get_Array_Element_Constraint(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4500,7 +4500,7 @@ def Set_Array_Element_Constraint(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_array_constraint_flag")
 def Get_Has_Array_Constraint_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4513,7 +4513,7 @@ def Set_Has_Array_Constraint_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_element_constraint_flag")
 def Get_Has_Element_Constraint_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4526,7 +4526,7 @@ def Set_Has_Element_Constraint_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_elements_declaration_list")
 def Get_Elements_Declaration_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4539,7 +4539,7 @@ def Set_Elements_Declaration_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_elements_definition_chain")
 def Get_Elements_Definition_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4552,7 +4552,7 @@ def Set_Elements_Definition_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_elements_definition_list")
 def Get_Elements_Definition_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4565,7 +4565,7 @@ def Set_Elements_Definition_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_owned_elements_chain")
 def Get_Owned_Elements_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4578,7 +4578,7 @@ def Set_Owned_Elements_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_designated_type")
 def Get_Designated_Type(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4591,7 +4591,7 @@ def Set_Designated_Type(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_designated_subtype_indication")
 def Get_Designated_Subtype_Indication(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4604,7 +4604,7 @@ def Set_Designated_Subtype_Indication(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_index_list")
 def Get_Index_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4617,7 +4617,7 @@ def Set_Index_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_reference")
 def Get_Reference(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4630,7 +4630,7 @@ def Set_Reference(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_nature_declarator")
 def Get_Nature_Declarator(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4643,7 +4643,7 @@ def Set_Nature_Declarator(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_across_type_mark")
 def Get_Across_Type_Mark(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4656,7 +4656,7 @@ def Set_Across_Type_Mark(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_through_type_mark")
 def Get_Through_Type_Mark(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4669,7 +4669,7 @@ def Set_Through_Type_Mark(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_across_type_definition")
 def Get_Across_Type_Definition(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4682,7 +4682,7 @@ def Set_Across_Type_Definition(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_through_type_definition")
 def Get_Through_Type_Definition(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4695,7 +4695,7 @@ def Set_Through_Type_Definition(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_across_type")
 def Get_Across_Type(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4708,7 +4708,7 @@ def Set_Across_Type(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_through_type")
 def Get_Through_Type(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4721,7 +4721,7 @@ def Set_Through_Type(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_target")
 def Get_Target(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4734,7 +4734,7 @@ def Set_Target(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_waveform_chain")
 def Get_Waveform_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4747,7 +4747,7 @@ def Set_Waveform_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_guard")
 def Get_Guard(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4760,7 +4760,7 @@ def Set_Guard(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_delay_mechanism")
 def Get_Delay_Mechanism(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4773,7 +4773,7 @@ def Set_Delay_Mechanism(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_reject_time_expression")
 def Get_Reject_Time_Expression(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4786,7 +4786,7 @@ def Set_Reject_Time_Expression(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_force_mode")
 def Get_Force_Mode(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4799,7 +4799,7 @@ def Set_Force_Mode(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_force_mode")
 def Get_Has_Force_Mode(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4812,7 +4812,7 @@ def Set_Has_Force_Mode(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_sensitivity_list")
 def Get_Sensitivity_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4825,7 +4825,7 @@ def Set_Sensitivity_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_process_origin")
 def Get_Process_Origin(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4838,7 +4838,7 @@ def Set_Process_Origin(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_package_origin")
 def Get_Package_Origin(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4851,7 +4851,7 @@ def Set_Package_Origin(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_condition_clause")
 def Get_Condition_Clause(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4864,7 +4864,7 @@ def Set_Condition_Clause(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_break_element")
 def Get_Break_Element(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4877,7 +4877,7 @@ def Set_Break_Element(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_selector_quantity")
 def Get_Selector_Quantity(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4890,7 +4890,7 @@ def Set_Selector_Quantity(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_break_quantity")
 def Get_Break_Quantity(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4903,7 +4903,7 @@ def Set_Break_Quantity(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_timeout_clause")
 def Get_Timeout_Clause(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4916,7 +4916,7 @@ def Set_Timeout_Clause(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_postponed_flag")
 def Get_Postponed_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4929,7 +4929,7 @@ def Set_Postponed_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_callees_list")
 def Get_Callees_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4942,7 +4942,7 @@ def Set_Callees_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_passive_flag")
 def Get_Passive_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4955,7 +4955,7 @@ def Set_Passive_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_resolution_function_flag")
 def Get_Resolution_Function_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4968,7 +4968,7 @@ def Set_Resolution_Function_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_wait_state")
 def Get_Wait_State(obj: Iir) -> TriStateType:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4981,7 +4981,7 @@ def Set_Wait_State(obj: Iir, value: TriStateType) -> None:
 @BindToLibGHDL("vhdl__nodes__get_all_sensitized_state")
 def Get_All_Sensitized_State(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -4994,7 +4994,7 @@ def Set_All_Sensitized_State(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_seen_flag")
 def Get_Seen_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5007,7 +5007,7 @@ def Set_Seen_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_pure_flag")
 def Get_Pure_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5020,7 +5020,7 @@ def Set_Pure_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_foreign_flag")
 def Get_Foreign_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5033,7 +5033,7 @@ def Set_Foreign_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_resolved_flag")
 def Get_Resolved_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5046,7 +5046,7 @@ def Set_Resolved_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_signal_type_flag")
 def Get_Signal_Type_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5059,7 +5059,7 @@ def Set_Signal_Type_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_signal_flag")
 def Get_Has_Signal_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5072,7 +5072,7 @@ def Set_Has_Signal_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_purity_state")
 def Get_Purity_State(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5085,7 +5085,7 @@ def Set_Purity_State(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_elab_flag")
 def Get_Elab_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5098,7 +5098,7 @@ def Set_Elab_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_vendor_library_flag")
 def Get_Vendor_Library_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5111,7 +5111,7 @@ def Set_Vendor_Library_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_configuration_mark_flag")
 def Get_Configuration_Mark_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5124,7 +5124,7 @@ def Set_Configuration_Mark_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_configuration_done_flag")
 def Get_Configuration_Done_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5137,7 +5137,7 @@ def Set_Configuration_Done_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_index_constraint_flag")
 def Get_Index_Constraint_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5150,7 +5150,7 @@ def Set_Index_Constraint_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_hide_implicit_flag")
 def Get_Hide_Implicit_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5163,7 +5163,7 @@ def Set_Hide_Implicit_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_assertion_condition")
 def Get_Assertion_Condition(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5176,7 +5176,7 @@ def Set_Assertion_Condition(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_report_expression")
 def Get_Report_Expression(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5189,7 +5189,7 @@ def Set_Report_Expression(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_severity_expression")
 def Get_Severity_Expression(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5202,7 +5202,7 @@ def Set_Severity_Expression(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_instantiated_unit")
 def Get_Instantiated_Unit(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5215,7 +5215,7 @@ def Set_Instantiated_Unit(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_instantiated_header")
 def Get_Instantiated_Header(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5228,7 +5228,7 @@ def Set_Instantiated_Header(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_generic_map_aspect_chain")
 def Get_Generic_Map_Aspect_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5241,7 +5241,7 @@ def Set_Generic_Map_Aspect_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_port_map_aspect_chain")
 def Get_Port_Map_Aspect_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5254,7 +5254,7 @@ def Set_Port_Map_Aspect_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_configuration_name")
 def Get_Configuration_Name(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5267,7 +5267,7 @@ def Set_Configuration_Name(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_component_configuration")
 def Get_Component_Configuration(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5280,7 +5280,7 @@ def Set_Component_Configuration(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_configuration_specification")
 def Get_Configuration_Specification(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5293,7 +5293,7 @@ def Set_Configuration_Specification(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_default_binding_indication")
 def Get_Default_Binding_Indication(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5306,7 +5306,7 @@ def Set_Default_Binding_Indication(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_default_configuration_declaration")
 def Get_Default_Configuration_Declaration(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5319,7 +5319,7 @@ def Set_Default_Configuration_Declaration(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_expression")
 def Get_Expression(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5332,7 +5332,7 @@ def Set_Expression(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_conditional_expression_chain")
 def Get_Conditional_Expression_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5345,7 +5345,7 @@ def Set_Conditional_Expression_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_allocator_designated_type")
 def Get_Allocator_Designated_Type(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5358,7 +5358,7 @@ def Set_Allocator_Designated_Type(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_selected_waveform_chain")
 def Get_Selected_Waveform_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5371,7 +5371,7 @@ def Set_Selected_Waveform_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_selected_expressions_chain")
 def Get_Selected_Expressions_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5384,7 +5384,7 @@ def Set_Selected_Expressions_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_conditional_waveform_chain")
 def Get_Conditional_Waveform_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5397,7 +5397,7 @@ def Set_Conditional_Waveform_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_guard_expression")
 def Get_Guard_Expression(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5410,7 +5410,7 @@ def Set_Guard_Expression(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_guard_decl")
 def Get_Guard_Decl(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5423,7 +5423,7 @@ def Set_Guard_Decl(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_guard_sensitivity_list")
 def Get_Guard_Sensitivity_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5436,7 +5436,7 @@ def Set_Guard_Sensitivity_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_attribute_implicit_chain")
 def Get_Attribute_Implicit_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5449,7 +5449,7 @@ def Set_Attribute_Implicit_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_block_block_configuration")
 def Get_Block_Block_Configuration(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5462,7 +5462,7 @@ def Set_Block_Block_Configuration(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_package_header")
 def Get_Package_Header(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5475,7 +5475,7 @@ def Set_Package_Header(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_block_header")
 def Get_Block_Header(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5488,7 +5488,7 @@ def Set_Block_Header(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_uninstantiated_package_name")
 def Get_Uninstantiated_Package_Name(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5501,7 +5501,7 @@ def Set_Uninstantiated_Package_Name(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_uninstantiated_package_decl")
 def Get_Uninstantiated_Package_Decl(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5514,7 +5514,7 @@ def Set_Uninstantiated_Package_Decl(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_associated_package")
 def Get_Associated_Package(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5527,7 +5527,7 @@ def Set_Associated_Package(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_instance_source_file")
 def Get_Instance_Source_File(obj: Iir) -> SourceFileEntry:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5540,7 +5540,7 @@ def Set_Instance_Source_File(obj: Iir, value: SourceFileEntry) -> None:
 @BindToLibGHDL("vhdl__nodes__get_generate_block_configuration")
 def Get_Generate_Block_Configuration(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5553,7 +5553,7 @@ def Set_Generate_Block_Configuration(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_generate_statement_body")
 def Get_Generate_Statement_Body(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5566,7 +5566,7 @@ def Set_Generate_Statement_Body(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_alternative_label")
 def Get_Alternative_Label(obj: Iir) -> NameId:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5579,7 +5579,7 @@ def Set_Alternative_Label(obj: Iir, value: NameId) -> None:
 @BindToLibGHDL("vhdl__nodes__get_generate_else_clause")
 def Get_Generate_Else_Clause(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5592,7 +5592,7 @@ def Set_Generate_Else_Clause(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_condition")
 def Get_Condition(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5605,7 +5605,7 @@ def Set_Condition(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_else_clause")
 def Get_Else_Clause(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5618,7 +5618,7 @@ def Set_Else_Clause(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_parameter_specification")
 def Get_Parameter_Specification(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5631,7 +5631,7 @@ def Set_Parameter_Specification(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_parent")
 def Get_Parent(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5644,7 +5644,7 @@ def Set_Parent(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_loop_label")
 def Get_Loop_Label(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5657,7 +5657,7 @@ def Set_Loop_Label(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_exit_flag")
 def Get_Exit_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5670,7 +5670,7 @@ def Set_Exit_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_next_flag")
 def Get_Next_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5683,7 +5683,7 @@ def Set_Next_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_component_name")
 def Get_Component_Name(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5696,7 +5696,7 @@ def Set_Component_Name(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_instantiation_list")
 def Get_Instantiation_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5709,7 +5709,7 @@ def Set_Instantiation_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_entity_aspect")
 def Get_Entity_Aspect(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5722,7 +5722,7 @@ def Set_Entity_Aspect(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_default_entity_aspect")
 def Get_Default_Entity_Aspect(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5735,7 +5735,7 @@ def Set_Default_Entity_Aspect(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_binding_indication")
 def Get_Binding_Indication(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5748,7 +5748,7 @@ def Set_Binding_Indication(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_named_entity")
 def Get_Named_Entity(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5761,7 +5761,7 @@ def Set_Named_Entity(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_referenced_name")
 def Get_Referenced_Name(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5774,7 +5774,7 @@ def Set_Referenced_Name(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_expr_staticness")
 def Get_Expr_Staticness(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5787,7 +5787,7 @@ def Set_Expr_Staticness(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_scalar_size")
 def Get_Scalar_Size(obj: Iir) -> ScalarSize:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5800,7 +5800,7 @@ def Set_Scalar_Size(obj: Iir, value: ScalarSize) -> None:
 @BindToLibGHDL("vhdl__nodes__get_error_origin")
 def Get_Error_Origin(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5813,7 +5813,7 @@ def Set_Error_Origin(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_operand")
 def Get_Operand(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5826,7 +5826,7 @@ def Set_Operand(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_left")
 def Get_Left(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5839,7 +5839,7 @@ def Set_Left(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_right")
 def Get_Right(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5852,7 +5852,7 @@ def Set_Right(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_unit_name")
 def Get_Unit_Name(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5865,7 +5865,7 @@ def Set_Unit_Name(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_name")
 def Get_Name(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5878,7 +5878,7 @@ def Set_Name(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_group_template_name")
 def Get_Group_Template_Name(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5891,7 +5891,7 @@ def Set_Group_Template_Name(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_name_staticness")
 def Get_Name_Staticness(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5904,7 +5904,7 @@ def Set_Name_Staticness(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_prefix")
 def Get_Prefix(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5917,7 +5917,7 @@ def Set_Prefix(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_signature_prefix")
 def Get_Signature_Prefix(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5930,7 +5930,7 @@ def Set_Signature_Prefix(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_external_pathname")
 def Get_External_Pathname(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5943,7 +5943,7 @@ def Set_External_Pathname(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_pathname_suffix")
 def Get_Pathname_Suffix(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5956,7 +5956,7 @@ def Set_Pathname_Suffix(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_pathname_expression")
 def Get_Pathname_Expression(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5969,7 +5969,7 @@ def Set_Pathname_Expression(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_in_formal_flag")
 def Get_In_Formal_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5982,7 +5982,7 @@ def Set_In_Formal_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_inertial_flag")
 def Get_Inertial_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -5995,7 +5995,7 @@ def Set_Inertial_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_slice_subtype")
 def Get_Slice_Subtype(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6008,7 +6008,7 @@ def Set_Slice_Subtype(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_suffix")
 def Get_Suffix(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6021,7 +6021,7 @@ def Set_Suffix(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_index_subtype")
 def Get_Index_Subtype(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6034,7 +6034,7 @@ def Set_Index_Subtype(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_parameter")
 def Get_Parameter(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6047,7 +6047,7 @@ def Set_Parameter(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_parameter_2")
 def Get_Parameter_2(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6060,7 +6060,7 @@ def Set_Parameter_2(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_parameter_3")
 def Get_Parameter_3(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6073,7 +6073,7 @@ def Set_Parameter_3(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_parameter_4")
 def Get_Parameter_4(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6086,7 +6086,7 @@ def Set_Parameter_4(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_attr_chain")
 def Get_Attr_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6099,7 +6099,7 @@ def Set_Attr_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_actual_type")
 def Get_Actual_Type(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6112,7 +6112,7 @@ def Set_Actual_Type(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_actual_type_definition")
 def Get_Actual_Type_Definition(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6125,7 +6125,7 @@ def Set_Actual_Type_Definition(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_association_chain")
 def Get_Association_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6138,7 +6138,7 @@ def Set_Association_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_individual_association_chain")
 def Get_Individual_Association_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6151,7 +6151,7 @@ def Set_Individual_Association_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_subprogram_association_chain")
 def Get_Subprogram_Association_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6164,7 +6164,7 @@ def Set_Subprogram_Association_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_aggregate_info")
 def Get_Aggregate_Info(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6177,7 +6177,7 @@ def Set_Aggregate_Info(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_sub_aggregate_info")
 def Get_Sub_Aggregate_Info(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6190,7 +6190,7 @@ def Set_Sub_Aggregate_Info(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_aggr_dynamic_flag")
 def Get_Aggr_Dynamic_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6203,7 +6203,7 @@ def Set_Aggr_Dynamic_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_aggr_min_length")
 def Get_Aggr_Min_Length(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6216,7 +6216,7 @@ def Set_Aggr_Min_Length(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_aggr_low_limit")
 def Get_Aggr_Low_Limit(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6229,7 +6229,7 @@ def Set_Aggr_Low_Limit(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_aggr_high_limit")
 def Get_Aggr_High_Limit(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6242,7 +6242,7 @@ def Set_Aggr_High_Limit(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_aggr_others_flag")
 def Get_Aggr_Others_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6255,7 +6255,7 @@ def Set_Aggr_Others_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_aggr_named_flag")
 def Get_Aggr_Named_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6268,7 +6268,7 @@ def Set_Aggr_Named_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_aggregate_expand_flag")
 def Get_Aggregate_Expand_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6281,7 +6281,7 @@ def Set_Aggregate_Expand_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_determined_aggregate_flag")
 def Get_Determined_Aggregate_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6294,7 +6294,7 @@ def Set_Determined_Aggregate_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_association_choices_chain")
 def Get_Association_Choices_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6307,7 +6307,7 @@ def Set_Association_Choices_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_case_statement_alternative_chain")
 def Get_Case_Statement_Alternative_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6320,7 +6320,7 @@ def Set_Case_Statement_Alternative_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_matching_flag")
 def Get_Matching_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6333,7 +6333,7 @@ def Set_Matching_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_choice_staticness")
 def Get_Choice_Staticness(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6346,7 +6346,7 @@ def Set_Choice_Staticness(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_procedure_call")
 def Get_Procedure_Call(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6359,7 +6359,7 @@ def Set_Procedure_Call(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_implementation")
 def Get_Implementation(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6372,7 +6372,7 @@ def Set_Implementation(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_parameter_association_chain")
 def Get_Parameter_Association_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6385,7 +6385,7 @@ def Set_Parameter_Association_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_method_object")
 def Get_Method_Object(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6398,7 +6398,7 @@ def Set_Method_Object(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_subtype_type_mark")
 def Get_Subtype_Type_Mark(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6411,7 +6411,7 @@ def Set_Subtype_Type_Mark(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_subnature_nature_mark")
 def Get_Subnature_Nature_Mark(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6424,7 +6424,7 @@ def Set_Subnature_Nature_Mark(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_type_conversion_subtype")
 def Get_Type_Conversion_Subtype(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6437,7 +6437,7 @@ def Set_Type_Conversion_Subtype(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_type_mark")
 def Get_Type_Mark(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6450,7 +6450,7 @@ def Set_Type_Mark(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_file_type_mark")
 def Get_File_Type_Mark(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6463,7 +6463,7 @@ def Set_File_Type_Mark(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_return_type_mark")
 def Get_Return_Type_Mark(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6476,7 +6476,7 @@ def Set_Return_Type_Mark(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_disconnect_flag")
 def Get_Has_Disconnect_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6489,7 +6489,7 @@ def Set_Has_Disconnect_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_active_flag")
 def Get_Has_Active_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6502,7 +6502,7 @@ def Set_Has_Active_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_is_within_flag")
 def Get_Is_Within_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6515,7 +6515,7 @@ def Set_Is_Within_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_type_marks_list")
 def Get_Type_Marks_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6528,7 +6528,7 @@ def Set_Type_Marks_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_implicit_alias_flag")
 def Get_Implicit_Alias_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6541,7 +6541,7 @@ def Set_Implicit_Alias_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_alias_signature")
 def Get_Alias_Signature(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6554,7 +6554,7 @@ def Set_Alias_Signature(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_attribute_signature")
 def Get_Attribute_Signature(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6567,7 +6567,7 @@ def Set_Attribute_Signature(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_overload_list")
 def Get_Overload_List(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6580,7 +6580,7 @@ def Set_Overload_List(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_simple_name_identifier")
 def Get_Simple_Name_Identifier(obj: Iir) -> NameId:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6593,7 +6593,7 @@ def Set_Simple_Name_Identifier(obj: Iir, value: NameId) -> None:
 @BindToLibGHDL("vhdl__nodes__get_simple_name_subtype")
 def Get_Simple_Name_Subtype(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6606,7 +6606,7 @@ def Set_Simple_Name_Subtype(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_protected_type_body")
 def Get_Protected_Type_Body(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6619,7 +6619,7 @@ def Set_Protected_Type_Body(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_protected_type_declaration")
 def Get_Protected_Type_Declaration(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6632,7 +6632,7 @@ def Set_Protected_Type_Declaration(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_use_flag")
 def Get_Use_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6645,7 +6645,7 @@ def Set_Use_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_elaborated_flag")
 def Get_Elaborated_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6658,7 +6658,7 @@ def Set_Elaborated_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_end_has_reserved_id")
 def Get_End_Has_Reserved_Id(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6671,7 +6671,7 @@ def Set_End_Has_Reserved_Id(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_end_has_identifier")
 def Get_End_Has_Identifier(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6684,7 +6684,7 @@ def Set_End_Has_Identifier(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_end_has_postponed")
 def Get_End_Has_Postponed(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6697,7 +6697,7 @@ def Set_End_Has_Postponed(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_begin")
 def Get_Has_Begin(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6710,7 +6710,7 @@ def Set_Has_Begin(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_end")
 def Get_Has_End(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6723,7 +6723,7 @@ def Set_Has_End(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_is")
 def Get_Has_Is(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6736,7 +6736,7 @@ def Set_Has_Is(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_pure")
 def Get_Has_Pure(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6749,7 +6749,7 @@ def Set_Has_Pure(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_body")
 def Get_Has_Body(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6762,7 +6762,7 @@ def Set_Has_Body(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_parameter")
 def Get_Has_Parameter(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6775,7 +6775,7 @@ def Set_Has_Parameter(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_component")
 def Get_Has_Component(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6788,7 +6788,7 @@ def Set_Has_Component(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_identifier_list")
 def Get_Has_Identifier_List(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6801,7 +6801,7 @@ def Set_Has_Identifier_List(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_mode")
 def Get_Has_Mode(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6814,7 +6814,7 @@ def Set_Has_Mode(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_class")
 def Get_Has_Class(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6827,7 +6827,7 @@ def Set_Has_Class(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_has_delay_mechanism")
 def Get_Has_Delay_Mechanism(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6840,7 +6840,7 @@ def Set_Has_Delay_Mechanism(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_suspend_flag")
 def Get_Suspend_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6853,7 +6853,7 @@ def Set_Suspend_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_covered_flag")
 def Get_Covered_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6866,7 +6866,7 @@ def Set_Covered_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_stop_flag")
 def Get_Stop_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6879,7 +6879,7 @@ def Set_Stop_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_is_ref")
 def Get_Is_Ref(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6892,7 +6892,7 @@ def Set_Is_Ref(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_is_forward_ref")
 def Get_Is_Forward_Ref(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6905,7 +6905,7 @@ def Set_Is_Forward_Ref(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_psl_property")
 def Get_Psl_Property(obj: Iir) -> PSLNode:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6918,7 +6918,7 @@ def Set_Psl_Property(obj: Iir, value: PSLNode) -> None:
 @BindToLibGHDL("vhdl__nodes__get_psl_sequence")
 def Get_Psl_Sequence(obj: Iir) -> PSLNode:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6931,7 +6931,7 @@ def Set_Psl_Sequence(obj: Iir, value: PSLNode) -> None:
 @BindToLibGHDL("vhdl__nodes__get_psl_declaration")
 def Get_Psl_Declaration(obj: Iir) -> PSLNode:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6944,7 +6944,7 @@ def Set_Psl_Declaration(obj: Iir, value: PSLNode) -> None:
 @BindToLibGHDL("vhdl__nodes__get_psl_expression")
 def Get_Psl_Expression(obj: Iir) -> PSLNode:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6957,7 +6957,7 @@ def Set_Psl_Expression(obj: Iir, value: PSLNode) -> None:
 @BindToLibGHDL("vhdl__nodes__get_psl_boolean")
 def Get_Psl_Boolean(obj: Iir) -> PSLNode:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6970,7 +6970,7 @@ def Set_Psl_Boolean(obj: Iir, value: PSLNode) -> None:
 @BindToLibGHDL("vhdl__nodes__get_psl_clock")
 def Get_PSL_Clock(obj: Iir) -> PSLNode:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6983,7 +6983,7 @@ def Set_PSL_Clock(obj: Iir, value: PSLNode) -> None:
 @BindToLibGHDL("vhdl__nodes__get_psl_abort")
 def Get_PSL_Abort(obj: Iir) -> PSLNode:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -6996,7 +6996,7 @@ def Set_PSL_Abort(obj: Iir, value: PSLNode) -> None:
 @BindToLibGHDL("vhdl__nodes__get_psl_nfa")
 def Get_PSL_NFA(obj: Iir) -> PSLNFA:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -7009,7 +7009,7 @@ def Set_PSL_NFA(obj: Iir, value: PSLNFA) -> None:
 @BindToLibGHDL("vhdl__nodes__get_psl_nbr_states")
 def Get_PSL_Nbr_States(obj: Iir) -> Int32:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -7022,7 +7022,7 @@ def Set_PSL_Nbr_States(obj: Iir, value: Int32) -> None:
 @BindToLibGHDL("vhdl__nodes__get_psl_clock_sensitivity")
 def Get_PSL_Clock_Sensitivity(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -7035,7 +7035,7 @@ def Set_PSL_Clock_Sensitivity(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_psl_eos_flag")
 def Get_PSL_EOS_Flag(obj: Iir) -> Boolean:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -7048,7 +7048,7 @@ def Set_PSL_EOS_Flag(obj: Iir, value: Boolean) -> None:
 @BindToLibGHDL("vhdl__nodes__get_count_expression")
 def Get_Count_Expression(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -7061,7 +7061,7 @@ def Set_Count_Expression(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_clock_expression")
 def Get_Clock_Expression(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -7074,7 +7074,7 @@ def Set_Clock_Expression(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_default_clock")
 def Get_Default_Clock(obj: Iir) -> PSLNode:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -7087,7 +7087,7 @@ def Set_Default_Clock(obj: Iir, value: PSLNode) -> None:
 @BindToLibGHDL("vhdl__nodes__get_foreign_node")
 def Get_Foreign_Node(obj: Iir) -> Int32:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -7100,7 +7100,7 @@ def Set_Foreign_Node(obj: Iir, value: Int32) -> None:
 @BindToLibGHDL("vhdl__nodes__get_suspend_state_index")
 def Get_Suspend_State_Index(obj: Iir) -> Int32:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -7113,7 +7113,7 @@ def Set_Suspend_State_Index(obj: Iir, value: Int32) -> None:
 @BindToLibGHDL("vhdl__nodes__get_suspend_state_chain")
 def Get_Suspend_State_Chain(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -7126,7 +7126,7 @@ def Set_Suspend_State_Chain(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_suspend_state_last")
 def Get_Suspend_State_Last(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -7139,7 +7139,7 @@ def Set_Suspend_State_Last(obj: Iir, value: Iir) -> None:
 @BindToLibGHDL("vhdl__nodes__get_suspend_state_decl")
 def Get_Suspend_State_Decl(obj: Iir) -> Iir:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export

--- a/pyGHDL/libghdl/vhdl/nodes_meta.py
+++ b/pyGHDL/libghdl/vhdl/nodes_meta.py
@@ -25,7 +25,7 @@ def get_fields_first(K: IirKind) -> int:
 
     :param K: Node to get first array index from.
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
@@ -42,14 +42,14 @@ def get_fields_last(K: IirKind) -> int:
 
     :param K: Node to get last array index from.
     """
-    return 0
+    return 0  # pragma: no cover
 
 
 @export
 @BindToLibGHDL("vhdl__nodes_meta__get_field_by_index")
 def get_field_by_index(K: IirKind) -> int:
     """"""
-    return 0
+    return 0  # pragma: no cover
 
 
 @export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,76 @@
 [build-system]
 requires = [
-    "pyTooling >= 4.0.1, <5.0",
-    "setuptools >= 62.3.3",
-    "wheel >= 0.38.1"
+  "setuptools ~= 75.5",
+  "wheel ~= 0.45",
+  "pyTooling ~= 8.0"
 ]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 120
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
+
+[tool.mypy]
+files = ["pyGHDL"]
+python_version = "3.13"
+#ignore_missing_imports = true
+strict = true
+pretty = true
+show_error_context = true
+show_error_codes = true
+namespace_packages = true
+html_report = "report/typing"
+
+[tool.pytest.ini_options]
+addopts = "--tb=native"
+# Don't set 'python_classes = *' otherwise, pytest doesn't search for classes
+# derived from unittest.Testcase
+python_files = "*"
+python_functions = "test_*"
+filterwarnings = [
+	"error::DeprecationWarning",
+	"error::PendingDeprecationWarning"
+]
+
+[tool.interrogate]
+color = true
+verbose = 1             # possible values: 0 (minimal output), 1 (-v), 2 (-vv)
+fail-under = 59
+exclude = [
+	"build",
+	"dist",
+	"doc",
+	"testsuite",
+	"setup.py"
+]
+ignore-setters = true
+
+[tool.coverage.run]
+branch = true
+relative_files = true
+omit = [
+	"*site-packages*",
+	"setup.py",
+	"testsuite/pyunit/*"
+]
+
+[tool.coverage.report]
+skip_covered = false
+skip_empty = true
+exclude_lines = [
+	"pragma: no cover",
+	"raise NotImplementedError"
+]
+omit = [
+	"tests/*"
+]
+
+[tool.coverage.xml]
+output = "report/coverage/coverage.xml"
+
+[tool.coverage.json]
+output = "report/coverage/coverage.json"
+
+[tool.coverage.html]
+directory = "report/coverage/html"
+title="Code Coverage of pyGHDL"

--- a/scripts/pnodespy.py
+++ b/scripts/pnodespy.py
@@ -36,8 +36,8 @@ def print_file_header(includeIntEnumUnique=True, includeBindToLibGHDL=True):
             # Call 'make' in 'src/vhdl' to regenerate:
             #
         """) + "{sysImports}from pyTooling.Decorators import export\n{moduleImports}".format(
-            sysImports = "from enum import IntEnum, unique\n" if includeIntEnumUnique else "",
-            moduleImports = "\nfrom pyGHDL.libghdl._decorator import BindToLibGHDL\n" if includeBindToLibGHDL else "",
+            sysImports="from enum import IntEnum, unique\n" if includeIntEnumUnique else "",
+            moduleImports="\nfrom pyGHDL.libghdl._decorator import BindToLibGHDL\n" if includeBindToLibGHDL else "",
         )
     )
 
@@ -66,13 +66,13 @@ def do_iirs_subprg():
         @BindToLibGHDL("{classname}__get_kind")
         def Get_Kind(node: Iir) -> IirKind:
             \"\"\"Get node kind.\"\"\"
-            return 0
+            return 0  # pragma: no cover
 
         @export
         @BindToLibGHDL("{classname}__get_location")
         def Get_Location(node: Iir) -> LocationType:
             \"\"\"\"\"\"
-            return 0
+            return 0  # pragma: no cover
         """)
     )
     for k in pnodes.funcs:
@@ -87,7 +87,7 @@ def do_iirs_subprg():
             @BindToLibGHDL("{classname}__get_{k.name.lower()}")
             def Get_{k.name}(obj: Iir) -> {rtype}:
                 \"\"\"\"\"\"
-                return 0
+                return 0  # pragma: no cover
             @export
             @BindToLibGHDL("{classname}__set_{k.name.lower()}")
             def Set_{k.name}(obj: Iir, value: {rtype}) -> None:
@@ -269,7 +269,7 @@ def do_libghdl_meta():
 
             :param K: Node to get first array index from.
             \"\"\"
-            return 0
+            return 0  # pragma: no cover
 
 
         @export
@@ -286,13 +286,13 @@ def do_libghdl_meta():
 
             :param K: Node to get last array index from.
             \"\"\"
-            return 0
+            return 0  # pragma: no cover
 
         @export
         @BindToLibGHDL("vhdl__nodes_meta__get_field_by_index")
         def get_field_by_index(K: IirKind) -> int:
             \"\"\"\"\"\"
-            return 0
+            return 0  # pragma: no cover
 
         @export
         def get_field_type(*args):

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,11 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
-from pathlib             import Path
-from pyTooling.Licensing import GPL_2_0_or_later
-from pyTooling.Packaging import DescribePythonPackageHostedOnGitHub
+from pathlib                  import Path
+from setuptools               import setup, Distribution
+
+from pyTooling.Licensing      import GPL_2_0_or_later
+from pyTooling.Packaging      import DescribePythonPackageHostedOnGitHub
 
 gitHubNamespace = "ghdl"
 packageName =  "pyGHDL"
@@ -43,30 +45,56 @@ packageDirectory = packageName
 packageInformationFile = Path(f"{packageDirectory}/__init__.py")
 requirementsFile = Path(f"{packageDirectory}/requirements.txt")
 
-DescribePythonPackageHostedOnGitHub(
-    packageName=packageName,
-    description="Python binding for GHDL and high-level APIs (incl. LSP).",
-    license=GPL_2_0_or_later,
-    gitHubNamespace=gitHubNamespace,
-    sourceFileWithVersion=packageInformationFile,
-    requirementsFile=requirementsFile,
-    developmentStatus="beta",
-    classifiers=[
-        "Operating System :: MacOS",
-        "Operating System :: Microsoft :: Windows :: Windows 10",
-        "Operating System :: POSIX :: Linux",
-        "Intended Audience :: Developers",
-        "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
-        "Topic :: Software Development :: Code Generators",
-        "Topic :: Software Development :: Compilers",
-        "Topic :: Software Development :: Testing",
-        "Topic :: Utilities",
-    ],
-    consoleScripts={
-        "ghdl-ls": "pyGHDL.cli.lsp:main",
-        "ghdl-dom": "pyGHDL.cli.dom:main"
-    },
-    dataFiles={
-        packageName: ["py.typed"]
-    }
+
+# Package data files
+sourceDirectory = Path().cwd() / "pyGHDL"
+dataFiles = [sourceDirectory / "py.typed"]
+additional = {}
+
+# libGHDL shared object and pre-analyzed files
+libGHDLDirectory = sourceDirectory / "lib"
+if libGHDLDirectory.exists():
+    dataFiles.extend(libGHDLDirectory.rglob("lib*.dll"))
+    dataFiles.extend(libGHDLDirectory.rglob("lib*.so"))
+    ghdlDirectory = libGHDLDirectory / "ghdl"
+    dataFiles.extend(ghdlDirectory.rglob("**/*.vhdl"))
+    dataFiles.extend(ghdlDirectory.rglob("**/*.cf"))
+
+    # Extend the Distribution class to force platform specific wheel
+    class BinaryDistribution(Distribution):
+        def has_ext_modules(self):
+            return True
+
+    additional["include_package_data"] = True
+    additional["distclass"] = BinaryDistribution
+
+setup(
+    **DescribePythonPackageHostedOnGitHub(
+        packageName=packageName,
+        description="Python binding for GHDL and high-level APIs (incl. LSP).",
+        license=GPL_2_0_or_later,
+        gitHubNamespace=gitHubNamespace,
+        sourceFileWithVersion=packageInformationFile,
+        requirementsFile=requirementsFile,
+        developmentStatus="beta",
+        classifiers=[
+            "Operating System :: MacOS",
+            "Operating System :: Microsoft :: Windows :: Windows 11",
+            "Operating System :: POSIX :: Linux",
+            "Intended Audience :: Developers",
+            "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
+            "Topic :: Software Development :: Code Generators",
+            "Topic :: Software Development :: Compilers",
+            "Topic :: Software Development :: Testing",
+            "Topic :: Utilities",
+        ],
+        consoleScripts={
+            "ghdl-ls":  "pyGHDL.cli.lsp:main",
+            "ghdl-dom": "pyGHDL.cli.dom:main"
+        },
+        dataFiles={
+            packageName: [str(file.relative_to(sourceDirectory)) for file in dataFiles]
+        }
+    ),
+    **additional,
 )

--- a/testsuite/__init__.py
+++ b/testsuite/__init__.py
@@ -1,0 +1,1 @@
+# This file is required by Coverage.py

--- a/testsuite/requirements.txt
+++ b/testsuite/requirements.txt
@@ -1,7 +1,7 @@
 -r ../pyGHDL/requirements.txt
 
 pytest>=7.3.0
-pytest-cov>=2.10.1
+pytest-cov ~= 6.0
 
 # Coverage collection
 Coverage>=7.2

--- a/testsuite/testsuite.sh
+++ b/testsuite/testsuite.sh
@@ -118,6 +118,23 @@ echo "> args: $@"
 # Run a testsuite
 do_test() {
   case $1 in
+    help)
+    	echo "Usage:"
+    	echo "  ./testsuite.sh                     run all testsuites"
+    	echo "  ./testsuite.sh <suite>             run single testsuite"
+    	echo "  ./testsuite.sh <suite> <suite> ... run multiple testsuites"
+
+    	echo "Supported testsuites:"
+    	echo " * sanity"
+    	echo " * gna"
+    	echo " * synth"
+    	echo " * vpi"
+    	echo " * vhpi"
+    	echo " * vests"
+    	echo " * pyunit"
+    	echo ""
+    	exit
+    	;;
     sanity|gna|synth|vpi|vhpi)
       gstart "[GHDL - test] $1"
       cd "$1"


### PR DESCRIPTION
This is a split from #2718.

# Changes

* Modifications to pyGHDL
  * Improved how to find libghdl.so/dll.
* Modifications needed for pyTooling v8.0+ support.
  * `pyAttributes` is now part of `pyTooling`.
* Modification needed for pyVHDLModel v0.29+ support.
* Improved `GHDLBaseException`
* Fixed missing multiple inheritance in derived DOM classes.
* Adjusted setup.py for usage also with platform dependent packaging.  
  Later no setup.in will be needed.

# Fixes

* ReStructure Text syntax fixes.
* Added `no cover` marker.