### PR TITLE
General updates

### DIFF
--- a/.github/ReleaseDescription.md
+++ b/.github/ReleaseDescription.md
@@ -2,7 +2,7 @@
 
 # GHDL %ghdl%
 
-GHDL offers the simulator and synthesis tool for VHDL. GHDL can be build for various backends:
+GHDL offers the simulator and synthesis tool for VHDL. GHDL can be built for various backends:
 * `gcc` - using the GCC compiler framework
 * `mcode` - in memory code generation
 * `llvm` - using the LLVM compiler framework

--- a/.github/workflows/Build-MSYS2.yml
+++ b/.github/workflows/Build-MSYS2.yml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # The command 'git describe' (used for version) needs the history.
           fetch-depth: 0
@@ -360,7 +360,7 @@ jobs:
           cp -r -v ./install/lib/* ./pyGHDL/lib
 
 #      - name: 🐍 Setup Python (only mcode backend)
-#        uses: actions/setup-python@v5
+#        uses: actions/setup-python@v6
 #        if: (inputs.unittesting || inputs.coverage) && inputs.backend == 'mcode'
 #        with:
 #          python-version: ${{ inputs.python_version }}
@@ -491,7 +491,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: '🟦 Setup MSYS2 for ${{ inputs.runtime }}'
         uses: msys2/setup-msys2@v2
@@ -501,7 +501,7 @@ jobs:
           pacboy: "diffutils:p"
 
       - name: 📥 Download artifacts '${{ needs.Build.outputs.pacman_artifact }}' from 'Package' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         with:
           name: ${{ needs.Build.outputs.pacman_artifact }}
           path: pacman
@@ -536,10 +536,10 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📥 Download artifacts '${{ needs.Build.outputs.windows_artifact }}' from 'Package' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         with:
           name: ${{ needs.Build.outputs.windows_artifact }}
           path: install

--- a/.github/workflows/Build-MacOS.yml
+++ b/.github/workflows/Build-MacOS.yml
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # The command 'git describe' (used for version) needs the history.
           fetch-depth: 0
@@ -241,7 +241,7 @@ jobs:
           cp -r -v ./install/lib/* ./pyGHDL/lib
 
       - name: 🐍 Setup Python (only mcode backend)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         if: (inputs.unittesting || inputs.coverage) && inputs.backend == 'mcode'
         with:
           python-version: ${{ inputs.python_version }}

--- a/.github/workflows/Build-Ubuntu.yml
+++ b/.github/workflows/Build-Ubuntu.yml
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # The command 'git describe' (used for version) needs the history.
           fetch-depth: 0
@@ -337,7 +337,7 @@ jobs:
           cp -r -v ./install/lib/* ./pyGHDL/lib
 
       - name: 🐍 Setup Python (only mcode backend)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         if: (inputs.unittesting || inputs.coverage) && inputs.ghdl_backend == 'mcode'
         with:
           python-version: ${{ inputs.python_version }}

--- a/.github/workflows/Check-pyGHDL.yml
+++ b/.github/workflows/Check-pyGHDL.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: '⏬ Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: '🐍 Setup Python'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python_version }}
 

--- a/.github/workflows/Documentation-GNAT.yml
+++ b/.github/workflows/Documentation-GNAT.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: '⏬ Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🔧 Install dependencies
         run: |

--- a/.github/workflows/Documentation-Sphinx.yml
+++ b/.github/workflows/Documentation-Sphinx.yml
@@ -56,10 +56,10 @@ jobs:
 
     steps:
       - name: '⏬ Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📥 Download artifacts '${{ inputs.ghdl_artifact }}' from 'Build' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         with:
           name: ${{ inputs.ghdl_artifact }}
           path: install
@@ -76,7 +76,7 @@ jobs:
           ghdl version
 
       - name: '🐍 Setup Python'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python_version }}
 
@@ -107,10 +107,10 @@ jobs:
 
     steps:
       - name: '⏬ Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📥 Download artifacts '${{ inputs.ghdl_artifact }}' from 'Build' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         with:
           name: ${{ inputs.ghdl_artifact }}
           path: install
@@ -127,7 +127,7 @@ jobs:
           ghdl version
 
       - name: '🐍 Setup Python'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python_version }}
 
@@ -160,7 +160,7 @@ jobs:
 
     steps:
       - name: 📥 Download artifacts '${{ inputs.latex_artifact }}' from 'Sphinx' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         with:
           name: ${{ inputs.latex_artifact }}
           path: latex

--- a/.github/workflows/Package-Docker.yml
+++ b/.github/workflows/Package-Docker.yml
@@ -52,10 +52,10 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📥 Download artifacts '${{ inputs.ghdl_artifact }}' from 'Build' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         with:
           name: ${{ inputs.ghdl_artifact }}
           path: dist/docker/install

--- a/.github/workflows/Package-pyGHDL.yml
+++ b/.github/workflows/Package-pyGHDL.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: '⏬ Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: '🟦 Setup MSYS2 for ${{ inputs.runtime }}'
         uses: msys2/setup-msys2@v2
@@ -67,7 +67,7 @@ jobs:
           pacboy: 'python:p python-pip:p python-wheel:p'
 
       - name: '🐍 Setup Python'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         if: inputs.runtime == ''
         with:
           python-version: ${{ inputs.python_version }}
@@ -84,7 +84,7 @@ jobs:
           python -m pip install --disable-pip-version-check "pyTooling[packaging]" wheel
 
       - name: 📥 Download artifacts '${{ inputs.libghdl_artifact }}-${{ inputs.backend }}' from 'Build' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         with:
           name: ${{ inputs.libghdl_artifact }}-${{ inputs.backend }}
           path: install
@@ -123,7 +123,7 @@ jobs:
 
     steps:
       - name: '⏬ Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: ghdl
 
@@ -193,13 +193,13 @@ jobs:
           rm -Rf ghdl
 
       - name: 🐍 Setup Python (Ubuntu, Windows)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         if: inputs.runtime == ''
         with:
           python-version: ${{ inputs.python_version }}
 
       - name: 📥 Download artifacts '${{ inputs.pyghdl_artifact }}' from 'Package' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         with:
           name: ${{ inputs.pyghdl_artifact }}
           path: wheels

--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -169,7 +169,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # The command 'git describe' (used for version) needs the history.
           fetch-depth: 0
@@ -422,7 +422,7 @@ jobs:
 
     steps:
       - name: '⏬ Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Generate 'params' and 'python_jobs'
         id: params

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -30,7 +30,7 @@ jobs:
       package_name: "ghdl"
       library_name: "libghdl"
       pyghdl_name:  "pyGHDL"
-#      testsuites:   "sanity"         # disable parameter to fall back to 'all'
+      testsuites:   "sanity"         # disable parameter to fall back to 'all'
 
   macOS:
     uses: ./.github/workflows/Build-MacOS.yml
@@ -173,18 +173,17 @@ jobs:
       - Params
 
   StaticTypeCheck:
-    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@r5
+    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@r6
     needs:
       - Params
     with:
-      requirements: mypy lxml
-      commands: |
-        mypy --html-report htmlmypy -p pyGHDL
-      html_report: 'htmlmypy'
+      requirements:   mypy lxml
+      html_report: >-
+        { "directory": "htmlmypy" }
       html_artifact: 'pyGHDL-typing-HTML'
 
   DocCoverage:
-    uses: pyTooling/Actions/.github/workflows/CheckDocumentation.yml@r5
+    uses: pyTooling/Actions/.github/workflows/CheckDocumentation.yml@r6
     needs:
       - Params
     with:
@@ -226,7 +225,7 @@ jobs:
     secrets: inherit
 
   PublishCoverageResults:
-    uses: pyTooling/Actions/.github/workflows/PublishCoverageResults.yml@r5
+    uses: pyTooling/Actions/.github/workflows/PublishCoverageResults.yml@r6
     needs:
       - macOS
       - Ubuntu-fast
@@ -243,7 +242,7 @@ jobs:
 #      CODACY_TOKEN:  ${{ secrets.CODACY_TOKEN }}
 
   PublishTestResults:
-    uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@r5
+    uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@r6
     needs:
       - macOS
       - Ubuntu-fast
@@ -259,7 +258,7 @@ jobs:
 #      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   IntermediateCleanUp:
-    uses: pyTooling/Actions/.github/workflows/IntermediateCleanUp.yml@r5
+    uses: pyTooling/Actions/.github/workflows/IntermediateCleanUp.yml@r6
     needs:
       - PublishCoverageResults
       - PublishTestResults
@@ -298,7 +297,7 @@ jobs:
       typing:        'pyGHDL-typing-HTML'
 
   Nightly:
-    uses: pyTooling/Actions/.github/workflows/PublishReleaseNotes.yml@r5
+    uses: pyTooling/Actions/.github/workflows/PublishReleaseNotes.yml@r6
     if: needs.Params.outputs.is_nightly_tag == 'true' || needs.Params.outputs.is_tagged_test == 'true'
     needs:
       - Params
@@ -361,7 +360,7 @@ jobs:
         pyGHDL-Windows-ucrt64-Python-3.12:      pyghdl-%pyghdl%-cp312-cp312-mingw_x86_64_ucrt_gnu.whl:        pyGHDL,windows,2022,x86-64,py3.12,ucrt64,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) + MSYS2/UCRT64 - Wheel for Python 3.12
 
   Release:
-    uses: pyTooling/Actions/.github/workflows/PublishReleaseNotes.yml@r5
+    uses: pyTooling/Actions/.github/workflows/PublishReleaseNotes.yml@r6
     if: needs.Params.outputs.is_release_tag == 'true'
     needs:
       - Params
@@ -378,7 +377,7 @@ jobs:
       - PublishTestResults
     permissions:
       contents: write
-      actions: write
+      actions:  write
     with:
       tag:                  ${{ needs.Params.outputs.version }}
       description_file:     ".github/ReleaseDescription.md"

--- a/.github/workflows/Publish-GitHubPages.yml
+++ b/.github/workflows/Publish-GitHubPages.yml
@@ -30,23 +30,23 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📥 Download artifacts '${{ inputs.documentation }}' from 'Sphinx' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         with:
           name: ${{ inputs.documentation }}
           path: public
 
       - name: 📥 Download artifacts '${{ inputs.coverage }}' from 'PublishCoverageResults' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         if: ${{ inputs.coverage != '' }}
         with:
           name: ${{ inputs.coverage }}
           path: public/coverage
 
       - name: 📥 Download artifacts '${{ inputs.typing }}' from 'StaticTypeCheck' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         if: ${{ inputs.typing != '' }}
         with:
           name: ${{ inputs.typing }}

--- a/.github/workflows/Test-Docker.yml
+++ b/.github/workflows/Test-Docker.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Version check
         run: |

--- a/.github/workflows/Test-GHDL.yml
+++ b/.github/workflows/Test-GHDL.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: '🟦 Setup MSYS2 for ${{ inputs.runtime }}'
         uses: msys2/setup-msys2@v2
@@ -51,7 +51,7 @@ jobs:
           pacboy: "diffutils:p"
 
       - name: 📥 Download artifacts '${{ inputs.ghdl_artifact }}' from 'Build' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         with:
           name: ${{ inputs.ghdl_artifact }}
           path: install

--- a/pyGHDL/cli/requirements.txt
+++ b/pyGHDL/cli/requirements.txt
@@ -1,3 +1,3 @@
 -r ../dom/requirements.txt
 
-pyTooling[terminal] ~= 8.5
+pyTooling[terminal] ~= 8.7

--- a/pyGHDL/libghdl/requirements.txt
+++ b/pyGHDL/libghdl/requirements.txt
@@ -1,1 +1,1 @@
-pyTooling[terminal] ~= 8.5
+pyTooling[terminal] ~= 8.7

--- a/testsuite/requirements.txt
+++ b/testsuite/requirements.txt
@@ -2,7 +2,7 @@
 
 # Test Runner
 pytest ~= 8.4
-pytest-cov ~= 6.2
+pytest-cov ~= 7.0
 
 # Coverage collection
-Coverage ~= 7.9
+Coverage ~= 7.10


### PR DESCRIPTION
# New Features

* By using `PublishReleaseNotes` from pyTooling/Actions in version `@r6`, it adds the version of the latest released version into the `inventory.json` file. This can be downloaded and read by `setup-ghdl` action.

# Changes

* Bumped Python dependencies.
* Bumped GitHub Action dependencies.
* Bumped GitHub Action windows image to 2025.