### PR TITLE
Add support for record subtype declarations (constraints)

### DIFF
--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -33,7 +33,7 @@
 """
 This module implements derived symbol classes from :mod:`pyVHDLModel.Symbol`.
 """
-from typing import List
+from typing import List, Mapping
 
 from pyTooling.Decorators import export, InheritDocString
 
@@ -54,6 +54,7 @@ from pyVHDLModel.Symbol import RecordElementSymbol as VHDLModel_RecordElementSym
 from pyVHDLModel.Symbol import ConstrainedScalarSubtypeSymbol as VHDLModel_ConstrainedScalarSubtypeSymbol
 from pyVHDLModel.Symbol import ConstrainedCompositeSubtypeSymbol as VHDLModel_ConstrainedCompositeSubtypeSymbol
 from pyVHDLModel.Symbol import ConstrainedRecordSubtypeSymbol as VHDLModel_ConstrainedRecordSubtypeSymbol
+from pyVHDLModel.Symbol import ConstrainedArraySubtypeSymbol as VHDLModel_ConstrainedArraySubtypeSymbol
 from pyVHDLModel.Symbol import SimpleObjectOrFunctionCallSymbol as VHDLModel_SimpleObjectOrFunctionCallSymbol
 from pyVHDLModel.Symbol import IndexedObjectOrFunctionCallSymbol as VHDLModel_IndexedObjectOrFunctionCallSymbol
 
@@ -318,10 +319,21 @@ class ConstrainedCompositeSubtypeSymbol(VHDLModel_ConstrainedCompositeSubtypeSym
         pass
 
 @export
+class ConstrainedArraySubtypeSymbol(VHDLModel_ConstrainedArraySubtypeSymbol, DOMMixin):
+    @InheritDocString(VHDLModel_ConstrainedArraySubtypeSymbol)
+    def __init__(self, node: Iir, subtypeName: Name, constraints: List):
+        super().__init__(subtypeName, constraints)
+        DOMMixin.__init__(self, node)
+
+    @classmethod
+    def parse():
+        pass
+
+@export
 class ConstrainedRecordSubtypeSymbol(VHDLModel_ConstrainedRecordSubtypeSymbol, DOMMixin):
     @InheritDocString(VHDLModel_ConstrainedRecordSubtypeSymbol)
-    def __init__(self, node: Iir, subtypeName: Name, constraints: List):
-        super().__init__(self, constraints)
+    def __init__(self, node: Iir, subtypeName: Name, constraints: Mapping):
+        super().__init__(subtypeName, constraints)
         DOMMixin.__init__(self, node)
 
 @export

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -50,15 +50,16 @@ from pyVHDLModel.Symbol import EntityInstantiationSymbol as VHDLModel_EntityInst
 from pyVHDLModel.Symbol import ComponentInstantiationSymbol as VHDLModel_ComponentInstantiationSymbol
 from pyVHDLModel.Symbol import ConfigurationInstantiationSymbol as VHDLModel_ConfigurationInstantiationSymbol
 from pyVHDLModel.Symbol import SimpleSubtypeSymbol as VHDLModel_SimpleSubtypeSymbol
+from pyVHDLModel.Symbol import RecordElementSymbol as VHDLModel_RecordElementSymbol
 from pyVHDLModel.Symbol import ConstrainedScalarSubtypeSymbol as VHDLModel_ConstrainedScalarSubtypeSymbol
 from pyVHDLModel.Symbol import ConstrainedCompositeSubtypeSymbol as VHDLModel_ConstrainedCompositeSubtypeSymbol
+from pyVHDLModel.Symbol import ConstrainedRecordSubtypeSymbol as VHDLModel_ConstrainedRecordSubtypeSymbol
 from pyVHDLModel.Symbol import SimpleObjectOrFunctionCallSymbol as VHDLModel_SimpleObjectOrFunctionCallSymbol
 from pyVHDLModel.Symbol import IndexedObjectOrFunctionCallSymbol as VHDLModel_IndexedObjectOrFunctionCallSymbol
 
 from pyGHDL.libghdl._types import Iir
 from pyGHDL.dom import DOMMixin
 from pyGHDL.dom.Range import Range
-
 
 @export
 class LibraryReferenceSymbol(VHDLModel_LibraryReferenceSymbol, DOMMixin):
@@ -316,6 +317,12 @@ class ConstrainedCompositeSubtypeSymbol(VHDLModel_ConstrainedCompositeSubtypeSym
     def parse(cls, node: Iir):
         pass
 
+@export
+class ConstrainedRecordSubtypeSymbol(VHDLModel_ConstrainedRecordSubtypeSymbol, DOMMixin):
+    @InheritDocString(VHDLModel_ConstrainedRecordSubtypeSymbol)
+    def __init__(self, node: Iir, subtypeName: Name, constraints: List):
+        super().__init__(self, constraints)
+        DOMMixin.__init__(self, node)
 
 @export
 class SimpleObjectOrFunctionCallSymbol(VHDLModel_SimpleObjectOrFunctionCallSymbol, DOMMixin):
@@ -332,6 +339,12 @@ class SimpleObjectOrFunctionCallSymbol(VHDLModel_SimpleObjectOrFunctionCallSymbo
 
         return cls(node, name)
 
+@export
+class RecordElementSymbol(VHDLModel_RecordElementSymbol, DOMMixin):
+    @InheritDocString(VHDLModel_RecordElementSymbol)
+    def __init__(self, node: Iir, name: Name) -> None:
+        super().__init__(name)
+        DOMMixin.__init__(self, node)
 
 @export
 class IndexedObjectOrFunctionCallSymbol(VHDLModel_IndexedObjectOrFunctionCallSymbol, DOMMixin):

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -395,30 +395,12 @@ def GetRecordConstraintsFromSubtypeIndication(
     constraints = dict()
 
     for constraint in utils.chain_iter(chain):
-        # element: Record_Element_Constraint
         symbol = RecordElementSymbol(constraint, GetNameOfNode(constraint))
 
-        # I think this is always the case?
-        constraintKind = GetIirKindOfNode(constraint)
+        subtypeIndication = nodes.Get_Subtype_Indication(constraint)
 
-        if constraintKind == nodes.Iir_Kind.Record_Element_Constraint:
-            arraySubtype = nodes.Get_Subtype_Indication(constraint)
-
-            for indexConstraint in utils.flist_iter(nodes.Get_Index_Constraint_List(arraySubtype)):
-                # Could be range exp. attribute name, maybe others?
-                indexKind = GetIirKindOfNode(indexConstraint)
-
-                if indexKind == nodes.Iir_Kind.Range_Expression:
-                    constraints[symbol] = RangeExpression.parse(indexConstraint)
-                else:
-                    prefixName = GetName(nodes.Get_Prefix(indexConstraint))
-
-                    # constraints[symbol] = ? # Needs to be a range...
-        else:
-            position = Position.parse(constraint)
-            raise DOMException(
-                f"Unknown record constraint kind '{constraintKind.name}': in expression '{subtypeIndicationNode}' at {position}"
-            )
+        for indexConstraint in utils.flist_iter(nodes.Get_Index_Constraint_List(subtypeIndication)):
+            constraints[symbol] = GetExpressionFromNode(indexConstraint)
 
     return constraints
 

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -34,10 +34,6 @@
 """
 This module offers helper functions to translate often used IIR substructures to pyGHDL.dom (pyVHDLModel) constructs.
 """
-
-# Remove:
-import code
-
 from typing import List, Generator, Type
 
 from pyTooling.Decorators import export

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -30,6 +30,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+
 """
 This module offers helper functions to translate often used IIR substructures to pyGHDL.dom (pyVHDLModel) constructs.
 """
@@ -227,22 +228,30 @@ def GetArrayConstraintsFromSubtypeIndication(
     subtypeIndication: Iir,
 ) -> List:
     constraints = []
-    for constraint in utils.flist_iter(nodes.Get_Index_Constraint_List(subtypeIndication)):
-        constraintKind = GetIirKindOfNode(constraint)
-        if constraintKind == nodes.Iir_Kind.Range_Expression:
-            constraints.append(RangeExpression.parse(constraint))
-        elif constraintKind in (
-            nodes.Iir_Kind.Simple_Name,
-            nodes.Iir_Kind.Parenthesis_Name,
-            nodes.Iir_Kind.Selected_Name,
-            nodes.Iir_Kind.Attribute_Name,
-        ):
-            constraints.append(GetName(constraint))
-        else:
-            position = Position.parse(constraint)
-            raise DOMException(
-                f"Unknown constraint kind '{constraintKind.name}' for constraint '{constraint}' in subtype indication '{subtypeIndication}' at {position}."
-            )
+
+    subtypeKind = GetIirKindOfNode(subtypeIndication)
+
+    if subtypeKind == nodes.Iir_Kind.Record_Subtype_Definition:
+        # Constraints get thrown away anyway?
+        # code.interact(local=dict(globals(), **locals()))
+        return constraints
+    else:
+        for constraint in utils.flist_iter(nodes.Get_Index_Constraint_List(subtypeIndication)):
+            constraintKind = GetIirKindOfNode(constraint)
+            if constraintKind == nodes.Iir_Kind.Range_Expression:
+                constraints.append(RangeExpression.parse(constraint))
+            elif constraintKind in (
+                nodes.Iir_Kind.Simple_Name,
+                nodes.Iir_Kind.Parenthesis_Name,
+                nodes.Iir_Kind.Selected_Name,
+                nodes.Iir_Kind.Attribute_Name,
+            ):
+                constraints.append(GetName(constraint))
+            else:
+                position = Position.parse(constraint)
+                raise DOMException(
+                    f"Unknown constraint kind '{constraintKind.name}' for constraint '{constraint}' in subtype indication '{subtypeIndication}' at {position}."
+                )
 
     return constraints
 
@@ -348,6 +357,8 @@ def GetSubtypeIndicationFromIndicationNode(subtypeIndicationNode: Iir, entity: s
     elif kind == nodes.Iir_Kind.Subtype_Definition:
         return GetScalarConstrainedSubtypeFromNode(subtypeIndicationNode)
     elif kind == nodes.Iir_Kind.Array_Subtype_Definition:
+        return GetCompositeConstrainedSubtypeFromNode(subtypeIndicationNode)
+    elif kind == nodes.Iir_Kind.Record_Subtype_Definition:
         return GetCompositeConstrainedSubtypeFromNode(subtypeIndicationNode)
     else:
         raise DOMException(f"Unknown kind '{kind.name}' for an subtype indication in a {entity} of `{name}`.")

--- a/pyGHDL/dom/formatting/prettyprint.py
+++ b/pyGHDL/dom/formatting/prettyprint.py
@@ -30,6 +30,9 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+# Remove
+import code
+
 from typing import List, Union
 
 from pyTooling.Decorators import export
@@ -65,7 +68,7 @@ from pyGHDL.dom.DesignUnit import (
     UseClause,
     PackageInstantiation,
 )
-from pyGHDL.dom.Symbol import SimpleSubtypeSymbol, ConstrainedCompositeSubtypeSymbol
+from pyGHDL.dom.Symbol import SimpleSubtypeSymbol, ConstrainedArraySubtypeSymbol, ConstrainedRecordSubtypeSymbol
 from pyGHDL.dom.Type import (
     IntegerType,
     Subtype,
@@ -447,14 +450,23 @@ class PrettyPrint:
     def formatSubtypeIndication(self, subtypeIndication, entity: str, name: str) -> str:
         if isinstance(subtypeIndication, SimpleSubtypeSymbol):
             return f"{subtypeIndication.Name.Identifier}"
-        elif isinstance(subtypeIndication, ConstrainedCompositeSubtypeSymbol):
+        elif isinstance(subtypeIndication, ConstrainedArraySubtypeSymbol):
             constraints = []
-            # FIXME: disabled due to problems with symbols
-            # for constraint in subtypeIndication.Constraints:
-            #     constraints.append(str(constraint))
+
+            for constraint in subtypeIndication.Constraints:
+                constraints.append(str(constraint))
+
+            return f"{subtypeIndication.Name.Identifier}({', '.join(constraints)})"
+        elif isinstance(subtypeIndication, ConstrainedRecordSubtypeSymbol):
+            constraints = []
+            # Constraints: Dict[RecordElementSymbol, Any]
+
+            for element, constraint  in subtypeIndication.Constraints.items():
+                constraints.append(str(constraint))
 
             return f"{subtypeIndication.Name.Identifier}({', '.join(constraints)})"
         else:
+            
             raise PrettyPrintException(
                 f"Unhandled subtype kind '{subtypeIndication.__class__.__name__}' for {entity} '{name}'."
             )

--- a/pyGHDL/dom/formatting/prettyprint.py
+++ b/pyGHDL/dom/formatting/prettyprint.py
@@ -30,9 +30,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
-# Remove
-import code
-
 from typing import List, Union
 
 from pyTooling.Decorators import export


### PR DESCRIPTION
Integrate the new types in [this commit](https://github.com/VHDL/pyVHDLModel/commit/64924f19f158e4113f2f45017416d71431691462) into pyGHDL, which it depends on. Record subtypes should have their constraits parsed now, like so, (output from `dom.py pretty`):

```
Architectures (1):
  - Name: rtl
    File: regoop_reg.vhd
    Position: 33:13
    Documentation:
    Entity: regoop_reg
    Declared:
      - constant lefty : natural := 10
      - constant righty : natural := 0
      - signal regtest : reg_state_t(lefty? downto righty?)
      - signal regdata : reg_state_t(BIT_FIELDS'range?) := get_reg_initial_value(BIT_FIELDS?, RESET_VALUE?)?
```

I was not sure how to use RecordConstraint and ArrayConstraint, since the constraints could be Symbol -> Expression?

This is my first PR, it is possible I have committed some devops embarrassments. In particular I did my work on master and only now realized I was supposed to have created a feature branch first. I used --force-with-lease to replace some commits accidentally containing dot folder detritus. Let me know if any of this needs reconciled.
