### PR TITLE
Disable macOS-15 builds due to cstdio.h issue.

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -49,8 +49,8 @@ jobs:
           - {icon: '🍏🟩', backend: 'llvm-jit', macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
 # macOS-15 is beta (broken/missing types in C)
 ###       - {icon: '🍏🟩', backend: 'mcode',    macos_image: 'macos-15', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: 'none'}                                    # mcode not yet supported for aarch64
-          - {icon: '🍏🟩', backend: 'llvm',     macos_image: 'macos-15', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-          - {icon: '🍏🟩', backend: 'llvm-jit', macos_image: 'macos-15', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+##        - {icon: '🍏🟩', backend: 'llvm',     macos_image: 'macos-15', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+##        - {icon: '🍏🟩', backend: 'llvm-jit', macos_image: 'macos-15', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
     with:
       macos_image:              ${{ matrix.macos_image }}
       gnat_arch:                ${{ matrix.gnat_arch }}


### PR DESCRIPTION
By accident, macOS-15 was enabled in the pipeline. This PR is deactivating macOS-15 builds (for now).

The current investigation shows 2 options:
* The GNAT compiler from https://github.com/alire-project/GNAT-FSF-builds doesn't contain a definition of `FILE*` in `cstdio.h`.
* The GNAT compiler's `cstdio.h` don't contain `FILE*` itself and references a `_stdio.h`. Maybe this file is provided by the operating system, which has changed from macOS-14 to macOS-15.