### PR TITLE
Updates for MSYS2

### DIFF
--- a/.github/workflows/Build-MSYS2.yml
+++ b/.github/workflows/Build-MSYS2.yml
@@ -45,7 +45,7 @@ on:
       python_version:
         description: 'Python version for pyGHDL testing.'
         required: false
-        default: '3.12'
+        default: '3.13'   # FIXME: MSYS2 is one or two versions behind for CPython
         type: string
       pyunit_testsuites:
         description: 'Name of the pyunit testsuites.'
@@ -379,12 +379,15 @@ jobs:
         run: |
           from os       import getenv
           from pathlib  import Path
-          from sys      import version
+          from sys      import version, version_info
           from textwrap import dedent
 
           print(f"Python: {version}")
 
-          from tomli import load as tomli_load
+          if version_info < (3, 11):
+            from tomli import load as toml_load
+          else:
+            from tomllib import load as toml_load
 
           htmlDirectory = Path("htmlcov")
           xmlFile =  Path("./coverage.xml")
@@ -394,7 +397,7 @@ jobs:
           pyProjectFile =  Path("pyproject.toml")
           if pyProjectFile.exists():
             with pyProjectFile.open("rb") as file:
-              pyProjectSettings = tomli_load(file)
+              pyProjectSettings = toml_load(file)
 
             htmlDirectory = Path(pyProjectSettings["tool"]["coverage"]["html"]["directory"])
             xmlFile       = Path(pyProjectSettings["tool"]["coverage"]["xml"]["output"])

--- a/.github/workflows/Build-MacOS.yml
+++ b/.github/workflows/Build-MacOS.yml
@@ -260,12 +260,15 @@ jobs:
         run: |
           from os       import getenv
           from pathlib  import Path
-          from sys      import version
+          from sys      import version, version_info
           from textwrap import dedent
 
           print(f"Python: {version}")
 
-          from tomli import load as tomli_load
+          if version_info < (3, 11):
+            from tomli import load as toml_load
+          else:
+            from tomllib import load as toml_load
 
           htmlDirectory = Path("htmlcov")
           xmlFile =  Path("./coverage.xml")
@@ -275,7 +278,7 @@ jobs:
           pyProjectFile =  Path("pyproject.toml")
           if pyProjectFile.exists():
             with pyProjectFile.open("rb") as file:
-              pyProjectSettings = tomli_load(file)
+              pyProjectSettings = toml_load(file)
 
             htmlDirectory = Path(pyProjectSettings["tool"]["coverage"]["html"]["directory"])
             xmlFile       = Path(pyProjectSettings["tool"]["coverage"]["xml"]["output"])

--- a/.github/workflows/Build-Ubuntu.yml
+++ b/.github/workflows/Build-Ubuntu.yml
@@ -356,12 +356,15 @@ jobs:
         run: |
           from os       import getenv
           from pathlib  import Path
-          from sys      import version
+          from sys      import version, version_info
           from textwrap import dedent
 
           print(f"Python: {version}")
 
-          from tomli import load as tomli_load
+          if version_info < (3, 11):
+            from tomli import load as toml_load
+          else:
+            from tomllib import load as toml_load
 
           htmlDirectory = Path("htmlcov")
           xmlFile =  Path("./coverage.xml")
@@ -371,7 +374,7 @@ jobs:
           pyProjectFile =  Path("pyproject.toml")
           if pyProjectFile.exists():
             with pyProjectFile.open("rb") as file:
-              pyProjectSettings = tomli_load(file)
+              pyProjectSettings = toml_load(file)
 
             htmlDirectory = Path(pyProjectSettings["tool"]["coverage"]["html"]["directory"])
             xmlFile       = Path(pyProjectSettings["tool"]["coverage"]["xml"]["output"])

--- a/.github/workflows/Package-pyGHDL.yml
+++ b/.github/workflows/Package-pyGHDL.yml
@@ -304,12 +304,15 @@ jobs:
         run: |
           from os       import getenv
           from pathlib  import Path
-          from sys      import version
+          from sys      import version, version_info
           from textwrap import dedent
 
           print(f"Python: {version}")
 
-          from tomli import load as tomli_load
+          if version_info < (3, 11):
+            from tomli import load as toml_load
+          else:
+            from tomllib import load as toml_load
 
           htmlDirectory = Path("htmlcov")
           xmlFile =  Path("./coverage.xml")
@@ -319,7 +322,7 @@ jobs:
           pyProjectFile =  Path("pyproject.toml")
           if pyProjectFile.exists():
             with pyProjectFile.open("rb") as file:
-              pyProjectSettings = tomli_load(file)
+              pyProjectSettings = toml_load(file)
 
             htmlDirectory = Path(pyProjectSettings["tool"]["coverage"]["html"]["directory"])
             xmlFile       = Path(pyProjectSettings["tool"]["coverage"]["xml"]["output"])

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -10,9 +10,11 @@ jobs:
 
 # pyGHDL wheel
 #   macOS
-#     Python 3.10
 #     Python 3.11
 #     Python 3.12
+#     Python 3.13
+#     Python 3.14
+#     Python 3.15
 
 # cleanups
 #   libghdl-
@@ -208,8 +210,8 @@ jobs:
         other:
           - {runtime: ''}
         include:
-          - {os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2025', libghdl_artifact: 'MSYS2-mingw64', pyghdl_artifact: 'Windows-mingw64'}, py: {icon: '🟡', version: '3.12'}, other: {runtime: 'mingw64'}}
-          - {os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2025', libghdl_artifact: 'MSYS2-ucrt64',  pyghdl_artifact: 'Windows-ucrt64' }, py: {icon: '🟡', version: '3.12'}, other: {runtime: 'ucrt64' }}
+          - {os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2025', libghdl_artifact: 'MSYS2-mingw64', pyghdl_artifact: 'Windows-mingw64'}, py: {icon: '🟡', version: '3.13'}, other: {runtime: 'mingw64'}}
+          - {os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2025', libghdl_artifact: 'MSYS2-ucrt64',  pyghdl_artifact: 'Windows-ucrt64' }, py: {icon: '🟡', version: '3.13'}, other: {runtime: 'ucrt64' }}
     with:
       os_name:               ${{ matrix.os.name }}
       os_image:              ${{ matrix.os.image }}
@@ -346,8 +348,8 @@ jobs:
         pyGHDL-Windows-x86_64-Python-3.12:      pyghdl-%pyghdl%-cp312-cp312-win_amd64.whl:                    pyGHDL,windows,2025,x86-64,py3.12,native,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.12
         pyGHDL-Windows-x86_64-Python-3.13:      pyghdl-%pyghdl%-cp313-cp313-win_amd64.whl:                    pyGHDL,windows,2025,x86-64,py3.13,native,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.13
         #pyGHDL-Windows-x86_64-Python-3.14:      pyghdl-%pyghdl%-cp314-cp314-win_amd64.whl:                    pyGHDL,windows,2025,x86-64,py3.14,native,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.14
-        pyGHDL-Windows-mingw64-Python-3.12:     pyghdl-%pyghdl%-cp312-cp312-mingw_x86_64_msvcrt_gnu.whl:      pyGHDL,windows,2025,x86-64,py3.12,mingw64,mcode: pyGHDL - v%ghdl% - Windows (x86-64) + MSYS2/MinGW64 - Wheel for Python 3.12
-        pyGHDL-Windows-ucrt64-Python-3.12:      pyghdl-%pyghdl%-cp312-cp312-mingw_x86_64_ucrt_gnu.whl:        pyGHDL,windows,2025,x86-64,py3.12,ucrt64,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) + MSYS2/UCRT64 - Wheel for Python 3.12
+        pyGHDL-Windows-mingw64-Python-3.13:     pyghdl-%pyghdl%-cp313-cp313-mingw_x86_64_msvcrt_gnu.whl:      pyGHDL,windows,2025,x86-64,py3.13,mingw64,mcode: pyGHDL - v%ghdl% - Windows (x86-64) + MSYS2/MinGW64 - Wheel for Python 3.13
+        pyGHDL-Windows-ucrt64-Python-3.13:      pyghdl-%pyghdl%-cp313-cp313-mingw_x86_64_ucrt_gnu.whl:        pyGHDL,windows,2025,x86-64,py3.13,ucrt64,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) + MSYS2/UCRT64 - Wheel for Python 3.13
 
   Release:
     uses: pyTooling/Actions/.github/workflows/PublishReleaseNotes.yml@r7


### PR DESCRIPTION
# Changes

* Updated Python 3.12 to 3.13 in MSYS2/MinGW64
* Updated Python 3.12 to 3.13 in MSYS2/UCRT64.

Somehow it looks like GitHub also partially updated some of the OS images from Python 3.9 to 3.12, thus I needed to add compatibility code depending on what runner / cached OS is selected.