### PR TITLE
synth: remove leading underscore from indices

### DIFF
--- a/src/synth/netlists-disp_common.adb
+++ b/src/synth/netlists-disp_common.adb
@@ -88,7 +88,7 @@ package body Netlists.Disp_Common is
          Prefix := Get_Sname_Prefix (N);
          if Prefix /= No_Sname then
             Put_Name_Inner (Prefix, Lang, Is_Extended);
-            if Kind /= Sname_Field then
+            if Kind /= Sname_Field and Kind /= Sname_Index then
                Wr ("_");
             end if;
          end if;


### PR DESCRIPTION
**Description**
This PR removes the leading underscore from `Sname_index` in synth mode (see #3202):

Without the PR, the synthesized verilog code looks like this:
```verilog
  test_Btest_arch_7d365770a971b07027c818f4000f2d87b3d5e441 \genfor_[1]_test_inst  (
    .a(test),
    .x(\genfor_[1]_test_inst.x ));
```

This is the changed behavior:
```verilog
  test_Btest_arch_7d365770a971b07027c818f4000f2d87b3d5e441 \genfor[1]_test_inst  (
    .a(test),
    .x(\genfor[1]_test_inst.x ));
```

This behavior is consistent with `Sname_Field`.