### PR TITLE
pyGHDL: Fixed testcase to iterate the compile order

### DIFF
--- a/pyGHDL/cli/requirements.txt
+++ b/pyGHDL/cli/requirements.txt
@@ -1,3 +1,3 @@
 -r ../dom/requirements.txt
 
-pyTooling[terminal] ~= 8.0
+pyTooling[terminal] ~= 8.1

--- a/pyGHDL/libghdl/requirements.txt
+++ b/pyGHDL/libghdl/requirements.txt
@@ -1,1 +1,1 @@
-pyTooling[terminal] ~= 8.0
+pyTooling[terminal] ~= 8.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "setuptools ~= 75.5",
   "wheel ~= 0.45",
-  "pyTooling ~= 8.0"
+  "pyTooling ~= 8.1"
 ]
 build-backend = "setuptools.build_meta"
 
@@ -20,6 +20,9 @@ show_error_context = true
 show_error_codes = true
 namespace_packages = true
 html_report = "report/typing"
+
+[tool.pytest]
+junit_xml = "report/unit/TestReportSummary.xml"
 
 [tool.pytest.ini_options]
 addopts = "--tb=native"

--- a/testsuite/pyunit/dom/StopWatch.py
+++ b/testsuite/pyunit/dom/StopWatch.py
@@ -33,17 +33,11 @@
 from time import perf_counter_ns as time_perf_counter
 from pathlib import Path
 from textwrap import dedent
-from typing import Dict, List
 from unittest import TestCase
 
-from pyTooling.Graph import Vertex
-
-import pyVHDLModel
-import pyVHDLModel.DesignUnit
 from pyGHDL.dom.NonStandard import Design, Document
 from pyGHDL.dom.formatting.GraphML import DependencyGraphFormatter, HierarchyGraphFormatter, CompileOrderGraphFormatter
-from pyGHDL.dom.formatting.prettyprint import PrettyPrint
-from pyVHDLModel import DependencyGraphVertexKind, DependencyGraphEdgeKind, Library
+
 
 if __name__ == "__main__":
     print("ERROR: you called a testcase declaration file as an executable module.")
@@ -156,8 +150,8 @@ class CompileOrder(Designs):
                 toplevel=", ".join(toplevel)
             )
         )
-        for i, vertex in enumerate(design.IterateDocumentsInCompileOrder()):
-            print(f"  {i:<2}: {vertex.Value.Path.relative_to(Path.cwd())}")
+        for i, document in enumerate(design.IterateDocumentsInCompileOrder()):
+            print(f"  {i:<2}: {document.Path.relative_to(Path.cwd())}")
 
         graphML = Path("dependencies.graphml")
         dependencyFormatter = DependencyGraphFormatter(design.DependencyGraph)


### PR DESCRIPTION
# Changes

* Bumped dependencies.  
  Fixes #2870.

# Bug Fixes

* Fixed testcase `CompileOrder.test_Encoder`, so compile order can be iterated.