### PR TITLE
Make GHDL's Docker images ready for attestation and Docker container scanning

### DIFF
--- a/.github/workflows/Package-Docker.yml
+++ b/.github/workflows/Package-Docker.yml
@@ -80,6 +80,11 @@ jobs:
           EOF
 
           dockerfile="./dist/docker/Dockerfile.${base_image}"
+          githubOrg="${{ github.repository_owner }}"
+          githubRepo="${{ github.repository }}"
+          githubRepo="${githubRepo##*/}"
+          githubUrl="${{ github.server_url }}/${{ github.repository }}"
+          githubDoc="https://${githubOrg}.github.io/${githubRepo}/"
           printf "Building docker file '%s' ...\n" "${dockerfile}"
           docker buildx build \
             --file "${dockerfile}" \
@@ -87,11 +92,21 @@ jobs:
             --build-arg IMAGE_TAG=${base_image_tag} \
             --build-arg GHDL_VERSION=${{ inputs.ghdl_version }} \
             --build-arg GHDL_BACKEND=${{ inputs.ghdl_backend }} \
+            --label "org.opencontainers.image.vendor=Tristan Gingold and contributors" \
+            --label "org.opencontainers.image.authors=Tristan Gingold <tgingold@free.fr>" \
+            --label "org.opencontainers.image.url=${githubUrl}" \
+            --label "org.opencontainers.image.documentation=${githubDoc}" \
+            --label "org.opencontainers.image.source=${{ github.repositoryUrl }}" \
+            --label "org.opencontainers.image.revision=${{ github.sha }}" \
+            --label "org.opencontainers.image.version=${{ inputs.ghdl_version }}" \
+            --label "org.opencontainers.image.description=GHDL ${{ inputs.ghdl_version }} - ${{ inputs.ghdl_backend }}" \
             --tag "ghdl:current" \
             ./dist/docker
 
           printf "Entrypoint: %s\n" "$(docker inspect -f '{{.Config.Entrypoint}}' ghdl:current)"
           printf "Cmd:        %s\n" "$(docker inspect -f '{{.Config.Cmd}}'        ghdl:current)"
+          printf "Image labels:\n"
+          docker inspect ghdl:current | jq -r '.[0].Config.Labels | to_entries | map("  " + .key + "=" + .value) | join("\n")'
 
           printf "Docker image 'ghdl:current' has %s\n" "$(docker image inspect ghdl:current --format='{{.Size}}' | numfmt --to=iec --format '%.2f')"
 


### PR DESCRIPTION
# New Features

This PR added [standardized labels](https://github.com/opencontainers/image-spec/blob/main/annotations.md) to the generated Docker images, so GHDL's Docker images will be ready for attestation and Docker container scanning (checking for vulnerabilities and outdated applications or libraries in the container).

Added labels:
* org.opencontainers.image.vendor
* org.opencontainers.image.authors
* org.opencontainers.image.url
* org.opencontainers.image.documentation
* org.opencontainers.image.source
* org.opencontainers.image.revision
* org.opencontainers.image.version
* org.opencontainers.image.description

A debug step was added for printing and formatting all applied labels of the image.  
Here the results from a run of `Paebbels/ghdl`:
<img width="447" alt="image" src="https://github.com/user-attachments/assets/3b58ede8-0a96-4b9d-aaf1-7c4ed3d07b60" />


@tgingold please check the used values for the vendor and author fields. These where taken from pyGHDL.