### PR TITLE
[libghw/performance] Improves the performance of loading big ghw files

### DIFF
--- a/ghw/libghw.c
+++ b/ghw/libghw.c
@@ -1668,9 +1668,8 @@ ghw_read_cycle_cont (struct ghw_handler *h, int *list)
 	{
 	  /* build the cache if not existing yet */
 	  if(h->no_null_sig_cache == NULL) {
-	    h->no_null_sig_cache = malloc_unwrap(sizeof(uint32_t)*h->nbr_sigs);
-	    memset(h->no_null_sig_cache,0xFF,sizeof(uint32_t)*h->nbr_sigs);
-
+	    h->no_null_sig_cache = calloc_unwrap(h->nbr_sigs, sizeof(uint32_t));
+	    
 	    k = 1; /* Note: Type of sigs[0] is ignored, thus we start from first index */
 	    for(j = 1; j < h->nbr_sigs; j++) {
 	      if(h->sigs[j].type != NULL) {

--- a/ghw/libghw.c
+++ b/ghw/libghw.c
@@ -1668,7 +1668,7 @@ ghw_read_cycle_cont (struct ghw_handler *h, int *list)
 	{
 	  /* build the cache if not existing yet */
 	  if(h->no_null_sig_cache == NULL){
-	    fprintf (stderr, "[libghw] Building non null signal cache for %d signals...\n", h->nbr_sigs);
+	    printf("[libghw] Building non null signal cache for %u signals...\n", h->nbr_sigs);
 	    h->no_null_sig_cache = malloc_unwrap(sizeof(uint32_t)*h->nbr_sigs);
 	    memset(h->no_null_sig_cache,0xFF,sizeof(uint32_t)*h->nbr_sigs);
 

--- a/ghw/libghw.c
+++ b/ghw/libghw.c
@@ -1672,23 +1672,19 @@ ghw_read_cycle_cont (struct ghw_handler *h, int *list)
 	    h->no_null_sig_cache = malloc_unwrap(sizeof(uint32_t)*h->nbr_sigs);
 	    memset(h->no_null_sig_cache,0xFF,sizeof(uint32_t)*h->nbr_sigs);
 
-	    k = 0;
+	    k = 1; /* Note: Type of sigs[0] is ignored, thus we start from first index */
 	    for(j = 1; j < h->nbr_sigs; j++) {
 	      if(h->sigs[j].type != NULL) {
 		/* mark into cache */
 		h->no_null_sig_cache[k] = j; 
-		/*
-		if(k < 10) {
-		  fprintf (stderr, "[libghw]    k=%d, j=%d\n",k,j);
-		  }*/
 		k++;
 	      }
 	    }
 	  }
 	  
-	  /* take the value from the cache */
+	  /* takes the value from the cache */
 	  p += d;
-	  i = h->no_null_sig_cache[p] - 1; /* Note: Type of sigs[0] is ignored, thus -1 */
+	  i = h->no_null_sig_cache[p]; 
 	}
 
       // i=0 is not a valid signal
@@ -2159,6 +2155,7 @@ ghw_close (struct ghw_handler *h)
 
   /* Free up the non null signal cache if still in memory */
   if(h->no_null_sig_cache != NULL) {
+    printf("[libghw] Clearing non null signal cache\n");
     free(h->no_null_sig_cache);
     h->no_null_sig_cache = NULL;
   }

--- a/ghw/libghw.c
+++ b/ghw/libghw.c
@@ -87,6 +87,14 @@ ghw_open (struct ghw_handler *h, const char *filename)
 {
   char hdr[16];
 
+  /*
+    resets cache for non null signals.
+    NOTE: this is freed on close, so we should have
+    no memory leaks, but if the user passes a non-initialized
+    handler then this avoids segfault later on
+   */
+  h->no_null_sig_cache = NULL; 
+
   h->stream = fopen (filename, "rb");
   if (h->stream == NULL)
     return -1;

--- a/ghw/libghw.c
+++ b/ghw/libghw.c
@@ -1667,8 +1667,7 @@ ghw_read_cycle_cont (struct ghw_handler *h, int *list)
       else
 	{
 	  /* build the cache if not existing yet */
-	  if(h->no_null_sig_cache == NULL){
-	    printf("[libghw] Building non null signal cache for %u signals...\n", h->nbr_sigs);
+	  if(h->no_null_sig_cache == NULL) {
 	    h->no_null_sig_cache = malloc_unwrap(sizeof(uint32_t)*h->nbr_sigs);
 	    memset(h->no_null_sig_cache,0xFF,sizeof(uint32_t)*h->nbr_sigs);
 
@@ -1687,7 +1686,7 @@ ghw_read_cycle_cont (struct ghw_handler *h, int *list)
 	  i = h->no_null_sig_cache[p]; 
 	}
 
-      // i=0 is not a valid signal
+      /* i=0 is not a valid signal */
       if (i == 0) goto err;
 
       if (ghw_read_signal_value (h, &h->sigs[i]) < 0) {
@@ -2155,7 +2154,6 @@ ghw_close (struct ghw_handler *h)
 
   /* Free up the non null signal cache if still in memory */
   if(h->no_null_sig_cache != NULL) {
-    printf("[libghw] Clearing non null signal cache\n");
     free(h->no_null_sig_cache);
     h->no_null_sig_cache = NULL;
   }

--- a/ghw/libghw.h
+++ b/ghw/libghw.h
@@ -387,6 +387,12 @@ struct ghw_handler
   /* 1: sigs does not contain any signals with type = NULL and index > 0 */
   int sigs_no_null;
 
+  /*
+    A cached array of uint32_t containing all non null signals indices. Length is equal to nbr_sigs. Empty array cells have values 0xFFFFFFFF
+    It is used in ghw_read_cycle_cont to speed up loading for large files
+   */
+  uint32_t* no_null_sig_cache;
+  
   /* Hierarchy.  */
   struct ghw_hie *hie;
 


### PR DESCRIPTION

**Description** 

This pr adds a signal index cache in libghw to drastically speed-up (especially in gtkwave) loading of big ghw files when null signals are present. 
The current algorithm parses again the list at every request, while this method improves performances.
The cache is then freed upon closure of the ghw file being loaded.
