### PR TITLE
Further pipeline improvements

### DIFF
--- a/.github/workflows/Build-Ubuntu.yml
+++ b/.github/workflows/Build-Ubuntu.yml
@@ -432,5 +432,6 @@ jobs:
       ghdl_artifact:       ${{ needs.Build.outputs.ghdl_artifact }}
       ubuntu_version:      ${{ inputs.ubuntu_version }}
       backend:             ${{ inputs.backend }}
+      publish:             ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/')) }}
       testsuites:          ${{ inputs.testsuites }}
     secrets: inherit

--- a/.github/workflows/Package-Docker.yml
+++ b/.github/workflows/Package-Docker.yml
@@ -20,6 +20,11 @@ on:
         description: 'GHDL backend.'
         required: true
         type: string
+      publish:
+        description: 'Publish Docker image to Docker Hub.'
+        required: false
+        default: true
+        type: boolean
       dockerhub_image:
         description: 'Docker Hub image name.'
         required: false
@@ -34,7 +39,6 @@ jobs:
   Ubuntu:
     name: Package GHDL as Docker Image
     runs-on: ${{ inputs.ubuntu_image }}
-    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/'))
     outputs:
       ghdl_image: ${{ steps.build.outputs.ghdl_image }}
 
@@ -71,35 +75,36 @@ jobs:
           cat $GITHUB_OUTPUT
 
           echo "Building docker file './dist/docker/Dockerfile.${base_image}' ..."
-          docker build \
+          docker buildx build \
             --file ./dist/docker/Dockerfile.${base_image} \
             --build-arg IMAGE=${base_image} \
             --build-arg IMAGE_TAG=${base_image_tag} \
-            --tag "${image}" \
+            --tag "ghdl:current" \
             ./dist/docker
 
-          echo "Docker image '${image}' has $(docker image inspect $1 --format='{{.Size}}' | numfmt --to=iec --format '%.2f' ${image})"
+          echo "Docker image 'ghdl:current' has $(docker image inspect $1 --format='{{.Size}}' | numfmt --to=iec --format '%.2f' ${image})"
 
-      - name: ☑ Checking GHDL image '${{ steps.build.outputs.ghdl_image }}'
+      - name: ☑ Checking GHDL image 'ghdl:current'
         run: |
-          docker container run --rm ${{ steps.build.outputs.ghdl_image }} 'echo "which ghdl: $(which ghdl)"; ghdl version'
+          docker container run --rm ghdl:current 'echo "which ghdl: $(which ghdl)"; ghdl version'
 
       - name: 🔑 Login and push to Docker Hub
-        if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/'))
+        if: inputs.publish
         run: |
           echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u ${{ vars.DOCKERHUB_USERNAME }} --password-stdin
+          docker image tag ghdl:current ${{ steps.build.outputs.ghdl_image }}
           echo "Docker image '${{ steps.build.outputs.ghdl_image }}' has $(docker image inspect $1 --format='{{.Size}}' | numfmt --to=iec --format '%.2f' ${{ steps.build.outputs.ghdl_image }})"
-          docker push ${{ steps.build.outputs.ghdl_image }}
+          docker image push ${{ steps.build.outputs.ghdl_image }}
 
       - name: 🚦 Testing GHDL image
         run: |
-          docker container run --rm -v $(pwd):/data ${{ steps.build.outputs.ghdl_image }} 'cd /data/testsuite; ./testsuite.sh ${{ inputs.testsuites }}'
+          docker container run --rm -v $(pwd):/data ghdl:current 'cd /data/testsuite; ./testsuite.sh ${{ inputs.testsuites }}'
 
   TestDocker:
     uses: ./.github/workflows/Test-Docker.yml
     needs:
       - Ubuntu
-    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/'))
+    if: inputs.publish
     with:
       os_image:   ${{ inputs.ubuntu_image }}
       ghdl_image: ${{ needs.Ubuntu.outputs.ghdl_image }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -177,11 +177,9 @@ jobs:
     uses: ./.github/workflows/Check-pyGHDL.yml
     needs:
       - Params
-#    with:
-#      black: false
 
   StaticTypeCheck:
-    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@r1
+    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@r2
     needs:
       - Params
     with:
@@ -192,7 +190,7 @@ jobs:
       html_artifact: 'pyGHDL-typing-HTML'
 
   DocCoverage:
-    uses: pyTooling/Actions/.github/workflows/CheckDocumentation.yml@r1
+    uses: pyTooling/Actions/.github/workflows/CheckDocumentation.yml@r2
     needs:
       - Params
     with:
@@ -229,7 +227,7 @@ jobs:
     secrets: inherit
 
   PublishCoverageResults:
-    uses: pyTooling/Actions/.github/workflows/PublishCoverageResults.yml@r1
+    uses: pyTooling/Actions/.github/workflows/PublishCoverageResults.yml@r2
     needs:
       - macOS
       - Ubuntu-fast
@@ -248,13 +246,13 @@ jobs:
       - Ubuntu-fast
       - Windows-fast
       - pyGHDL
-    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/'))
     with:
       merged_junit_artifact: 'pyGHDL-Unittest-XML'
       additional_merge_args: '-d "--render=tree" "--name=pyGHDL" "--pytest=rewrite-dunder-init;reduce-depth:pytest.testsuite.pyunit;split:pytest"'
+      publish: ${{ github.event_name != 'pull_request' }}
 
   IntermediateCleanUp:
-    uses: pyTooling/Actions/.github/workflows/IntermediateCleanUp.yml@r1
+    uses: pyTooling/Actions/.github/workflows/IntermediateCleanUp.yml@r2
     needs:
       - PublishCoverageResults
       - PublishTestResults
@@ -311,7 +309,7 @@ jobs:
         run: echo "Dummy"
 
   ReleasePage:
-    uses: pyTooling/Actions/.github/workflows/Release.yml@r1
+    uses: pyTooling/Actions/.github/workflows/Release.yml@r2
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - macOS


### PR DESCRIPTION
# Changes

* Updated used pipeline templates to `pyTooling/Actions@r2`
* Run Test Result Publishing not in pull request pipelines.
* Reactivated Docker image building and Docker image checking (execute GHDL's testsuite inside).
  * Skip Docker image pushing in pull-request pipelines.