### PR TITLE
Fix to_hstring and to_ostring bug on empty vectors

### DIFF
--- a/libraries/ieee2008/std_logic_1164-body.vhdl
+++ b/libraries/ieee2008/std_logic_1164-body.vhdl
@@ -1018,6 +1018,8 @@ package body std_logic_1164 is
   -- string conversion and write operations
   -------------------------------------------------------------------
 
+  constant NUS  : STRING(2 to 1) := (others => ' ');
+
   function TO_OSTRING (value : STD_ULOGIC_VECTOR) return STRING is
     constant result_length : NATURAL := (value'length+2)/3;
     variable pad           : STD_ULOGIC_VECTOR(1 to result_length*3 - value'length);
@@ -1025,6 +1027,9 @@ package body std_logic_1164 is
     variable result        : STRING(1 to result_length);
     variable tri           : STD_ULOGIC_VECTOR(1 to 3);
   begin
+    if value'length < 1 then
+      return NUS;
+    end if;
     if value (value'left) = 'Z' then
       pad := (others => 'Z');
     else
@@ -1056,6 +1061,9 @@ package body std_logic_1164 is
     variable result        : STRING(1 to result_length);
     variable quad          : STD_ULOGIC_VECTOR(1 to 4);
   begin
+    if value'length < 1 then
+      return NUS;
+    end if;
     if value (value'left) = 'Z' then
       pad := (others => 'Z');
     else


### PR DESCRIPTION
**Description** Please explain the changes you made here.
GHDL raise an error when `to_hstring` is called with an empty `std_ulogic_vector`. It does not raise an error with an empty `bit_vector`. This is due to the way `to_hstring` is written in `lib/ghdl/src/ieee2008/std_logic_1164-body.vhdl` at line 1059: `if value (value'left) = 'Z' then`. A test on `value'length` is missing. Test added.

:rotating_light: Before submitting your PR, please read [contribute](http://ghdl.github.io/ghdl/contribute.html#fork-modify-and-pull-request) in the [Docs](http://ghdl.github.io/ghdl), and review the following checklist:

- [X] DO indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

Fixes ghdl/ghdl#2951

**When contributing to the GHDL codebase...**

- [X] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [X] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
- [ ] CONSIDER adding a unit test if your PR resolves an issue.
- [ ] CONSIDER modifying the docs, if your contribution is relevant to any of the content.
- [X] AVOID breaking the continuous integration build.
- [X] AVOID breaking the testsuite.

**When contributing to the docs...**

- [ ] DO make sure that the build is successful.

**Further comments**

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
