### PR TITLE
Package pyGHDL for MSYS2 runtimes MinGW64 and UCRT64

### DIFF
--- a/.github/workflows/Build-MSYS2.yml
+++ b/.github/workflows/Build-MSYS2.yml
@@ -292,7 +292,7 @@ jobs:
           retention-days: 7
 
       - name: ✂ Remove binaries, libraries and other files for libghdl
-        if: inputs.runtime == 'ucrt64' && inputs.backend == 'mcode'
+        if: (inputs.runtime == 'mingw64' || inputs.runtime == 'ucrt64') && inputs.backend == 'mcode'
         run: |
           rm -Rf ./install/bin
           rm -Rf ./install/include
@@ -304,13 +304,13 @@ jobs:
           rm -Rf ./install/*.requirements
 
       - name: List './install' directory as tree
-        if: inputs.runtime == 'ucrt64' && inputs.backend == 'mcode'
+        if: (inputs.runtime == 'mingw64' || inputs.runtime == 'ucrt64') && inputs.backend == 'mcode'
         run: |
           tree ./install
           ldd ./install/lib/*.dll
 
       - name: Copy and check dependency (MSYS2)
-        if: inputs.runtime == 'ucrt64' && inputs.backend == 'mcode'
+        if: (inputs.runtime == 'mingw64' || inputs.runtime == 'ucrt64') && inputs.backend == 'mcode'
         run: |
           GetMinGWLibraries() {
             ldd "$1" | while IFS="" read -r dependency; do
@@ -334,7 +334,7 @@ jobs:
 
       - name: 📤 Upload '${{ steps.artifact_name.outputs.libghdl_artifact }}' artifact
         uses: pyTooling/upload-artifact@v4
-        if: inputs.runtime == 'ucrt64' && inputs.backend == 'mcode'
+        if: (inputs.runtime == 'mingw64' || inputs.runtime == 'ucrt64') && inputs.backend == 'mcode'
         with:
           name: ${{ steps.artifact_name.outputs.libghdl_artifact }}
           working-directory: install

--- a/.github/workflows/Build-MSYS2.yml
+++ b/.github/workflows/Build-MSYS2.yml
@@ -108,7 +108,9 @@ jobs:
         shell: bash
         run: |
           # Generic packages installed in MSYS2
-          echo "msys2_packages=make tree git" >> $GITHUB_OUTPUT
+          tee "${GITHUB_OUTPUT}" <<EOF
+          msys2_packages=make tree git
+          EOF
 
           # Runtime (and backend) specific packages
           common_packages="python:p python-pip:p gcc:p gcc-ada:p binutils:p diffutils:p zlib:p"
@@ -116,11 +118,17 @@ jobs:
           llvm_packages="llvm:p clang:p"
 
           if ${{ startsWith(inputs.backend, 'mcode') }}; then
-            echo "pacboy_packages=${common_packages} ${mcode_packages}" >> $GITHUB_OUTPUT
+            tee -a "${GITHUB_OUTPUT}" <<EOF
+          pacboy_packages=${common_packages} ${mcode_packages}
+          EOF
           elif ${{ startsWith(inputs.backend, 'llvm') }}; then
-            echo "pacboy_packages=${common_packages} ${llvm_packages}" >> $GITHUB_OUTPUT
+            tee -a "${GITHUB_OUTPUT}" <<EOF
+          pacboy_packages=${common_packages} ${llvm_packages}
+          EOF
           else
-            echo "pacboy_packages=${common_packages}" >> $GITHUB_OUTPUT
+            tee -a "${GITHUB_OUTPUT}" <<EOF
+          pacboy_packages=${common_packages}
+          EOF
           fi
 
       - name: '🟦 Setup MSYS2 for ${{ inputs.runtime }}'
@@ -134,11 +142,12 @@ jobs:
       - name: 🖉 Assemble artifact name
         id: artifact_name
         run: |
-          echo "ghdl_artifact=${{ inputs.msys2_artifact }}-${{ inputs.runtime }}-${{ inputs.backend }}" >> $GITHUB_OUTPUT
-          echo "pacman_artifact=${{ inputs.pacman_artifact }}-${{ inputs.runtime }}-${{ inputs.backend }}" >> $GITHUB_OUTPUT
-          echo "windows_artifact=${{ inputs.windows_artifact }}-${{ inputs.runtime }}-${{ inputs.backend }}" >> $GITHUB_OUTPUT
-          echo "libghdl_artifact=${{ inputs.libghdl_artifact }}-${{ inputs.runtime }}-${{ inputs.backend }}" >> $GITHUB_OUTPUT
-
+          tee "${GITHUB_OUTPUT}" <<EOF
+          ghdl_artifact=${{ inputs.msys2_artifact }}-${{ inputs.runtime }}-${{ inputs.backend }}
+          pacman_artifact=${{ inputs.pacman_artifact }}-${{ inputs.runtime }}-${{ inputs.backend }}
+          windows_artifact=${{ inputs.windows_artifact }}-${{ inputs.runtime }}-${{ inputs.backend }}
+          libghdl_artifact=${{ inputs.libghdl_artifact }}-${{ inputs.runtime }}-${{ inputs.backend }}
+          EOF
       - name: ☑ Check build environemnt
         run: |
           echo "which gnat:        $(which gnat) ($($(which gnat) --version))"

--- a/.github/workflows/Build-MacOS.yml
+++ b/.github/workflows/Build-MacOS.yml
@@ -85,13 +85,17 @@ jobs:
       - name: 🖉 Assemble artifact name
         id: artifact_name
         run: |
-          echo "ghdl_artifact=${{ inputs.macos_artifact }}-${{ inputs.backend }}" >> $GITHUB_OUTPUT
+          tee "${GITHUB_OUTPUT}" <<EOF
+          ghdl_artifact=${{ inputs.macos_artifact }}-${{ inputs.backend }}
+          EOF
 
       - name: 🔧 Install dependencies
         run: |
           brew install llvm
 
-          echo "LLVM_BINARY_PATH=$(brew --prefix llvm)/bin" >> $GITHUB_ENV
+          tee "${GITHUB_ENV}" <<EOF
+          LLVM_BINARY_PATH=$(brew --prefix llvm)/bin
+          EOF
 
       - name: 🔧 Install GNAT
         id: gnat
@@ -132,7 +136,9 @@ jobs:
             exit 1
           fi
 
-          echo "GNAT_MAJOR_VERSION=${GNAT_MAJOR_VERSION}" >> $GITHUB_OUTPUT
+          tee "${GITHUB_OUTPUT}" <<EOF
+          GNAT_MAJOR_VERSION=${GNAT_MAJOR_VERSION}
+          EOF
 
       - name: Prepare build environment
         run: |

--- a/.github/workflows/Package-pyGHDL.yml
+++ b/.github/workflows/Package-pyGHDL.yml
@@ -127,7 +127,15 @@ jobs:
         with:
           path: ghdl
 
-      - name: Prepare testsuite (Ubuntu)
+      - name: '🟦 Setup MSYS2 for ${{ inputs.runtime }}'
+        uses: msys2/setup-msys2@v2
+        if: inputs.runtime != ''
+        with:
+          msystem: ${{ inputs.runtime }}
+          update: true
+          pacboy: 'python:p python-pip:p python-wheel:p'
+
+      - name: Prepare testsuite (Ubuntu, MSYS2)
         if: startsWith(inputs.os_image, 'ubuntu')
         run: |
           mkdir pyGHDL
@@ -146,7 +154,7 @@ jobs:
           rm -Rf ghdl
 
       - name: Prepare testsuite (Windows)
-        if: startsWith(inputs.os_image, 'windows')
+        if: startsWith(inputs.os_image, 'windows') && inputs.runtime == ''
         run: |
           mkdir pyGHDL
           cp ghdl\pyGHDL\requirements.txt pyGHDL
@@ -163,8 +171,28 @@ jobs:
 
           Remove-Item -Force -Recurse ghdl
 
-      - name: '🐍 Setup Python'
+      - name: Prepare testsuite (Ubuntu, MSYS2)
+        if: startsWith(inputs.os_image, 'windows') && inputs.runtime != ''
+        shell: "msys2 {0}"
+        run: |
+          mkdir pyGHDL
+          cp -v ghdl/pyGHDL/requirements.txt pyGHDL
+          mkdir pyGHDL/cli
+          cp -v ghdl/pyGHDL/cli/requirements.txt pyGHDL/cli
+          mkdir pyGHDL/dom
+          cp -v ghdl/pyGHDL/dom/requirements.txt pyGHDL/dom
+          mkdir pyGHDL/libghdl
+          cp -v ghdl/pyGHDL/libghdl/requirements.txt pyGHDL/libghdl
+          mkdir pyGHDL/lsp
+          cp -v ghdl/pyGHDL/lsp/requirements.txt pyGHDL/lsp
+          cp -r ghdl/testsuite .
+          cp -v ghdl/pyproject.toml .
+
+          rm -Rf ghdl
+
+      - name: 🐍 Setup Python (Ubuntu, Windows)
         uses: actions/setup-python@v5
+        if: inputs.runtime == ''
         with:
           python-version: ${{ inputs.python_version }}
 
@@ -182,10 +210,17 @@ jobs:
           python -m pip install --disable-pip-version-check -r testsuite/requirements.txt
 
       - name: 🔧 Install dependencies (Windows)
-        if: startsWith(inputs.os_image, 'windows')
+        if: startsWith(inputs.os_image, 'windows') && inputs.runtime == ''
         run: |
           python -m pip install -v --disable-pip-version-check (Get-Item .\wheels\pyGHDL-*.whl).FullName
           python -m pip install --disable-pip-version-check -r testsuite\requirements.txt
+
+      - name: 🔧 Install dependencies (MSYS2)
+        if: startsWith(inputs.os_image, 'windows') && inputs.runtime != ''
+        shell: "msys2 {0}"
+        run: |
+          python -m pip install -v --disable-pip-version-check ./wheels/pyGHDL-*.whl
+          python -m pip install --disable-pip-version-check -r testsuite/requirements.txt
 
       - name: List pyGHDL installation directory (Ubuntu)
         if: startsWith(inputs.os_image, 'ubuntu')
@@ -198,7 +233,15 @@ jobs:
 #        run: |
 #          tree /F /A ${env:Python3_ROOT_DIR}\Lib\site-packages\pyGHDL
 
-      - name: Sanity check ghdl-lsp
+      - name: List pyGHDL installation directory (MSYS2)
+        if: startsWith(inputs.os_image, 'windows') && inputs.runtime != ''
+        shell: "msys2 {0}"
+        run: |
+          ls -lAh ${MSYSTEM_PREFIX}/lib/python3.*/site-packages/pyGHDL/lib
+          tree ${MSYSTEM_PREFIX}/lib/python3.*/site-packages/pyGHDL
+
+      - name: Sanity check ghdl-lsp (Ubuntu, Windows)
+        if: startsWith(inputs.os_image, 'ubuntu') || (startsWith(inputs.os_image, 'windows') && inputs.runtime == '')
         run: |
           echo "Testing Python module:"
           python -m pyGHDL.cli.lsp --version
@@ -207,7 +250,19 @@ jobs:
           echo "Testing entrypoint (executable):"
           ghdl-ls --version
 
-      - name: Sanity check ghdl-dom
+      - name: Sanity check ghdl-lsp (MSYS2)
+        if: startsWith(inputs.os_image, 'windows') && inputs.runtime != ''
+        shell: "msys2 {0}"
+        run: |
+          echo "Testing Python module:"
+          python -m pyGHDL.cli.lsp --version
+
+          echo ""
+          echo "Testing entrypoint (executable):"
+          ghdl-ls --version
+
+      - name: Sanity check ghdl-dom (Ubuntu, Windows)
+        if: startsWith(inputs.os_image, 'ubuntu') || (startsWith(inputs.os_image, 'windows') && inputs.runtime == '')
         run: |
           echo "Testing Python module:"
           python -m pyGHDL.cli.dom version
@@ -216,8 +271,25 @@ jobs:
           echo "Testing entrypoint (executable):"
           ghdl-dom version
 
-      - name: 🧰 Install dependencies (Ubuntu)
-        if: inputs.coverage
+      - name: Sanity check ghdl-dom (MSYS2)
+        if: startsWith(inputs.os_image, 'windows') && inputs.runtime != ''
+        shell: "msys2 {0}"
+        run: |
+          echo "Testing Python module:"
+          python -m pyGHDL.cli.dom version
+
+          echo ""
+          echo "Testing entrypoint (executable):"
+          ghdl-dom version
+
+      - name: 🧰 Install dependencies (Ubuntu, Windows)
+        if: inputs.coverage && (startsWith(inputs.os_image, 'ubuntu') || (startsWith(inputs.os_image, 'windows') && inputs.runtime == ''))
+        run: |
+          python -m pip install --disable-pip-version-check tomli
+
+      - name: 🧰 Install dependencies (MSYS2)
+        if: inputs.coverage && (startsWith(inputs.os_image, 'windows') && inputs.runtime != '')
+        shell: "msys2 {0}"
         run: |
           python -m pip install --disable-pip-version-check tomli
 
@@ -277,12 +349,22 @@ jobs:
           python -m pytest -raP $PYTEST_ARGS --color=yes ${{ inputs.pyunit_testsuites }}
 
       - name: '🚦 Testsuite: pyunit (Windows)'
-        if: startsWith(inputs.os_image, 'windows')
+        if: startsWith(inputs.os_image, 'windows') && inputs.runtime == ''
         run: |
           $env:PYTHONPATH = (Get-Location).ToString()
 
           $PYTEST_ARGS = if ("${{ inputs.unittest_xml_artifact }}") { "--junitxml=report/unit/TestReportSummary.xml" } else { "" }
           Write-Host "python -m pytest -raP $PYTEST_ARGS --color=yes ${{ inputs.pyunit_testsuites }}"
+          python -m pytest -raP $PYTEST_ARGS --color=yes ${{ inputs.pyunit_testsuites }}
+
+      - name: '🚦 Testsuite: pyunit (MSYS2)'
+        if: startsWith(inputs.os_image, 'windows') && inputs.runtime != ''
+        shell: "msys2 {0}"
+        run: |
+          export PYTHONPATH=$(pwd)
+
+          [ -n '${{ inputs.unittest_xml_artifact }}' ] && PYTEST_ARGS='--junitxml=report/unit/TestReportSummary.xml' || unset PYTEST_ARGS
+          echo "python -m pytest -raP $PYTEST_ARGS --color=yes ${{ inputs.pyunit_testsuites }}"
           python -m pytest -raP $PYTEST_ARGS --color=yes ${{ inputs.pyunit_testsuites }}
 
 # Upload test result artifacts

--- a/.github/workflows/Package-pyGHDL.yml
+++ b/.github/workflows/Package-pyGHDL.yml
@@ -228,7 +228,7 @@ jobs:
         if: startsWith(inputs.os_image, 'ubuntu')
         run: |
           ls -lAh ${Python3_ROOT_DIR}/lib/python3.*/site-packages/pyGHDL/lib
-          tree ${Python3_ROOT_DIR}/lib/python3.*/site-packages/pyGHDL
+          tree ${Python3_ROOT_DIR}/lib/python3.*/site-packages/pyGHDL -I __pycache__
 
 #      - name: List pyGHDL installation directory (Windows)
 #        if: startsWith(inputs.os_image, 'windows')
@@ -240,7 +240,7 @@ jobs:
         shell: "msys2 {0}"
         run: |
           ls -lAh "${{ steps.msys2.outputs.msys2-location }}${MSYSTEM_PREFIX}/lib/python$(python --version | sed -E 's/Python ([0-9]+\.[0-9]+)\.[0-9]+/\1/')/site-packages/pyGHDL/lib"
-          tree    "${{ steps.msys2.outputs.msys2-location }}${MSYSTEM_PREFIX}/lib/python$(python --version | sed -E 's/Python ([0-9]+\.[0-9]+)\.[0-9]+/\1/')/site-packages/pyGHDL"
+          tree    "${{ steps.msys2.outputs.msys2-location }}${MSYSTEM_PREFIX}/lib/python$(python --version | sed -E 's/Python ([0-9]+\.[0-9]+)\.[0-9]+/\1/')/site-packages/pyGHDL" -I __pycache__
 
       - name: Sanity check ghdl-lsp (Ubuntu, Windows)
         if: startsWith(inputs.os_image, 'ubuntu') || (startsWith(inputs.os_image, 'windows') && inputs.runtime == '')

--- a/.github/workflows/Package-pyGHDL.yml
+++ b/.github/workflows/Package-pyGHDL.yml
@@ -128,11 +128,13 @@ jobs:
           path: ghdl
 
       - name: '🟦 Setup MSYS2 for ${{ inputs.runtime }}'
+        id: msys2
         uses: msys2/setup-msys2@v2
         if: inputs.runtime != ''
         with:
           msystem: ${{ inputs.runtime }}
           update: true
+          install: 'tree'
           pacboy: 'python:p python-pip:p python-wheel:p'
 
       - name: Prepare testsuite (Ubuntu, MSYS2)
@@ -237,8 +239,8 @@ jobs:
         if: startsWith(inputs.os_image, 'windows') && inputs.runtime != ''
         shell: "msys2 {0}"
         run: |
-          ls -lAh ${MSYSTEM_PREFIX}/lib/python3.*/site-packages/pyGHDL/lib
-          tree ${MSYSTEM_PREFIX}/lib/python3.*/site-packages/pyGHDL
+          ls -lAh "${{ steps.msys2.outputs.msys2-location }}${MSYSTEM_PREFIX}/lib/python$(python --version | sed -E 's/Python ([0-9]+\.[0-9]+)\.[0-9]+/\1/')/site-packages/pyGHDL/lib"
+          tree    "${{ steps.msys2.outputs.msys2-location }}${MSYSTEM_PREFIX}/lib/python$(python --version | sed -E 's/Python ([0-9]+\.[0-9]+)\.[0-9]+/\1/')/site-packages/pyGHDL"
 
       - name: Sanity check ghdl-lsp (Ubuntu, Windows)
         if: startsWith(inputs.os_image, 'ubuntu') || (startsWith(inputs.os_image, 'windows') && inputs.runtime == '')

--- a/.github/workflows/Package-pyGHDL.yml
+++ b/.github/workflows/Package-pyGHDL.yml
@@ -11,6 +11,10 @@ on:
         description: 'Name of the OS image.'
         required: true
         type: string
+      runtime:
+        description: 'MSYS2 runtime if MSYS2 is used.'
+        required: true
+        type: string
       python_icon:
         description: 'Name of the OS image.'
         required: true
@@ -54,12 +58,28 @@ jobs:
       - name: '⏬ Checkout'
         uses: actions/checkout@v4
 
+      - name: '🟦 Setup MSYS2 for ${{ inputs.runtime }}'
+        uses: msys2/setup-msys2@v2
+        if: inputs.runtime != ''
+        with:
+          msystem: ${{ inputs.runtime }}
+          update: true
+          pacboy: 'python:p python-pip:p python-wheel:p'
+
       - name: '🐍 Setup Python'
         uses: actions/setup-python@v5
+        if: inputs.runtime == ''
         with:
           python-version: ${{ inputs.python_version }}
 
-      - name: '🔧 Install dependencies'
+      - name: '🔧 Install dependencies (MSYS2)'
+        if: inputs.runtime != ''
+        run: |
+          python -m pip install --disable-pip-version-check "pyTooling[packaging]"
+
+      - name: '🔧 Install dependencies (Linux, Windows)'
+        if: inputs.runtime == ''
+        shell: "msys2 {0}"
         run: |
           python -m pip install --disable-pip-version-check "pyTooling[packaging]" wheel
 
@@ -69,17 +89,23 @@ jobs:
           name: ${{ inputs.libghdl_artifact }}-${{ inputs.backend }}
           path: install
 
-      - name: Copy libghdl files (Ubuntu)
-        if: startsWith(inputs.os_image, 'ubuntu')
+      - name: Copy libghdl files (Ubuntu, MSYS2)
+        if: startsWith(inputs.os_image, 'ubuntu') || (startsWith(inputs.os_image, 'windows') && inputs.runtime != '')
         run: |
           cp -r -v install/lib/* pyGHDL/lib
 
       - name: Copy libghdl files (Windows)
-        if: startsWith(inputs.os_image, 'windows')
+        if: startsWith(inputs.os_image, 'windows') && inputs.runtime == ''
         run: |
           cp -Recurse install/lib/* pyGHDL/lib
 
-      - name: 📦 Build Python package (binary distribution - wheel)
+      - name: 📦 Build Python package (binary distribution - wheel) (MSYS2)
+        if: inputs.runtime != ''
+        run: python setup.py bdist_wheel
+
+      - name: 📦 Build Python package (binary distribution - wheel) (Linux, Windows)
+        if: inputs.runtime == ''
+        shell: "msys2 {0}"
         run: python setup.py bdist_wheel
 
       - name: '📤 Upload artifact: ${{ inputs.pyghdl_artifact }}'

--- a/.github/workflows/Package-pyGHDL.yml
+++ b/.github/workflows/Package-pyGHDL.yml
@@ -74,12 +74,12 @@ jobs:
 
       - name: '🔧 Install dependencies (MSYS2)'
         if: inputs.runtime != ''
+        shell: "msys2 {0}"
         run: |
           python -m pip install --disable-pip-version-check "pyTooling[packaging]"
 
       - name: '🔧 Install dependencies (Linux, Windows)'
         if: inputs.runtime == ''
-        shell: "msys2 {0}"
         run: |
           python -m pip install --disable-pip-version-check "pyTooling[packaging]" wheel
 
@@ -101,11 +101,11 @@ jobs:
 
       - name: 📦 Build Python package (binary distribution - wheel) (MSYS2)
         if: inputs.runtime != ''
+        shell: "msys2 {0}"
         run: python setup.py bdist_wheel
 
       - name: 📦 Build Python package (binary distribution - wheel) (Linux, Windows)
         if: inputs.runtime == ''
-        shell: "msys2 {0}"
         run: python setup.py bdist_wheel
 
       - name: '📤 Upload artifact: ${{ inputs.pyghdl_artifact }}'

--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -70,24 +70,34 @@ jobs:
         id: params
         run: |
           if [ '${{ inputs.testsuites }}' == 'all' ]; then
-            echo "testsuites=sanity gna vests synth vpi vhpi" >> $GITHUB_OUTPUT
+            tee "${GITHUB_OUTPUT}" <<EOF
+          testsuites=sanity gna vests synth vpi vhpi
+          EOF
           else
-            echo "testsuites=${{ inputs.testsuites }}" >> $GITHUB_OUTPUT
+            tee "${GITHUB_OUTPUT}" <<EOF
+          testsuites=${{ inputs.testsuites }}
+          EOF
           fi
 
           ghdl_version=$(grep "^ghdl_version=\".*\"$" ./configure)
           ghdl_version=${ghdl_version/ghdl_version=/}
           ghdl_version=${ghdl_version//\"/}
           echo "GHDL version: $ghdl_version"
-          echo "ghdl_version=$ghdl_version" >> $GITHUB_OUTPUT
+          tee -a "${GITHUB_OUTPUT}" <<EOF
+          ghdl_version=${ghdl_version}
+          EOF
 
           pyghdl_version=${ghdl_version/-dev/.dev0}
-          echo "pyghdl_version=$pyghdl_version" >> $GITHUB_OUTPUT
+          tee -a "${GITHUB_OUTPUT}" <<EOF
+          pyghdl_version=${pyghdl_version}
+          EOF
 
           pacghdl_version=${ghdl_version/-dev/.dev-1}
-          echo "pacghdl_version=$pacghdl_version" >> $GITHUB_OUTPUT
+          tee -a "${GITHUB_OUTPUT}" <<EOF
+          pacghdl_version=${pacghdl_version}
+          EOF
 
-          cat $GITHUB_OUTPUT
+          cat "${GITHUB_OUTPUT}"
 
       - name: Check variables
         run: |

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -30,7 +30,7 @@ jobs:
       package_name: "ghdl"
       library_name: "libghdl"
       pyghdl_name:  "pyGHDL"
-#      testsuites:   "sanity"         # disable parameter to fall back to 'all'
+      testsuites:   "sanity"         # disable parameter to fall back to 'all'
 
   macOS:
     uses: ./.github/workflows/Build-MacOS.yml
@@ -42,11 +42,11 @@ jobs:
         include:
 # macOS-13 is the last Intel x86_64 release
           - {icon: '🍎🟨', backend: 'mcode',    macos_image: 'macos-13', gnat_arch: 'x86_64',  gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-          - {icon: '🍎🟨', backend: 'llvm',     macos_image: 'macos-13', gnat_arch: 'x86_64',  gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+#          - {icon: '🍎🟨', backend: 'llvm',     macos_image: 'macos-13', gnat_arch: 'x86_64',  gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
 # macOS-14 is the latest ARM v9 release
 ###       - {icon: '🍏🟩', backend: 'mcode',    macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: 'none'}                                    # mcode not yet supported for aarch64
-          - {icon: '🍏🟩', backend: 'llvm',     macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-          - {icon: '🍏🟩', backend: 'llvm-jit', macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+#          - {icon: '🍏🟩', backend: 'llvm',     macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+#          - {icon: '🍏🟩', backend: 'llvm-jit', macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
 # macOS-15 is beta (broken/missing types in C)
 ###       - {'icon': '🍏🟩', 'backend': 'mcode',    'macos_image': 'macos-15', 'gnat_arch': 'aarch64', 'gnat_version': '14.2.0-1', 'testsuites': 'none'}                                    # mcode not yet supported for aarch64
 ##        - {'icon': '🍏🟩', 'backend': 'llvm',     'macos_image': 'macos-15', 'gnat_arch': 'aarch64', 'gnat_version': '14.2.0-1', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
@@ -73,7 +73,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {icon: '🐧🟨', backend: 'mcode',    ubuntu_version: '22.04', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+#          - {icon: '🐧🟨', backend: 'mcode',    ubuntu_version: '22.04', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
           - {icon: '🐧🟩', backend: 'mcode',    ubuntu_version: '24.04', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
     with:
       ubuntu_version:           ${{ matrix.ubuntu_version }}
@@ -96,13 +96,13 @@ jobs:
       matrix:
         include:
 ###       - {'icon': '🐧🟨', 'backend': 'mcode',    'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites     # used by Ubuntu-fast
-          - {'icon': '🐧🟨', 'backend': 'llvm',     'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-          - {'icon': '🐧🟨', 'backend': 'llvm-jit', 'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-          - {'icon': '🐧🟨', 'backend': 'gcc',      'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+#          - {'icon': '🐧🟨', 'backend': 'llvm',     'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+#          - {'icon': '🐧🟨', 'backend': 'llvm-jit', 'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+#          - {'icon': '🐧🟨', 'backend': 'gcc',      'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
 ###       - {'icon': '🐧🟩', 'backend': 'mcode',    'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites     # used by Ubuntu-fast
           - {'icon': '🐧🟩', 'backend': 'llvm',     'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-          - {'icon': '🐧🟩', 'backend': 'llvm-jit', 'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-          - {'icon': '🐧🟩', 'backend': 'gcc',      'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+#          - {'icon': '🐧🟩', 'backend': 'llvm-jit', 'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+#          - {'icon': '🐧🟩', 'backend': 'gcc',      'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
     with:
       ubuntu_version:           ${{ matrix.ubuntu_version }}
       ghdl_backend:             ${{ matrix.backend }}
@@ -149,11 +149,11 @@ jobs:
         include:
 ###       - {icon: '🪟', runtime: 'mingw32', backend: 'mcode',    testsuites: '${{ needs.Params.outputs.testsuites }}'}   # No gcc-ada package for MinGW32, support was dropped
           - {icon: '🪟', runtime: 'mingw64', backend: 'mcode',    testsuites: '${{ needs.Params.outputs.testsuites }}'}
-          - {icon: '🪟', runtime: 'mingw64', backend: 'llvm',     testsuites: 'sanity gna synth vpi vhpi'}                # no vests (too slow)
-          - {icon: '🪟', runtime: 'mingw64', backend: 'llvm-jit', testsuites: 'sanity vpi vhpi'}                          # gna and synth fail (#2726); no vests (too slow)
+#          - {icon: '🪟', runtime: 'mingw64', backend: 'llvm',     testsuites: 'sanity gna synth vpi vhpi'}                # no vests (too slow)
+#          - {icon: '🪟', runtime: 'mingw64', backend: 'llvm-jit', testsuites: 'sanity vpi vhpi'}                          # gna and synth fail (#2726); no vests (too slow)
 ###       - {icon: '🪟', runtime: 'ucrt64',  backend: 'mcode',    testsuites: '${{ needs.Params.outputs.testsuites }}'}   # used by Windows-fast
-          - {icon: '🪟', runtime: 'ucrt64',  backend: 'llvm',     testsuites: 'sanity gna synth vpi vhpi'}                # no vests (too slow)
-          - {icon: '🪟', runtime: 'ucrt64',  backend: 'llvm-jit', testsuites: 'sanity vpi vhpi'}                          # gna and synth fail (#2726); no vests (too slow)
+#          - {icon: '🪟', runtime: 'ucrt64',  backend: 'llvm',     testsuites: 'sanity gna synth vpi vhpi'}                # no vests (too slow)
+#          - {icon: '🪟', runtime: 'ucrt64',  backend: 'llvm-jit', testsuites: 'sanity vpi vhpi'}                          # gna and synth fail (#2726); no vests (too slow)
     with:
       runtime:                  ${{ matrix.runtime }}
       backend:                  ${{ matrix.backend }}
@@ -202,12 +202,12 @@ jobs:
         os:
           - {icon: '🐧', name: 'Ubuntu',  image: 'ubuntu-24.04', libghdl_artifact: 'ubuntu-24.04-x86_64', pyghdl_artifact: 'Ubuntu-24.04-x86_64'}
 ###       - {icon: '🍏', name: 'macOS',   image: 'macos-14',     libghdl_artifact: 'macos-14-aarch64',    pyghdl_artifact: 'macOS-14-aarch64'}
-          - {icon: '🪟', name: 'Windows', image: 'windows-2022', libghdl_artifact: 'MSYS2-ucrt64',        pyghdl_artifact: 'Windows-x86_64'}
+#          - {icon: '🪟', name: 'Windows', image: 'windows-2022', libghdl_artifact: 'MSYS2-ucrt64',        pyghdl_artifact: 'Windows-x86_64'}
         py:
-          - {icon: '🔴', version: "3.9"}
-          - {icon: '🟠', version: "3.10"}
-          - {icon: '🟡', version: "3.11"}
-          - {icon: '🟢', version: "3.12"}
+#          - {icon: '🔴', version: "3.9"}
+#          - {icon: '🟠', version: "3.10"}
+#          - {icon: '🟡', version: "3.11"}
+#          - {icon: '🟢', version: "3.12"}
           - {icon: '🟢', version: "3.13"}
     with:
       os_name:               ${{ matrix.os.name }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -209,9 +209,15 @@ jobs:
 #          - {icon: '🟡', version: "3.11"}
 #          - {icon: '🟢', version: "3.12"}
           - {icon: '🟢', version: "3.13"}
+        other:
+          - {runtime: ''}
+        include:
+          - {os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', libghdl_artifact: 'MSYS2-mingw64', pyghdl_artifact: 'Windows-mingw64'}, py: {icon: '🟢', version: "3.12"}, other: {runtime: 'mingw64'}}
+          - {os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', libghdl_artifact: 'MSYS2-ucrt64',  pyghdl_artifact: 'Windows-ucrt64' }, py: {icon: '🟢', version: "3.12"}, other: {runtime: 'ucrt64' }}
     with:
       os_name:               ${{ matrix.os.name }}
       os_image:              ${{ matrix.os.image }}
+      runtime:               ${{ matrix.other.runtime }}
       python_icon:           ${{ matrix.py.icon }}
       python_version:        ${{ matrix.py.version }}
       libghdl_artifact:      ${{ needs.Params.outputs.libghdl_basename }}-${{ matrix.os.libghdl_artifact }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -30,7 +30,7 @@ jobs:
       package_name: "ghdl"
       library_name: "libghdl"
       pyghdl_name:  "pyGHDL"
-      testsuites:   "sanity"         # disable parameter to fall back to 'all'
+#      testsuites:   "sanity"         # disable parameter to fall back to 'all'
 
   macOS:
     uses: ./.github/workflows/Build-MacOS.yml
@@ -42,11 +42,11 @@ jobs:
         include:
 # macOS-13 is the last Intel x86_64 release
           - {icon: '🍎🟨', backend: 'mcode',    macos_image: 'macos-13', gnat_arch: 'x86_64',  gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-#          - {icon: '🍎🟨', backend: 'llvm',     macos_image: 'macos-13', gnat_arch: 'x86_64',  gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {icon: '🍎🟨', backend: 'llvm',     macos_image: 'macos-13', gnat_arch: 'x86_64',  gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
 # macOS-14 is the latest ARM v9 release
 ###       - {icon: '🍏🟩', backend: 'mcode',    macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: 'none'}                                    # mcode not yet supported for aarch64
-#          - {icon: '🍏🟩', backend: 'llvm',     macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-#          - {icon: '🍏🟩', backend: 'llvm-jit', macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {icon: '🍏🟩', backend: 'llvm',     macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {icon: '🍏🟩', backend: 'llvm-jit', macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
 # macOS-15 is beta (broken/missing types in C)
 ###       - {'icon': '🍏🟩', 'backend': 'mcode',    'macos_image': 'macos-15', 'gnat_arch': 'aarch64', 'gnat_version': '14.2.0-1', 'testsuites': 'none'}                                    # mcode not yet supported for aarch64
 ##        - {'icon': '🍏🟩', 'backend': 'llvm',     'macos_image': 'macos-15', 'gnat_arch': 'aarch64', 'gnat_version': '14.2.0-1', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
@@ -73,7 +73,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#          - {icon: '🐧🟨', backend: 'mcode',    ubuntu_version: '22.04', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {icon: '🐧🟨', backend: 'mcode',    ubuntu_version: '22.04', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
           - {icon: '🐧🟩', backend: 'mcode',    ubuntu_version: '24.04', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
     with:
       ubuntu_version:           ${{ matrix.ubuntu_version }}
@@ -96,13 +96,13 @@ jobs:
       matrix:
         include:
 ###       - {'icon': '🐧🟨', 'backend': 'mcode',    'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites     # used by Ubuntu-fast
-#          - {'icon': '🐧🟨', 'backend': 'llvm',     'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-#          - {'icon': '🐧🟨', 'backend': 'llvm-jit', 'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-#          - {'icon': '🐧🟨', 'backend': 'gcc',      'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {'icon': '🐧🟨', 'backend': 'llvm',     'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {'icon': '🐧🟨', 'backend': 'llvm-jit', 'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {'icon': '🐧🟨', 'backend': 'gcc',      'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
 ###       - {'icon': '🐧🟩', 'backend': 'mcode',    'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites     # used by Ubuntu-fast
           - {'icon': '🐧🟩', 'backend': 'llvm',     'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-#          - {'icon': '🐧🟩', 'backend': 'llvm-jit', 'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-#          - {'icon': '🐧🟩', 'backend': 'gcc',      'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {'icon': '🐧🟩', 'backend': 'llvm-jit', 'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {'icon': '🐧🟩', 'backend': 'gcc',      'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
     with:
       ubuntu_version:           ${{ matrix.ubuntu_version }}
       ghdl_backend:             ${{ matrix.backend }}
@@ -149,11 +149,11 @@ jobs:
         include:
 ###       - {icon: '🪟', runtime: 'mingw32', backend: 'mcode',    testsuites: '${{ needs.Params.outputs.testsuites }}'}   # No gcc-ada package for MinGW32, support was dropped
           - {icon: '🪟', runtime: 'mingw64', backend: 'mcode',    testsuites: '${{ needs.Params.outputs.testsuites }}'}
-#          - {icon: '🪟', runtime: 'mingw64', backend: 'llvm',     testsuites: 'sanity gna synth vpi vhpi'}                # no vests (too slow)
-#          - {icon: '🪟', runtime: 'mingw64', backend: 'llvm-jit', testsuites: 'sanity vpi vhpi'}                          # gna and synth fail (#2726); no vests (too slow)
+          - {icon: '🪟', runtime: 'mingw64', backend: 'llvm',     testsuites: 'sanity gna synth vpi vhpi'}                # no vests (too slow)
+          - {icon: '🪟', runtime: 'mingw64', backend: 'llvm-jit', testsuites: 'sanity vpi vhpi'}                          # gna and synth fail (#2726); no vests (too slow)
 ###       - {icon: '🪟', runtime: 'ucrt64',  backend: 'mcode',    testsuites: '${{ needs.Params.outputs.testsuites }}'}   # used by Windows-fast
-#          - {icon: '🪟', runtime: 'ucrt64',  backend: 'llvm',     testsuites: 'sanity gna synth vpi vhpi'}                # no vests (too slow)
-#          - {icon: '🪟', runtime: 'ucrt64',  backend: 'llvm-jit', testsuites: 'sanity vpi vhpi'}                          # gna and synth fail (#2726); no vests (too slow)
+          - {icon: '🪟', runtime: 'ucrt64',  backend: 'llvm',     testsuites: 'sanity gna synth vpi vhpi'}                # no vests (too slow)
+          - {icon: '🪟', runtime: 'ucrt64',  backend: 'llvm-jit', testsuites: 'sanity vpi vhpi'}                          # gna and synth fail (#2726); no vests (too slow)
     with:
       runtime:                  ${{ matrix.runtime }}
       backend:                  ${{ matrix.backend }}
@@ -202,12 +202,12 @@ jobs:
         os:
           - {icon: '🐧', name: 'Ubuntu',  image: 'ubuntu-24.04', libghdl_artifact: 'ubuntu-24.04-x86_64', pyghdl_artifact: 'Ubuntu-24.04-x86_64'}
 ###       - {icon: '🍏', name: 'macOS',   image: 'macos-14',     libghdl_artifact: 'macos-14-aarch64',    pyghdl_artifact: 'macOS-14-aarch64'}
-#          - {icon: '🪟', name: 'Windows', image: 'windows-2022', libghdl_artifact: 'MSYS2-ucrt64',        pyghdl_artifact: 'Windows-x86_64'}
+          - {icon: '🪟', name: 'Windows', image: 'windows-2022', libghdl_artifact: 'MSYS2-ucrt64',        pyghdl_artifact: 'Windows-x86_64'}
         py:
-#          - {icon: '🔴', version: "3.9"}
-#          - {icon: '🟠', version: "3.10"}
-#          - {icon: '🟡', version: "3.11"}
-#          - {icon: '🟢', version: "3.12"}
+          - {icon: '🔴', version: "3.9"}
+          - {icon: '🟠', version: "3.10"}
+          - {icon: '🟡', version: "3.11"}
+          - {icon: '🟢', version: "3.12"}
           - {icon: '🟢', version: "3.13"}
         other:
           - {runtime: ''}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -354,6 +354,7 @@ jobs:
       inventory-version: ${{ needs.Params.outputs.ghdl_version }}
       inventory-categories: "application,os-name,os-version,os-arch,runtime,ghdl-backend"
       assets: |
+        # Artifact Name                        File Name ($/! -> archive with/without subdir)                 Labels                                           Title
         ghdl-macos-13-x86_64-llvm:             $ghdl-llvm-%ghdl%-macos13-x86_64.tar.gz:                       ghdl,macos,13,x86-64,native,llvm:                GHDL - v%ghdl% - macOS 13 (x86-64) - llvm backend
         ghdl-macos-13-x86_64-mcode:            $ghdl-mcode-%ghdl%-macos13-x86_64.tar.gz:                      ghdl,macos,13,x86-64,native,mcode:               GHDL - v%ghdl% - macOS 13 (x86-64) - mcode backend
         ghdl-macos-14-aarch64-llvm:            $ghdl-llvm-%ghdl%-macos14-aarch64.tar.gz:                      ghdl,macos,14,aarch64,native,llvm:               GHDL - v%ghdl% - macOS 14 (aarch64) - llvm backend
@@ -380,9 +381,8 @@ jobs:
         pyGHDL-Windows-x86_64-Python-3.11:      pyGHDL-%pyghdl%-cp311-cp311-win_amd64.whl:                    pyGHDL,windows,2022,x86-64,py3.11,native,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.11
         pyGHDL-Windows-x86_64-Python-3.12:      pyGHDL-%pyghdl%-cp312-cp312-win_amd64.whl:                    pyGHDL,windows,2022,x86-64,py3.12,native,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.12
         pyGHDL-Windows-x86_64-Python-3.13:      pyGHDL-%pyghdl%-cp313-cp313-win_amd64.whl:                    pyGHDL,windows,2022,x86-64,py3.13,native,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.13
-        pyGHDL-Windows-MinGW64-Python-3.12:     pyGHDL-%pyghdl%-cp312-cp312-mingw_x86_64_msvcrt_gnu.whl:      pyGHDL,windows,2022,x86-64,py3.13,mingw64,mcode: pyGHDL - v%ghdl% - Windows (x86-64) + MSYS2/MinGW64 - Wheel for Python 3.12
-        pyGHDL-Windows-UCRT64-Python-3.12:      pyGHDL-%pyghdl%-cp312-cp312-mingw_x86_64_ucrt_gnu.whl:        pyGHDL,windows,2022,x86-64,py3.13,ucrt64,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) + MSYS2/UCRT64 - Wheel for Python 3.12
-
+        pyGHDL-Windows-mingw64-Python-3.12:     pyGHDL-%pyghdl%-cp312-cp312-mingw_x86_64_msvcrt_gnu.whl:      pyGHDL,windows,2022,x86-64,py3.12,mingw64,mcode: pyGHDL - v%ghdl% - Windows (x86-64) + MSYS2/MinGW64 - Wheel for Python 3.12
+        pyGHDL-Windows-ucrt64-Python-3.12:      pyGHDL-%pyghdl%-cp312-cp312-mingw_x86_64_ucrt_gnu.whl:        pyGHDL,windows,2022,x86-64,py3.12,ucrt64,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) + MSYS2/UCRT64 - Wheel for Python 3.12
 
   Release:
     uses: pyTooling/Actions/.github/workflows/NightlyRelease.yml@r4

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -349,36 +349,39 @@ jobs:
         The following asset categories are provided for pyGHDL:
         * Platform specific Python wheel package for Ubuntu incl. `pyGHDL...so`
         * Platform specific Python wheel package for Windows incl. `pyGHDL...dll`
+        * Platform specific Python wheel package for Windows + MSYS2 (MinGW64, UCRT64) incl. `pyGHDL...dll`
       inventory-json: "inventory.json"
       inventory-version: ${{ needs.Params.outputs.ghdl_version }}
       inventory-categories: "application,os-name,os-version,os-arch,runtime,ghdl-backend"
       assets: |
-        ghdl-macos-13-x86_64-llvm:             $ghdl-llvm-%ghdl%-macos13-x86_64.tar.gz:                       ghdl,macos,13,x86-64,native,llvm:         GHDL - v%ghdl% - macOS 13 (x86-64) - llvm backend
-        ghdl-macos-13-x86_64-mcode:            $ghdl-mcode-%ghdl%-macos13-x86_64.tar.gz:                      ghdl,macos,13,x86-64,native,mcode:        GHDL - v%ghdl% - macOS 13 (x86-64) - mcode backend
-        ghdl-macos-14-aarch64-llvm:            $ghdl-llvm-%ghdl%-macos14-aarch64.tar.gz:                      ghdl,macos,14,aarch64,native,llvm:        GHDL - v%ghdl% - macOS 14 (aarch64) - llvm backend
-        ghdl-macos-14-aarch64-llvm-jit:        $ghdl-llvm-jit-%ghdl%-macos14-aarch64.tar.gz:                  ghdl,macos,14,aarch64,native,llvm-jit:    GHDL - v%ghdl% - macOS 14 (aarch64) - llvm-jit backend
-        ghdl-ubuntu-24.04-x86_64-gcc:          $ghdl-gcc-%ghdl%-ubuntu24.04-x86_64.tar.gz:                    ghdl,ubuntu,24.04,x86-64,native,gcc:      GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - gcc backend
-        ghdl-ubuntu-24.04-x86_64-llvm:         $ghdl-llvm-%ghdl%-ubuntu24.04-x86_64.tar.gz:                   ghdl,ubuntu,24.04,x86-64,native,llvm:     GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - llvm backend
-        ghdl-ubuntu-24.04-x86_64-llvm-jit:     $ghdl-llvm-jit-%ghdl%-ubuntu24.04-x86_64.tar.gz:               ghdl,ubuntu,24.04,x86-64,native,llvm-jit: GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - llvm-jit backend
-        ghdl-ubuntu-24.04-x86_64-mcode:        $ghdl-mcode-%ghdl%-ubuntu24.04-x86_64.tar.gz:                  ghdl,ubuntu,24.04,x86-64,native,mcode:    GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - mcode backend
-        ghdl-Pacman-mingw64-llvm:               mingw-w64-x86_64-ghdl-llvm-%pacghdl%-any.pkg.tar.zst:         ghdl,windows,2022,x86-64,mingw64,llvm:    GHDL - v%ghdl% - MSYS2/MinGW64 - LLVM backend
-        ghdl-Pacman-mingw64-llvm-jit:           mingw-w64-x86_64-ghdl-llvm-jit-%pacghdl%-any.pkg.tar.zst:     ghdl,windows,2022,x86-64,mingw64,llvm-jit:GHDL - v%ghdl% - MSYS2/MinGW64 - LLVM-JIT backend
-        ghdl-Pacman-mingw64-mcode:              mingw-w64-x86_64-ghdl-mcode-%pacghdl%-any.pkg.tar.zst:        ghdl,windows,2022,x86-64,mingw64,mcode:   GHDL - v%ghdl% - MSYS2/MinGW64 - mcode backend
-        ghdl-Pacman-ucrt64-llvm:                mingw-w64-ucrt-x86_64-ghdl-llvm-%pacghdl%-any.pkg.tar.zst:    ghdl,windows,2022,x86-64,ucrt64,llvm:     GHDL - v%ghdl% - MSYS2/UCRT64 - LLVM backend
-        ghdl-Pacman-ucrt64-llvm-jit:            mingw-w64-ucrt-x86_64-ghdl-llvm-jit-%pacghdl%-any.pkg.tar.zst:ghdl,windows,2022,x86-64,ucrt64,llvm-jit: GHDL - v%ghdl% - MSYS2/UCRT64 - LLVM-JIT backend
-        ghdl-Pacman-ucrt64-mcode:               mingw-w64-ucrt-x86_64-ghdl-mcode-%pacghdl%-any.pkg.tar.zst:   ghdl,windows,2022,x86-64,ucrt64,mcode:    GHDL - v%ghdl% - MSYS2/UCRT64 - mcode backend
-        ghdl-Windows-mingw64-mcode:            !ghdl-mcode-%ghdl%-mingw64.zip:                                ghdl,windows,2022,x86-64,native,mcode:    GHDL - v%ghdl% - Windows (x86-64, MinGW64, standalone) - mcode backend
-        ghdl-Windows-ucrt64-mcode:             !ghdl-mcode-%ghdl%-ucrt64.zip:                                 ghdl,windows,2022,x86-64,native,mcode:    GHDL - v%ghdl% - Windows (x86-64, UCRT64, standalone) - mcode backend
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.9:  pyGHDL-%pyghdl%-cp39-cp39-linux_x86_64.whl:                   pyGHDL,ubuntu,24.04,x86-64,py3.9,mcode:   pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.9
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.10: pyGHDL-%pyghdl%-cp310-cp310-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.10,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.10
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.11: pyGHDL-%pyghdl%-cp311-cp311-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.11,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.11
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.12: pyGHDL-%pyghdl%-cp312-cp312-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.12,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.12
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.13: pyGHDL-%pyghdl%-cp313-cp313-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.13,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.13
-        pyGHDL-Windows-x86_64-Python-3.9:       pyGHDL-%pyghdl%-cp39-cp39-win_amd64.whl:                      pyGHDL,windows,2022,x86-64,py3.9,mcode:   pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.9
-        pyGHDL-Windows-x86_64-Python-3.10:      pyGHDL-%pyghdl%-cp310-cp310-win_amd64.whl:                    pyGHDL,windows,2022,x86-64,py3.10,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.10
-        pyGHDL-Windows-x86_64-Python-3.11:      pyGHDL-%pyghdl%-cp311-cp311-win_amd64.whl:                    pyGHDL,windows,2022,x86-64,py3.11,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.11
-        pyGHDL-Windows-x86_64-Python-3.12:      pyGHDL-%pyghdl%-cp312-cp312-win_amd64.whl:                    pyGHDL,windows,2022,x86-64,py3.12,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.12
-        pyGHDL-Windows-x86_64-Python-3.13:      pyGHDL-%pyghdl%-cp313-cp313-win_amd64.whl:                    pyGHDL,windows,2022,x86-64,py3.13,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.13
+        ghdl-macos-13-x86_64-llvm:             $ghdl-llvm-%ghdl%-macos13-x86_64.tar.gz:                       ghdl,macos,13,x86-64,native,llvm:                GHDL - v%ghdl% - macOS 13 (x86-64) - llvm backend
+        ghdl-macos-13-x86_64-mcode:            $ghdl-mcode-%ghdl%-macos13-x86_64.tar.gz:                      ghdl,macos,13,x86-64,native,mcode:               GHDL - v%ghdl% - macOS 13 (x86-64) - mcode backend
+        ghdl-macos-14-aarch64-llvm:            $ghdl-llvm-%ghdl%-macos14-aarch64.tar.gz:                      ghdl,macos,14,aarch64,native,llvm:               GHDL - v%ghdl% - macOS 14 (aarch64) - llvm backend
+        ghdl-macos-14-aarch64-llvm-jit:        $ghdl-llvm-jit-%ghdl%-macos14-aarch64.tar.gz:                  ghdl,macos,14,aarch64,native,llvm-jit:           GHDL - v%ghdl% - macOS 14 (aarch64) - llvm-jit backend
+        ghdl-ubuntu-24.04-x86_64-gcc:          $ghdl-gcc-%ghdl%-ubuntu24.04-x86_64.tar.gz:                    ghdl,ubuntu,24.04,x86-64,native,gcc:             GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - gcc backend
+        ghdl-ubuntu-24.04-x86_64-llvm:         $ghdl-llvm-%ghdl%-ubuntu24.04-x86_64.tar.gz:                   ghdl,ubuntu,24.04,x86-64,native,llvm:            GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - llvm backend
+        ghdl-ubuntu-24.04-x86_64-llvm-jit:     $ghdl-llvm-jit-%ghdl%-ubuntu24.04-x86_64.tar.gz:               ghdl,ubuntu,24.04,x86-64,native,llvm-jit:        GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - llvm-jit backend
+        ghdl-ubuntu-24.04-x86_64-mcode:        $ghdl-mcode-%ghdl%-ubuntu24.04-x86_64.tar.gz:                  ghdl,ubuntu,24.04,x86-64,native,mcode:           GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - mcode backend
+        ghdl-Pacman-mingw64-llvm:               mingw-w64-x86_64-ghdl-llvm-%pacghdl%-any.pkg.tar.zst:         ghdl,windows,2022,x86-64,mingw64,llvm:           GHDL - v%ghdl% - MSYS2/MinGW64 - LLVM backend
+        ghdl-Pacman-mingw64-llvm-jit:           mingw-w64-x86_64-ghdl-llvm-jit-%pacghdl%-any.pkg.tar.zst:     ghdl,windows,2022,x86-64,mingw64,llvm-jit:       GHDL - v%ghdl% - MSYS2/MinGW64 - LLVM-JIT backend
+        ghdl-Pacman-mingw64-mcode:              mingw-w64-x86_64-ghdl-mcode-%pacghdl%-any.pkg.tar.zst:        ghdl,windows,2022,x86-64,mingw64,mcode:          GHDL - v%ghdl% - MSYS2/MinGW64 - mcode backend
+        ghdl-Pacman-ucrt64-llvm:                mingw-w64-ucrt-x86_64-ghdl-llvm-%pacghdl%-any.pkg.tar.zst:    ghdl,windows,2022,x86-64,ucrt64,llvm:            GHDL - v%ghdl% - MSYS2/UCRT64 - LLVM backend
+        ghdl-Pacman-ucrt64-llvm-jit:            mingw-w64-ucrt-x86_64-ghdl-llvm-jit-%pacghdl%-any.pkg.tar.zst:ghdl,windows,2022,x86-64,ucrt64,llvm-jit:        GHDL - v%ghdl% - MSYS2/UCRT64 - LLVM-JIT backend
+        ghdl-Pacman-ucrt64-mcode:               mingw-w64-ucrt-x86_64-ghdl-mcode-%pacghdl%-any.pkg.tar.zst:   ghdl,windows,2022,x86-64,ucrt64,mcode:           GHDL - v%ghdl% - MSYS2/UCRT64 - mcode backend
+        ghdl-Windows-mingw64-mcode:            !ghdl-mcode-%ghdl%-mingw64.zip:                                ghdl,windows,2022,x86-64,native,mcode:           GHDL - v%ghdl% - Windows (x86-64, MinGW64, standalone) - mcode backend
+        ghdl-Windows-ucrt64-mcode:             !ghdl-mcode-%ghdl%-ucrt64.zip:                                 ghdl,windows,2022,x86-64,native,mcode:           GHDL - v%ghdl% - Windows (x86-64, UCRT64, standalone) - mcode backend
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.9:  pyGHDL-%pyghdl%-cp39-cp39-linux_x86_64.whl:                   pyGHDL,ubuntu,24.04,x86-64,py3.9,native,mcode:   pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.9
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.10: pyGHDL-%pyghdl%-cp310-cp310-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.10,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.10
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.11: pyGHDL-%pyghdl%-cp311-cp311-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.11,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.11
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.12: pyGHDL-%pyghdl%-cp312-cp312-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.12,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.12
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.13: pyGHDL-%pyghdl%-cp313-cp313-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.13,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.13
+        pyGHDL-Windows-x86_64-Python-3.9:       pyGHDL-%pyghdl%-cp39-cp39-win_amd64.whl:                      pyGHDL,windows,2022,x86-64,py3.9,native,mcode:   pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.9
+        pyGHDL-Windows-x86_64-Python-3.10:      pyGHDL-%pyghdl%-cp310-cp310-win_amd64.whl:                    pyGHDL,windows,2022,x86-64,py3.10,native,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.10
+        pyGHDL-Windows-x86_64-Python-3.11:      pyGHDL-%pyghdl%-cp311-cp311-win_amd64.whl:                    pyGHDL,windows,2022,x86-64,py3.11,native,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.11
+        pyGHDL-Windows-x86_64-Python-3.12:      pyGHDL-%pyghdl%-cp312-cp312-win_amd64.whl:                    pyGHDL,windows,2022,x86-64,py3.12,native,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.12
+        pyGHDL-Windows-x86_64-Python-3.13:      pyGHDL-%pyghdl%-cp313-cp313-win_amd64.whl:                    pyGHDL,windows,2022,x86-64,py3.13,native,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.13
+        pyGHDL-Windows-MinGW64-Python-3.12:     pyGHDL-%pyghdl%-cp312-cp312-mingw_x86_64_msvcrt_gnu.whl:      pyGHDL,windows,2022,x86-64,py3.13,mingw64,mcode: pyGHDL - v%ghdl% - Windows (x86-64) + MSYS2/MinGW64 - Wheel for Python 3.12
+        pyGHDL-Windows-UCRT64-Python-3.12:      pyGHDL-%pyghdl%-cp312-cp312-mingw_x86_64_ucrt_gnu.whl:        pyGHDL,windows,2022,x86-64,py3.13,ucrt64,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) + MSYS2/UCRT64 - Wheel for Python 3.12
 
 
   Release:

--- a/.github/workflows/Test-GHDL.yml
+++ b/.github/workflows/Test-GHDL.yml
@@ -9,7 +9,7 @@ on:
         default: 'ubuntu-24.04'
         type: string
       runtime:
-        description: 'Used runtime if MSYS2.'
+        description: 'MSYS2 runtime if MSYS2 is used.'
         required: false
         default: ''
         type: string

--- a/.github/workflows/Test-SetupGHDL.yml
+++ b/.github/workflows/Test-SetupGHDL.yml
@@ -10,6 +10,7 @@ on:
         required: true
         type: string
       runtime:
+        description: 'MSYS2 runtime if MSYS2 is used.'
         required: true
         type: string
       ghdl_version:


### PR DESCRIPTION
This PR will add the packaging of pyGHDL for MinGW64 and UCRT64 as platform specific wheel packages.

Steps:
* [x] Provide libghdl for MinGW64 as artifact.
* [x] Package pyGHDL for MinGW64.
* [x] Package pyGHDL for UCRT64.
* [x] Fix pyGHDL testcases.
* [x] Add new wheel files to nightly release.
* [x] Reactivate all jobs.