### PR TITLE
Paebbels/preserve permissions

### DIFF
--- a/.github/workflows/Build-MSYS2.yml
+++ b/.github/workflows/Build-MSYS2.yml
@@ -196,13 +196,14 @@ jobs:
           echo "================================================================================"
 
       - name: 📤 Upload '${{ steps.artifact_name.outputs.pacman_artifact }}' artifact
-        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         if: inputs.pacman_artifact != ''
         with:
           name: ${{ steps.artifact_name.outputs.pacman_artifact }}
-          path: dist/msys2/${{ inputs.backend }}/*.pkg.tar.zst
+          working-directory: dist/msys2/${{ inputs.backend }}
+          path: "*.pkg.tar.zst"
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 7
 
       - name: "🚦 Run testsuite: 'sanity'"
         run: |
@@ -233,13 +234,14 @@ jobs:
           cat ./install/*.requirements
 
       - name: 📤 Upload '${{ steps.artifact_name.outputs.ghdl_artifact }}' artifact
-        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         if: inputs.msys2_artifact != ''
         with:
           name: ${{ steps.artifact_name.outputs.ghdl_artifact }}
-          path: ./install
+          working-directory: install
+          path: "*"
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 7
 
       - name: 🗐 Copy and check dependency (MSYS2) for standalone usage
         if: inputs.backend == 'mcode' && inputs.windows_artifact != ''
@@ -281,13 +283,14 @@ jobs:
           tree ./standalone
 
       - name: 📤 Upload '${{ steps.artifact_name.outputs.windows_artifact }}' artifact
-        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         if: inputs.backend == 'mcode' && inputs.windows_artifact != ''
         with:
           name: ${{ steps.artifact_name.outputs.windows_artifact }}
-          path: ./standalone
+          working-directory: standalone
+          path: "*"
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 7
 
       - name: ✂ Remove binaries, libraries and other files for libghdl
         if: inputs.runtime == 'ucrt64' && inputs.backend == 'mcode'
@@ -331,11 +334,12 @@ jobs:
           done
 
       - name: 📤 Upload '${{ steps.artifact_name.outputs.libghdl_artifact }}' artifact
-        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         if: inputs.runtime == 'ucrt64' && inputs.backend == 'mcode'
         with:
           name: ${{ steps.artifact_name.outputs.libghdl_artifact }}
-          path: ./install
+          working-directory: install
+          path: "*"
           if-no-files-found: error
           retention-days: 1
 
@@ -424,10 +428,11 @@ jobs:
       - name: 📤 Upload 'TestReportSummary.xml' artifact (only mcode backend)
         if: inputs.unittesting && inputs.backend == 'mcode' && inputs.unittest_xml_artifact != ''
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         with:
           name: ${{ inputs.unittest_xml_artifact }}-Windows-${{ inputs.windows_version }}-${{ inputs.runtime }}-${{ inputs.python_version }}
-          path: report/unit/TestReportSummary.xml
+          working-directory: report/unit
+          path: TestReportSummary.xml
           if-no-files-found: error
           retention-days: 1
 
@@ -440,7 +445,7 @@ jobs:
       - name: 📤 Upload 'Coverage SQLite Database' artifact (only mcode backend)
         if: inputs.coverage && inputs.backend == 'mcode' && inputs.coverage_sqlite_artifact != ''
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         with:
           name: ${{ inputs.coverage_sqlite_artifact }}-Windows-${{ inputs.windows_version }}-${{ inputs.runtime }}-${{ inputs.python_version }}
           path: .coverage
@@ -485,7 +490,7 @@ jobs:
           pacboy: "diffutils:p"
 
       - name: 📥 Download artifacts '${{ needs.Build.outputs.pacman_artifact }}' from 'Package' job
-        uses: actions/download-artifact@v4
+        uses: pyTooling/download-artifact@v4
         with:
           name: ${{ needs.Build.outputs.pacman_artifact }}
           path: pacman
@@ -523,7 +528,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 📥 Download artifacts '${{ needs.Build.outputs.windows_artifact }}' from 'Package' job
-        uses: actions/download-artifact@v4
+        uses: pyTooling/download-artifact@v4
         with:
           name: ${{ needs.Build.outputs.windows_artifact }}
           path: install

--- a/.github/workflows/Build-MSYS2.yml
+++ b/.github/workflows/Build-MSYS2.yml
@@ -196,12 +196,11 @@ jobs:
           echo "================================================================================"
 
       - name: 📤 Upload '${{ steps.artifact_name.outputs.pacman_artifact }}' artifact
-        uses: pyTooling/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         if: inputs.pacman_artifact != ''
         with:
           name: ${{ steps.artifact_name.outputs.pacman_artifact }}
-          working-directory: dist/msys2/${{ inputs.backend }}
-          path: "*.pkg.tar.zst"
+          path: dist/msys2/${{ inputs.backend }}/*.pkg.tar.zst
           if-no-files-found: error
           retention-days: 7
 

--- a/.github/workflows/Build-MacOS.yml
+++ b/.github/workflows/Build-MacOS.yml
@@ -204,12 +204,15 @@ jobs:
           ./testsuite.sh sanity
 
       - name: 📤 Upload '${{ inputs.macos_artifact }}-${{ inputs.backend }}' artifact
-        uses: actions/upload-artifact@v4
+#        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         with:
           name: ${{ inputs.macos_artifact }}-${{ inputs.backend }}
-          path: ./install
+          working-directory: install
+          path: "*"
+#          path: install
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 7
 
       - name: ✂ Remove binaries, libraries and other files for libghdl (only mcode backend)
         if: inputs.macos_image == 'macos-13' && inputs.backend == 'mcode'
@@ -309,10 +312,13 @@ jobs:
       - name: 📤 Upload 'TestReportSummary.xml' artifact (only mcode backend)
         if: inputs.unittesting && inputs.backend == 'mcode' && inputs.unittest_xml_artifact != ''
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+#        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         with:
           name: ${{ inputs.unittest_xml_artifact }}-${{ inputs.macos_image }}-${{ inputs.python_version }}
-          path: report/unit/TestReportSummary.xml
+          working-directory: report/unit
+          path: TestReportSummary.xml
+#          path: report/unit/TestReportSummary.xml
           if-no-files-found: error
           retention-days: 1
 
@@ -325,7 +331,8 @@ jobs:
       - name: 📤 Upload 'Coverage SQLite Database' artifact (only mcode backend)
         if: inputs.coverage && inputs.backend == 'mcode' && inputs.coverage_sqlite_artifact != ''
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+#        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         with:
           name: ${{ inputs.coverage_sqlite_artifact }}-${{ inputs.macos_image }}-${{ inputs.python_version }}
           path: .coverage

--- a/.github/workflows/Build-Ubuntu.yml
+++ b/.github/workflows/Build-Ubuntu.yml
@@ -284,13 +284,14 @@ jobs:
           ./testsuite.sh sanity
 
       - name: 📤 Upload '${{ steps.artifact_name.outputs.ghdl_artifact }}' artifact
-        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         if: inputs.ubuntu_artifact != ''
         with:
           name: ${{ steps.artifact_name.outputs.ghdl_artifact }}
-          path: ./install
+          working-directory: install
+          path: "*"
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 7
 
       - name: ✂ Remove binaries, libraries and other files for libghdl (only mcode backend)
         if: inputs.ubuntu_version == '24.04' && inputs.backend == 'mcode'
@@ -312,13 +313,14 @@ jobs:
           cp -v /lib/x86_64-linux-gnu/libgnat-${{ steps.requirements.outputs.GNAT_MAJOR_VERSION }}.so ./install/lib
 
       - name: 📤 Upload '${{ steps.artifact_name.outputs.libghdl_artifact }}' artifact (only mcode backend)
-        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         if: inputs.ubuntu_version == '24.04' && inputs.backend == 'mcode'
         with:
           name: ${{ steps.artifact_name.outputs.libghdl_artifact }}
-          path: ./install
+          working-directory: install
+          path: "*"
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 7
 
       - name: Install libghdl into pyGHDL/lib (only mcode backend)
         if: (inputs.unittesting || inputs.coverage) && inputs.backend == 'mcode'
@@ -405,10 +407,11 @@ jobs:
       - name: 📤 Upload 'TestReportSummary.xml' artifact (only mcode backend)
         if: inputs.unittesting && inputs.backend == 'mcode' && inputs.unittest_xml_artifact != ''
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         with:
           name: ${{ inputs.unittest_xml_artifact }}-Ubuntu-${{ inputs.ubuntu_version }}-${{ inputs.python_version }}
-          path: report/unit/TestReportSummary.xml
+          working-directory: report/unit
+          path: TestReportSummary.xml
           if-no-files-found: error
           retention-days: 1
 
@@ -421,7 +424,7 @@ jobs:
       - name: 📤 Upload 'Coverage SQLite Database' artifact (only mcode backend)
         if: inputs.coverage && inputs.backend == 'mcode' && inputs.coverage_sqlite_artifact != ''
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         with:
           name: ${{ inputs.coverage_sqlite_artifact }}-Ubuntu-${{ inputs.ubuntu_version }}-${{ inputs.python_version }}
           path: .coverage

--- a/.github/workflows/Documentation-GNAT.yml
+++ b/.github/workflows/Documentation-GNAT.yml
@@ -46,8 +46,9 @@ jobs:
           ls -lAh gnat*
 
       - name: "📤 Upload artifact: '${{ inputs.html_artifact }}'"
-        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         if: inputs.html_artifact != ''
         with:
           name: ${{ inputs.html_artifact }}
-          path: gnatdoc
+          working-directory: gnatdoc
+          path: "*"

--- a/.github/workflows/Documentation-Sphinx.yml
+++ b/.github/workflows/Documentation-Sphinx.yml
@@ -48,11 +48,11 @@ on:
         type: string
 
 jobs:
-  Sphinx:
-    name: '📓 Sphinx to LaTeX and HTML'
+  HTML:
+    name: '📓 Sphinx to HTML'
     runs-on: ${{ inputs.ubuntu_image }}
 
-    if: inputs.html_artifact != '' || inputs.latex_artifact != ''
+    if: inputs.html_artifact != ''
 
     steps:
       - name: '⏬ Checkout'
@@ -92,18 +92,56 @@ jobs:
           cd ${{ inputs.doc_directory }}
           make html
 
-      - name: '📓 Compile LaTeX documentation'
-        if: inputs.latex_artifact != ''
-        run: |
-          cd ${{ inputs.doc_directory }}
-          make latex
-
       - name: '📤 Upload artifact: HTML'
         uses: actions/upload-artifact@v4
         if: inputs.html_artifact != ''
         with:
           name: ${{ inputs.html_artifact }}
           path: doc/_build/html
+
+  LaTeX:
+    name: '📓 Sphinx to LaTeX'
+    runs-on: ${{ inputs.ubuntu_image }}
+
+    if: inputs.latex_artifact != ''
+
+    steps:
+      - name: '⏬ Checkout'
+        uses: actions/checkout@v4
+
+      - name: 📥 Download artifacts '${{ inputs.ghdl_artifact }}' from 'Build' job
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.ghdl_artifact }}
+          path: install
+
+      - name: Install GHDL (chmod) and prepare test environment
+        run: |
+          chmod +x ./install/bin/*
+          cp -r -v ./install/lib/* pyGHDL/lib
+          sudo xargs --no-run-if-empty -a ./install/ubuntu.requirements -- apt-get install -y --no-install-recommends
+          echo "PATH=$(pwd)/install/bin:$PATH" >> $GITHUB_ENV
+
+      - name: Version check
+        run: |
+          echo "which ghdl: $(which ghdl)"
+          ghdl version
+
+      - name: '🐍 Setup Python'
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: '🔧 Install dependencies'
+        run: |
+          sudo xargs --no-run-if-empty -a ./doc/ubuntu.requirements -- apt-get install -y --no-install-recommends
+          python -m pip install --disable-pip-version-check ${{ inputs.requirements }}
+
+      - name: '📓 Compile LaTeX documentation'
+        if: inputs.latex_artifact != ''
+        run: |
+          cd ${{ inputs.doc_directory }}
+          make latex
 
       - name: '📤 Upload artifact: LaTeX'
         uses: actions/upload-artifact@v4
@@ -112,11 +150,11 @@ jobs:
           name: ${{ inputs.latex_artifact }}
           path: doc/_build/latex
 
-  LaTeX:
+  PDF:
     name: 📓 Converting LaTeX Documentation to PDF
     runs-on: ${{ inputs.ubuntu_image }}
     needs:
-      - Sphinx
+      - LaTeX
 
     if: inputs.latex_artifact != '' && inputs.pdf_artifact != ''
 

--- a/.github/workflows/Documentation-Sphinx.yml
+++ b/.github/workflows/Documentation-Sphinx.yml
@@ -59,14 +59,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 📥 Download artifacts '${{ inputs.ghdl_artifact }}' from 'Build' job
-        uses: actions/download-artifact@v4
+        uses: pyTooling/download-artifact@v4
         with:
           name: ${{ inputs.ghdl_artifact }}
           path: install
 
-      - name: Install GHDL (chmod) and prepare test environment
+      - name: Prepare test environment
         run: |
-          chmod +x ./install/bin/*
           cp -r -v ./install/lib/* pyGHDL/lib
           sudo xargs --no-run-if-empty -a ./install/ubuntu.requirements -- apt-get install -y --no-install-recommends
           echo "PATH=$(pwd)/install/bin:$PATH" >> $GITHUB_ENV
@@ -93,11 +92,12 @@ jobs:
           make html
 
       - name: '📤 Upload artifact: HTML'
-        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         if: inputs.html_artifact != ''
         with:
           name: ${{ inputs.html_artifact }}
-          path: doc/_build/html
+          working-directory: doc/_build/html
+          path: "*"
 
   LaTeX:
     name: '📓 Sphinx to LaTeX'
@@ -110,14 +110,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 📥 Download artifacts '${{ inputs.ghdl_artifact }}' from 'Build' job
-        uses: actions/download-artifact@v4
+        uses: pyTooling/download-artifact@v4
         with:
           name: ${{ inputs.ghdl_artifact }}
           path: install
 
-      - name: Install GHDL (chmod) and prepare test environment
+      - name: Prepare test environment
         run: |
-          chmod +x ./install/bin/*
           cp -r -v ./install/lib/* pyGHDL/lib
           sudo xargs --no-run-if-empty -a ./install/ubuntu.requirements -- apt-get install -y --no-install-recommends
           echo "PATH=$(pwd)/install/bin:$PATH" >> $GITHUB_ENV
@@ -144,11 +143,12 @@ jobs:
           make latex
 
       - name: '📤 Upload artifact: LaTeX'
-        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         if: inputs.latex_artifact != ''
         with:
           name: ${{ inputs.latex_artifact }}
-          path: doc/_build/latex
+          working-directory: doc/_build/latex
+          path: "*"
 
   PDF:
     name: 📓 Converting LaTeX Documentation to PDF
@@ -160,7 +160,7 @@ jobs:
 
     steps:
       - name: 📥 Download artifacts '${{ inputs.latex_artifact }}' from 'Sphinx' job
-        uses: actions/download-artifact@v4
+        uses: pyTooling/download-artifact@v4
         with:
           name: ${{ inputs.latex_artifact }}
           path: latex
@@ -172,10 +172,10 @@ jobs:
           root_file: ${{ inputs.latex_document }}.tex
 
       - name: 📤 Upload 'PDF Documentation' artifact
-        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         if: inputs.pdf_artifact != ''
         with:
           name: ${{ inputs.pdf_artifact }}
           path: ${{ inputs.document }}.pdf
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 7

--- a/.github/workflows/Package-Docker.yml
+++ b/.github/workflows/Package-Docker.yml
@@ -51,10 +51,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 📥 Download artifacts '${{ inputs.ghdl_artifact }}' from 'Build' job
-        uses: actions/download-artifact@v4
+        uses: pyTooling/download-artifact@v4
         with:
           name: ${{ inputs.ghdl_artifact }}
-          path: ./dist/docker/install
+          path: dist/docker/install
 
       - name: 🐋 Building GHDL image
         id: build
@@ -73,8 +73,6 @@ jobs:
           echo "ghdl_image_tag=${image_tag}" >> $GITHUB_OUTPUT
           echo "ghdl_image=${image}" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
-
-          chmod +x ./dist/docker/install/libexec/gcc/*/*/*1 || true
 
           echo "Building docker file './dist/docker/Dockerfile.${base_image}' ..."
           docker buildx build \

--- a/.github/workflows/Package-pyGHDL.yml
+++ b/.github/workflows/Package-pyGHDL.yml
@@ -64,7 +64,7 @@ jobs:
           python -m pip install --disable-pip-version-check "pyTooling[packaging]" wheel
 
       - name: 📥 Download artifacts '${{ inputs.libghdl_artifact }}-${{ inputs.backend }}' from 'Build' job
-        uses: actions/download-artifact@v4
+        uses: pyTooling/download-artifact@v4
         with:
           name: ${{ inputs.libghdl_artifact }}-${{ inputs.backend }}
           path: install
@@ -83,10 +83,11 @@ jobs:
         run: python setup.py bdist_wheel
 
       - name: '📤 Upload artifact: ${{ inputs.pyghdl_artifact }}'
-        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         with:
           name: ${{ inputs.pyghdl_artifact }}
-          path: dist/pyGHDL*.whl
+          working-directory: dist
+          path: pyGHDL*.whl
           if-no-files-found: error
 
   Test:
@@ -143,7 +144,7 @@ jobs:
           python-version: ${{ inputs.python_version }}
 
       - name: 📥 Download artifacts '${{ inputs.pyghdl_artifact }}' from 'Package' job
-        uses: actions/download-artifact@v4
+        uses: pyTooling/download-artifact@v4
         with:
           name: ${{ inputs.pyghdl_artifact }}
           path: wheels
@@ -264,17 +265,18 @@ jobs:
       - name: 📤 Upload 'TestReportSummary.xml' artifact
         if: inputs.unittest_xml_artifact != ''
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         with:
           name: ${{ inputs.unittest_xml_artifact }}-${{ inputs.os_name }}-${{ inputs.python_version }}
-          path: report/unit/TestReportSummary.xml
+          working-directory: report/unit
+          path: TestReportSummary.xml
           if-no-files-found: error
           retention-days: 1
 
 #      - name: 📤 Upload 'Unit Tests HTML Report' artifact
 #        if: inputs.unittest_html_artifact != ''
 #        continue-on-error: true
-#        uses: actions/upload-artifact@v4
+#        uses: pyTooling/upload-artifact@v4
 #        with:
 #          name: ${{ inputs.unittest_html_artifact }}-${{ inputs.python_version }}
 #          path: ${{ steps.getVariables.outputs.unittest_report_html_directory }}

--- a/.github/workflows/Package-pyGHDL.yml
+++ b/.github/workflows/Package-pyGHDL.yml
@@ -83,11 +83,10 @@ jobs:
         run: python setup.py bdist_wheel
 
       - name: '📤 Upload artifact: ${{ inputs.pyghdl_artifact }}'
-        uses: pyTooling/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.pyghdl_artifact }}
-          working-directory: dist
-          path: pyGHDL*.whl
+          path: dist/pyGHDL*.whl
           if-no-files-found: error
 
   Test:

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -5,11 +5,6 @@ on:
   pull_request:
 
 jobs:
-# Building
-#   Ubuntu (x86-64)
-#     mcode + GPL
-#     gcc
-
 # Windows Standalone - ZIP
 #   UCRT64 - llvm
 
@@ -18,9 +13,6 @@ jobs:
 #     Python 3.10
 #     Python 3.11
 #     Python 3.12
-
-# Release Page (on tag)
-#   Assets
 
 # cleanups
 #   libghdl-
@@ -105,11 +97,11 @@ jobs:
 ###       - {'icon': '🐧🟨', 'backend': 'mcode',    'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites     # used by Ubuntu-fast
           - {'icon': '🐧🟨', 'backend': 'llvm',     'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
           - {'icon': '🐧🟨', 'backend': 'llvm-jit', 'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-##        - {'icon': '🐧🟨', 'backend': 'gcc',      'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites     # currently broken
+          - {'icon': '🐧🟨', 'backend': 'gcc',      'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
 ###       - {'icon': '🐧🟩', 'backend': 'mcode',    'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites     # used by Ubuntu-fast
           - {'icon': '🐧🟩', 'backend': 'llvm',     'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
           - {'icon': '🐧🟩', 'backend': 'llvm-jit', 'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-          - {'icon': '🐧🟩', 'backend': 'gcc',      'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites     # currently broken
+          - {'icon': '🐧🟩', 'backend': 'gcc',      'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
     with:
       ubuntu_version:           ${{ matrix.ubuntu_version }}
       backend:                  ${{ matrix.backend }}
@@ -179,7 +171,7 @@ jobs:
       - Params
 
   StaticTypeCheck:
-    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@r2
+    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@dev
     needs:
       - Params
     with:
@@ -190,7 +182,7 @@ jobs:
       html_artifact: 'pyGHDL-typing-HTML'
 
   DocCoverage:
-    uses: pyTooling/Actions/.github/workflows/CheckDocumentation.yml@r2
+    uses: pyTooling/Actions/.github/workflows/CheckDocumentation.yml@dev
     needs:
       - Params
     with:
@@ -227,7 +219,7 @@ jobs:
     secrets: inherit
 
   PublishCoverageResults:
-    uses: pyTooling/Actions/.github/workflows/PublishCoverageResults.yml@r2
+    uses: pyTooling/Actions/.github/workflows/PublishCoverageResults.yml@dev
     needs:
       - macOS
       - Ubuntu-fast
@@ -252,7 +244,7 @@ jobs:
       publish: ${{ github.event_name != 'pull_request' }}
 
   IntermediateCleanUp:
-    uses: pyTooling/Actions/.github/workflows/IntermediateCleanUp.yml@r2
+    uses: pyTooling/Actions/.github/workflows/IntermediateCleanUp.yml@dev
     needs:
       - PublishCoverageResults
       - PublishTestResults
@@ -317,7 +309,7 @@ jobs:
       nightly_description: |
         This *nightly* release contains all latest and important artifacts created by GHDL's CI pipeline.
 
-        # GHDL ${{ needs.Params.outputs.ghdl_version }}
+        # GHDL %ghdl%
 
         GHDL offers the simulator and synthesis tool for VHDL. GHDL can be build for various backends:
         * `gcc` - using the GCC compiler framework
@@ -332,7 +324,11 @@ jobs:
         * Windows builds for standalone usage (without MSYS2) as ZIP file
         * MSYS2 packages as TAR/ZST file
 
-        # pyGHDL ${{ needs.Params.outputs.ghdl_version }}
+        ## Docker Images
+
+        Latest docker images at pushed to [Docker Hub - ghdl/ghdl:latest](https://hub.docker.com/r/ghdl/ghdl/tags).
+
+        # pyGHDL %ghdl%
 
         The Python package `pyGHDL` offers Python binding (`pyGHDL.libghdl`) to a `libghdl` shared library (`*.so`/`*.dll`).
         In addition to the low-level binding layer, pyGHDL offers:
@@ -371,7 +367,7 @@ jobs:
 
 
   ReleasePage:
-    uses: pyTooling/Actions/.github/workflows/Release.yml@r2
+    uses: pyTooling/Actions/.github/workflows/Release.yml@dev
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - macOS

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -369,18 +369,88 @@ jobs:
         pyGHDL-Windows-x86_64-Python-3.13:      pyGHDL-%pyghdl%-cp313-cp313-win_amd64.whl:                    pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.13
 
 
-  ReleasePage:
-    uses: pyTooling/Actions/.github/workflows/Release.yml@r3
-    if: startsWith(github.ref, 'refs/tags')
+  Release:
+    uses: pyTooling/Actions/.github/workflows/NightlyRelease.yml@r3
+    if: startsWith(github.ref, 'refs/tags/v')
     needs:
+      - Params
       - macOS
       - Ubuntu-fast
       - Ubuntu
       - Windows-fast
       - Windows
-      - PublishToGitHubPages
       - Python
-      - StaticTypeCheck
-      - DocCoverage
+#      - PublishToGitHubPages
+#      - StaticTypeCheck
+#      - DocCoverage
       - PublishCoverageResults
       - PublishTestResults
+    secrets: inherit
+    permissions:
+      contents: write
+      actions: write
+      attestations: write
+    with:
+      prerelease: true
+      replacements: |
+        ghdl=${{ needs.Params.outputs.ghdl_version }}
+        pyghdl=${{ needs.Params.outputs.pyghdl_version }}
+        pacghdl=${{ needs.Params.outputs.pacghdl_version }}
+      nightly_name: nightly
+      nightly_description: |
+        # GHDL %ghdl%
+
+        GHDL offers the simulator and synthesis tool for VHDL. GHDL can be build for various backends:
+        * `gcc` - using the GCC compiler framework
+        * `mcode` - in memory code generation
+        * `llvm` - using the LLVM compiler framework
+        * `llvm-jit` - using the LLVM compiler framework, but in memory
+
+        The following asset categories are provided for GHDL:
+        * macOS x64-64 builds as TAR/GZ file
+        * macOS aarch64 builds as TAR/GZ file
+        * Ubuntu 24.04 LTS builds as TAR/GZ file
+        * Windows builds for standalone usage (without MSYS2) as ZIP file
+        * MSYS2 packages as TAR/ZST file
+
+        ## Docker Images
+
+        Latest docker images at pushed to [Docker Hub - ghdl/ghdl:latest](https://hub.docker.com/r/ghdl/ghdl/tags).
+
+        # pyGHDL %ghdl%
+
+        The Python package `pyGHDL` offers Python binding (`pyGHDL.libghdl`) to a `libghdl` shared library (`*.so`/`*.dll`).
+        In addition to the low-level binding layer, pyGHDL offers:
+        * a Language Server Protocol (LSP) instance for e.g. live code checking by editors
+        * a Code Document Object Model (CodeDOM) based on [pyVHDLModel](https://github.com/VHDL/pyVHDLModel)
+
+        The following asset categories are provided for pyGHDL:
+        * Platform specific Python wheel package for Ubuntu incl. `pyGHDL...so`
+        * Platform specific Python wheel package for Windows incl. `pyGHDL...dll`
+      assets: |
+        ghdl-macos-13-x86_64-llvm:             $ghdl-llvm-%ghdl%-macos13-x86_64.tar.gz:                       GHDL - v%ghdl% - macOS 13 (x86-64) - llvm backend
+        ghdl-macos-13-x86_64-mcode:            $ghdl-mcode-%ghdl%-macos13-x86_64.tar.gz:                      GHDL - v%ghdl% - macOS 13 (x86-64) - mcode backend
+        ghdl-macos-14-aarch64-llvm:            $ghdl-llvm-%ghdl%-macos14-aarch64.tar.gz:                      GHDL - v%ghdl% - macOS 14 (aarch64) - llvm backend
+        ghdl-macos-14-aarch64-llvm-jit:        $ghdl-llvm-jit-%ghdl%-macos14-aarch64.tar.gz:                  GHDL - v%ghdl% - macOS 14 (aarch64) - llvm-jit backend
+        ghdl-ubuntu-24.04-x86_64-gcc:          $ghdl-gcc-%ghdl%-ubuntu24.04-x86_64.tar.gz:                    GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - gcc backend
+        ghdl-ubuntu-24.04-x86_64-llvm:         $ghdl-llvm-%ghdl%-ubuntu24.04-x86_64.tar.gz:                   GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - llvm backend
+        ghdl-ubuntu-24.04-x86_64-llvm-jit:     $ghdl-llvm-jit-%ghdl%-ubuntu24.04-x86_64.tar.gz:               GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - llvm-jit backend
+        ghdl-ubuntu-24.04-x86_64-mcode:        $ghdl-mcode-%ghdl%-ubuntu24.04-x86_64.tar.gz:                  GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - mcode backend
+        ghdl-Pacman-mingw64-llvm:               mingw-w64-x86_64-ghdl-llvm-%pacghdl%-any.pkg.tar.zst:         GHDL - v%ghdl% - MSYS2/MinGW64 - LLVM backend
+        ghdl-Pacman-mingw64-llvm-jit:           mingw-w64-x86_64-ghdl-llvm-jit-%pacghdl%-any.pkg.tar.zst:     GHDL - v%ghdl% - MSYS2/MinGW64 - LLVM-JIT backend
+        ghdl-Pacman-mingw64-mcode:              mingw-w64-x86_64-ghdl-mcode-%pacghdl%-any.pkg.tar.zst:        GHDL - v%ghdl% - MSYS2/MinGW64 - mcode backend
+        ghdl-Pacman-ucrt64-llvm:                mingw-w64-ucrt-x86_64-ghdl-llvm-%pacghdl%-any.pkg.tar.zst:    GHDL - v%ghdl% - MSYS2/UCRT64 - LLVM backend
+        ghdl-Pacman-ucrt64-llvm-jit:            mingw-w64-ucrt-x86_64-ghdl-llvm-jit-%pacghdl%-any.pkg.tar.zst:GHDL - v%ghdl% - MSYS2/UCRT64 - LLVM-JIT backend
+        ghdl-Pacman-ucrt64-mcode:               mingw-w64-ucrt-x86_64-ghdl-mcode-%pacghdl%-any.pkg.tar.zst:   GHDL - v%ghdl% - MSYS2/UCRT64 - mcode backend
+        ghdl-Windows-mingw64-mcode:            !ghdl-mcode-%ghdl%-mingw64.zip:                                GHDL - v%ghdl% - Windows (x86-64, MinGW64, standalone) - mcode backend
+        ghdl-Windows-ucrt64-mcode:             !ghdl-mcode-%ghdl%-ucrt64.zip:                                 GHDL - v%ghdl% - Windows (x86-64, UCRT64, standalone) - mcode backend
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.9:  pyGHDL-%pyghdl%-cp39-cp39-linux_x86_64.whl:                   pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.9
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.10: pyGHDL-%pyghdl%-cp310-cp310-linux_x86_64.whl:                 pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.10
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.11: pyGHDL-%pyghdl%-cp311-cp311-linux_x86_64.whl:                 pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.11
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.12: pyGHDL-%pyghdl%-cp312-cp312-linux_x86_64.whl:                 pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.12
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.13: pyGHDL-%pyghdl%-cp313-cp313-linux_x86_64.whl:                 pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.13
+        pyGHDL-Windows-x86_64-Python-3.9:       pyGHDL-%pyghdl%-cp39-cp39-win_amd64.whl:                      pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.9
+        pyGHDL-Windows-x86_64-Python-3.10:      pyGHDL-%pyghdl%-cp310-cp310-win_amd64.whl:                    pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.10
+        pyGHDL-Windows-x86_64-Python-3.11:      pyGHDL-%pyghdl%-cp311-cp311-win_amd64.whl:                    pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.11
+        pyGHDL-Windows-x86_64-Python-3.12:      pyGHDL-%pyghdl%-cp312-cp312-win_amd64.whl:                    pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.12
+        pyGHDL-Windows-x86_64-Python-3.13:      pyGHDL-%pyghdl%-cp313-cp313-win_amd64.whl:                    pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.13

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -171,7 +171,7 @@ jobs:
       - Params
 
   StaticTypeCheck:
-    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@dev
+    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@r3
     needs:
       - Params
     with:
@@ -182,7 +182,7 @@ jobs:
       html_artifact: 'pyGHDL-typing-HTML'
 
   DocCoverage:
-    uses: pyTooling/Actions/.github/workflows/CheckDocumentation.yml@dev
+    uses: pyTooling/Actions/.github/workflows/CheckDocumentation.yml@r3
     needs:
       - Params
     with:
@@ -219,32 +219,34 @@ jobs:
     secrets: inherit
 
   PublishCoverageResults:
-    uses: pyTooling/Actions/.github/workflows/PublishCoverageResults.yml@dev
+    uses: pyTooling/Actions/.github/workflows/PublishCoverageResults.yml@r3
     needs:
       - macOS
       - Ubuntu-fast
       - Windows-fast
 ###   - pyGHDL         # pyGHDL is installed into site-packages, where no coverage is collected -> empty coverage report
     with:
+      coverage_artifacts_pattern: '*-Coverage-SQLite-*'
       coverage_json_artifact: 'pyGHDL-Coverage-JSON'
       coverage_html_artifact: 'pyGHDL-Coverage-HTML'
     secrets:
       codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   PublishTestResults:
-    uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@dev
+    uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@r3
     needs:
       - macOS
       - Ubuntu-fast
       - Windows-fast
       - pyGHDL
     with:
+      unittest_artifacts_pattern: '*-Unittest-XML-*'
       merged_junit_artifact: 'pyGHDL-Unittest-XML'
       additional_merge_args: '-d "--render=tree" "--name=pyGHDL" "--pytest=rewrite-dunder-init;reduce-depth:pytest.testsuite.pyunit;split:pytest"'
       publish: ${{ github.event_name != 'pull_request' }}
 
   IntermediateCleanUp:
-    uses: pyTooling/Actions/.github/workflows/IntermediateCleanUp.yml@dev
+    uses: pyTooling/Actions/.github/workflows/IntermediateCleanUp.yml@r3
     needs:
       - PublishCoverageResults
       - PublishTestResults
@@ -283,7 +285,7 @@ jobs:
       typing:        'pyGHDL-typing-HTML'
 
   Nightly:
-    uses: pyTooling/Actions/.github/workflows/NightlyRelease.yml@dev
+    uses: pyTooling/Actions/.github/workflows/NightlyRelease.yml@r3
     needs:
       - Params
       - macOS
@@ -367,7 +369,7 @@ jobs:
 
 
   ReleasePage:
-    uses: pyTooling/Actions/.github/workflows/Release.yml@dev
+    uses: pyTooling/Actions/.github/workflows/Release.yml@r3
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - macOS

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -345,6 +345,7 @@ jobs:
         ghdl-macos-13-x86_64-mcode:            $ghdl-mcode-%ghdl%-macos13-x86_64.tar.gz:                      GHDL - v%ghdl% - macOS 13 (x86-64) - mcode backend
         ghdl-macos-14-aarch64-llvm:            $ghdl-llvm-%ghdl%-macos14-aarch64.tar.gz:                      GHDL - v%ghdl% - macOS 14 (aarch64) - llvm backend
         ghdl-macos-14-aarch64-llvm-jit:        $ghdl-llvm-jit-%ghdl%-macos14-aarch64.tar.gz:                  GHDL - v%ghdl% - macOS 14 (aarch64) - llvm-jit backend
+        ghdl-ubuntu-24.04-x86_64-gcc:          $ghdl-gcc-%ghdl%-ubuntu24.04-x86_64.tar.gz:                    GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - gcc backend
         ghdl-ubuntu-24.04-x86_64-llvm:         $ghdl-llvm-%ghdl%-ubuntu24.04-x86_64.tar.gz:                   GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - llvm backend
         ghdl-ubuntu-24.04-x86_64-llvm-jit:     $ghdl-llvm-jit-%ghdl%-ubuntu24.04-x86_64.tar.gz:               GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - llvm-jit backend
         ghdl-ubuntu-24.04-x86_64-mcode:        $ghdl-mcode-%ghdl%-ubuntu24.04-x86_64.tar.gz:                  GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - mcode backend

--- a/.github/workflows/Publish-GitHubPages.yml
+++ b/.github/workflows/Publish-GitHubPages.yml
@@ -33,21 +33,21 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 📥 Download artifacts '${{ inputs.documentation }}' from 'Sphinx' job
-        uses: actions/download-artifact@v4
+        uses: pyTooling/download-artifact@v4
         with:
           name: ${{ inputs.documentation }}
           path: public
 
       - name: 📥 Download artifacts '${{ inputs.coverage }}' from 'PublishCoverageResults' job
         if: ${{ inputs.coverage != '' }}
-        uses: actions/download-artifact@v4
+        uses: pyTooling/download-artifact@v4
         with:
           name: ${{ inputs.coverage }}
           path: public/coverage
 
       - name: 📥 Download artifacts '${{ inputs.typing }}' from 'StaticTypeCheck' job
         if: ${{ inputs.typing != '' }}
-        uses: actions/download-artifact@v4
+        uses: pyTooling/download-artifact@v4
         with:
           name: ${{ inputs.typing }}
           path: public/typing

--- a/.github/workflows/Test-GHDL.yml
+++ b/.github/workflows/Test-GHDL.yml
@@ -51,31 +51,27 @@ jobs:
           pacboy: "diffutils:p"
 
       - name: 📥 Download artifacts '${{ inputs.ghdl_artifact }}' from 'Build' job
-        uses: actions/download-artifact@v4
+        uses: pyTooling/download-artifact@v4
         with:
           name: ${{ inputs.ghdl_artifact }}
           path: install
 
-      - name: Install GHDL (chmod) and prepare test environment (Ubuntu)
+      - name: Prepare test environment (Ubuntu)
         if: startsWith(inputs.os_image, 'ubuntu')
         run: |
-          chmod +x ./install/bin/*
-          chmod +x ./install/libexec/gcc/*/*/*1 || true
           sudo xargs --no-run-if-empty -a ./install/ubuntu.requirements -- apt-get install -y --no-install-recommends
           echo "PATH=$(pwd)/install/bin:$PATH" >> $GITHUB_ENV
           ls -lR install
 
-      - name: Install GHDL (chmod) and prepare test environment (macOS)
+      - name: Prepare test environment (macOS)
         if: startsWith(inputs.os_image, 'macos')
         run: |
-          chmod +x ./install/bin/*
           echo "PATH=$(pwd)/install/bin:$PATH" >> $GITHUB_ENV
           cat $GITHUB_ENV
 
-      - name: Install GHDL (chmod) and prepare test environment (MSYS2)
+      - name: Prepare test environment (MSYS2)
         if: startsWith(inputs.os_image, 'windows') && inputs.runtime != ''
         run: |
-          chmod +x ./install/bin/*
           xargs --no-run-if-empty -a ./install/${{ inputs.runtime }}.requirements -- pacman -S --noconfirm
           echo "PATH=$(pwd)/install/bin:$PATH" >> $GITHUB_ENV
           cat $GITHUB_ENV


### PR DESCRIPTION
# New Features

* Added a note on the nightly release page, where to find latest Docker images.
* Added a release job.

# Changes

* Split the Sphinx job into 2 jobs for HTML and LaTeX creation to optimize runtime (parallel execution).
* Replaced `actions/upload-artifact` by `pyTooling/upload-artifact`, to preserve file permissions by packing files in a tarball.
  * Kept `actions/upload-artifact` for already packaged `*.whl` and `*.pkg.tar.zst` files.
* Replaced `actions/download-artifact` by `pyTooling/download-artifact`, to restore artifact data from uploaded tarballs.
  * `pyTooling/download-artifact` can also handle (legacy) uploads from `actions/upload-artifact`.
  * Removed `chmod +x` calls from CI scripts.  
    (Previously needed in CI scripts to manually adjust file permissions after file transfer via artifacts.)
* Increased retention time on binaries to 7 days.  
  Intermediate artifacts (reports, results, HTML content, ...) are still 1 day.
* Upgraded to `r3` job templates from pyTooling.

# Bug Fixes

* Preserve file permissions when transferring artifacts from job to job.
* Preserve file permissions when assets are created from artifacts.  
  (Because artifacts preserved file permissions.)