### PR TITLE
Synth: Fix invalid VHDL type names generated when block RAM signal names contain escaped characters

### DIFF
--- a/src/synth/netlists-disp_vhdl.adb
+++ b/src/synth/netlists-disp_vhdl.adb
@@ -732,7 +732,7 @@ package body Netlists.Disp_Vhdl is
       Depth := Get_Width (Ports) / Data_W;
 
       --  Declare the memory.
-      Disp_Template ("    type \l0_type is array (0 to \n0)" & NL,
+      Disp_Template ("    type mem_type is array (0 to \n0)" & NL,
                      Mem, (0 => Depth - 1));
       if Data_W = 1 then
          Disp_Template ("      of std_logic;" & NL, Mem);
@@ -740,7 +740,7 @@ package body Netlists.Disp_Vhdl is
          Disp_Template ("      of std_logic_vector (\n0 downto 0);" & NL,
                         Mem, (0 => Data_W - 1));
       end if;
-      Disp_Template ("    variable \l0 : \l0_type", Mem);
+      Disp_Template ("    variable \l0 : mem_type", Mem);
       if Get_Id (Mem) = Id_Memory_Init then
          declare
             Val : Net;

--- a/testsuite/synth/issue3232/tb.vhdl
+++ b/testsuite/synth/issue3232/tb.vhdl
@@ -1,0 +1,25 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+
+entity tb is
+  port (
+    clk : in  std_logic;
+    a   : in  std_logic_vector(31 downto 0);
+    b   : out std_logic_vector(31 downto 0)
+    );
+end entity;
+
+architecture synthesis of tb is
+  type xyz is array (0 to 1) of std_logic_vector (31 downto 0);
+  signal \:\ : xyz := (others => (others => '1'));
+  signal idx : integer;
+begin
+  p : process (clk)
+  begin
+    if rising_edge(clk) then
+      \:\(idx) <= a;
+      b        <= \:\(idx);
+    end if;
+  end process;
+end architecture;

--- a/testsuite/synth/issue3232/testsuite.sh
+++ b/testsuite/synth/issue3232/testsuite.sh
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+synth_analyze tb
+
+echo "Test successful"


### PR DESCRIPTION
**Description**
See #3232

Hope the test is okay. I will adapt if not :)