### PR TITLE
New nightly releases

### DIFF
--- a/.github/workflows/Build-MSYS2.yml
+++ b/.github/workflows/Build-MSYS2.yml
@@ -426,7 +426,7 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.unittest_xml_artifact }}-Windows-${{ inputs.windows_version }}-${{ inputs.python_version }}
+          name: ${{ inputs.unittest_xml_artifact }}-Windows-${{ inputs.windows_version }}-${{ inputs.runtime }}-${{ inputs.python_version }}
           path: report/unit/TestReportSummary.xml
           if-no-files-found: error
           retention-days: 1
@@ -442,7 +442,7 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.coverage_sqlite_artifact }}-Windows-${{ inputs.windows_version }}-${{ inputs.python_version }}
+          name: ${{ inputs.coverage_sqlite_artifact }}-Windows-${{ inputs.windows_version }}-${{ inputs.runtime }}-${{ inputs.python_version }}
           path: .coverage
           include-hidden-files: true
           if-no-files-found: error

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -304,14 +304,30 @@ jobs:
       - DocCoverage
       - PublishCoverageResults
       - PublishTestResults
-    if: github.ref == 'refs/tags/testing'
+    if: github.ref == 'refs/tags/nightly'
     secrets: inherit
     permissions:
       contents: write
       actions: write
       attestations: write
     with:
-      nightly_name: testing
+      nightly_name: nightly
+      nightly_description: |
+        This *nightly* release contains all latest and important artifacts created by GHDL's CI pipeline.
+
+        # GHDL 5.0.0-dev0
+
+        The following asset categories are provided for GHDL:
+        * macOS x64-64 builds as TAR/GZ file
+        * macOS aarch64 builds as TAR/GZ file
+        * Ubuntu 24.04 LTS builds as TAR/GZ file
+        * Windows builds for standalone usage (without MSYS2) as ZIP file
+        * MSYS2 packages as TAR/ZST file
+
+        # pyGHDL 5.0.0-dev0
+        The following asset categories are provided for pyGHDL:
+        * Platform specific Python wheel package for Ubuntu incl. `pyGHDL...so`
+        * Platform specific Python wheel package for Windows incl. `pyGHDL...dll`
       prerelease: true
       assets: |
         ghdl-macos-13-x86_64-llvm:            !ghdl-llvm-5.0.0.dev0-macos13-x86_64.tgz:                        GHDL - v5.0.0-dev0 - llvm backend for macOS 13 (x86-64)

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -315,7 +315,13 @@ jobs:
       nightly_description: |
         This *nightly* release contains all latest and important artifacts created by GHDL's CI pipeline.
 
-        # GHDL 5.0.0-dev0
+        # GHDL 5.0.0-dev
+
+        GHDL offers the simulator and synthesis tool for VHDL. GHDL can be build for various backends:
+        * `gcc` - using the GCC compiler framework
+        * `mcode` - in memory code generation
+        * `llvm` - using the LLVM compiler framework
+        * `llvm-jit` - using the LLVM compiler framework, but in memory
 
         The following asset categories are provided for GHDL:
         * macOS x64-64 builds as TAR/GZ file
@@ -324,27 +330,33 @@ jobs:
         * Windows builds for standalone usage (without MSYS2) as ZIP file
         * MSYS2 packages as TAR/ZST file
 
-        # pyGHDL 5.0.0-dev0
+        # pyGHDL 5.0.0-dev
+
+        The Python package `pyGHDL` offers Python binding (`pyGHDL.libghdl`) to a `libghdl` shared library (`*.so`/`*.dll`).
+        In addition to the low-level binding layer, pyGHDL offers:
+        * a Language Server Protocol (LSP) instance for e.g. live code checking by editors
+        * a Code Document Object Model (CodeDOM) based on [pyVHDLModel](https://github.com/VHDL/pyVHDLModel)
+
         The following asset categories are provided for pyGHDL:
         * Platform specific Python wheel package for Ubuntu incl. `pyGHDL...so`
         * Platform specific Python wheel package for Windows incl. `pyGHDL...dll`
       prerelease: true
       assets: |
-        ghdl-macos-13-x86_64-llvm:            !ghdl-llvm-5.0.0.dev0-macos13-x86_64.tgz:                        GHDL - v5.0.0-dev - macOS 13 (x86-64) - llvm backend
-        ghdl-macos-13-x86_64-mcode:           !ghdl-mcode-5.0.0.dev0-macos13-x86_64.tgz:                       GHDL - v5.0.0-dev - macOS 13 (x86-64) - mcode backend
-        ghdl-macos-14-aarch64-llvm:           !ghdl-llvm-5.0.0.dev0-macos14-aarch64.tgz:                       GHDL - v5.0.0-dev - macOS 14 (aarch64) - llvm backend
-        ghdl-macos-14-aarch64-llvm-jit:       !ghdl-llvm-jit-5.0.0.dev0-macos14-aarch64.tgz:                   GHDL - v5.0.0-dev - macOS 14 (aarch64) - llvm-jit backend
-        ghdl-ubuntu-24.04-x86_64-llvm:        !ghdl-llvm-5.0.0.dev0-ubuntu24.04-x86_64.tgz:                    GHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - llvm backend
-        ghdl-ubuntu-24.04-x86_64-llvm-jit:    !ghdl-llvm-jit-5.0.0.dev0-ubuntu24.04-x86_64.tgz:                GHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - llvm-jit backend
-        ghdl-ubuntu-24.04-x86_64-mcode:       !ghdl-mcode-5.0.0.dev0-ubuntu24.04-x86_64.tgz:                   GHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - mcode backend
+        ghdl-macos-13-x86_64-llvm:            !ghdl-llvm-5.0.0-dev-macos13-x86_64.tgz:                         GHDL - v5.0.0-dev - macOS 13 (x86-64) - llvm backend
+        ghdl-macos-13-x86_64-mcode:           !ghdl-mcode-5.0.0-dev-macos13-x86_64.tgz:                        GHDL - v5.0.0-dev - macOS 13 (x86-64) - mcode backend
+        ghdl-macos-14-aarch64-llvm:           !ghdl-llvm-5.0.0-dev-macos14-aarch64.tgz:                        GHDL - v5.0.0-dev - macOS 14 (aarch64) - llvm backend
+        ghdl-macos-14-aarch64-llvm-jit:       !ghdl-llvm-jit-5.0.0-dev-macos14-aarch64.tgz:                    GHDL - v5.0.0-dev - macOS 14 (aarch64) - llvm-jit backend
+        ghdl-ubuntu-24.04-x86_64-llvm:        !ghdl-llvm-5.0.0-dev-ubuntu24.04-x86_64.tgz:                     GHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - llvm backend
+        ghdl-ubuntu-24.04-x86_64-llvm-jit:    !ghdl-llvm-jit-5.0.0-dev-ubuntu24.04-x86_64.tgz:                 GHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - llvm-jit backend
+        ghdl-ubuntu-24.04-x86_64-mcode:       !ghdl-mcode-5.0.0-dev-ubuntu24.04-x86_64.tgz:                    GHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - mcode backend
         ghdl-Pacman-mingw64-llvm:              mingw-w64-x86_64-ghdl-llvm-5.0.0.dev-1-any.pkg.tar.zst:         GHDL - v5.0.0-dev - MSYS2/MinGW64 - LLVM backend
         ghdl-Pacman-mingw64-llvm-jit:          mingw-w64-x86_64-ghdl-llvm-jit-5.0.0.dev-1-any.pkg.tar.zst:     GHDL - v5.0.0-dev - MSYS2/MinGW64 - LLVM-JIT backend
         ghdl-Pacman-mingw64-mcode:             mingw-w64-x86_64-ghdl-mcode-5.0.0.dev-1-any.pkg.tar.zst:        GHDL - v5.0.0-dev - MSYS2/MinGW64 - mcode backend
         ghdl-Pacman-ucrt64-llvm:               mingw-w64-ucrt-x86_64-ghdl-llvm-5.0.0.dev-1-any.pkg.tar.zst:    GHDL - v5.0.0-dev - MSYS2/UCRT64 - LLVM backend
         ghdl-Pacman-ucrt64-llvm-jit:           mingw-w64-ucrt-x86_64-ghdl-llvm-jit-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev - MSYS2/UCRT64 - LLVM-JIT backend
         ghdl-Pacman-ucrt64-mcode:              mingw-w64-ucrt-x86_64-ghdl-mcode-5.0.0.dev-1-any.pkg.tar.zst:   GHDL - v5.0.0-dev - MSYS2/UCRT64 - mcode backend
-        ghdl-Windows-mingw64-mcode:           !ghdl-mcode-5.0.0.dev0-mingw64.zip:                              GHDL - v5.0.0-dev - Windows (x86-64, MinGW64, standalone) - mcode backend
-        ghdl-Windows-ucrt64-mcode:            !ghdl-mcode-5.0.0.dev0-ucrt64.zip:                               GHDL - v5.0.0-dev - Windows (x86-64, UCRT64, standalone) - mcode backend
+        ghdl-Windows-mingw64-mcode:           !ghdl-mcode-5.0.0-dev-mingw64.zip:                               GHDL - v5.0.0-dev - Windows (x86-64, MinGW64, standalone) - mcode backend
+        ghdl-Windows-ucrt64-mcode:            !ghdl-mcode-5.0.0-dev-ucrt64.zip:                                GHDL - v5.0.0-dev - Windows (x86-64, UCRT64, standalone) - mcode backend
         pyGHDL-Ubuntu-24.04-x86_64-Python-3.9: pyGHDL-5.0.0.dev0-cp39-cp39-linux_x86_64.whl:                   pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.9
         pyGHDL-Ubuntu-24.04-x86_64-Python-3.10:pyGHDL-5.0.0.dev0-cp310-cp310-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.10
         pyGHDL-Ubuntu-24.04-x86_64-Python-3.11:pyGHDL-5.0.0.dev0-cp311-cp311-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.11

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -314,24 +314,31 @@ jobs:
       nightly_name: testing
       prerelease: true
       assets: |
-        ghdl-Pacman-mingw64-llvm:mingw-w64-x86_64-ghdl-llvm-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev0 - LLVM backend for MSYS2/MinGW64
-        ghdl-Pacman-mingw64-llvm-jit:mingw-w64-x86_64-ghdl-llvm-jit-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev0 - LLVM-JIT backend for MSYS2/MinGW64
-        ghdl-Pacman-mingw64-mcode:mingw-w64-x86_64-ghdl-mcode-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev0 - mcode backend for MSYS2/MinGW64
-        ghdl-Pacman-ucrt64-llvm:mingw-w64-ucrt-x86_64-ghdl-llvm-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev0 - LLVM backend for MSYS2/UCRT64
-        ghdl-Pacman-ucrt64-llvm-jit:mingw-w64-ucrt-x86_64-ghdl-llvm-jit-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev0 - LLVM-JIT backend for MSYS2/UCRT64
-        ghdl-Pacman-ucrt64-mcode:mingw-w64-ucrt-x86_64-ghdl-mcode-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev0 - mcode backend for MSYS2/UCRT64
-        ghdl-Windows-mingw64-mcode:!ghdl-mcode-5.0.0.dev0-mingw64.zip:GHDL - v5.0.0-dev0 - mcode backend for Windows (x86-64, MinGW64)
-        ghdl-Windows-ucrt64-mcode:!ghdl-mcode-5.0.0.dev0-ucrt64.zip:GHDL - v5.0.0-dev0 - mcode backend for Windows (x86-64, UCRT64)
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.9:pyGHDL-5.0.0.dev0-cp39-cp39-linux_x86_64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.9 on Ubuntu 24.04 (x86-64)
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.10:pyGHDL-5.0.0.dev0-cp310-cp310-linux_x86_64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.10 on Ubuntu 24.04 (x86-64)
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.11:pyGHDL-5.0.0.dev0-cp311-cp311-linux_x86_64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.11 on Ubuntu 24.04 (x86-64)
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.12:pyGHDL-5.0.0.dev0-cp312-cp312-linux_x86_64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.12 on Ubuntu 24.04 (x86-64)
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.13:pyGHDL-5.0.0.dev0-cp313-cp313-linux_x86_64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.13 on Ubuntu 24.04 (x86-64)
-        pyGHDL-Windows-x86_64-Python-3.9:pyGHDL-5.0.0.dev0-cp39-cp39-win_amd64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.9 on Windows (x86-64)
-        pyGHDL-Windows-x86_64-Python-3.10:pyGHDL-5.0.0.dev0-cp310-cp310-win_amd64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.10 on Windows (x86-64)
-        pyGHDL-Windows-x86_64-Python-3.11:pyGHDL-5.0.0.dev0-cp311-cp311-win_amd64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.11 on Windows (x86-64)
-        pyGHDL-Windows-x86_64-Python-3.12:pyGHDL-5.0.0.dev0-cp312-cp312-win_amd64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.12 on Windows (x86-64)
-        pyGHDL-Windows-x86_64-Python-3.13:pyGHDL-5.0.0.dev0-cp313-cp313-win_amd64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.13 on Windows (x86-64)
+        ghdl-macos-13-x86_64-llvm:            !ghdl-llvm-5.0.0.dev0-macos13-x86_64.tgz:                        GHDL - v5.0.0-dev0 - llvm backend for macOS 13 (x86-64)
+        ghdl-macos-13-x86_64-mcode:           !ghdl-mcode-5.0.0.dev0-macos13-x86_64.tgz:                       GHDL - v5.0.0-dev0 - mcode backend for macOS 13 (x86-64)
+        ghdl-macos-14-aarch64-llvm:           !ghdl-llvm-5.0.0.dev0-macos14-aarch64.tgz:                       GHDL - v5.0.0-dev0 - llvm backend for macOS 14 (aarch64)
+        ghdl-macos-14-aarch64-llvm-jit:       !ghdl-llvm-jit-5.0.0.dev0-macos14-aarch64.tgz:                   GHDL - v5.0.0-dev0 - llvm-jit backend for macOS 14 (aarch64)
+        ghdl-ubuntu-24.04-x86_64-llvm:        !ghdl-llvm-5.0.0.dev0-ubuntu24.04-x86_64.tgz:                    GHDL - v5.0.0-dev0 - llvm backend for Ubuntu 24.04 LTS (x86-64)
+        ghdl-ubuntu-24.04-x86_64-llvm-jit:    !ghdl-llvm-jit-5.0.0.dev0-ubuntu24.04-x86_64.tgz:                GHDL - v5.0.0-dev0 - llvm-jit backend for Ubuntu 24.04 LTS (x86-64)
+        ghdl-ubuntu-24.04-x86_64-mcode:       !ghdl-mcode-5.0.0.dev0-ubuntu24.04-x86_64.tgz:                   GHDL - v5.0.0-dev0 - mcode backend for Ubuntu 24.04 LTS (x86-64)
+        ghdl-Pacman-mingw64-llvm:              mingw-w64-x86_64-ghdl-llvm-5.0.0.dev-1-any.pkg.tar.zst:         GHDL - v5.0.0-dev0 - LLVM backend for MSYS2/MinGW64
+        ghdl-Pacman-mingw64-llvm-jit:          mingw-w64-x86_64-ghdl-llvm-jit-5.0.0.dev-1-any.pkg.tar.zst:     GHDL - v5.0.0-dev0 - LLVM-JIT backend for MSYS2/MinGW64
+        ghdl-Pacman-mingw64-mcode:             mingw-w64-x86_64-ghdl-mcode-5.0.0.dev-1-any.pkg.tar.zst:        GHDL - v5.0.0-dev0 - mcode backend for MSYS2/MinGW64
+        ghdl-Pacman-ucrt64-llvm:               mingw-w64-ucrt-x86_64-ghdl-llvm-5.0.0.dev-1-any.pkg.tar.zst:    GHDL - v5.0.0-dev0 - LLVM backend for MSYS2/UCRT64
+        ghdl-Pacman-ucrt64-llvm-jit:           mingw-w64-ucrt-x86_64-ghdl-llvm-jit-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev0 - LLVM-JIT backend for MSYS2/UCRT64
+        ghdl-Pacman-ucrt64-mcode:              mingw-w64-ucrt-x86_64-ghdl-mcode-5.0.0.dev-1-any.pkg.tar.zst:   GHDL - v5.0.0-dev0 - mcode backend for MSYS2/UCRT64
+        ghdl-Windows-mingw64-mcode:           !ghdl-mcode-5.0.0.dev0-mingw64.zip:                              GHDL - v5.0.0-dev0 - mcode backend for Windows (x86-64, MinGW64)
+        ghdl-Windows-ucrt64-mcode:            !ghdl-mcode-5.0.0.dev0-ucrt64.zip:                               GHDL - v5.0.0-dev0 - mcode backend for Windows (x86-64, UCRT64)
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.9: pyGHDL-5.0.0.dev0-cp39-cp39-linux_x86_64.whl:                   pyGHDL - v5.0.0-dev0 - Wheel for Python 3.9 on Ubuntu 24.04 (x86-64)
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.10:pyGHDL-5.0.0.dev0-cp310-cp310-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev0 - Wheel for Python 3.10 on Ubuntu 24.04 (x86-64)
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.11:pyGHDL-5.0.0.dev0-cp311-cp311-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev0 - Wheel for Python 3.11 on Ubuntu 24.04 (x86-64)
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.12:pyGHDL-5.0.0.dev0-cp312-cp312-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev0 - Wheel for Python 3.12 on Ubuntu 24.04 (x86-64)
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.13:pyGHDL-5.0.0.dev0-cp313-cp313-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev0 - Wheel for Python 3.13 on Ubuntu 24.04 (x86-64)
+        pyGHDL-Windows-x86_64-Python-3.9:      pyGHDL-5.0.0.dev0-cp39-cp39-win_amd64.whl:                      pyGHDL - v5.0.0-dev0 - Wheel for Python 3.9 on Windows (x86-64)
+        pyGHDL-Windows-x86_64-Python-3.10:     pyGHDL-5.0.0.dev0-cp310-cp310-win_amd64.whl:                    pyGHDL - v5.0.0-dev0 - Wheel for Python 3.10 on Windows (x86-64)
+        pyGHDL-Windows-x86_64-Python-3.11:     pyGHDL-5.0.0.dev0-cp311-cp311-win_amd64.whl:                    pyGHDL - v5.0.0-dev0 - Wheel for Python 3.11 on Windows (x86-64)
+        pyGHDL-Windows-x86_64-Python-3.12:     pyGHDL-5.0.0.dev0-cp312-cp312-win_amd64.whl:                    pyGHDL - v5.0.0-dev0 - Wheel for Python 3.12 on Windows (x86-64)
+        pyGHDL-Windows-x86_64-Python-3.13:     pyGHDL-5.0.0.dev0-cp313-cp313-win_amd64.whl:                    pyGHDL - v5.0.0-dev0 - Wheel for Python 3.13 on Windows (x86-64)
 
 
   ReleasePage:

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -291,7 +291,7 @@ jobs:
       typing:        'pyGHDL-typing-HTML'
 
   Nightly:
-    runs-on: ubuntu-24.04
+    uses: pyTooling/Actions/.github/workflows/NightlyRelease.yml@dev
     needs:
       - macOS
       - Ubuntu-fast
@@ -304,9 +304,35 @@ jobs:
       - DocCoverage
       - PublishCoverageResults
       - PublishTestResults
-    steps:
-      - name: "Dummy"
-        run: echo "Dummy"
+    if: github.ref == 'refs/tags/testing'
+    secrets: inherit
+    permissions:
+      contents: write
+      actions: write
+      attestations: write
+    with:
+      nightly_name: testing
+      prerelease: true
+      assets: |
+        ghdl-Pacman-mingw64-llvm:mingw-w64-x86_64-ghdl-llvm-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev0 - LLVM backend for MSYS2/MinGW64
+        ghdl-Pacman-mingw64-llvm-jit:mingw-w64-x86_64-ghdl-llvm-jit-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev0 - LLVM-JIT backend for MSYS2/MinGW64
+        ghdl-Pacman-mingw64-mcode:mingw-w64-x86_64-ghdl-mcode-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev0 - mcode backend for MSYS2/MinGW64
+        ghdl-Pacman-ucrt64-llvm:mingw-w64-ucrt-x86_64-ghdl-llvm-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev0 - LLVM backend for MSYS2/UCRT64
+        ghdl-Pacman-ucrt64-llvm-jit:mingw-w64-ucrt-x86_64-ghdl-llvm-jit-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev0 - LLVM-JIT backend for MSYS2/UCRT64
+        ghdl-Pacman-ucrt64-mcode:mingw-w64-ucrt-x86_64-ghdl-mcode-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev0 - mcode backend for MSYS2/UCRT64
+        ghdl-Windows-mingw64-mcode:!ghdl-mcode-5.0.0.dev0-mingw64.zip:GHDL - v5.0.0-dev0 - mcode backend for Windows (x86-64, MinGW64)
+        ghdl-Windows-ucrt64-mcode:!ghdl-mcode-5.0.0.dev0-ucrt64.zip:GHDL - v5.0.0-dev0 - mcode backend for Windows (x86-64, UCRT64)
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.9:pyGHDL-5.0.0.dev0-cp39-cp39-linux_x86_64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.9 on Ubuntu 24.04 (x86-64)
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.10:pyGHDL-5.0.0.dev0-cp310-cp310-linux_x86_64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.10 on Ubuntu 24.04 (x86-64)
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.11:pyGHDL-5.0.0.dev0-cp311-cp311-linux_x86_64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.11 on Ubuntu 24.04 (x86-64)
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.12:pyGHDL-5.0.0.dev0-cp312-cp312-linux_x86_64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.12 on Ubuntu 24.04 (x86-64)
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.13:pyGHDL-5.0.0.dev0-cp313-cp313-linux_x86_64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.13 on Ubuntu 24.04 (x86-64)
+        pyGHDL-Windows-x86_64-Python-3.9:pyGHDL-5.0.0.dev0-cp39-cp39-win_amd64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.9 on Windows (x86-64)
+        pyGHDL-Windows-x86_64-Python-3.10:pyGHDL-5.0.0.dev0-cp310-cp310-win_amd64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.10 on Windows (x86-64)
+        pyGHDL-Windows-x86_64-Python-3.11:pyGHDL-5.0.0.dev0-cp311-cp311-win_amd64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.11 on Windows (x86-64)
+        pyGHDL-Windows-x86_64-Python-3.12:pyGHDL-5.0.0.dev0-cp312-cp312-win_amd64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.12 on Windows (x86-64)
+        pyGHDL-Windows-x86_64-Python-3.13:pyGHDL-5.0.0.dev0-cp313-cp313-win_amd64.whl:pyGHDL - v5.0.0-dev0 - Wheel for Python 3.13 on Windows (x86-64)
+
 
   ReleasePage:
     uses: pyTooling/Actions/.github/workflows/Release.yml@r2

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -330,31 +330,31 @@ jobs:
         * Platform specific Python wheel package for Windows incl. `pyGHDL...dll`
       prerelease: true
       assets: |
-        ghdl-macos-13-x86_64-llvm:            !ghdl-llvm-5.0.0.dev0-macos13-x86_64.tgz:                        GHDL - v5.0.0-dev0 - llvm backend for macOS 13 (x86-64)
-        ghdl-macos-13-x86_64-mcode:           !ghdl-mcode-5.0.0.dev0-macos13-x86_64.tgz:                       GHDL - v5.0.0-dev0 - mcode backend for macOS 13 (x86-64)
-        ghdl-macos-14-aarch64-llvm:           !ghdl-llvm-5.0.0.dev0-macos14-aarch64.tgz:                       GHDL - v5.0.0-dev0 - llvm backend for macOS 14 (aarch64)
-        ghdl-macos-14-aarch64-llvm-jit:       !ghdl-llvm-jit-5.0.0.dev0-macos14-aarch64.tgz:                   GHDL - v5.0.0-dev0 - llvm-jit backend for macOS 14 (aarch64)
-        ghdl-ubuntu-24.04-x86_64-llvm:        !ghdl-llvm-5.0.0.dev0-ubuntu24.04-x86_64.tgz:                    GHDL - v5.0.0-dev0 - llvm backend for Ubuntu 24.04 LTS (x86-64)
-        ghdl-ubuntu-24.04-x86_64-llvm-jit:    !ghdl-llvm-jit-5.0.0.dev0-ubuntu24.04-x86_64.tgz:                GHDL - v5.0.0-dev0 - llvm-jit backend for Ubuntu 24.04 LTS (x86-64)
-        ghdl-ubuntu-24.04-x86_64-mcode:       !ghdl-mcode-5.0.0.dev0-ubuntu24.04-x86_64.tgz:                   GHDL - v5.0.0-dev0 - mcode backend for Ubuntu 24.04 LTS (x86-64)
-        ghdl-Pacman-mingw64-llvm:              mingw-w64-x86_64-ghdl-llvm-5.0.0.dev-1-any.pkg.tar.zst:         GHDL - v5.0.0-dev0 - LLVM backend for MSYS2/MinGW64
-        ghdl-Pacman-mingw64-llvm-jit:          mingw-w64-x86_64-ghdl-llvm-jit-5.0.0.dev-1-any.pkg.tar.zst:     GHDL - v5.0.0-dev0 - LLVM-JIT backend for MSYS2/MinGW64
-        ghdl-Pacman-mingw64-mcode:             mingw-w64-x86_64-ghdl-mcode-5.0.0.dev-1-any.pkg.tar.zst:        GHDL - v5.0.0-dev0 - mcode backend for MSYS2/MinGW64
-        ghdl-Pacman-ucrt64-llvm:               mingw-w64-ucrt-x86_64-ghdl-llvm-5.0.0.dev-1-any.pkg.tar.zst:    GHDL - v5.0.0-dev0 - LLVM backend for MSYS2/UCRT64
-        ghdl-Pacman-ucrt64-llvm-jit:           mingw-w64-ucrt-x86_64-ghdl-llvm-jit-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev0 - LLVM-JIT backend for MSYS2/UCRT64
-        ghdl-Pacman-ucrt64-mcode:              mingw-w64-ucrt-x86_64-ghdl-mcode-5.0.0.dev-1-any.pkg.tar.zst:   GHDL - v5.0.0-dev0 - mcode backend for MSYS2/UCRT64
-        ghdl-Windows-mingw64-mcode:           !ghdl-mcode-5.0.0.dev0-mingw64.zip:                              GHDL - v5.0.0-dev0 - mcode backend for Windows (x86-64, MinGW64)
-        ghdl-Windows-ucrt64-mcode:            !ghdl-mcode-5.0.0.dev0-ucrt64.zip:                               GHDL - v5.0.0-dev0 - mcode backend for Windows (x86-64, UCRT64)
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.9: pyGHDL-5.0.0.dev0-cp39-cp39-linux_x86_64.whl:                   pyGHDL - v5.0.0-dev0 - Wheel for Python 3.9 on Ubuntu 24.04 (x86-64)
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.10:pyGHDL-5.0.0.dev0-cp310-cp310-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev0 - Wheel for Python 3.10 on Ubuntu 24.04 (x86-64)
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.11:pyGHDL-5.0.0.dev0-cp311-cp311-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev0 - Wheel for Python 3.11 on Ubuntu 24.04 (x86-64)
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.12:pyGHDL-5.0.0.dev0-cp312-cp312-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev0 - Wheel for Python 3.12 on Ubuntu 24.04 (x86-64)
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.13:pyGHDL-5.0.0.dev0-cp313-cp313-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev0 - Wheel for Python 3.13 on Ubuntu 24.04 (x86-64)
-        pyGHDL-Windows-x86_64-Python-3.9:      pyGHDL-5.0.0.dev0-cp39-cp39-win_amd64.whl:                      pyGHDL - v5.0.0-dev0 - Wheel for Python 3.9 on Windows (x86-64)
-        pyGHDL-Windows-x86_64-Python-3.10:     pyGHDL-5.0.0.dev0-cp310-cp310-win_amd64.whl:                    pyGHDL - v5.0.0-dev0 - Wheel for Python 3.10 on Windows (x86-64)
-        pyGHDL-Windows-x86_64-Python-3.11:     pyGHDL-5.0.0.dev0-cp311-cp311-win_amd64.whl:                    pyGHDL - v5.0.0-dev0 - Wheel for Python 3.11 on Windows (x86-64)
-        pyGHDL-Windows-x86_64-Python-3.12:     pyGHDL-5.0.0.dev0-cp312-cp312-win_amd64.whl:                    pyGHDL - v5.0.0-dev0 - Wheel for Python 3.12 on Windows (x86-64)
-        pyGHDL-Windows-x86_64-Python-3.13:     pyGHDL-5.0.0.dev0-cp313-cp313-win_amd64.whl:                    pyGHDL - v5.0.0-dev0 - Wheel for Python 3.13 on Windows (x86-64)
+        ghdl-macos-13-x86_64-llvm:            !ghdl-llvm-5.0.0.dev0-macos13-x86_64.tgz:                        GHDL - v5.0.0-dev - macOS 13 (x86-64) - llvm backend
+        ghdl-macos-13-x86_64-mcode:           !ghdl-mcode-5.0.0.dev0-macos13-x86_64.tgz:                       GHDL - v5.0.0-dev - macOS 13 (x86-64) - mcode backend
+        ghdl-macos-14-aarch64-llvm:           !ghdl-llvm-5.0.0.dev0-macos14-aarch64.tgz:                       GHDL - v5.0.0-dev - macOS 14 (aarch64) - llvm backend
+        ghdl-macos-14-aarch64-llvm-jit:       !ghdl-llvm-jit-5.0.0.dev0-macos14-aarch64.tgz:                   GHDL - v5.0.0-dev - macOS 14 (aarch64) - llvm-jit backend
+        ghdl-ubuntu-24.04-x86_64-llvm:        !ghdl-llvm-5.0.0.dev0-ubuntu24.04-x86_64.tgz:                    GHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - llvm backend
+        ghdl-ubuntu-24.04-x86_64-llvm-jit:    !ghdl-llvm-jit-5.0.0.dev0-ubuntu24.04-x86_64.tgz:                GHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - llvm-jit backend
+        ghdl-ubuntu-24.04-x86_64-mcode:       !ghdl-mcode-5.0.0.dev0-ubuntu24.04-x86_64.tgz:                   GHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - mcode backend
+        ghdl-Pacman-mingw64-llvm:              mingw-w64-x86_64-ghdl-llvm-5.0.0.dev-1-any.pkg.tar.zst:         GHDL - v5.0.0-dev - MSYS2/MinGW64 - LLVM backend
+        ghdl-Pacman-mingw64-llvm-jit:          mingw-w64-x86_64-ghdl-llvm-jit-5.0.0.dev-1-any.pkg.tar.zst:     GHDL - v5.0.0-dev - MSYS2/MinGW64 - LLVM-JIT backend
+        ghdl-Pacman-mingw64-mcode:             mingw-w64-x86_64-ghdl-mcode-5.0.0.dev-1-any.pkg.tar.zst:        GHDL - v5.0.0-dev - MSYS2/MinGW64 - mcode backend
+        ghdl-Pacman-ucrt64-llvm:               mingw-w64-ucrt-x86_64-ghdl-llvm-5.0.0.dev-1-any.pkg.tar.zst:    GHDL - v5.0.0-dev - MSYS2/UCRT64 - LLVM backend
+        ghdl-Pacman-ucrt64-llvm-jit:           mingw-w64-ucrt-x86_64-ghdl-llvm-jit-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev - MSYS2/UCRT64 - LLVM-JIT backend
+        ghdl-Pacman-ucrt64-mcode:              mingw-w64-ucrt-x86_64-ghdl-mcode-5.0.0.dev-1-any.pkg.tar.zst:   GHDL - v5.0.0-dev - MSYS2/UCRT64 - mcode backend
+        ghdl-Windows-mingw64-mcode:           !ghdl-mcode-5.0.0.dev0-mingw64.zip:                              GHDL - v5.0.0-dev - Windows (x86-64, MinGW64, standalone) - mcode backend
+        ghdl-Windows-ucrt64-mcode:            !ghdl-mcode-5.0.0.dev0-ucrt64.zip:                               GHDL - v5.0.0-dev - Windows (x86-64, UCRT64, standalone) - mcode backend
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.9: pyGHDL-5.0.0.dev0-cp39-cp39-linux_x86_64.whl:                   pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.9
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.10:pyGHDL-5.0.0.dev0-cp310-cp310-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.10
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.11:pyGHDL-5.0.0.dev0-cp311-cp311-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.11
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.12:pyGHDL-5.0.0.dev0-cp312-cp312-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.12
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.13:pyGHDL-5.0.0.dev0-cp313-cp313-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.13
+        pyGHDL-Windows-x86_64-Python-3.9:      pyGHDL-5.0.0.dev0-cp39-cp39-win_amd64.whl:                      pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.9
+        pyGHDL-Windows-x86_64-Python-3.10:     pyGHDL-5.0.0.dev0-cp310-cp310-win_amd64.whl:                    pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.10
+        pyGHDL-Windows-x86_64-Python-3.11:     pyGHDL-5.0.0.dev0-cp311-cp311-win_amd64.whl:                    pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.11
+        pyGHDL-Windows-x86_64-Python-3.12:     pyGHDL-5.0.0.dev0-cp312-cp312-win_amd64.whl:                    pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.12
+        pyGHDL-Windows-x86_64-Python-3.13:     pyGHDL-5.0.0.dev0-cp313-cp313-win_amd64.whl:                    pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.13
 
 
   ReleasePage:


### PR DESCRIPTION
This PR enhances the upload of pipeline artifacts from "nightly" tagged builds as assets to the "nightly" release page.

Pipeline to review for tag `testing`: https://github.com/Paebbels/ghdl/actions/runs/12056535122  
Matching release page `testing`: https://github.com/Paebbels/ghdl/releases/tag/testing

**Features:**
* run "Nightly" job only on tagged pipeline runs
* Set name of the release: "nightly"
* Set artifacts to upload as assets (release attachments)
  * Format: `artifact:asset:title`
  * Asset names can contain leading whitespace, which will be trimmed
  * Titles can contain leading whitespace, which will be trimmed
  * Asset names starting with ! and ending with zip e.g. `!document.zip` will result in a compressed archive of the mentioned artifact.
  * Similar for tar/gz using `"!document.tgz`
  * A release can be configured as: draft, prerelease, latest
  * A description can be gives as a multi-line YAML string (Markdown).
  * The release page contains a link to the publishing pipeline, the triggering person and the datetime.

**Examples:**
1. uploading macOS 13 build results:  
   ```
   ghdl-macos-13-x86_64-llvm:!ghdl-llvm-5.0.0.dev0-macos13-x86_64.tgz:GHDL - v5.0.0-dev0 - llvm backend for macOS 13 (x86-64)
   ```
2. uploading Python wheel files:  
   ```
   pyGHDL-Ubuntu-24.04-x86_64-Python-3.9:  pyGHDL-5.0.0.dev0-cp39-cp39-linux_x86_64.whl:   pyGHDL - v5.0.0-dev0 - Wheel for Python 3.9 on Ubuntu 24.04 (x86-64)
   pyGHDL-Ubuntu-24.04-x86_64-Python-3.10: pyGHDL-5.0.0.dev0-cp310-cp310-linux_x86_64.whl: pyGHDL - v5.0.0-dev0 - Wheel for Python 3.10 on Ubuntu 24.04 (x86-64)
   ```