### PR TITLE
Fix the setup-ghdl matrix

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -464,10 +464,37 @@ jobs:
         pyGHDL-Windows-x86_64-Python-3.13:      pyGHDL-%pyghdl%-cp313-cp313-win_amd64.whl:                    pyGHDL,windows,2022,x86-64,py3.13,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.13
 
   Test-SetupGHDL:
+    name: ${{ matrix.icon }} Setup GHDL ${{ matrix.backend }} on ${{ matrix.os_name }}
     uses: ./.github/workflows/Test-SetupGHDL.yml
     needs:
       - Params
       - Nightly
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+#         - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-20.04', runtime: '',        backend: 'mcode'}
+#         - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'xcode'}
+          - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'mcode'}
+          - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'llvm'}
+          - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'llvm-jit'}
+          - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'gcc'}
+#         - {icon: '🍎',   name: 'macOS',   image: 'macos-13',     runtime: '',        backend: 'gcc'}
+          - {icon: '🍎',   name: 'macOS',   image: 'macos-13',     runtime: '',        backend: 'mcode'}
+          - {icon: '🍎',   name: 'macOS',   image: 'macos-13',     runtime: '',        backend: 'llvm'}
+          - {icon: '🍏',   name: 'macOS',   image: 'macos-14',     runtime: '',        backend: 'llvm'}
+          - {icon: '🪟',   name: 'Windows', image: 'windows-2022', runtime: '',        backend: 'mcode'}
+#         - {icon: '🪟⬛', name: 'Windows', image: 'windows-2022', runtime: 'mingw32', backend: 'mcode'}
+          - {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'mcode'}
+          - {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm'}
+          - {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm-jit'}
+          - {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'mcode'}
+          - {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm'}
+          - {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm-jit'}
     if: github.ref == 'refs/tags/nightly'
     with:
+      os_image:     ${{ matrix.image }}
+      os_name:      ${{ matrix.name }}
+      runtime:      ${{ matrix.runtime }}
       ghdl_version: ${{ needs.Params.outputs.ghdl_version }}
+      ghdl_backend: ${{ matrix.backend }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -41,12 +41,12 @@ jobs:
       matrix:
         include:
 # macOS-13 is the last Intel x86_64 release
-          - {'icon': '🍎🟨', 'backend': 'mcode',    'macos_image': 'macos-13', 'gnat_arch': 'x86_64',  'gnat_version': '14.2.0-1', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-          - {'icon': '🍎🟨', 'backend': 'llvm',     'macos_image': 'macos-13', 'gnat_arch': 'x86_64',  'gnat_version': '14.2.0-1', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {icon: '🍎🟨', backend: 'mcode',    macos_image: 'macos-13', gnat_arch: 'x86_64',  gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {icon: '🍎🟨', backend: 'llvm',     macos_image: 'macos-13', gnat_arch: 'x86_64',  gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
 # macOS-14 is the latest ARM v9 release
-###       - {'icon': '🍏🟩', 'backend': 'mcode',    'macos_image': 'macos-14', 'gnat_arch': 'aarch64', 'gnat_version': '14.2.0-1', 'testsuites': 'none'}                                    # mcode not yet supported for aarch64
-          - {'icon': '🍏🟩', 'backend': 'llvm',     'macos_image': 'macos-14', 'gnat_arch': 'aarch64', 'gnat_version': '14.2.0-1', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-          - {'icon': '🍏🟩', 'backend': 'llvm-jit', 'macos_image': 'macos-14', 'gnat_arch': 'aarch64', 'gnat_version': '14.2.0-1', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+###       - {icon: '🍏🟩', backend: 'mcode',    macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: 'none'}                                    # mcode not yet supported for aarch64
+          - {icon: '🍏🟩', backend: 'llvm',     macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {icon: '🍏🟩', backend: 'llvm-jit', macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
 # macOS-15 is beta (broken/missing types in C)
 ###       - {'icon': '🍏🟩', 'backend': 'mcode',    'macos_image': 'macos-15', 'gnat_arch': 'aarch64', 'gnat_version': '14.2.0-1', 'testsuites': 'none'}                                    # mcode not yet supported for aarch64
 ##        - {'icon': '🍏🟩', 'backend': 'llvm',     'macos_image': 'macos-15', 'gnat_arch': 'aarch64', 'gnat_version': '14.2.0-1', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
@@ -73,8 +73,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {'icon': '🐧🟨', 'backend': 'mcode',    'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-          - {'icon': '🐧🟩', 'backend': 'mcode',    'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {icon: '🐧🟨', backend: 'mcode',    ubuntu_version: '22.04', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {icon: '🐧🟩', backend: 'mcode',    ubuntu_version: '24.04', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
     with:
       ubuntu_version:           ${{ matrix.ubuntu_version }}
       ghdl_backend:             ${{ matrix.backend }}
@@ -125,7 +125,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {'icon': '🪟', 'runtime': 'ucrt64',  'backend': 'mcode',    'testsuites': '${{ needs.Params.outputs.testsuites }}'}
+          - {icon: '🪟', runtime: 'ucrt64',  backend: 'mcode',    testsuites: '${{ needs.Params.outputs.testsuites }}'}
     with:
       runtime:                  ${{ matrix.runtime }}
       backend:                  ${{ matrix.backend }}
@@ -147,13 +147,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-###       - {'icon': '🪟', 'runtime': 'mingw32', 'backend': 'mcode',    'testsuites': '${{ needs.Params.outputs.testsuites }}'}   # No gcc-ada package for MinGW32, support was dropped
-          - {'icon': '🪟', 'runtime': 'mingw64', 'backend': 'mcode',    'testsuites': '${{ needs.Params.outputs.testsuites }}'}
-          - {'icon': '🪟', 'runtime': 'mingw64', 'backend': 'llvm',     'testsuites': 'sanity gna synth vpi vhpi'}                # no vests (too slow)
-          - {'icon': '🪟', 'runtime': 'mingw64', 'backend': 'llvm-jit', 'testsuites': 'sanity vpi vhpi'}                          # gna and synth fail (#2726); no vests (too slow)
-###       - {'icon': '🪟', 'runtime': 'ucrt64',  'backend': 'mcode',    'testsuites': '${{ needs.Params.outputs.testsuites }}'}   # used by Windows-fast
-          - {'icon': '🪟', 'runtime': 'ucrt64',  'backend': 'llvm',     'testsuites': 'sanity gna synth vpi vhpi'}                # no vests (too slow)
-          - {'icon': '🪟', 'runtime': 'ucrt64',  'backend': 'llvm-jit', 'testsuites': 'sanity vpi vhpi'}                          # gna and synth fail (#2726); no vests (too slow)
+###       - {icon: '🪟', runtime: 'mingw32', backend: 'mcode',    testsuites: '${{ needs.Params.outputs.testsuites }}'}   # No gcc-ada package for MinGW32, support was dropped
+          - {icon: '🪟', runtime: 'mingw64', backend: 'mcode',    testsuites: '${{ needs.Params.outputs.testsuites }}'}
+          - {icon: '🪟', runtime: 'mingw64', backend: 'llvm',     testsuites: 'sanity gna synth vpi vhpi'}                # no vests (too slow)
+          - {icon: '🪟', runtime: 'mingw64', backend: 'llvm-jit', testsuites: 'sanity vpi vhpi'}                          # gna and synth fail (#2726); no vests (too slow)
+###       - {icon: '🪟', runtime: 'ucrt64',  backend: 'mcode',    testsuites: '${{ needs.Params.outputs.testsuites }}'}   # used by Windows-fast
+          - {icon: '🪟', runtime: 'ucrt64',  backend: 'llvm',     testsuites: 'sanity gna synth vpi vhpi'}                # no vests (too slow)
+          - {icon: '🪟', runtime: 'ucrt64',  backend: 'llvm-jit', testsuites: 'sanity vpi vhpi'}                          # gna and synth fail (#2726); no vests (too slow)
     with:
       runtime:                  ${{ matrix.runtime }}
       backend:                  ${{ matrix.backend }}
@@ -200,15 +200,15 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - {'icon': '🐧', 'name': 'Ubuntu',  'image': 'ubuntu-24.04', 'libghdl_artifact': 'ubuntu-24.04-x86_64', 'pyghdl_artifact': 'Ubuntu-24.04-x86_64'}
-###       - {'icon': '🍏', 'name': 'macOS',   'image': 'macos-14',     'libghdl_artifact': 'macos-14-aarch64',    'pyghdl_artifact': 'macOS-14-aarch64'}
-          - {'icon': '🪟', 'name': 'Windows', 'image': 'windows-2022', 'libghdl_artifact': 'MSYS2-ucrt64',        'pyghdl_artifact': 'Windows-x86_64'}
+          - {icon: '🐧', name: 'Ubuntu',  image: 'ubuntu-24.04', libghdl_artifact: 'ubuntu-24.04-x86_64', pyghdl_artifact: 'Ubuntu-24.04-x86_64'}
+###       - {icon: '🍏', name: 'macOS',   image: 'macos-14',     libghdl_artifact: 'macos-14-aarch64',    pyghdl_artifact: 'macOS-14-aarch64'}
+          - {icon: '🪟', name: 'Windows', image: 'windows-2022', libghdl_artifact: 'MSYS2-ucrt64',        pyghdl_artifact: 'Windows-x86_64'}
         py:
-          - {'icon': '🔴', 'version': "3.9"}
-          - {'icon': '🟠', 'version': "3.10"}
-          - {'icon': '🟡', 'version': "3.11"}
-          - {'icon': '🟢', 'version': "3.12"}
-          - {'icon': '🟢', 'version': "3.13"}
+          - {icon: '🔴', version: "3.9"}
+          - {icon: '🟠', version: "3.10"}
+          - {icon: '🟡', version: "3.11"}
+          - {icon: '🟢', version: "3.12"}
+          - {icon: '🟢', version: "3.13"}
     with:
       os_name:               ${{ matrix.os.name }}
       os_image:              ${{ matrix.os.image }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -464,7 +464,7 @@ jobs:
         pyGHDL-Windows-x86_64-Python-3.13:      pyGHDL-%pyghdl%-cp313-cp313-win_amd64.whl:                    pyGHDL,windows,2022,x86-64,py3.13,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.13
 
   Test-SetupGHDL:
-    name: ${{ matrix.icon }} Setup GHDL ${{ matrix.backend }} on ${{ matrix.os_name }}
+#    name: ${{ matrix.icon }} Setup GHDL ${{ matrix.backend }} on ${{ matrix.os_name }}
     uses: ./.github/workflows/Test-SetupGHDL.yml
     needs:
       - Params

--- a/.github/workflows/Test-SetupGHDL.yml
+++ b/.github/workflows/Test-SetupGHDL.yml
@@ -3,37 +3,28 @@ name: Verification of setup-ghdl
 on:
   workflow_call:
     inputs:
+      os_image:
+        required: true
+        type: string
+      os_name:
+        required: true
+        type: string
+      runtime:
+        required: true
+        type: string
       ghdl_version:
         description: 'Version of the GHDL.'
+        required: true
+        type: string
+      ghdl_backend:
+        description: 'GHDL''s backend.'
         required: true
         type: string
 
 jobs:
   Setup-GHDL-Nightly:
-    name: ${{ matrix.icon }} Setup GHDL ${{ matrix.backend }} on ${{ matrix.name }}
-    runs-on: ${{ matrix.image }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-#         - {'icon': '🐧',   'name': 'Ubuntu',  'image': 'ubuntu-20.04', 'runtime': '',        'shell': 'bash',      'backend': 'mcode'}
-#         - {'icon': '🐧',   'name': 'Ubuntu',  'image': 'ubuntu-24.04', 'runtime': '',        'shell': 'bash',      'backend': 'xcode'}
-          - {'icon': '🐧',   'name': 'Ubuntu',  'image': 'ubuntu-24.04', 'runtime': '',        'shell': 'bash',      'backend': 'mcode'}
-          - {'icon': '🐧',   'name': 'Ubuntu',  'image': 'ubuntu-24.04', 'runtime': '',        'shell': 'bash',      'backend': 'llvm'}
-          - {'icon': '🐧',   'name': 'Ubuntu',  'image': 'ubuntu-24.04', 'runtime': '',        'shell': 'bash',      'backend': 'llvm-jit'}
-          - {'icon': '🐧',   'name': 'Ubuntu',  'image': 'ubuntu-24.04', 'runtime': '',        'shell': 'bash',      'backend': 'gcc'}
-#         - {'icon': '🍎',   'name': 'macOS',   'image': 'macos-13',     'runtime': '',        'shell': 'bash',      'backend': 'gcc'}
-          - {'icon': '🍎',   'name': 'macOS',   'image': 'macos-13',     'runtime': '',        'shell': 'bash',      'backend': 'mcode'}
-          - {'icon': '🍎',   'name': 'macOS',   'image': 'macos-13',     'runtime': '',        'shell': 'bash',      'backend': 'llvm'}
-          - {'icon': '🍏',   'name': 'macOS',   'image': 'macos-14',     'runtime': '',        'shell': 'bash',      'backend': 'llvm'}
-          - {'icon': '🪟',   'name': 'Windows', 'image': 'windows-2022', 'runtime': '',        'shell': 'bash',      'backend': 'mcode'}
-#         - {'icon': '🪟⬛', 'name': 'Windows', 'image': 'windows-2022', 'runtime': 'mingw32', 'shell': 'bash',      'backend': 'mcode'}
-          - {'icon': '🪟🟦', 'name': 'Windows', 'image': 'windows-2022', 'runtime': 'mingw64', 'shell': 'msys2 {0}', 'backend': 'mcode'}
-          - {'icon': '🪟🟦', 'name': 'Windows', 'image': 'windows-2022', 'runtime': 'mingw64', 'shell': 'msys2 {0}', 'backend': 'llvm'}
-          - {'icon': '🪟🟦', 'name': 'Windows', 'image': 'windows-2022', 'runtime': 'mingw64', 'shell': 'msys2 {0}', 'backend': 'llvm-jit'}
-          - {'icon': '🪟🟨', 'name': 'Windows', 'image': 'windows-2022', 'runtime': 'ucrt64',  'shell': 'msys2 {0}', 'backend': 'mcode'}
-          - {'icon': '🪟🟨', 'name': 'Windows', 'image': 'windows-2022', 'runtime': 'ucrt64',  'shell': 'msys2 {0}', 'backend': 'llvm'}
-          - {'icon': '🪟🟨', 'name': 'Windows', 'image': 'windows-2022', 'runtime': 'ucrt64',  'shell': 'msys2 {0}', 'backend': 'llvm-jit'}
+    name: ${{ matrix.icon }} Setup GHDL ${{ inputs.backend }} on ${{ inputs.os_name }}
+    runs-on: ${{ inputs.os_image }}
 
     steps:
 #      - name: Detect correct shell
@@ -49,21 +40,21 @@ jobs:
 
       - name: '🟦 Setup MSYS2 for ${{ matrix.runtime }}'
         uses: msys2/setup-msys2@v2
-        if: matrix.runtime != ''
+        if: inputs.runtime != ''
         with:
-          msystem: ${{ matrix.runtime }}
+          msystem: ${{ inputs.runtime }}
           update: true
 
-      - name: Setup GHDL ${{ matrix.backend }}
+      - name: Setup GHDL ${{ inputs.backend }}
         uses: ghdl/setup-ghdl@v1
         with:
           version: nightly
-          backend: ${{ matrix.backend }}
-          runtime: ${{ matrix.runtime }}
+          backend: ${{ inputs.backend }}
+          runtime: ${{ inputs.runtime }}
           investigate: true
 
       - name: Verify GHDL version via Bash
-        if: matrix.name == 'Ubuntu' || matrix.name == 'macOS' || ( matrix.name == 'Windows' && matrix.runtime == '' )
+        if: inputs.name == 'Ubuntu' || inputs.name == 'macOS' || ( inputs.name == 'Windows' && inputs.runtime == '' )
         shell: bash   # ${{ steps.detect.outputs.shell }}
         run: |
           ANSI_LIGHT_RED=$'\x1b[91m'
@@ -84,7 +75,7 @@ jobs:
           fi
 
       - name: Verify GHDL version via Bash
-        if: matrix.name == 'Windows' && matrix.runtime != ''
+        if: inputs.name == 'Windows' && inputs.runtime != ''
         # BUG: GitHub Action doesn't accept contexts for shell
         shell: "msys2 {0}"   # ${{ steps.detect.outputs.shell }}
         run: |
@@ -106,7 +97,7 @@ jobs:
           fi
 
       - name: Verify on Windows (native)
-        if: matrix.name == 'Windows' && matrix.runtime == ''
+        if: inputs.name == 'Windows' && inputs.runtime == ''
         shell: powershell
         run: |
           echo $(Get-Command ghdl).Source

--- a/.github/workflows/Test-SetupGHDL.yml
+++ b/.github/workflows/Test-SetupGHDL.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   Setup-GHDL-Nightly:
-    name: ${{ matrix.icon }} Setup GHDL ${{ inputs.backend }} on ${{ inputs.os_name }}
+    name: Setup GHDL ${{ inputs.ghdl_backend }} on ${{ inputs.os_name }} ${{ inputs.runtime }}
     runs-on: ${{ inputs.os_image }}
 
     steps:
@@ -38,23 +38,23 @@ jobs:
 #            printf "shell=bash" >> $GITHUB_OUTPUT
 #          fi
 
-      - name: '🟦 Setup MSYS2 for ${{ matrix.runtime }}'
+      - name: '🟦 Setup MSYS2 for ${{ inputs.runtime }}'
         uses: msys2/setup-msys2@v2
         if: inputs.runtime != ''
         with:
           msystem: ${{ inputs.runtime }}
           update: true
 
-      - name: Setup GHDL ${{ inputs.backend }}
+      - name: Setup GHDL ${{ inputs.ghdl_backend }}
         uses: ghdl/setup-ghdl@v1
         with:
           version: nightly
-          backend: ${{ inputs.backend }}
+          backend: ${{ inputs.ghdl_backend }}
           runtime: ${{ inputs.runtime }}
           investigate: true
 
       - name: Verify GHDL version via Bash
-        if: inputs.name == 'Ubuntu' || inputs.name == 'macOS' || ( inputs.name == 'Windows' && inputs.runtime == '' )
+        if: inputs.os_name == 'Ubuntu' || inputs.os_name == 'macOS' || ( inputs.os_name == 'Windows' && inputs.runtime == '' )
         shell: bash   # ${{ steps.detect.outputs.shell }}
         run: |
           ANSI_LIGHT_RED=$'\x1b[91m'
@@ -75,7 +75,7 @@ jobs:
           fi
 
       - name: Verify GHDL version via Bash
-        if: inputs.name == 'Windows' && inputs.runtime != ''
+        if: inputs.os_name == 'Windows' && inputs.runtime != ''
         # BUG: GitHub Action doesn't accept contexts for shell
         shell: "msys2 {0}"   # ${{ steps.detect.outputs.shell }}
         run: |
@@ -97,7 +97,7 @@ jobs:
           fi
 
       - name: Verify on Windows (native)
-        if: inputs.name == 'Windows' && inputs.runtime == ''
+        if: inputs.os_name == 'Windows' && inputs.runtime == ''
         shell: powershell
         run: |
           echo $(Get-Command ghdl).Source


### PR DESCRIPTION
When the testing of `setup-ghdl` was added to the pipeline, the matrix got accidentally added as a nested matrix. Ideally, all matrix descriptions should be in the top-level YAML to ease control.

This PR fixes that behavior and brings the nested matrix to the top-level YAML file.

# Changes

* Improved YAML coding style
* Moved nested matrix of `Test-SetupGHDL.yml` to `Pipeline.yml`.

The pipeline is currently tested in Paebbels/ghdl: https://github.com/Paebbels/ghdl/actions/runs/13229282625 using tag `testing`.