### PR TITLE
Added builds for macOS 26

### DIFF
--- a/.github/ReleaseDescription.md
+++ b/.github/ReleaseDescription.md
@@ -12,7 +12,6 @@ GHDL offers the simulator and synthesis tool for VHDL. GHDL can be built for var
 * `llvm-jit` - using the LLVM compiler framework, but in memory
 
 The following asset categories are provided for GHDL:
-* macOS x64-64 builds as TAR/GZ file
 * macOS aarch64 builds as TAR/GZ file
 * Ubuntu 24.04 LTS builds as TAR/GZ file
 * Windows builds for standalone usage (without MSYS2) as ZIP file

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -44,14 +44,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-# macOS-14 is the latest ARM v9 release
-###       - {icon: '🍏🟩', backend: 'mcode',    macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: 'none'}                                    # mcode not yet supported for aarch64
-          - {icon: '🍏🟩', backend: 'llvm',     macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-          - {icon: '🍏🟩', backend: 'llvm-jit', macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-# macOS-15 is beta (broken/missing types in C)
-###       - {icon: '🍏🟩', backend: 'mcode',    macos_image: 'macos-15', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: 'none'}                                    # mcode not yet supported for aarch64
-          - {icon: '🍏🟩', backend: 'llvm',     macos_image: 'macos-15', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-          - {icon: '🍏🟩', backend: 'llvm-jit', macos_image: 'macos-15', gnat_arch: 'aarch64', gnat_version: '14.2.0-1', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+###       - {icon: '🍏🟩', backend: 'mcode',    macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '15.1.0-2', testsuites: 'none'}                                    # mcode not yet supported for aarch64
+          - {icon: '🍏🟩', backend: 'llvm',     macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '15.1.0-2', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {icon: '🍏🟩', backend: 'llvm-jit', macos_image: 'macos-14', gnat_arch: 'aarch64', gnat_version: '15.1.0-2', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+###       - {icon: '🍏🟩', backend: 'mcode',    macos_image: 'macos-15', gnat_arch: 'aarch64', gnat_version: '15.1.0-2', testsuites: 'none'}                                    # mcode not yet supported for aarch64
+          - {icon: '🍏🟩', backend: 'llvm',     macos_image: 'macos-15', gnat_arch: 'aarch64', gnat_version: '15.1.0-2', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {icon: '🍏🟩', backend: 'llvm-jit', macos_image: 'macos-15', gnat_arch: 'aarch64', gnat_version: '15.1.0-2', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+###       - {icon: '🍏🟩', backend: 'mcode',    macos_image: 'macos-26', gnat_arch: 'aarch64', gnat_version: '15.1.0-2', testsuites: 'none'}                                    # mcode not yet supported for aarch64
+          - {icon: '🍏🟩', backend: 'llvm',     macos_image: 'macos-26', gnat_arch: 'aarch64', gnat_version: '15.1.0-2', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {icon: '🍏🟩', backend: 'llvm-jit', macos_image: 'macos-26', gnat_arch: 'aarch64', gnat_version: '15.1.0-2', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
     with:
       macos_image:              ${{ matrix.macos_image }}
       gnat_arch:                ${{ matrix.gnat_arch }}
@@ -329,6 +330,8 @@ jobs:
         ghdl-macos-14-aarch64-llvm-jit:        $ghdl-llvm-jit-%ghdl%-macos14-aarch64.tar.gz:                  ghdl,macos,14,aarch64,native,llvm-jit:           GHDL - v%ghdl% - macOS 14 (aarch64) - llvm-jit backend
         ghdl-macos-15-aarch64-llvm:            $ghdl-llvm-%ghdl%-macos15-aarch64.tar.gz:                      ghdl,macos,15,aarch64,native,llvm:               GHDL - v%ghdl% - macOS 15 (aarch64) - llvm backend
         ghdl-macos-15-aarch64-llvm-jit:        $ghdl-llvm-jit-%ghdl%-macos15-aarch64.tar.gz:                  ghdl,macos,15,aarch64,native,llvm-jit:           GHDL - v%ghdl% - macOS 15 (aarch64) - llvm-jit backend
+        ghdl-macos-26-aarch64-llvm:            $ghdl-llvm-%ghdl%-macos26-aarch64.tar.gz:                      ghdl,macos,26,aarch64,native,llvm:               GHDL - v%ghdl% - macOS 26 (aarch64) - llvm backend
+        ghdl-macos-26-aarch64-llvm-jit:        $ghdl-llvm-jit-%ghdl%-macos26-aarch64.tar.gz:                  ghdl,macos,26,aarch64,native,llvm-jit:           GHDL - v%ghdl% - macOS 26 (aarch64) - llvm-jit backend
         ghdl-ubuntu-24.04-x86_64-gcc:          $ghdl-gcc-%ghdl%-ubuntu24.04-x86_64.tar.gz:                    ghdl,ubuntu,24.04,x86-64,native,gcc:             GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - gcc backend
         ghdl-ubuntu-24.04-x86_64-llvm:         $ghdl-llvm-%ghdl%-ubuntu24.04-x86_64.tar.gz:                   ghdl,ubuntu,24.04,x86-64,native,llvm:            GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - llvm backend
         ghdl-ubuntu-24.04-x86_64-llvm-jit:     $ghdl-llvm-jit-%ghdl%-ubuntu24.04-x86_64.tar.gz:               ghdl,ubuntu,24.04,x86-64,native,llvm-jit:        GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - llvm-jit backend
@@ -404,6 +407,8 @@ jobs:
           - {icon: '🍏',   name: 'macOS',   image: 'macos-14',     runtime: '',        backend: 'llvm-jit'}
           - {icon: '🍏',   name: 'macOS',   image: 'macos-15',     runtime: '',        backend: 'llvm'}
           - {icon: '🍏',   name: 'macOS',   image: 'macos-15',     runtime: '',        backend: 'llvm-jit'}
+          - {icon: '🍏',   name: 'macOS',   image: 'macos-26',     runtime: '',        backend: 'llvm'}
+          - {icon: '🍏',   name: 'macOS',   image: 'macos-26',     runtime: '',        backend: 'llvm-jit'}
           - {icon: '🪟',   name: 'Windows', image: 'windows-2025', runtime: '',        backend: 'mcode'}
 #         - {icon: '🪟⬛', name: 'Windows', image: 'windows-2025', runtime: 'mingw32', backend: 'mcode'}
           - {icon: '🪟🟦', name: 'Windows', image: 'windows-2025', runtime: 'mingw64', backend: 'mcode'}


### PR DESCRIPTION
# CI Pipeline

* Added macOS-26 (aarch64).
* Removed macOS x86-64 from released notes template.
* Changed GNAT/GCC version for macOS builds from v14.2.0 to v15.1.0.  
  (v15.2.0 doesn't provide Darwin builds; v16.0.1 is experimental)