### PR TITLE
Add setup-ghdl testing to pipeline

### DIFF
--- a/.github/workflows/Build-MSYS2.yml
+++ b/.github/workflows/Build-MSYS2.yml
@@ -361,8 +361,8 @@ jobs:
 
       # TODO: replace with https://github.com/pyTooling/Actions/blob/dev/.github/workflows/ExtractConfiguration.yml
       - name: 🔁 Extract configurations from pyproject.toml (only mcode backend)
-        if: inputs.coverage && inputs.backend == 'mcode'
         id: getVariables
+        if: inputs.coverage && inputs.backend == 'mcode'
         shell: python
         run: |
           from os       import getenv
@@ -425,9 +425,9 @@ jobs:
 # Upload test result artifacts
 
       - name: 📤 Upload 'TestReportSummary.xml' artifact (only mcode backend)
+        uses: pyTooling/upload-artifact@v4
         if: inputs.unittesting && inputs.backend == 'mcode' && inputs.unittest_xml_artifact != ''
         continue-on-error: true
-        uses: pyTooling/upload-artifact@v4
         with:
           name: ${{ inputs.unittest_xml_artifact }}-Windows-${{ inputs.windows_version }}-${{ inputs.runtime }}-${{ inputs.python_version }}
           working-directory: report/unit
@@ -442,9 +442,9 @@ jobs:
         run: coverage report --rcfile=pyproject.toml --data-file=.coverage
 
       - name: 📤 Upload 'Coverage SQLite Database' artifact (only mcode backend)
+        uses: pyTooling/upload-artifact@v4
         if: inputs.coverage && inputs.backend == 'mcode' && inputs.coverage_sqlite_artifact != ''
         continue-on-error: true
-        uses: pyTooling/upload-artifact@v4
         with:
           name: ${{ inputs.coverage_sqlite_artifact }}-Windows-${{ inputs.windows_version }}-${{ inputs.runtime }}-${{ inputs.python_version }}
           path: .coverage

--- a/.github/workflows/Build-MacOS.yml
+++ b/.github/workflows/Build-MacOS.yml
@@ -246,8 +246,8 @@ jobs:
 
       # TODO: replace with https://github.com/pyTooling/Actions/blob/dev/.github/workflows/ExtractConfiguration.yml
       - name: 🔁 Extract configurations from pyproject.toml (only mcode backend)
-        if: inputs.coverage && inputs.backend == 'mcode'
         id: getVariables
+        if: inputs.coverage && inputs.backend == 'mcode'
         shell: python
         run: |
           from os       import getenv
@@ -310,10 +310,10 @@ jobs:
 # Upload test result artifacts
 
       - name: 📤 Upload 'TestReportSummary.xml' artifact (only mcode backend)
+        uses: pyTooling/upload-artifact@v4
         if: inputs.unittesting && inputs.backend == 'mcode' && inputs.unittest_xml_artifact != ''
         continue-on-error: true
 #        uses: actions/upload-artifact@v4
-        uses: pyTooling/upload-artifact@v4
         with:
           name: ${{ inputs.unittest_xml_artifact }}-${{ inputs.macos_image }}-${{ inputs.python_version }}
           working-directory: report/unit

--- a/.github/workflows/Build-Ubuntu.yml
+++ b/.github/workflows/Build-Ubuntu.yml
@@ -341,8 +341,8 @@ jobs:
 
       # TODO: replace with https://github.com/pyTooling/Actions/blob/dev/.github/workflows/ExtractConfiguration.yml
       - name: 🔁 Extract configurations from pyproject.toml (only mcode backend)
-        if: inputs.coverage && inputs.backend == 'mcode'
         id: getVariables
+        if: inputs.coverage && inputs.backend == 'mcode'
         shell: python
         run: |
           from os       import getenv
@@ -405,9 +405,9 @@ jobs:
 # Upload test result artifacts
 
       - name: 📤 Upload 'TestReportSummary.xml' artifact (only mcode backend)
+        uses: pyTooling/upload-artifact@v4
         if: inputs.unittesting && inputs.backend == 'mcode' && inputs.unittest_xml_artifact != ''
         continue-on-error: true
-        uses: pyTooling/upload-artifact@v4
         with:
           name: ${{ inputs.unittest_xml_artifact }}-Ubuntu-${{ inputs.ubuntu_version }}-${{ inputs.python_version }}
           working-directory: report/unit
@@ -422,9 +422,9 @@ jobs:
         run: coverage report --rcfile=pyproject.toml --data-file=.coverage
 
       - name: 📤 Upload 'Coverage SQLite Database' artifact (only mcode backend)
+        uses: pyTooling/upload-artifact@v4
         if: inputs.coverage && inputs.backend == 'mcode' && inputs.coverage_sqlite_artifact != ''
         continue-on-error: true
-        uses: pyTooling/upload-artifact@v4
         with:
           name: ${{ inputs.coverage_sqlite_artifact }}-Ubuntu-${{ inputs.ubuntu_version }}-${{ inputs.python_version }}
           path: .coverage

--- a/.github/workflows/Package-pyGHDL.yml
+++ b/.github/workflows/Package-pyGHDL.yml
@@ -197,8 +197,8 @@ jobs:
 
       # TODO: replace with https://github.com/pyTooling/Actions/blob/dev/.github/workflows/ExtractConfiguration.yml
       - name: 🔁 Extract configurations from pyproject.toml
-        if: inputs.coverage
         id: getVariables
+        if: inputs.coverage
         shell: python
         run: |
           from os       import getenv
@@ -262,9 +262,9 @@ jobs:
 # Upload test result artifacts
 
       - name: 📤 Upload 'TestReportSummary.xml' artifact
+        uses: pyTooling/upload-artifact@v4
         if: inputs.unittest_xml_artifact != ''
         continue-on-error: true
-        uses: pyTooling/upload-artifact@v4
         with:
           name: ${{ inputs.unittest_xml_artifact }}-${{ inputs.os_name }}-${{ inputs.python_version }}
           working-directory: report/unit

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -308,6 +308,7 @@ jobs:
         pyghdl=${{ needs.Params.outputs.pyghdl_version }}
         pacghdl=${{ needs.Params.outputs.pacghdl_version }}
       nightly_name: nightly
+      nightly_title: "Nightly Release"
       nightly_description: |
         This *nightly* release contains all latest and important artifacts created by GHDL's CI pipeline.
 
@@ -459,3 +460,12 @@ jobs:
         pyGHDL-Windows-x86_64-Python-3.11:      pyGHDL-%pyghdl%-cp311-cp311-win_amd64.whl:                    pyGHDL,windows,2022,x86-64,py3.11,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.11
         pyGHDL-Windows-x86_64-Python-3.12:      pyGHDL-%pyghdl%-cp312-cp312-win_amd64.whl:                    pyGHDL,windows,2022,x86-64,py3.12,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.12
         pyGHDL-Windows-x86_64-Python-3.13:      pyGHDL-%pyghdl%-cp313-cp313-win_amd64.whl:                    pyGHDL,windows,2022,x86-64,py3.13,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.13
+
+  Test-SetupGHDL:
+    uses: ./.github/workflows/Test-SetupGHDL.yml
+    needs:
+      - Params
+      - Nightly
+    if: github.ref == 'refs/tags/nightly'
+    with:
+      ghdl_version: ${{ needs.Params.outputs.ghdl_version }}

--- a/.github/workflows/Publish-GitHubPages.yml
+++ b/.github/workflows/Publish-GitHubPages.yml
@@ -39,15 +39,15 @@ jobs:
           path: public
 
       - name: 📥 Download artifacts '${{ inputs.coverage }}' from 'PublishCoverageResults' job
-        if: ${{ inputs.coverage != '' }}
         uses: pyTooling/download-artifact@v4
+        if: ${{ inputs.coverage != '' }}
         with:
           name: ${{ inputs.coverage }}
           path: public/coverage
 
       - name: 📥 Download artifacts '${{ inputs.typing }}' from 'StaticTypeCheck' job
-        if: ${{ inputs.typing != '' }}
         uses: pyTooling/download-artifact@v4
+        if: ${{ inputs.typing != '' }}
         with:
           name: ${{ inputs.typing }}
           path: public/typing

--- a/.github/workflows/Test-SetupGHDL.yml
+++ b/.github/workflows/Test-SetupGHDL.yml
@@ -63,7 +63,7 @@ jobs:
           investigate: true
 
       - name: Verify GHDL version via Bash
-        if: matrix.name == 'Linux' || matrix.name == 'macOS' || ( matrix.name == 'Windows' && matrix.runtime == '' )
+        if: matrix.name == 'Ubuntu' || matrix.name == 'macOS' || ( matrix.name == 'Windows' && matrix.runtime == '' )
         shell: bash   # ${{ steps.detect.outputs.shell }}
         run: |
           ANSI_LIGHT_RED=$'\x1b[91m'
@@ -73,7 +73,7 @@ jobs:
           printf "which ghdl: %s\n" "$(which ghdl)"
 
           expected="${{ inputs.ghdl_version }}"
-          printf "%s\n" "Verify GHDL version '${expected}' ..."
+          printf "%s" "Verify GHDL version '${expected}' ... "
           if [[ "$(ghdl --version | head -n 1)" =~ ${expected//./\\.} ]]; then
             printf "${ANSI_LIGHT_GREEN}%s${ANSI_NOCOLOR}\n" "[OK]"
           else
@@ -95,7 +95,7 @@ jobs:
           printf "which ghdl: %s\n" "$(which ghdl)"
 
           expected="${{ inputs.ghdl_version }}"
-          printf "%s" "Verify GHDL version '${expected}' ..."
+          printf "%s" "Verify GHDL version '${expected}' ... "
           if [[ "$(ghdl --version | head -n 1)" =~ ${expected//./\\.} ]]; then
             printf "${ANSI_LIGHT_GREEN}%s${ANSI_NOCOLOR}\n" "[OK]"
           else

--- a/.github/workflows/Test-SetupGHDL.yml
+++ b/.github/workflows/Test-SetupGHDL.yml
@@ -1,0 +1,113 @@
+name: Verification of setup-ghdl
+
+on:
+  workflow_call:
+    inputs:
+      ghdl_version:
+        description: 'Version of the GHDL.'
+        required: true
+        type: string
+
+jobs:
+  Setup-GHDL-Nightly:
+    name: ${{ matrix.icon }} Setup GHDL ${{ matrix.backend }} on ${{ matrix.name }}
+    runs-on: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+#         - {'icon': '🐧',   'name': 'Ubuntu',  'image': 'ubuntu-20.04', 'runtime': '',        'shell': 'bash',      'backend': 'mcode'}
+#         - {'icon': '🐧',   'name': 'Ubuntu',  'image': 'ubuntu-24.04', 'runtime': '',        'shell': 'bash',      'backend': 'xcode'}
+          - {'icon': '🐧',   'name': 'Ubuntu',  'image': 'ubuntu-24.04', 'runtime': '',        'shell': 'bash',      'backend': 'mcode'}
+          - {'icon': '🐧',   'name': 'Ubuntu',  'image': 'ubuntu-24.04', 'runtime': '',        'shell': 'bash',      'backend': 'llvm'}
+          - {'icon': '🐧',   'name': 'Ubuntu',  'image': 'ubuntu-24.04', 'runtime': '',        'shell': 'bash',      'backend': 'llvm-jit'}
+          - {'icon': '🐧',   'name': 'Ubuntu',  'image': 'ubuntu-24.04', 'runtime': '',        'shell': 'bash',      'backend': 'gcc'}
+#         - {'icon': '🍎',   'name': 'macOS',   'image': 'macos-13',     'runtime': '',        'shell': 'bash',      'backend': 'gcc'}
+          - {'icon': '🍎',   'name': 'macOS',   'image': 'macos-13',     'runtime': '',        'shell': 'bash',      'backend': 'mcode'}
+          - {'icon': '🍎',   'name': 'macOS',   'image': 'macos-13',     'runtime': '',        'shell': 'bash',      'backend': 'llvm'}
+          - {'icon': '🍏',   'name': 'macOS',   'image': 'macos-14',     'runtime': '',        'shell': 'bash',      'backend': 'llvm'}
+          - {'icon': '🪟',   'name': 'Windows', 'image': 'windows-2022', 'runtime': '',        'shell': 'bash',      'backend': 'mcode'}
+#         - {'icon': '🪟⬛', 'name': 'Windows', 'image': 'windows-2022', 'runtime': 'mingw32', 'shell': 'bash',      'backend': 'mcode'}
+          - {'icon': '🪟🟦', 'name': 'Windows', 'image': 'windows-2022', 'runtime': 'mingw64', 'shell': 'msys2 {0}', 'backend': 'mcode'}
+          - {'icon': '🪟🟦', 'name': 'Windows', 'image': 'windows-2022', 'runtime': 'mingw64', 'shell': 'msys2 {0}', 'backend': 'llvm'}
+          - {'icon': '🪟🟦', 'name': 'Windows', 'image': 'windows-2022', 'runtime': 'mingw64', 'shell': 'msys2 {0}', 'backend': 'llvm-jit'}
+          - {'icon': '🪟🟨', 'name': 'Windows', 'image': 'windows-2022', 'runtime': 'ucrt64',  'shell': 'msys2 {0}', 'backend': 'mcode'}
+          - {'icon': '🪟🟨', 'name': 'Windows', 'image': 'windows-2022', 'runtime': 'ucrt64',  'shell': 'msys2 {0}', 'backend': 'llvm'}
+          - {'icon': '🪟🟨', 'name': 'Windows', 'image': 'windows-2022', 'runtime': 'ucrt64',  'shell': 'msys2 {0}', 'backend': 'llvm-jit'}
+
+    steps:
+#      - name: Detect correct shell
+#        id: detect
+#        shell: bash
+#        run: |
+#          # Detect correct shell
+#          if [[ "${{ matrix.name }}" == "Windows" && "${{ matrix.runtime }}" != "" ]]; then
+#            printf "shell=msys2 {0}" >> $GITHUB_OUTPUT
+#          else
+#            printf "shell=bash" >> $GITHUB_OUTPUT
+#          fi
+
+      - name: '🟦 Setup MSYS2 for ${{ matrix.runtime }}'
+        uses: msys2/setup-msys2@v2
+        if: matrix.runtime != ''
+        with:
+          msystem: ${{ matrix.runtime }}
+          update: true
+
+      - name: Setup GHDL ${{ matrix.backend }}
+        uses: ghdl/setup-ghdl@v1
+        with:
+          version: nightly
+          backend: ${{ matrix.backend }}
+          runtime: ${{ matrix.runtime }}
+          investigate: true
+
+      - name: Verify GHDL version via Bash
+        if: matrix.name == 'Linux' || matrix.name == 'macOS' || ( matrix.name == 'Windows' && matrix.runtime == '' )
+        shell: bash   # ${{ steps.detect.outputs.shell }}
+        run: |
+          ANSI_LIGHT_RED=$'\x1b[91m'
+          ANSI_LIGHT_GREEN=$'\x1b[92m'
+          ANSI_NOCOLOR=$'\x1b[0m'
+
+          printf "which ghdl: %s\n" "$(which ghdl)"
+
+          expected="${{ inputs.ghdl_version }}"
+          printf "%s\n" "Verify GHDL version '${expected}' ..."
+          if [[ "$(ghdl --version | head -n 1)" =~ ${expected//./\\.} ]]; then
+            printf "${ANSI_LIGHT_GREEN}%s${ANSI_NOCOLOR}\n" "[OK]"
+          else
+            printf "${ANSI_LIGHT_RED}%s\${ANSI_NOCOLOR}n" "[FAILED]"
+            printf "::warning title=%s::%s\n" "Test-SetupGHDL" "GHDL version doesn't match."
+
+            ghdl --version
+          fi
+
+      - name: Verify GHDL version via Bash
+        if: matrix.name == 'Windows' && matrix.runtime != ''
+        # BUG: GitHub Action doesn't accept contexts for shell
+        shell: "msys2 {0}"   # ${{ steps.detect.outputs.shell }}
+        run: |
+          ANSI_LIGHT_RED=$'\x1b[91m'
+          ANSI_LIGHT_GREEN=$'\x1b[92m'
+          ANSI_NOCOLOR=$'\x1b[0m'
+
+          printf "which ghdl: %s\n" "$(which ghdl)"
+
+          expected="${{ inputs.ghdl_version }}"
+          printf "%s" "Verify GHDL version '${expected}' ..."
+          if [[ "$(ghdl --version | head -n 1)" =~ ${expected//./\\.} ]]; then
+            printf "${ANSI_LIGHT_GREEN}%s${ANSI_NOCOLOR}\n" "[OK]"
+          else
+            printf "${ANSI_LIGHT_RED}%s${ANSI_NOCOLOR}\n" "[FAILED]"
+            printf "::warning title=%s::%s\n" "Test-SetupGHDL" "GHDL version doesn't match."
+
+            ghdl --version
+          fi
+
+      - name: Verify on Windows (native)
+        if: matrix.name == 'Windows' && matrix.runtime == ''
+        shell: powershell
+        run: |
+          echo $(Get-Command ghdl).Source
+          ghdl --version

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,12 +1,12 @@
 -r ../pyGHDL/requirements.txt
 
-sphinx ~= 8.0
-python-dateutil ~= 2.8
+sphinx ~= 8.1
+python-dateutil ~= 2.9
 
 # Sphinx Extenstions
 autoapi ~= 2.0
 myst-parser ~= 4.0
-sphinx_autodoc_typehints ~= 2.3
+sphinx_autodoc_typehints ~= 3.0
 
 # Theme
 furo

--- a/testsuite/requirements.txt
+++ b/testsuite/requirements.txt
@@ -1,7 +1,7 @@
 -r ../pyGHDL/requirements.txt
 
-pytest ~= 7.3.0
+pytest ~= 8.3
 pytest-cov ~= 6.0
 
 # Coverage collection
-Coverage ~= 7.3
+Coverage ~= 7.6


### PR DESCRIPTION
This PR will add a test using `setup-ghdl` using release assets from nightly releases. In case the nightly release asset upload is broken, we can immediately identify if dozens to hundreds of GitHub pipeline using `setup-ghdl` might be broken. GHDL is installed in all variants and the version number is verified. Each installation takes just a few seconds. No test cases are executed.

# New Feature

* Install uploaded asset files provided by a nightly release using `setup-ghdl@v1`.

# Changes

* Set release page title for nightly release to a fixed value  
  (currently, it shows nightly plus commit title).
* Improved YAML coding style.
* Bumped dependencies.