### PR TITLE
Python 3.14 assets

### DIFF
--- a/.github/workflows/Build-MSYS2.yml
+++ b/.github/workflows/Build-MSYS2.yml
@@ -208,7 +208,7 @@ jobs:
           echo "================================================================================"
 
       - name: 📤 Upload '${{ steps.artifact_name.outputs.pacman_artifact }}' artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: inputs.pacman_artifact != ''
         with:
           name: ${{ steps.artifact_name.outputs.pacman_artifact }}
@@ -245,7 +245,7 @@ jobs:
           cat ./install/*.requirements
 
       - name: 📤 Upload '${{ steps.artifact_name.outputs.ghdl_artifact }}' artifact
-        uses: pyTooling/upload-artifact@v6
+        uses: pyTooling/upload-artifact@v7
         if: inputs.msys2_artifact != ''
         with:
           name: ${{ steps.artifact_name.outputs.ghdl_artifact }}
@@ -294,7 +294,7 @@ jobs:
           tree ./standalone
 
       - name: 📤 Upload '${{ steps.artifact_name.outputs.windows_artifact }}' artifact
-        uses: pyTooling/upload-artifact@v6
+        uses: pyTooling/upload-artifact@v7
         if: inputs.backend == 'mcode' && inputs.windows_artifact != ''
         with:
           name: ${{ steps.artifact_name.outputs.windows_artifact }}
@@ -345,7 +345,7 @@ jobs:
           done
 
       - name: 📤 Upload '${{ steps.artifact_name.outputs.libghdl_artifact }}' artifact
-        uses: pyTooling/upload-artifact@v6
+        uses: pyTooling/upload-artifact@v7
         if: (inputs.runtime == 'mingw64' || inputs.runtime == 'ucrt64') && inputs.backend == 'mcode'
         with:
           name: ${{ steps.artifact_name.outputs.libghdl_artifact }}
@@ -440,7 +440,7 @@ jobs:
 # Upload test result artifacts
 
       - name: 📤 Upload 'TestReportSummary.xml' artifact (only mcode backend)
-        uses: pyTooling/upload-artifact@v6
+        uses: pyTooling/upload-artifact@v7
         if: inputs.unittesting && inputs.backend == 'mcode' && inputs.unittest_xml_artifact != ''
         continue-on-error: true
         with:
@@ -457,7 +457,7 @@ jobs:
         run: coverage report --rcfile=pyproject.toml --data-file=.coverage
 
       - name: 📤 Upload 'Coverage SQLite Database' artifact (only mcode backend)
-        uses: pyTooling/upload-artifact@v6
+        uses: pyTooling/upload-artifact@v7
         if: inputs.coverage && inputs.backend == 'mcode' && inputs.coverage_sqlite_artifact != ''
         continue-on-error: true
         with:
@@ -504,7 +504,7 @@ jobs:
           pacboy: "diffutils:p"
 
       - name: 📥 Download artifacts '${{ needs.Build.outputs.pacman_artifact }}' from 'Package' job
-        uses: pyTooling/download-artifact@v7
+        uses: pyTooling/download-artifact@v8
         with:
           name: ${{ needs.Build.outputs.pacman_artifact }}
           path: pacman
@@ -542,7 +542,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 📥 Download artifacts '${{ needs.Build.outputs.windows_artifact }}' from 'Package' job
-        uses: pyTooling/download-artifact@v7
+        uses: pyTooling/download-artifact@v8
         with:
           name: ${{ needs.Build.outputs.windows_artifact }}
           path: install

--- a/.github/workflows/Build-MacOS.yml
+++ b/.github/workflows/Build-MacOS.yml
@@ -213,7 +213,7 @@ jobs:
           ./testsuite.sh sanity
 
       - name: 📤 Upload '${{ inputs.macos_artifact }}-${{ inputs.backend }}' artifact
-        uses: pyTooling/upload-artifact@v6
+        uses: pyTooling/upload-artifact@v7
         with:
           name: ${{ inputs.macos_artifact }}-${{ inputs.backend }}
           working-directory: install
@@ -321,7 +321,7 @@ jobs:
 # Upload test result artifacts
 
       - name: 📤 Upload 'TestReportSummary.xml' artifact (only mcode backend)
-        uses: pyTooling/upload-artifact@v6
+        uses: pyTooling/upload-artifact@v7
         if: inputs.unittesting && inputs.backend == 'mcode' && inputs.unittest_xml_artifact != ''
         continue-on-error: true
         with:
@@ -340,7 +340,7 @@ jobs:
       - name: 📤 Upload 'Coverage SQLite Database' artifact (only mcode backend)
         if: inputs.coverage && inputs.backend == 'mcode' && inputs.coverage_sqlite_artifact != ''
         continue-on-error: true
-        uses: pyTooling/upload-artifact@v6
+        uses: pyTooling/upload-artifact@v7
         with:
           name: ${{ inputs.coverage_sqlite_artifact }}-${{ inputs.macos_image }}-${{ inputs.python_version }}
           path: .coverage

--- a/.github/workflows/Build-Ubuntu.yml
+++ b/.github/workflows/Build-Ubuntu.yml
@@ -293,7 +293,7 @@ jobs:
           ./testsuite.sh sanity
 
       - name: 📤 Upload '${{ steps.artifact_name.outputs.ghdl_artifact }}' artifact
-        uses: pyTooling/upload-artifact@v6
+        uses: pyTooling/upload-artifact@v7
         if: inputs.ubuntu_artifact != ''
         with:
           name: ${{ steps.artifact_name.outputs.ghdl_artifact }}
@@ -322,7 +322,7 @@ jobs:
           cp -v /lib/x86_64-linux-gnu/libgnat-${{ steps.requirements.outputs.GNAT_MAJOR_VERSION }}.so ./install/lib
 
       - name: 📤 Upload '${{ steps.artifact_name.outputs.libghdl_artifact }}' artifact (only mcode backend)
-        uses: pyTooling/upload-artifact@v6
+        uses: pyTooling/upload-artifact@v7
         if: inputs.ubuntu_version == '24.04' && inputs.ghdl_backend == 'mcode'
         with:
           name: ${{ steps.artifact_name.outputs.libghdl_artifact }}
@@ -417,7 +417,7 @@ jobs:
 # Upload test result artifacts
 
       - name: 📤 Upload 'TestReportSummary.xml' artifact (only mcode backend)
-        uses: pyTooling/upload-artifact@v6
+        uses: pyTooling/upload-artifact@v7
         if: inputs.unittesting && inputs.ghdl_backend == 'mcode' && inputs.unittest_xml_artifact != ''
         continue-on-error: true
         with:
@@ -434,7 +434,7 @@ jobs:
         run: coverage report --rcfile=pyproject.toml --data-file=.coverage
 
       - name: 📤 Upload 'Coverage SQLite Database' artifact (only mcode backend)
-        uses: pyTooling/upload-artifact@v6
+        uses: pyTooling/upload-artifact@v7
         if: inputs.coverage && inputs.ghdl_backend == 'mcode' && inputs.coverage_sqlite_artifact != ''
         continue-on-error: true
         with:

--- a/.github/workflows/Documentation-GNAT.yml
+++ b/.github/workflows/Documentation-GNAT.yml
@@ -46,7 +46,7 @@ jobs:
           ls -lAh gnat*
 
       - name: "📤 Upload artifact: '${{ inputs.html_artifact }}'"
-        uses: pyTooling/upload-artifact@v6
+        uses: pyTooling/upload-artifact@v7
         if: inputs.html_artifact != ''
         with:
           name: ${{ inputs.html_artifact }}

--- a/.github/workflows/Documentation-Sphinx.yml
+++ b/.github/workflows/Documentation-Sphinx.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 📥 Download artifacts '${{ inputs.ghdl_artifact }}' from 'Build' job
-        uses: pyTooling/download-artifact@v7
+        uses: pyTooling/download-artifact@v8
         with:
           name: ${{ inputs.ghdl_artifact }}
           path: install
@@ -92,7 +92,7 @@ jobs:
           make html
 
       - name: '📤 Upload artifact: HTML'
-        uses: pyTooling/upload-artifact@v6
+        uses: pyTooling/upload-artifact@v7
         if: inputs.html_artifact != ''
         with:
           name: ${{ inputs.html_artifact }}
@@ -110,7 +110,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 📥 Download artifacts '${{ inputs.ghdl_artifact }}' from 'Build' job
-        uses: pyTooling/download-artifact@v7
+        uses: pyTooling/download-artifact@v8
         with:
           name: ${{ inputs.ghdl_artifact }}
           path: install
@@ -143,7 +143,7 @@ jobs:
           make latex
 
       - name: '📤 Upload artifact: LaTeX'
-        uses: pyTooling/upload-artifact@v6
+        uses: pyTooling/upload-artifact@v7
         if: inputs.latex_artifact != ''
         with:
           name: ${{ inputs.latex_artifact }}
@@ -160,7 +160,7 @@ jobs:
 
     steps:
       - name: 📥 Download artifacts '${{ inputs.latex_artifact }}' from 'Sphinx' job
-        uses: pyTooling/download-artifact@v7
+        uses: pyTooling/download-artifact@v8
         with:
           name: ${{ inputs.latex_artifact }}
           path: latex
@@ -172,7 +172,7 @@ jobs:
           root_file: ${{ inputs.latex_document }}.tex
 
       - name: 📤 Upload 'PDF Documentation' artifact
-        uses: pyTooling/upload-artifact@v6
+        uses: pyTooling/upload-artifact@v7
         if: inputs.pdf_artifact != ''
         with:
           name: ${{ inputs.pdf_artifact }}

--- a/.github/workflows/Package-Docker.yml
+++ b/.github/workflows/Package-Docker.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 📥 Download artifacts '${{ inputs.ghdl_artifact }}' from 'Build' job
-        uses: pyTooling/download-artifact@v7
+        uses: pyTooling/download-artifact@v8
         with:
           name: ${{ inputs.ghdl_artifact }}
           path: dist/docker/install

--- a/.github/workflows/Package-pyGHDL.yml
+++ b/.github/workflows/Package-pyGHDL.yml
@@ -84,7 +84,7 @@ jobs:
           python -m pip install --disable-pip-version-check "pyTooling[packaging]" wheel
 
       - name: 📥 Download artifacts '${{ inputs.libghdl_artifact }}-${{ inputs.backend }}' from 'Build' job
-        uses: pyTooling/download-artifact@v7
+        uses: pyTooling/download-artifact@v8
         with:
           name: ${{ inputs.libghdl_artifact }}-${{ inputs.backend }}
           path: install
@@ -109,7 +109,7 @@ jobs:
         run: python setup.py bdist_wheel
 
       - name: '📤 Upload artifact: ${{ inputs.pyghdl_artifact }}'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.pyghdl_artifact }}
           path: dist/pyghdl*.whl
@@ -199,7 +199,7 @@ jobs:
           python-version: ${{ inputs.python_version }}
 
       - name: 📥 Download artifacts '${{ inputs.pyghdl_artifact }}' from 'Package' job
-        uses: pyTooling/download-artifact@v7
+        uses: pyTooling/download-artifact@v8
         with:
           name: ${{ inputs.pyghdl_artifact }}
           path: wheels
@@ -376,7 +376,7 @@ jobs:
 # Upload test result artifacts
 
       - name: 📤 Upload 'TestReportSummary.xml' artifact
-        uses: pyTooling/upload-artifact@v6
+        uses: pyTooling/upload-artifact@v7
         if: inputs.unittest_xml_artifact != ''
         continue-on-error: true
         with:
@@ -389,7 +389,7 @@ jobs:
 #      - name: 📤 Upload 'Unit Tests HTML Report' artifact
 #        if: inputs.unittest_html_artifact != ''
 #        continue-on-error: true
-#        uses: pyTooling/upload-artifact@v6
+#        uses: pyTooling/upload-artifact@v7
 #        with:
 #          name: ${{ inputs.unittest_html_artifact }}-${{ inputs.python_version }}
 #          path: ${{ steps.getVariables.outputs.unittest_report_html_directory }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -254,13 +254,14 @@ jobs:
 #      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   IntermediateCleanUp:
-    uses: pyTooling/Actions/.github/workflows/IntermediateCleanUp.yml@r7
+    uses: pyTooling/Actions/.github/workflows/CleanupArtifacts.yml@r7
     needs:
       - PublishCoverageResults
       - PublishPytestResults
     with:
-      sqlite_coverage_artifacts_prefix: 'pyGHDL-Coverage-SQLite-'
-      xml_unittest_artifacts_prefix:    'pyGHDL-Unittest-XML-'
+      others: |
+        pyGHDL-Coverage-SQLite-*
+        pyGHDL-Unittest-XML-*
 
 #  GNATdoc:
 #    uses: ./.github/workflows/Documentation-GNAT.yml

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -343,11 +343,11 @@ jobs:
         pyGHDL-Ubuntu-24.04-x86_64-Python-3.11: pyghdl-%pyghdl%-cp311-cp311-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.11,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.11
         pyGHDL-Ubuntu-24.04-x86_64-Python-3.12: pyghdl-%pyghdl%-cp312-cp312-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.12,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.12
         pyGHDL-Ubuntu-24.04-x86_64-Python-3.13: pyghdl-%pyghdl%-cp313-cp313-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.13,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.13
-        #pyGHDL-Ubuntu-24.04-x86_64-Python-3.14: pyghdl-%pyghdl%-cp314-cp314-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.14,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.14
+        pyGHDL-Ubuntu-24.04-x86_64-Python-3.14: pyghdl-%pyghdl%-cp314-cp314-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.14,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.14
         pyGHDL-Windows-x86_64-Python-3.11:      pyghdl-%pyghdl%-cp311-cp311-win_amd64.whl:                    pyGHDL,windows,2025,x86-64,py3.11,native,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.11
         pyGHDL-Windows-x86_64-Python-3.12:      pyghdl-%pyghdl%-cp312-cp312-win_amd64.whl:                    pyGHDL,windows,2025,x86-64,py3.12,native,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.12
         pyGHDL-Windows-x86_64-Python-3.13:      pyghdl-%pyghdl%-cp313-cp313-win_amd64.whl:                    pyGHDL,windows,2025,x86-64,py3.13,native,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.13
-        #pyGHDL-Windows-x86_64-Python-3.14:      pyghdl-%pyghdl%-cp314-cp314-win_amd64.whl:                    pyGHDL,windows,2025,x86-64,py3.14,native,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.14
+        pyGHDL-Windows-x86_64-Python-3.14:      pyghdl-%pyghdl%-cp314-cp314-win_amd64.whl:                    pyGHDL,windows,2025,x86-64,py3.14,native,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.14
         pyGHDL-Windows-mingw64-Python-3.14:     pyghdl-%pyghdl%-cp314-cp314-mingw_x86_64_msvcrt_gnu.whl:      pyGHDL,windows,2025,x86-64,py3.14,mingw64,mcode: pyGHDL - v%ghdl% - Windows (x86-64) + MSYS2/MinGW64 - Wheel for Python 3.14
         pyGHDL-Windows-ucrt64-Python-3.14:      pyghdl-%pyghdl%-cp314-cp314-mingw_x86_64_ucrt_gnu.whl:        pyGHDL,windows,2025,x86-64,py3.14,ucrt64,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) + MSYS2/UCRT64 - Wheel for Python 3.14
 

--- a/.github/workflows/Publish-GitHubPages.yml
+++ b/.github/workflows/Publish-GitHubPages.yml
@@ -41,20 +41,20 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 📥 Download artifacts '${{ inputs.documentation }}' from 'Sphinx' job
-        uses: pyTooling/download-artifact@v7
+        uses: pyTooling/download-artifact@v8
         with:
           name: ${{ inputs.documentation }}
           path: public
 
       - name: 📥 Download artifacts '${{ inputs.coverage }}' from 'PublishCoverageResults' job
-        uses: pyTooling/download-artifact@v7
+        uses: pyTooling/download-artifact@v8
         if: ${{ inputs.coverage != '' }}
         with:
           name: ${{ inputs.coverage }}
           path: public/coverage
 
       - name: 📥 Download artifacts '${{ inputs.typing }}' from 'StaticTypeCheck' job
-        uses: pyTooling/download-artifact@v7
+        uses: pyTooling/download-artifact@v8
         if: ${{ inputs.typing != '' }}
         with:
           name: ${{ inputs.typing }}
@@ -62,11 +62,11 @@ jobs:
 
       - name: 📑 Upload static files as artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: public/
 
       - name: 📖 Deploy to GitHub Pages
         id: deployment
         if: github.event_name != 'pull_request'
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/Test-GHDL.yml
+++ b/.github/workflows/Test-GHDL.yml
@@ -51,7 +51,7 @@ jobs:
           pacboy: "diffutils:p"
 
       - name: 📥 Download artifacts '${{ inputs.ghdl_artifact }}' from 'Build' job
-        uses: pyTooling/download-artifact@v7
+        uses: pyTooling/download-artifact@v8
         with:
           name: ${{ inputs.ghdl_artifact }}
           path: install

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,7 +6,7 @@ python-dateutil ~= 2.9
 # Sphinx Extenstions
 autoapi ~= 2.0
 myst-parser ~= 5.0
-sphinx_autodoc_typehints ~= 3.6
+sphinx_autodoc_typehints ~= 3.10
 
 # Theme
 furo >= 2025.12.19

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -571,7 +571,8 @@ class WaitStatement(VHDLModel_WaitStatement, DOMMixin):
         sensitivityList = None
         sensitivityListNode = nodes.Get_Sensitivity_List(waitNode)
         if sensitivityListNode is not nodes.Null_Iir:
-            print(GetIirKindOfNode(sensitivityListNode))
+            pass
+            # print(f"WaitStatement: wait on {GetIirKindOfNode(sensitivityListNode)}")
 
         conditionNode = nodes.Get_Condition_Clause(waitNode)
         condition = None if conditionNode is nodes.Null_Iir else GetExpressionFromNode(conditionNode)

--- a/pyGHDL/dom/requirements.txt
+++ b/pyGHDL/dom/requirements.txt
@@ -1,4 +1,4 @@
 -r ../libghdl/requirements.txt
 
-pyVHDLModel ~= 0.33
+pyVHDLModel ~= 0.34.0
 #https://github.com/VHDL/pyVHDLModel/archive/dev.zip#pyVHDLModel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
-  "setuptools >= 80.0",
-  "wheel ~= 0.45",
-  "pyTooling ~= 8.8"
+  "setuptools >= 82.0",
+  "pyTooling ~= 8.14"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/testsuite/pyunit/dom/examples/StopWatch/sync_Bits.vhdl
+++ b/testsuite/pyunit/dom/examples/StopWatch/sync_Bits.vhdl
@@ -36,9 +36,7 @@ architecture rtl of sync_Bits is
 	end component;
 begin
 	gen : for i in Input'range generate
-	begin
---		bit: component work.sync_Bit
-		bit: entity work.sync_Bit
+		bit: component work.sync_Bit
 			generic map (
 				STAGES => STAGES
 			)

--- a/testsuite/requirements.txt
+++ b/testsuite/requirements.txt
@@ -2,7 +2,7 @@
 
 # Test Runner
 pytest ~= 9.0
-pytest-cov ~= 7.0
+pytest-cov ~= 7.1
 
 # Coverage collection
 Coverage ~= 7.13


### PR DESCRIPTION
When the release was created, I didn't notice Python 3.14 assets were still disabled.

# CI Pipeline

* Create and publish Python 3.14 assets for pyGHDL.
* Use new simplified artifact cleanup template from pyTooling.
* Bumped Actions dependencies:
  * Updated `actions/upload-artifact` to `@v7`  
    This will fix #3240
  * Updated `actions/upload-pages-artifact` to `@v5`  
    This will fix #3238
  * Updated `actions/deploy-pages` to `@v5`  
    This will fix #3241
  * Updated `pyTooling/upload-artifact` to `@v7`  
    This will fix #3243
  * Updated `pyTooling/download-artifact` to `@v8`  
    This will fix #3239
* Bumped Python dependencies:
  * Updated `sphinx-autodoc-typehints` to `v3.10`.  
    This will fix #3137 
  * Updated `setuptools` to `v82.0`.  
    This will fix #3242
  * Updated `pyTooling` to `v8.14`.  
    This will fix #3245
  * Updated `pytest-cov` to `v7.1`.  
    This will fix #3247
  * Removed explicit dependency `wheel`.  
    This will fix #3246
* A new pipeline run will use the latest `pyTooling/Actions` v7.10.1:
  * Fixed the missing replacement of `%%TAG%%`: used in the image showing the download numbers per release.  
    See also: https://github.com/pyTooling/Actions/releases/tag/v7.10.1
