### PR TITLE
Pipeline finetuning

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -298,12 +298,8 @@ jobs:
       - Ubuntu
       - Windows-fast
       - Windows
-      - PublishToGitHubPages
       - Python
-      - StaticTypeCheck
-      - DocCoverage
-      - PublishCoverageResults
-      - PublishTestResults
+#      - Sphinx
     if: github.ref == 'refs/tags/nightly'
     secrets: inherit
     permissions:
@@ -342,31 +338,31 @@ jobs:
         * Platform specific Python wheel package for Windows incl. `pyGHDL...dll`
       prerelease: true
       assets: |
-        ghdl-macos-13-x86_64-llvm:            !ghdl-llvm-5.0.0-dev-macos13-x86_64.tgz:                         GHDL - v5.0.0-dev - macOS 13 (x86-64) - llvm backend
-        ghdl-macos-13-x86_64-mcode:           !ghdl-mcode-5.0.0-dev-macos13-x86_64.tgz:                        GHDL - v5.0.0-dev - macOS 13 (x86-64) - mcode backend
-        ghdl-macos-14-aarch64-llvm:           !ghdl-llvm-5.0.0-dev-macos14-aarch64.tgz:                        GHDL - v5.0.0-dev - macOS 14 (aarch64) - llvm backend
-        ghdl-macos-14-aarch64-llvm-jit:       !ghdl-llvm-jit-5.0.0-dev-macos14-aarch64.tgz:                    GHDL - v5.0.0-dev - macOS 14 (aarch64) - llvm-jit backend
-        ghdl-ubuntu-24.04-x86_64-llvm:        !ghdl-llvm-5.0.0-dev-ubuntu24.04-x86_64.tgz:                     GHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - llvm backend
-        ghdl-ubuntu-24.04-x86_64-llvm-jit:    !ghdl-llvm-jit-5.0.0-dev-ubuntu24.04-x86_64.tgz:                 GHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - llvm-jit backend
-        ghdl-ubuntu-24.04-x86_64-mcode:       !ghdl-mcode-5.0.0-dev-ubuntu24.04-x86_64.tgz:                    GHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - mcode backend
-        ghdl-Pacman-mingw64-llvm:              mingw-w64-x86_64-ghdl-llvm-5.0.0.dev-1-any.pkg.tar.zst:         GHDL - v5.0.0-dev - MSYS2/MinGW64 - LLVM backend
-        ghdl-Pacman-mingw64-llvm-jit:          mingw-w64-x86_64-ghdl-llvm-jit-5.0.0.dev-1-any.pkg.tar.zst:     GHDL - v5.0.0-dev - MSYS2/MinGW64 - LLVM-JIT backend
-        ghdl-Pacman-mingw64-mcode:             mingw-w64-x86_64-ghdl-mcode-5.0.0.dev-1-any.pkg.tar.zst:        GHDL - v5.0.0-dev - MSYS2/MinGW64 - mcode backend
-        ghdl-Pacman-ucrt64-llvm:               mingw-w64-ucrt-x86_64-ghdl-llvm-5.0.0.dev-1-any.pkg.tar.zst:    GHDL - v5.0.0-dev - MSYS2/UCRT64 - LLVM backend
-        ghdl-Pacman-ucrt64-llvm-jit:           mingw-w64-ucrt-x86_64-ghdl-llvm-jit-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev - MSYS2/UCRT64 - LLVM-JIT backend
-        ghdl-Pacman-ucrt64-mcode:              mingw-w64-ucrt-x86_64-ghdl-mcode-5.0.0.dev-1-any.pkg.tar.zst:   GHDL - v5.0.0-dev - MSYS2/UCRT64 - mcode backend
-        ghdl-Windows-mingw64-mcode:           !ghdl-mcode-5.0.0-dev-mingw64.zip:                               GHDL - v5.0.0-dev - Windows (x86-64, MinGW64, standalone) - mcode backend
-        ghdl-Windows-ucrt64-mcode:            !ghdl-mcode-5.0.0-dev-ucrt64.zip:                                GHDL - v5.0.0-dev - Windows (x86-64, UCRT64, standalone) - mcode backend
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.9: pyGHDL-5.0.0.dev0-cp39-cp39-linux_x86_64.whl:                   pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.9
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.10:pyGHDL-5.0.0.dev0-cp310-cp310-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.10
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.11:pyGHDL-5.0.0.dev0-cp311-cp311-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.11
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.12:pyGHDL-5.0.0.dev0-cp312-cp312-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.12
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.13:pyGHDL-5.0.0.dev0-cp313-cp313-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.13
-        pyGHDL-Windows-x86_64-Python-3.9:      pyGHDL-5.0.0.dev0-cp39-cp39-win_amd64.whl:                      pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.9
-        pyGHDL-Windows-x86_64-Python-3.10:     pyGHDL-5.0.0.dev0-cp310-cp310-win_amd64.whl:                    pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.10
-        pyGHDL-Windows-x86_64-Python-3.11:     pyGHDL-5.0.0.dev0-cp311-cp311-win_amd64.whl:                    pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.11
-        pyGHDL-Windows-x86_64-Python-3.12:     pyGHDL-5.0.0.dev0-cp312-cp312-win_amd64.whl:                    pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.12
-        pyGHDL-Windows-x86_64-Python-3.13:     pyGHDL-5.0.0.dev0-cp313-cp313-win_amd64.whl:                    pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.13
+        ghdl-macos-13-x86_64-llvm:             $ghdl-llvm-5.0.0-dev-macos13-x86_64.tar.gz:                      GHDL - v5.0.0-dev - macOS 13 (x86-64) - llvm backend
+        ghdl-macos-13-x86_64-mcode:            $ghdl-mcode-5.0.0-dev-macos13-x86_64.tar.gz:                     GHDL - v5.0.0-dev - macOS 13 (x86-64) - mcode backend
+        ghdl-macos-14-aarch64-llvm:            $ghdl-llvm-5.0.0-dev-macos14-aarch64.tar.gz:                     GHDL - v5.0.0-dev - macOS 14 (aarch64) - llvm backend
+        ghdl-macos-14-aarch64-llvm-jit:        $ghdl-llvm-jit-5.0.0-dev-macos14-aarch64.tar.gz:                 GHDL - v5.0.0-dev - macOS 14 (aarch64) - llvm-jit backend
+        ghdl-ubuntu-24.04-x86_64-llvm:         $ghdl-llvm-5.0.0-dev-ubuntu24.04-x86_64.tar.gz:                  GHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - llvm backend
+        ghdl-ubuntu-24.04-x86_64-llvm-jit:     $ghdl-llvm-jit-5.0.0-dev-ubuntu24.04-x86_64.tar.gz:              GHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - llvm-jit backend
+        ghdl-ubuntu-24.04-x86_64-mcode:        $ghdl-mcode-5.0.0-dev-ubuntu24.04-x86_64.tar.gz:                 GHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - mcode backend
+        ghdl-Pacman-mingw64-llvm:               mingw-w64-x86_64-ghdl-llvm-5.0.0.dev-1-any.pkg.tar.zst:         GHDL - v5.0.0-dev - MSYS2/MinGW64 - LLVM backend
+        ghdl-Pacman-mingw64-llvm-jit:           mingw-w64-x86_64-ghdl-llvm-jit-5.0.0.dev-1-any.pkg.tar.zst:     GHDL - v5.0.0-dev - MSYS2/MinGW64 - LLVM-JIT backend
+        ghdl-Pacman-mingw64-mcode:              mingw-w64-x86_64-ghdl-mcode-5.0.0.dev-1-any.pkg.tar.zst:        GHDL - v5.0.0-dev - MSYS2/MinGW64 - mcode backend
+        ghdl-Pacman-ucrt64-llvm:                mingw-w64-ucrt-x86_64-ghdl-llvm-5.0.0.dev-1-any.pkg.tar.zst:    GHDL - v5.0.0-dev - MSYS2/UCRT64 - LLVM backend
+        ghdl-Pacman-ucrt64-llvm-jit:            mingw-w64-ucrt-x86_64-ghdl-llvm-jit-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev - MSYS2/UCRT64 - LLVM-JIT backend
+        ghdl-Pacman-ucrt64-mcode:               mingw-w64-ucrt-x86_64-ghdl-mcode-5.0.0.dev-1-any.pkg.tar.zst:   GHDL - v5.0.0-dev - MSYS2/UCRT64 - mcode backend
+        ghdl-Windows-mingw64-mcode:            !ghdl-mcode-5.0.0-dev-mingw64.zip:                               GHDL - v5.0.0-dev - Windows (x86-64, MinGW64, standalone) - mcode backend
+        ghdl-Windows-ucrt64-mcode:             !ghdl-mcode-5.0.0-dev-ucrt64.zip:                                GHDL - v5.0.0-dev - Windows (x86-64, UCRT64, standalone) - mcode backend
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.9:  pyGHDL-5.0.0.dev0-cp39-cp39-linux_x86_64.whl:                   pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.9
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.10: pyGHDL-5.0.0.dev0-cp310-cp310-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.10
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.11: pyGHDL-5.0.0.dev0-cp311-cp311-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.11
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.12: pyGHDL-5.0.0.dev0-cp312-cp312-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.12
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.13: pyGHDL-5.0.0.dev0-cp313-cp313-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.13
+        pyGHDL-Windows-x86_64-Python-3.9:       pyGHDL-5.0.0.dev0-cp39-cp39-win_amd64.whl:                      pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.9
+        pyGHDL-Windows-x86_64-Python-3.10:      pyGHDL-5.0.0.dev0-cp310-cp310-win_amd64.whl:                    pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.10
+        pyGHDL-Windows-x86_64-Python-3.11:      pyGHDL-5.0.0.dev0-cp311-cp311-win_amd64.whl:                    pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.11
+        pyGHDL-Windows-x86_64-Python-3.12:      pyGHDL-5.0.0.dev0-cp312-cp312-win_amd64.whl:                    pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.12
+        pyGHDL-Windows-x86_64-Python-3.13:      pyGHDL-5.0.0.dev0-cp313-cp313-win_amd64.whl:                    pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.13
 
 
   ReleasePage:


### PR DESCRIPTION
Currently, TAR/GZ archives have `bin`, `lib`, ... as root directories in the tarball.

As I learned today, a convention enforces archive creates to add a single root-directory into the tarball, which has the same name as the archive, so at decompression, users don't need to create a directory.

> I my opinion this is a still and almost dumb convention, we need to follow this convention ...

Therefore, the job template used in the pipeline supports a new mode, so artifacts packages as an archive can be packaged with such a single root-directory.

**Modifications:**
* Renamed `*.tgz` to `*.tar.gz` (this will match the files from MSYS2/Pacman `*.tar.zst`.
* Package macOS and Ubuntu build results in TAR/GZ archives with a single root-directory.
