### PR TITLE
Update date in --version response

### DIFF
--- a/src/ghdldrv/ghdlmain.adb
+++ b/src/ghdldrv/ghdlmain.adb
@@ -350,7 +350,7 @@ package body Ghdlmain is
       Put_Line ("Written by Tristan Gingold.");
       New_Line;
       --  Display copyright.  Assume 80 cols terminal.
-      Put_Line ("Copyright (C) 2003 - 2024 Tristan Gingold.");
+      Put_Line ("Copyright (C) 2003 - 2025 Tristan Gingold.");
       Put_Line ("GHDL is free software, covered by the "
                 & "GNU General Public License.  There is NO");
       Put_Line ("warranty; not even for MERCHANTABILITY or"


### PR DESCRIPTION
**Description** Please explain the changes you made here.

When I ran `ghdl --version`, I noticed that the date had not yet been updated.
This PR fixes the issue.

**When contributing to the GHDL codebase...**

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
- [ ] CONSIDER adding a unit test if your PR resolves an issue.
- [ ] CONSIDER modifying the docs, if your contribution is relevant to any of the content.
- [ ] AVOID breaking the continuous integration build.
- [ ] AVOID breaking the testsuite.

**When contributing to the docs...**

- [ ] DO make sure that the build is successful.

**Further comments**

To verify that the change was applied correctly, I recompiled GHDL inside a container, modifying the line with sed as follows:

```bash 
sed -i '353s|      Put_Line ("Copyright (C) 2003 - 2024 Tristan Gingold.");|      Put_Line ("Copyright (C) 2003 - 2025 Tristan Gingold.");|' ghdl/src/ghdldrv/ghdlmain.adb \
```
The container was built as follows:

```bash
# Licensed under the GNU General Public License v3.0;
# You may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#     https://www.gnu.org/licenses/gpl-3.0.html

# GHDL container

FROM ubuntu:latest AS base

MAINTAINER <unike267@gmail.com>

ARG GNAT_VER="13"
ARG LLVM_VER="18"

# Install dependencies
RUN apt-get update -qq \
 && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
    ca-certificates \
    clang-$LLVM_VER \
    gcc \
    gnat-$GNAT_VER \
    llvm-$LLVM_VER-dev \
    make \
    zlib1g-dev \
 && apt-get autoclean && apt-get clean && apt-get -y autoremove \
 && update-ca-certificates \
 && rm -rf /var/lib/apt/lists/* 

FROM base AS build

ARG LLVM_VER="18"

# Install ghdl
RUN apt-get update -qq \
 && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
    git \
 && git clone https://github.com/ghdl/ghdl \
 && sed -i '353s|      Put_Line ("Copyright (C) 2003 - 2024 Tristan Gingold.");|      Put_Line ("Copyright (C) 2003 - 2025 Tristan Gingold.");|' ghdl/src/ghdldrv/ghdlmain.adb \
 && cd ghdl \
 && mkdir build-llvm \
 && cd build-llvm \
 && CXX=clang++-$LLVM_VER ../configure --with-llvm-config=llvm-config-$LLVM_VER --default-pic --disable-werror \
 && make -j$(nproc) \
 && make DESTDIR=/opt/ghdl/ install \
 && cd ../.. \
 && rm -rf ghdl 

# Temporary scratch image for “transporting” the compiled GHDL binaries
FROM scratch AS tmp_ghdl
COPY --from=build /opt/ghdl/ /ghdl/

# Final ghdl dependent target
FROM base AS ghdl_fix
COPY --from=tmp_ghdl /ghdl/usr/local /usr/local/

RUN ghdl --version
```
It’s a bit convoluted since it incorporates several features that @umarcor  showed me the other day.

As shown in the following image, the change was successfully applied:

![fix](https://github.com/user-attachments/assets/8f52b6ea-c889-494b-9ba9-3381ce64d58b)

Note: Using `grep`, I found other files with outdated information, but only in comments. If you’d like, I can submit another PR tomorrow to update them!

Cheers! :smile: 

:heart: Thank you!
