### PR TITLE
Improve DLL compiling flow on Windows.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -491,11 +491,30 @@ lib/$(libghdl_name): $(GRT_SRC_DEPS) $(LIBGHDL_GRT_OBJS) version.ads force
 #	Use -g for gnatlink so that the binder file is not removed.  We need
 #	it for libghdl.a
 	$(GNATMAKE) -I- -aI. -D pic -z libghdl -o $@ -gnat12 $(GNATFLAGS) $(PIC_FLAGS) $(LIBGHDL_INCFLAGS) -bargs -shared -Llibghdl_ -largs -R -g -shared $(SHLIB_FLAGS) $(filter-out -static,$(LDFLAGS)) $(LIBGHDL_GRT_OBJS)
-#       On windows, gnatmake (via Osint.Executable_Name) always appends .exe
-#       Adjust.  (Other solution: use gnatmake for compilation and binding,
-#       then use gnatlink directly for linking).
 ifeq ($(SOEXT),.dll)
+#       On windows, gnatmake (via Osint.Executable_Name) always appends .exe
+#       GNU ld can link directly against DLLs, while MSVC cannot. However,
+#       the DLL "remembers" the filename it was created with (via the Name RVA
+#       in .edata). So even if the DLL is moved to remove the .exe extension,
+#       applications linked directly against this DLL will still try to load a
+#       DLL with the old name.
+#
+#       Instead of linking directly to the DLL, use an import lib. The Name RVA
+#       in the DLL (with .exe appended) is not  touched. GNU ld's can create a
+#       DEF file from the DLL, which can be used to create an MSVC-style import
+#       library with external tools. dlltool can use this DEF file to create a
+#       GNU/GNAT-style import library, while also telling applications to load
+#       a DLL filename without .exe appended.
+#       Note that MSVC's LIB.exe does not have an equivalent to dlltool's -D
+#       arg. So to change the DLL name that applications try to load, you'll
+#       need to add a LIBRARY section to your DEF file. See:
+#       * https://gcc.gnu.org/onlinedocs/gnat_ugn/Creating-an-Import-Library.html#g_t1f6
+#       * https://learn.microsoft.com/en-us/cpp/build/reference/library?view=msvc-170
+	$(GNATMAKE) -I- -aI. -D pic -z libghdl -o $@ -gnat12 $(GNATFLAGS) $(PIC_FLAGS) $(LIBGHDL_INCFLAGS) -bargs -shared -Llibghdl_ -largs -R -g -Wl,--output-def lib/libghdl-$(libghdl_version).def.orig -shared $(SHLIB_FLAGS) $(filter-out -static,$(LDFLAGS)) $(LIBGHDL_GRT_OBJS)
+	dlltool -D libghdl-$(libghdl_version).dll -d lib/libghdl-$(libghdl_version).def -l lib/libghdl-$(libghdl_version).dll.a
 	-mv lib/$(libghdl_name).exe $@
+else
+	$(GNATMAKE) -I- -aI. -D pic -z libghdl -o $@ -gnat12 $(GNATFLAGS) $(PIC_FLAGS) $(LIBGHDL_INCFLAGS) -bargs -shared -Llibghdl_ -largs -R -g -shared $(SHLIB_FLAGS) $(filter-out -static,$(LDFLAGS)) $(LIBGHDL_GRT_OBJS)
 endif
 
 libghdl.a: lib/$(libghdl_name)
@@ -531,7 +550,13 @@ install.libghdl.local: all.libghdl $(srcdir)/src/synth/include/synth_gates.h
 	$(INSTALL_DATA) -p $(srcdir)/src/synth/include/synth_gates.h $(incdirsuffix)/ghdl/
 
 install.libghdl.lib:
-	$(INSTALL_PROGRAM) -p lib/$(libghdl_name) "$(DESTDIR)$(libdir)/"
+ifeq ($(SOEXT),.dll)
+		$(INSTALL_PROGRAM) -p lib/$(libghdl_name) "$(DESTDIR)$(bindir)/"
+		$(INSTALL_PROGRAM) -p lib/libghdl-$(libghdl_version).dll.a "$(DESTDIR)$(libdir)/"
+		$(INSTALL_PROGRAM) -p lib/libghdl-$(libghdl_version).def "$(DESTDIR)$(libdir)/"
+else
+		$(INSTALL_PROGRAM) -p lib/$(libghdl_name) "$(DESTDIR)$(libdir)/"
+endif
 	$(INSTALL_PROGRAM) -p libghdl.a "$(DESTDIR)$(libdir)/"
 	$(INSTALL_DATA) -p libghdl.link "$(DESTDIR)$(libdir)/"
 
@@ -557,6 +582,9 @@ uninstall.libghdl:
 	$(RM) $(DESTDIR)$(libdir)/libghdl.a
 	$(RM) $(DESTDIR)$(libdir)/libghdl.link
 	$(RM) $(DESTDIR)$(libdir)/libghdl$(SOEXT)
+ifeq ($(SOEXT),.dll)
+
+endif
 	$(RM) $(DESTDIR)$(libdir)/libghw.dll
 	$(RM) $(DESTDIR)$(libdir)/libghw$(SOEXT)
 	$(RM) $(DESTDIR)$(incdir)/synth.h

--- a/configure
+++ b/configure
@@ -70,7 +70,7 @@ enable_gplcompat enable_libghdl libghdl_version ghdl_version
 with_sundials sundials_incflags sundials_ldflags
 COMPILER_GCC COMPILER_DEBUG COMPILER_MCODE COMPILER_LLVM POST_PROCESSOR
 INSTALL_PREFIX LIBDIR_SUFFIX LIBGHDLDIR_SUFFIX INCDIR_SUFFIX
-LLVM_LDFLAGS
+LLVM_LDFLAGS SOIMPEXT
 "
 
 # Find srcdir
@@ -345,9 +345,9 @@ fi
 # Define default file extensions for Windows or Linux-like systems and
 # use -fPIC or not.
 case "$build" in
-  *mingw* | *cygwin* | *windows-gnu*) SOEXT=".dll";   EXEEXT=".exe"; PIC_FLAGS="";;
-  *darwin*)           SOEXT=".dylib"; EXEEXT="";     PIC_FLAGS="";;
-  *)                  SOEXT=".so";    EXEEXT="";     PIC_FLAGS="-fPIC";;
+  *mingw* | *cygwin* | *windows-gnu*) SOEXT=".dll";   EXEEXT=".exe"; PIC_FLAGS=""; SOIMPEXT=".dll.a";;
+  *darwin*)           SOEXT=".dylib"; EXEEXT="";     PIC_FLAGS=""; SOIMPEXT=".dylib";;
+  *)                  SOEXT=".so";    EXEEXT="";     PIC_FLAGS="-fPIC"; SOIMPEXT=".so";;
 esac
 
 # Define libghdl_version

--- a/default_paths.ads.in
+++ b/default_paths.ads.in
@@ -40,6 +40,7 @@ package Default_Paths is
      "@POST_PROCESSOR@";
 
    Shared_Library_Extension : constant String := "@SOEXT@";
+   Shared_Or_Import_Library_Extension : constant String := "@SOIMPEXT@";
    Executable_Extension : constant String := "@EXEEXT@";
    Default_Pie : constant Boolean := "@default_pic@" = String'("true");
 

--- a/src/ghdldrv/ghdllib.adb
+++ b/src/ghdldrv/ghdllib.adb
@@ -34,7 +34,7 @@ package body Ghdllib is
          end if;
       end loop;
       return "libghdl-" & Libghdl_Version
-        & Default_Paths.Shared_Library_Extension;
+        & Default_Paths.Shared_Or_Import_Library_Extension;
    end Get_Libghdl_Name;
 
    function Get_Libghdl_Path return String is


### PR DESCRIPTION
**Description**

`ghdl-yosys-plugin` technically works on Windows, but my experience is that it does not work out-of-the-box. This PR adds some adjustments on the `ghdl` side of things to make compiling and using `ghdl-yosys-plugin` on Windows more seamless.
_This is a proof-of-concept._ I'll check off the rest of the PR list (included as an HTML comment), if this PR moves forward. I don't want it merged, but I would like feedback:

1. Link against a static import library instead of the DLL directly.

   `gnatmake` [hardcodes](https://github.com/ghdl/ghdl/blob/423a12de95955f12832ffa920840bf973c26e84a/Makefile.in#L494-L496) outputs with an `.exe` extension. The current solution is to move the generated `.dll.exe` filename to `.dll`. Unfortunately, I've found that this isn't enough to solve load time problems. DLLs/PEs have a [field](https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#export-directory-table) called Name RVA, which holds the original filename the DLL was created with. When linking an app against a `libghdl.dll` directly<sup>1</sup>, GNU `ld` tells the application "look for a filename corresponding the Name RVA when loading DLLs"<sup>2</sup>.

   The end result is that the plugin can't find `libghdl-7_0_0_dev.dll` because it's trying to look for `libghdl-7_0_0_dev.dll.exe`:

   ```
   William@DESKTOP-3H1DSBV MINGW64 ~/Projects/FPGA/ghdl-yosys-plugin
   $ make YOSYS_CONFIG=/home/William/Projects/FPGA/yosys/build/yosys-config -B
   /home/William/Projects/FPGA/yosys/build/yosys-config --exec --cxx -c --cxxflags -o ghdl.o src/ghdl.cc -fPIC -DYOSYS_ENABLE_GHDL -IC:\msys64\mingw64\include -O -DGHDL_VER_HASH="\"233dffb\""
   /home/William/Projects/FPGA/yosys/build/yosys-config --exec --cxx --cxxflags --ldflags -o ghdl.so ghdl.o --ldlibs -shared C:\msys64\mingw64\lib\libghdl-7_0_0_dev.dll -Wl,-rpath,C:\msys64\mingw64\lib\

   William@DESKTOP-3H1DSBV MINGW64 ~/Projects/FPGA/ghdl-yosys-plugin
   $ ldd ghdl.so
         ntdll.dll => /c/Windows/SYSTEM32/ntdll.dll (0x7ffb2bed0000)
         KERNEL32.DLL => /c/Windows/System32/KERNEL32.DLL (0x7ffb2ae00000)
         KERNELBASE.dll => /c/Windows/System32/KERNELBASE.dll (0x7ffb295e0000)
         msvcrt.dll => /c/Windows/System32/msvcrt.dll (0x7ffb2b630000)
         ghdl.so => /home/William/Projects/FPGA/ghdl-yosys-plugin/ghdl.so (0x7ffb19a60000)
         yosys.exe => /mingw64/bin/yosys.exe (0x7ff6eaed0000)
         libstdc++-6.dll => /mingw64/bin/libstdc++-6.dll (0x7ffaf45b0000)
         libgcc_s_seh-1.dll => /mingw64/bin/libgcc_s_seh-1.dll (0x7ffb19920000)
         libwinpthread-1.dll => /mingw64/bin/libwinpthread-1.dll (0x7ffb19900000)
         libwinpthread-1.dll => /mingw64/bin/libwinpthread-1.dll (0xda0000)
         libghdl-7_0_0_dev.dll.exe => not found
   ```


   There are [several](https://github.com/OpenMathLib/OpenBLAS/issues/127) solutions to this. I chose to have the build create a DEF file and static import library instead of trying to link against the DLL directly. DEF files can be used to create import libraries (for both the GNU and MSVC toolchains- see "MSVC support"), and stopping at a DEF file gives me an opportunity via `dlltool` to modify the DLL name that plugins/applications should try to load without hex editing the DLL's "Name RVA" field  :)<sup>3</sup>.  

2. Install the DLL in `$PREFIX/bin`.
   
    DLLs are loaded by querying paths specified by the Windows `PATH` variable and the invocation directory; `rpath` has no effect. They are normally installed alongside application binaries, so install them to `$PREFIX/bin`, so the loader finds them. OTOTH, `lib` directories are fine hold import libraries (and DEF files?).

3. MSVC Support?

   AFAICT from reading the GNAT Manual [section](https://gcc.gnu.org/onlinedocs/gnat_ugn/Mixed-Language-Programming-on-Windows.html), GNAT produces code that works with GNU or MSVC. However Only GNU `ld` can link against a DLL directly, while both can link against a static import library (`.dll.a` or `.lib`, different styles), and can load the DLL later. Microsoft tools can [ingest](https://gcc.gnu.org/onlinedocs/gnat_ugn/Creating-an-Import-Library.html#Microsoft-Style-Import-Library) DEF files to make import libraries compatible with MSVC. So this new process opens up using `libghdl` against the MSVC toolchain with less friction.

## Footnotes

1. Linking directly against a DLL is a GNU `ld` thing on Windows, presumably to more closely mimic Unix. It is not a thing with MSVC, and you must link against an import library.

1. I think it's analogous to ELF `.SONAME`, but I'm not very familiar with that.

2. While GNU `ld` can create an import library directly, I wasn't able to convince `dlltool` to accept an import library as input. It seems `dlltool` can only _emit_ import libraries.

<!-- :rotating_light: Before submitting your PR, please read [contribute](http://ghdl.github.io/ghdl/contribute.html#fork-modify-and-pull-request) in the [Docs](http://ghdl.github.io/ghdl), and review the following checklist:

- [ ] DO indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

**When contributing to the GHDL codebase...**

- [ ] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [ ] DO make sure that GHDL can be successfully built. See [Building GHDL](https://github.com/ghdl/ghdl#building-ghdl).
- [ ] CONSIDER adding a unit test if your PR resolves an issue.
- [ ] CONSIDER modifying the docs, if your contribution is relevant to any of the content.
- [ ] AVOID breaking the continuous integration build.
- [ ] AVOID breaking the testsuite.

**When contributing to the docs...**

- [ ] DO make sure that the build is successful.

**Further comments**

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you! -->
