### PR TITLE
doc/ghdl.1: fix typo ("Elabortation")

### DIFF
--- a/doc/ghdl.1
+++ b/doc/ghdl.1
@@ -41,7 +41,7 @@ Basic commands:
 Analysis, i.e. \fIghdl \-a file.vhdl\fP
 .TP 
 .B \-e
-Elabortation, i.e. \fIghdl \-e unit_name\fP
+Elaboration, i.e. \fIghdl \-e unit_name\fP
 .TP 
 .B \-r
 Run: run the simulation, i.e. \fIghdl \-r unit_name\fP


### PR DESCRIPTION
Replace with "Elaboration".

Fixes #3147