### PR TITLE
Implement option --expect-finish for std.env.finish.

### DIFF
--- a/doc/using/Simulation.rst
+++ b/doc/using/Simulation.rst
@@ -110,6 +110,15 @@ Here is the list of the most useful options. For further info, see :ref:`DEV:Deb
 
   .. index:: display time
 
+.. option:: --expect-finish
+
+  Simulations may timeout before they are complete. This option will return a
+  non-zero exit code status (indicating an error) unless ``std.env.finish`` is
+  explicitly called to terminate the simulation. This option will allow
+  automated testbenches to distinguish between a timeout and a successfully
+  completed test. When combined with ``--stop-time``, it can be assured that
+  the simulated terminated gracefully rather than reaching the stop time.
+
 .. option:: --disp-time
 
   Display the time and delta cycle number as simulation advances.

--- a/src/grt/ghdl_main.adb
+++ b/src/grt/ghdl_main.adb
@@ -64,6 +64,17 @@ begin
    --  Initialize, elaborate and simulate.
    Grt.Main.Run;
 
+   -- If the simulation is expected to be finished by std.env.finish, check if
+   -- that is the case, and set a non-zero status (indicating an error)
+   -- otherwise.  This is useful for distinguishing between timeouts or tests
+   -- that finish explicitly.
+   if Grt.Options.Expect_Finish
+     and then not Grt.Errors.Finished_By_Std_Env_Finish
+     and then Grt.Errors.Exit_Status = 0
+   then
+      Grt.Errors.Exit_Status := 1;
+   end if;
+
    --  Return the status.
    return Grt.Errors.Exit_Status;
 end Ghdl_Main;

--- a/src/grt/grt-errors.ads
+++ b/src/grt/grt-errors.ads
@@ -103,6 +103,9 @@ package Grt.Errors is
    pragma No_Return (Fatal_Error);
    pragma Export (C, Fatal_Error, "__ghdl_fatal");
 
+   -- Record if std.env.finish halts the simulation.
+   Finished_By_Std_Env_Finish : Boolean := False;
+
    --  Stop or finish simulation (for VHPI or std.env).
    Exit_Status : Integer := 0;
    procedure Exit_Simulation;

--- a/src/grt/grt-lib.adb
+++ b/src/grt/grt-lib.adb
@@ -520,6 +520,7 @@ package body Grt.Lib is
          Diag_C ("stopped");
       else
          Diag_C ("finished");
+         Finished_By_Std_Env_Finish := True;
       end if;
       Diag_C (" @");
       Diag_C_Now;

--- a/src/grt/grt-options.adb
+++ b/src/grt/grt-options.adb
@@ -93,6 +93,7 @@ package body Grt.Options is
       P ("       X is expressed as a time value, without spaces: 1ns, ps...");
       P (" --stop-delta=X    stop the simulation cycle after X delta");
       P (" --expect-failure  invert exit status");
+      P (" --expect-finish  return non-zero unless std.env.finish is called");
       P (" --max-stack-alloc=X  error if variables are larger than X KB");
       P (" --no-run          do not simulate, only elaborate");
       P (" --unbuffered      disable buffering on stdout, stderr and");
@@ -342,6 +343,8 @@ package body Grt.Options is
             --  In case of error...
             return;
          end if;
+      elsif Option = "--expect-finish" then
+         Expect_Finish := True;
       elsif Len > 13 and then Option (1 .. 13) = "--stop-delta=" then
          declare
             Ok : Boolean;

--- a/src/grt/grt-options.ads
+++ b/src/grt/grt-options.ads
@@ -153,6 +153,10 @@ package Grt.Options is
    --  Set by --stop-time=X to stop the simulation at time X.
    Stop_Time : Std_Time := Std_Time'Last;
 
+   -- Specify that the test must be ended by std.env.finish, otherwise
+   -- a non-zero exit code (error) will be returned.
+   Expect_Finish : Boolean := False;
+
    --  Set by --no-run
    --  If set, do not simulate, only elaborate.
    Flag_No_Run : Boolean := False;

--- a/testsuite/gna/issue3259/tb_finish.vhdl
+++ b/testsuite/gna/issue3259/tb_finish.vhdl
@@ -1,0 +1,16 @@
+library std;
+use std.env.finish;
+
+entity tb_finish is
+end entity tb_finish;
+
+architecture behav of tb_finish is
+begin
+
+   main_p : process
+   begin
+      wait for 1 ns;
+      finish;
+   end process main_p;
+
+end architecture behav;

--- a/testsuite/gna/issue3259/tb_late_finish.vhd
+++ b/testsuite/gna/issue3259/tb_late_finish.vhd
@@ -1,15 +1,15 @@
 library std;
 use std.env.finish;
 
-entity tb_finish is
-end entity tb_finish;
+entity tb_late_finish is
+end entity tb_late_finish;
 
-architecture behav of tb_finish is
+architecture behav of tb_late_finish is
 begin
 
    main_p : process
    begin
-      wait for 5 ns;
+      wait for 1 us;
       finish;
    end process main_p;
 

--- a/testsuite/gna/issue3259/tb_no_finish.vhdl
+++ b/testsuite/gna/issue3259/tb_no_finish.vhdl
@@ -1,0 +1,12 @@
+entity tb_no_finish is
+end entity tb_no_finish;
+
+architecture behav of tb_no_finish is
+begin
+
+   main_p : process
+   begin
+      wait;
+   end process main_p;
+
+end architecture behav;

--- a/testsuite/gna/issue3259/testsuite.sh
+++ b/testsuite/gna/issue3259/testsuite.sh
@@ -1,0 +1,28 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+GHDL_STD_FLAGS=--std=08
+
+analyze tb_finish.vhdl
+analyze tb_no_finish.vhdl
+
+elab tb_finish
+elab tb_no_finish
+
+# Explicit finish before timeout.  std.env.finish should exit gracefully.
+simulate tb_finish --expect-finish --stop-time=10ns
+
+# No std.env.finish should return an error code.
+if simulate tb_no_finish --expect-finish --stop-time=1ns; then
+    echo "Failure: An error expected on stop time being reached."
+    exit 1
+fi
+
+# Preservice old functionality; that is a timeout on --stop-time
+# without --expect-failure returns a 0 status for success.
+simulate tb_no_finish --stop-time=1ns
+
+clean
+
+echo "Test successful"

--- a/testsuite/gna/issue3259/testsuite.sh
+++ b/testsuite/gna/issue3259/testsuite.sh
@@ -6,9 +6,11 @@ GHDL_STD_FLAGS=--std=08
 
 analyze tb_finish.vhdl
 analyze tb_no_finish.vhdl
+analyze tb_late_finish.vhdl
 
 elab tb_finish
 elab tb_no_finish
+elab tb_late_finish
 
 # Explicit finish before timeout.  std.env.finish should exit gracefully.
 simulate tb_finish --expect-finish --stop-time=10ns

--- a/testsuite/gna/issue3259/testsuite.sh
+++ b/testsuite/gna/issue3259/testsuite.sh
@@ -14,20 +14,20 @@ elab tb_no_finish
 simulate tb_finish --expect-finish --stop-time=10ns
 
 # No std.env.finish should return an error code.
-if simulate tb_no_finish --expect-finish --stop-time=1ns; then
+if simulate tb_no_finish --expect-finish --stop-time=5ns; then
     echo "Failure: An error expected on stop time being reached."
     exit 1
 fi
 
 # Timeout before std.env.finish should return an error code.
-if simulate tb_no_finish --expect-finish --stop-time=500ps; then
+if simulate tb_late_finish --expect-finish --stop-time=5ns; then
     echo "Failure: An error expected on stop time being reached."
     exit 1
 fi
 
-# Preserve old functionality; that is a timeout on --stop-time
-# without --expect-failure returns a 0 status for success.
-simulate tb_no_finish --stop-time=1ns
+# Preservice old functionality; that is a timeout on --stop-time
+# without --expect-finish returns a 0 status for success.
+simulate tb_no_finish --stop-time=5ns
 
 clean
 

--- a/testsuite/gna/issue3259/testsuite.sh
+++ b/testsuite/gna/issue3259/testsuite.sh
@@ -19,7 +19,13 @@ if simulate tb_no_finish --expect-finish --stop-time=1ns; then
     exit 1
 fi
 
-# Preservice old functionality; that is a timeout on --stop-time
+# Timeout before std.env.finish should return an error code.
+if simulate tb_no_finish --expect-finish --stop-time=500ps; then
+    echo "Failure: An error expected on stop time being reached."
+    exit 1
+fi
+
+# Preserve old functionality; that is a timeout on --stop-time
 # without --expect-failure returns a 0 status for success.
 simulate tb_no_finish --stop-time=1ns
 


### PR DESCRIPTION
Simulations may timeout before they are complete. This option will return a non-zero error code unless std.env.finish is explicitly called to terminate the simulator. This will allow automated testbenches to distinguish between a timeout and a successfully completed test.

Looking for feedback and review before merging.