### PR TITLE
doc/development: Update LLVM Version Information

### DIFF
--- a/doc/development/building/LLVM.rst
+++ b/doc/development/building/LLVM.rst
@@ -8,7 +8,7 @@ LLVM backend
 * GCC (Gnu Compiler Collection)
 * GNAT (Ada compiler for GCC)
 * LLVM (Low-Level-Virtual Machine) and CLANG (Compiler front-end for LLVM): 3.5, 3.8, 3.9, 4.0, 5.0, 6.0, 7.0, 8.0,
-  9.0, 10.0, 11.0, 11.1, 12.0, 13.0 or 14.0
+  9.0, 10.0, 11.0, 11.1, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.1, 19.x or 20.x
 
 .. _BUILD:llvm:GNAT:
 


### PR DESCRIPTION
**Description** 
Fixes #3178. 

Because older LLVM versions are increasingly unspported/unavailable GHDL users benefit from up to date information on the supported LLVM versions.

**When contributing to the GHDL codebase...**

- [ X] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ X] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [ X] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).

**When contributing to the docs...**

- [ X] DO make sure that the build is successful.


