### PR TITLE
ghw: handle i64 in ghw_read_value

### DIFF
--- a/ghw/libghw.c
+++ b/ghw/libghw.c
@@ -1154,6 +1154,7 @@ ghw_read_value (struct ghw_handler *h,
 	val->f64 = v;
       }
       break;
+    case ghdl_rtik_type_i64:
     case ghdl_rtik_type_p64:
       {
 	int64_t v;


### PR DESCRIPTION
While testing some changes in GTKWave I've noticed that libghw didn't read values of type `ghdl_rtik_type_i64` and instead printed this error message:
```
read_value: cannot handle format 26
```
This error was also reproducible by using `ghwdump` from a recent GHDL version.

Adding the `ghdl_rtik_type_i64` case statement fixed the issue. I'm not familiar with the internals of libghw, but `i32` and `p32` are handled the same way, which makes me believe that this fix is correct.

VHDL file to generate a GHW file to trigger the issue:
```vhdl
entity ghw_issue is
begin
end;

architecture beh of ghw_issue is
	type i64 is range 0 to 4000000000;
	signal sig_i64 : i64;

begin
end;
```

I didn't see any unit tests related to libghw that would need to be updated, but let me know if I missed something.