### PR TITLE
Dropped ISO-8859-1 characters from ieee2008 files.

### DIFF
--- a/libraries/ieee2008/numeric_bit.vhdl
+++ b/libraries/ieee2008/numeric_bit.vhdl
@@ -58,7 +58,7 @@ use STD.TEXTIO.all;
 
 package NUMERIC_BIT is
   constant CopyRightNotice : STRING
-    := "Copyright © 2008 IEEE. All rights reserved.";
+    := "Copyright 2008 IEEE. All rights reserved.";
 
   --============================================================================
   -- Numeric Array Type Definitions

--- a/libraries/ieee2008/numeric_std.vhdl
+++ b/libraries/ieee2008/numeric_std.vhdl
@@ -68,7 +68,7 @@ use IEEE.STD_LOGIC_1164.all;
 
 package NUMERIC_STD is
   constant CopyRightNotice : STRING
-    := "Copyright © 2008 IEEE. All rights reserved.";
+    := "Copyright 2008 IEEE. All rights reserved.";
 
 
   --============================================================================


### PR DESCRIPTION
This ensure they are readable as UTF-8 and ASCII alike, and bring the Copyright lines in line with the ones in the libraries/ieee/ directory.

An alternative might be to switch to UTF-8, but from PR #3174 I suspect this also would require changing the
‎pyGHDL/libghdl/vhdl/utils.py processing and risk break user written code currently using ISO-8859-1 files because of the use of decode("iso-8859-1") in that file.