### PR TITLE
Replace hardcoded versions with placeholders.

### DIFF
--- a/.github/workflows/Package-Docker.yml
+++ b/.github/workflows/Package-Docker.yml
@@ -84,7 +84,7 @@ jobs:
             --tag "ghdl:current" \
             ./dist/docker
 
-          echo "Docker image 'ghdl:current' has $(docker image inspect $1 --format='{{.Size}}' | numfmt --to=iec --format '%.2f' ${image})"
+          echo "Docker image 'ghdl:current' has $(docker image inspect ghdl:current --format='{{.Size}}' | numfmt --to=iec --format '%.2f')"
 
       - name: ☑ Checking GHDL image 'ghdl:current'
         run: |
@@ -95,7 +95,8 @@ jobs:
         run: |
           echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u ${{ vars.DOCKERHUB_USERNAME }} --password-stdin
           docker image tag ghdl:current ${{ steps.build.outputs.ghdl_image }}
-          echo "Docker image '${{ steps.build.outputs.ghdl_image }}' has $(docker image inspect $1 --format='{{.Size}}' | numfmt --to=iec --format '%.2f' ${{ steps.build.outputs.ghdl_image }})"
+
+          echo "Docker image '${{ steps.build.outputs.ghdl_image }}' has $(docker image inspect ${{ steps.build.outputs.ghdl_image }} --format='{{.Size}}' | numfmt --to=iec --format '%.2f')"
           docker image push ${{ steps.build.outputs.ghdl_image }}
 
       - name: 🚦 Testing GHDL image

--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -31,6 +31,15 @@ on:
         type: string
 
     outputs:
+      ghdl_version:
+        description: "GHDL's version."
+        value: ${{ jobs.Parameters.outputs.ghdl_version }}
+      pyghdl_version:
+        description: "pyGHDL's version."
+        value: ${{ jobs.Parameters.outputs.pyghdl_version }}
+      pacghdl_version:
+        description: "GHDL's version for MSYS2."
+        value: ${{ jobs.Parameters.outputs.pacghdl_version }}
       ghdl_basename:
         description: "Artifact basename for GHDL."
         value: ${{ inputs.package_name }}
@@ -48,9 +57,15 @@ jobs:
   Parameters:
     runs-on: ${{ inputs.ubuntu_image }}
     outputs:
-      testsuites: ${{ steps.params.outputs.testsuites }}
+      testsuites:      ${{ steps.params.outputs.testsuites }}
+      ghdl_version:    ${{ steps.params.outputs.ghdl_version }}
+      pyghdl_version:  ${{ steps.params.outputs.pyghdl_version }}
+      pacghdl_version: ${{ steps.params.outputs.pacghdl_version }}
 
     steps:
+      - name: '⏬ Checkout'
+        uses: actions/checkout@v4
+
       - name: Generate 'params' and 'python_jobs'
         id: params
         run: |
@@ -59,3 +74,23 @@ jobs:
           else
             echo "testsuites=${{ inputs.testsuites }}" >> $GITHUB_OUTPUT
           fi
+
+          ghdl_version=$(grep "^ghdl_version=\".*\"$" ./configure)
+          ghdl_version=${ghdl_version/ghdl_version=/}
+          ghdl_version=${ghdl_version//\"/}
+          echo "GHDL version: $ghdl_version"
+          echo "ghdl_version=$ghdl_version" >> $GITHUB_OUTPUT
+
+          pyghdl_version=${ghdl_version/-dev/.dev0}
+          echo "pyghdl_version=$pyghdl_version" >> $GITHUB_OUTPUT
+
+          pacghdl_version=${ghdl_version/-dev/.dev-1}
+          echo "pacghdl_version=$pacghdl_version" >> $GITHUB_OUTPUT
+
+          cat $GITHUB_OUTPUT
+
+      - name: Check variables
+        run: |
+          echo "ghdl_version:    ${{ steps.params.outputs.ghdl_version }}"
+          echo "pyghdl_version:  ${{ steps.params.outputs.pyghdl_version }}"
+          echo "pacghdl_version: ${{ steps.params.outputs.pacghdl_version }}"

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -293,6 +293,7 @@ jobs:
   Nightly:
     uses: pyTooling/Actions/.github/workflows/NightlyRelease.yml@dev
     needs:
+      - Params
       - macOS
       - Ubuntu-fast
       - Ubuntu
@@ -307,11 +308,16 @@ jobs:
       actions: write
       attestations: write
     with:
+      prerelease: true
+      replacements: |
+        ghdl=${{ needs.Params.outputs.ghdl_version }}
+        pyghdl=${{ needs.Params.outputs.pyghdl_version }}
+        pacghdl=${{ needs.Params.outputs.pacghdl_version }}
       nightly_name: nightly
       nightly_description: |
         This *nightly* release contains all latest and important artifacts created by GHDL's CI pipeline.
 
-        # GHDL 5.0.0-dev
+        # GHDL ${{ needs.Params.outputs.ghdl_version }}
 
         GHDL offers the simulator and synthesis tool for VHDL. GHDL can be build for various backends:
         * `gcc` - using the GCC compiler framework
@@ -326,7 +332,7 @@ jobs:
         * Windows builds for standalone usage (without MSYS2) as ZIP file
         * MSYS2 packages as TAR/ZST file
 
-        # pyGHDL 5.0.0-dev
+        # pyGHDL ${{ needs.Params.outputs.ghdl_version }}
 
         The Python package `pyGHDL` offers Python binding (`pyGHDL.libghdl`) to a `libghdl` shared library (`*.so`/`*.dll`).
         In addition to the low-level binding layer, pyGHDL offers:
@@ -336,33 +342,32 @@ jobs:
         The following asset categories are provided for pyGHDL:
         * Platform specific Python wheel package for Ubuntu incl. `pyGHDL...so`
         * Platform specific Python wheel package for Windows incl. `pyGHDL...dll`
-      prerelease: true
       assets: |
-        ghdl-macos-13-x86_64-llvm:             $ghdl-llvm-5.0.0-dev-macos13-x86_64.tar.gz:                      GHDL - v5.0.0-dev - macOS 13 (x86-64) - llvm backend
-        ghdl-macos-13-x86_64-mcode:            $ghdl-mcode-5.0.0-dev-macos13-x86_64.tar.gz:                     GHDL - v5.0.0-dev - macOS 13 (x86-64) - mcode backend
-        ghdl-macos-14-aarch64-llvm:            $ghdl-llvm-5.0.0-dev-macos14-aarch64.tar.gz:                     GHDL - v5.0.0-dev - macOS 14 (aarch64) - llvm backend
-        ghdl-macos-14-aarch64-llvm-jit:        $ghdl-llvm-jit-5.0.0-dev-macos14-aarch64.tar.gz:                 GHDL - v5.0.0-dev - macOS 14 (aarch64) - llvm-jit backend
-        ghdl-ubuntu-24.04-x86_64-llvm:         $ghdl-llvm-5.0.0-dev-ubuntu24.04-x86_64.tar.gz:                  GHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - llvm backend
-        ghdl-ubuntu-24.04-x86_64-llvm-jit:     $ghdl-llvm-jit-5.0.0-dev-ubuntu24.04-x86_64.tar.gz:              GHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - llvm-jit backend
-        ghdl-ubuntu-24.04-x86_64-mcode:        $ghdl-mcode-5.0.0-dev-ubuntu24.04-x86_64.tar.gz:                 GHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - mcode backend
-        ghdl-Pacman-mingw64-llvm:               mingw-w64-x86_64-ghdl-llvm-5.0.0.dev-1-any.pkg.tar.zst:         GHDL - v5.0.0-dev - MSYS2/MinGW64 - LLVM backend
-        ghdl-Pacman-mingw64-llvm-jit:           mingw-w64-x86_64-ghdl-llvm-jit-5.0.0.dev-1-any.pkg.tar.zst:     GHDL - v5.0.0-dev - MSYS2/MinGW64 - LLVM-JIT backend
-        ghdl-Pacman-mingw64-mcode:              mingw-w64-x86_64-ghdl-mcode-5.0.0.dev-1-any.pkg.tar.zst:        GHDL - v5.0.0-dev - MSYS2/MinGW64 - mcode backend
-        ghdl-Pacman-ucrt64-llvm:                mingw-w64-ucrt-x86_64-ghdl-llvm-5.0.0.dev-1-any.pkg.tar.zst:    GHDL - v5.0.0-dev - MSYS2/UCRT64 - LLVM backend
-        ghdl-Pacman-ucrt64-llvm-jit:            mingw-w64-ucrt-x86_64-ghdl-llvm-jit-5.0.0.dev-1-any.pkg.tar.zst:GHDL - v5.0.0-dev - MSYS2/UCRT64 - LLVM-JIT backend
-        ghdl-Pacman-ucrt64-mcode:               mingw-w64-ucrt-x86_64-ghdl-mcode-5.0.0.dev-1-any.pkg.tar.zst:   GHDL - v5.0.0-dev - MSYS2/UCRT64 - mcode backend
-        ghdl-Windows-mingw64-mcode:            !ghdl-mcode-5.0.0-dev-mingw64.zip:                               GHDL - v5.0.0-dev - Windows (x86-64, MinGW64, standalone) - mcode backend
-        ghdl-Windows-ucrt64-mcode:             !ghdl-mcode-5.0.0-dev-ucrt64.zip:                                GHDL - v5.0.0-dev - Windows (x86-64, UCRT64, standalone) - mcode backend
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.9:  pyGHDL-5.0.0.dev0-cp39-cp39-linux_x86_64.whl:                   pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.9
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.10: pyGHDL-5.0.0.dev0-cp310-cp310-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.10
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.11: pyGHDL-5.0.0.dev0-cp311-cp311-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.11
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.12: pyGHDL-5.0.0.dev0-cp312-cp312-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.12
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.13: pyGHDL-5.0.0.dev0-cp313-cp313-linux_x86_64.whl:                 pyGHDL - v5.0.0-dev - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.13
-        pyGHDL-Windows-x86_64-Python-3.9:       pyGHDL-5.0.0.dev0-cp39-cp39-win_amd64.whl:                      pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.9
-        pyGHDL-Windows-x86_64-Python-3.10:      pyGHDL-5.0.0.dev0-cp310-cp310-win_amd64.whl:                    pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.10
-        pyGHDL-Windows-x86_64-Python-3.11:      pyGHDL-5.0.0.dev0-cp311-cp311-win_amd64.whl:                    pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.11
-        pyGHDL-Windows-x86_64-Python-3.12:      pyGHDL-5.0.0.dev0-cp312-cp312-win_amd64.whl:                    pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.12
-        pyGHDL-Windows-x86_64-Python-3.13:      pyGHDL-5.0.0.dev0-cp313-cp313-win_amd64.whl:                    pyGHDL - v5.0.0-dev - Windows (x86-64) - Wheel for Python 3.13
+        ghdl-macos-13-x86_64-llvm:             $ghdl-llvm-%ghdl%-macos13-x86_64.tar.gz:                       GHDL - v%ghdl% - macOS 13 (x86-64) - llvm backend
+        ghdl-macos-13-x86_64-mcode:            $ghdl-mcode-%ghdl%-macos13-x86_64.tar.gz:                      GHDL - v%ghdl% - macOS 13 (x86-64) - mcode backend
+        ghdl-macos-14-aarch64-llvm:            $ghdl-llvm-%ghdl%-macos14-aarch64.tar.gz:                      GHDL - v%ghdl% - macOS 14 (aarch64) - llvm backend
+        ghdl-macos-14-aarch64-llvm-jit:        $ghdl-llvm-jit-%ghdl%-macos14-aarch64.tar.gz:                  GHDL - v%ghdl% - macOS 14 (aarch64) - llvm-jit backend
+        ghdl-ubuntu-24.04-x86_64-llvm:         $ghdl-llvm-%ghdl%-ubuntu24.04-x86_64.tar.gz:                   GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - llvm backend
+        ghdl-ubuntu-24.04-x86_64-llvm-jit:     $ghdl-llvm-jit-%ghdl%-ubuntu24.04-x86_64.tar.gz:               GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - llvm-jit backend
+        ghdl-ubuntu-24.04-x86_64-mcode:        $ghdl-mcode-%ghdl%-ubuntu24.04-x86_64.tar.gz:                  GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - mcode backend
+        ghdl-Pacman-mingw64-llvm:               mingw-w64-x86_64-ghdl-llvm-%pacghdl%-any.pkg.tar.zst:         GHDL - v%ghdl% - MSYS2/MinGW64 - LLVM backend
+        ghdl-Pacman-mingw64-llvm-jit:           mingw-w64-x86_64-ghdl-llvm-jit-%pacghdl%-any.pkg.tar.zst:     GHDL - v%ghdl% - MSYS2/MinGW64 - LLVM-JIT backend
+        ghdl-Pacman-mingw64-mcode:              mingw-w64-x86_64-ghdl-mcode-%pacghdl%-any.pkg.tar.zst:        GHDL - v%ghdl% - MSYS2/MinGW64 - mcode backend
+        ghdl-Pacman-ucrt64-llvm:                mingw-w64-ucrt-x86_64-ghdl-llvm-%pacghdl%-any.pkg.tar.zst:    GHDL - v%ghdl% - MSYS2/UCRT64 - LLVM backend
+        ghdl-Pacman-ucrt64-llvm-jit:            mingw-w64-ucrt-x86_64-ghdl-llvm-jit-%pacghdl%-any.pkg.tar.zst:GHDL - v%ghdl% - MSYS2/UCRT64 - LLVM-JIT backend
+        ghdl-Pacman-ucrt64-mcode:               mingw-w64-ucrt-x86_64-ghdl-mcode-%pacghdl%-any.pkg.tar.zst:   GHDL - v%ghdl% - MSYS2/UCRT64 - mcode backend
+        ghdl-Windows-mingw64-mcode:            !ghdl-mcode-%ghdl%-mingw64.zip:                                GHDL - v%ghdl% - Windows (x86-64, MinGW64, standalone) - mcode backend
+        ghdl-Windows-ucrt64-mcode:             !ghdl-mcode-%ghdl%-ucrt64.zip:                                 GHDL - v%ghdl% - Windows (x86-64, UCRT64, standalone) - mcode backend
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.9:  pyGHDL-%pyghdl%-cp39-cp39-linux_x86_64.whl:                   pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.9
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.10: pyGHDL-%pyghdl%-cp310-cp310-linux_x86_64.whl:                 pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.10
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.11: pyGHDL-%pyghdl%-cp311-cp311-linux_x86_64.whl:                 pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.11
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.12: pyGHDL-%pyghdl%-cp312-cp312-linux_x86_64.whl:                 pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.12
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.13: pyGHDL-%pyghdl%-cp313-cp313-linux_x86_64.whl:                 pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.13
+        pyGHDL-Windows-x86_64-Python-3.9:       pyGHDL-%pyghdl%-cp39-cp39-win_amd64.whl:                      pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.9
+        pyGHDL-Windows-x86_64-Python-3.10:      pyGHDL-%pyghdl%-cp310-cp310-win_amd64.whl:                    pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.10
+        pyGHDL-Windows-x86_64-Python-3.11:      pyGHDL-%pyghdl%-cp311-cp311-win_amd64.whl:                    pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.11
+        pyGHDL-Windows-x86_64-Python-3.12:      pyGHDL-%pyghdl%-cp312-cp312-win_amd64.whl:                    pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.12
+        pyGHDL-Windows-x86_64-Python-3.13:      pyGHDL-%pyghdl%-cp313-cp313-win_amd64.whl:                    pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.13
 
 
   ReleasePage:


### PR DESCRIPTION
This PR will use the latest NightlyRelease job template, which supports replacements.

See evidence of the individual steps:
1. extraction of GHDL's version and formatting for ghdl, pyghdl and pacman:  
   https://github.com/Paebbels/ghdl/actions/runs/12109215420/job/33758082405#step:4:7
   ```
   ghdl_version:    5.0.0-dev
   pyghdl_version:  5.0.0.dev0
   pacghdl_version: 5.0.0.dev-1
   ```
2. Running the pipeline at paebbels/ghdl with tag testing: https://github.com/Paebbels/ghdl/actions/runs/12109731158
3. checking release 'testing': https://github.com/Paebbels/ghdl/releases/tag/testing  
   <img width="939" alt="image" src="https://github.com/user-attachments/assets/6393587a-e453-4c70-b685-9fd0c3136706">
