### PR TITLE
Fix typo: s|overriden|overridden

### DIFF
--- a/src/grt/grt-change_generics.adb
+++ b/src/grt/grt-change_generics.adb
@@ -437,7 +437,7 @@ package body Grt.Change_Generics is
                   if Uc_Array.Base = Null_Address then
                      Error_S ("top-level generic '");
                      Diag_C (Obj_Rti.Name);
-                     Error_E ("' must be overriden (use -gGEN=VAL)");
+                     Error_E ("' must be overridden (use -gGEN=VAL)");
                   end if;
                end;
             end if;

--- a/src/grt/grt-change_generics.ads
+++ b/src/grt/grt-change_generics.ads
@@ -26,6 +26,6 @@ package Grt.Change_Generics is
    procedure Change_All_Generics;
 
    --  Emit an error if a generic that required override (unconstrained array)
-   --  wasn't overriden.
+   --  wasn't overridden.
    procedure Check_Required_Generic_Override;
 end Grt.Change_Generics;

--- a/src/grt/grt-signals.adb
+++ b/src/grt/grt-signals.adb
@@ -834,7 +834,7 @@ package body Grt.Signals is
                --  Set the last transaction of the driver.
                Driver.Last_Trans := Last;
                --  Cut the chain.  This is not strickly necessary, since
-               --  it will be overriden below, by appending TRANS to the
+               --  it will be overridden below, by appending TRANS to the
                --  driver.
                Last.Next := null;
                --  Free removed transactions.

--- a/src/verilog/verilog-elaborate.ads
+++ b/src/verilog/verilog-elaborate.ads
@@ -30,7 +30,7 @@ package Verilog.Elaborate is
    --
    --  The design hierarchy is instantiated (until the generate blocks).
    --
-   --  Parameters are overriden.
+   --  Parameters are overridden.
    --
    --  Design hierarchy is analyzed.
    --   Declarations

--- a/src/vhdl/translate/trans-chap1.adb
+++ b/src/vhdl/translate/trans-chap1.adb
@@ -58,7 +58,7 @@ package body Trans.Chap1 is
               and then Get_Constraint_State (El_Type) /= Fully_Constrained
             then
                --  Do not initialize unconstrained array.  They will have
-               --  to be overriden by user.
+               --  to be overridden by user.
                null;
             else
                Chap4.Elab_Object_Value (El, Val);

--- a/src/vhdl/vhdl-configuration.adb
+++ b/src/vhdl/vhdl-configuration.adb
@@ -1347,7 +1347,7 @@ package body Vhdl.Configuration is
                      then
                         --  Could be a generic package, a generic type...
                         Error_Msg_Elab
-                          ("generic %n cannot be overriden (not a constant)",
+                          ("generic %n cannot be overridden (not a constant)",
                            +Gen_Id);
                      else
                         Override_Generic (Inter, Over.Value);

--- a/src/vhdl/vhdl-sem.adb
+++ b/src/vhdl/vhdl-sem.adb
@@ -3671,7 +3671,7 @@ package body Vhdl.Sem is
       Sem_Scopes.Use_All_Names (Standard_Package);
 
       --  Use pre-defined locations for STD and WORK library (as they may
-      --  be later overriden).
+      --  be later overridden).
       Set_Location (Libraries.Std_Library, Libraries.Library_Location);
       Set_Location (Library, Libraries.Library_Location);
 

--- a/src/vhdl/vhdl-sem_decls.adb
+++ b/src/vhdl/vhdl-sem_decls.adb
@@ -1635,7 +1635,7 @@ package body Vhdl.Sem_Decls is
         or else (Flags.Vhdl_Std > Vhdl_87
                  and then Ident in Std_Names.Name_Id_Vhdl93_Attributes)
       then
-         Error_Msg_Sem (+Decl, "predefined attribute %i overriden", +Decl);
+         Error_Msg_Sem (+Decl, "predefined attribute %i overridden", +Decl);
       end if;
       Sem_Scopes.Add_Name (Decl);
       Xref_Decl (Decl);

--- a/src/vhdl/vhdl-sem_names.adb
+++ b/src/vhdl/vhdl-sem_names.adb
@@ -386,7 +386,7 @@ package body Vhdl.Sem_Names is
                end if;
             when others =>
                --  Consider only visible declarations (case of an implicit
-               --  declaration that is overriden by explicit one).
+               --  declaration that is overridden by explicit one).
                if Get_Identifier (Decl) = Id and Get_Visible_Flag (Decl) then
                   Add_Result (Res, Decl);
                end if;

--- a/src/vhdl/vhdl-sem_scopes.adb
+++ b/src/vhdl/vhdl-sem_scopes.adb
@@ -1535,7 +1535,7 @@ package body Vhdl.Sem_Scopes is
               and then Is_Operation_For_Type (El, Base_Type)
             then
                if Get_Visible_Flag (El) then
-                  --  Implicit declaration EL was overriden by a user
+                  --  Implicit declaration EL was overridden by a user
                   --  declaration.  Don't make it visible.
                   Potentially_Add_Name (El);
                else


### PR DESCRIPTION
**Description** 

Fix typo: s|overriden|overridden

Substitute `overriden` for `overridden`.

**When contributing to the GHDL codebase...**

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
- [ ] CONSIDER adding a unit test if your PR resolves an issue.
- [ ] CONSIDER modifying the docs, if your contribution is relevant to any of the content.
- [ ] AVOID breaking the continuous integration build.
- [ ] AVOID breaking the testsuite.

**When contributing to the docs...**

- [ ] DO make sure that the build is successful.

**Further comments**

To verify that the change was applied correctly, I built GHDL container, modifying these lines with sed before the compilation:

```bash
sed -i '440s|overriden|overridden|#' ghdl/src/grt/grt-change_generics.adb 
sed -i '29s|overriden|overridden|#' ghdl/src/grt/grt-change_generics.ads 
sed -i '837s|overriden|overridden|#' ghdl/src/grt/grt-signals.adb 
sed -i '33s|overriden|overridden|#' ghdl/src/verilog/verilog-elaborate.ads 
sed -i '61s|overriden|overridden|#' ghdl/src/vhdl/translate/trans-chap1.adb 
sed -i '1350s|overriden|overridden|#' ghdl/src/vhdl/vhdl-configuration.adb 
sed -i '3674s|overriden|overridden|#' ghdl/src/vhdl/vhdl-sem.adb 
sed -i '1638s|overriden|overridden|#' ghdl/src/vhdl/vhdl-sem_decls.adb 
sed -i '389s|overriden|overridden|#' ghdl/src/vhdl/vhdl-sem_names.adb 
sed -i '1538s|overriden|overridden|#' ghdl/src/vhdl/vhdl-sem_scopes.adb 
```

These files have been chosen according to the search for this typo in the repository:

``` 
./src/grt/grt-change_generics.adb:440:                     Error_E ("' must be overriden (use -gGEN=VAL)");
./src/grt/grt-change_generics.ads:29:   --  wasn't overriden.
./src/grt/grt-signals.adb:837:               --  it will be overriden below, by appending TRANS to the
./src/verilog/verilog-elaborate.ads:33:   --  Parameters are overriden.
./src/vhdl/translate/trans-chap1.adb:61:               --  to be overriden by user.
./src/vhdl/vhdl-configuration.adb:1350:                          ("generic %n cannot be overriden (not a constant)",
./src/vhdl/vhdl-sem.adb:3674:      --  be later overriden).
./src/vhdl/vhdl-sem_decls.adb:1638:         Error_Msg_Sem (+Decl, "predefined attribute %i overriden", +Decl);
./src/vhdl/vhdl-sem_names.adb:389:               --  declaration that is overriden by explicit one).
./src/vhdl/vhdl-sem_scopes.adb:1538:                  --  Implicit declaration EL was overriden by a user
```

The container was built as follows:

```dockerfile
# Licensed under the GNU General Public License v3.0;
# You may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#     https://www.gnu.org/licenses/gpl-3.0.html

# GHDL container

FROM ubuntu:latest AS base

MAINTAINER <unike267@gmail.com>

ARG GNAT_VER="13"
ARG LLVM_VER="18"

# Install dependencies
RUN apt-get update -qq \
 && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
    ca-certificates \
    clang-$LLVM_VER \
    gcc \
    gnat-$GNAT_VER \
    llvm-$LLVM_VER-dev \
    make \
    zlib1g-dev \
 && apt-get autoclean && apt-get clean && apt-get -y autoremove \
 && update-ca-certificates \
 && rm -rf /var/lib/apt/lists/* 

FROM base AS build

ARG LLVM_VER="18"

# Install ghdl
RUN apt-get update -qq \
 && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
    git \
 && git clone https://github.com/ghdl/ghdl \
 && sed -i '440s|overriden|overridden|#' ghdl/src/grt/grt-change_generics.adb \
 && sed -i '29s|overriden|overridden|#' ghdl/src/grt/grt-change_generics.ads \
 && sed -i '837s|overriden|overridden|#' ghdl/src/grt/grt-signals.adb \
 && sed -i '33s|overriden|overridden|#' ghdl/src/verilog/verilog-elaborate.ads \
 && sed -i '61s|overriden|overridden|#' ghdl/src/vhdl/translate/trans-chap1.adb \
 && sed -i '1350s|overriden|overridden|#' ghdl/src/vhdl/vhdl-configuration.adb \
 && sed -i '3674s|overriden|overridden|#' ghdl/src/vhdl/vhdl-sem.adb \
 && sed -i '1638s|overriden|overridden|#' ghdl/src/vhdl/vhdl-sem_decls.adb \
 && sed -i '389s|overriden|overridden|#' ghdl/src/vhdl/vhdl-sem_names.adb \
 && sed -i '1538s|overriden|overridden|#' ghdl/src/vhdl/vhdl-sem_scopes.adb \
 && cd ghdl \
 && mkdir build-llvm \
 && cd build-llvm \
 && CXX=clang++-$LLVM_VER ../configure --with-llvm-config=llvm-config-$LLVM_VER --default-pic --disable-werror \
 && make -j$(nproc) \
 && make DESTDIR=/opt/ghdl/ install \
 && cd ../.. \
 && rm -rf ghdl 

# Temporary scratch image for “transporting” the compiled GHDL binaries
FROM scratch AS tmp_ghdl
COPY --from=build /opt/ghdl/ /ghdl/

# Final ghdl dependent target
FROM base AS ghdl_fix
COPY --from=tmp_ghdl /ghdl/usr/local /usr/local/

RUN ghdl --version
```

Correct compilation result!

Related issue: #2916 

Cheers! :smiley: 

:heart: Thank you!