### PR TITLE
WIP Added binding to elaboration of the toplevel design #2728

### DIFF
--- a/pyGHDL/libghdl/utils.py
+++ b/pyGHDL/libghdl/utils.py
@@ -36,6 +36,7 @@ from typing import List, Any, Generator
 
 from pyTooling.Decorators import export
 
+from pyGHDL.libghdl._decorator import BindToLibGHDL
 from pyGHDL.libghdl._decorator import EnumLookupTable
 from pyGHDL.libghdl._types import NameId
 import pyGHDL.libghdl.name_table as name_table
@@ -455,3 +456,8 @@ def sequential_iter(n) -> Generator[Any, None, None]:
         return
     else:
         raise Exception("Unknown node of kind {}".format(kind_image(k)))
+
+@export
+@BindToLibGHDL("elab__vhdl_insts__elab_top_unit")
+def elab_top_unit(config: int) -> int:
+    return 0    


### PR DESCRIPTION
Pull request for feedback on issue #2728 . I added a binding to libghdl that when I poke at appears to work however I have not yet managed to actually get the design to elaborate. When I pass a node from the tree to be elaborated I typically get the error `no field Block_Configuration`. I believe from looking at the source that I am basing my changes on (`src/ghdldrv/ghdlsynth.adb`) that the design needs to be configured first. There is not a binding for that either however I can see that things are flags for configuration status when inspecting the tree. In my testing I also attempted to bind the `ghdl_synth` function for verifying these changes could work however I was unable to get that working either. I would love feedback and suggestions for how to move forward. 