### PR TITLE
Build for Ubuntu 26.04

### DIFF
--- a/.github/ReleaseDescription.md
+++ b/.github/ReleaseDescription.md
@@ -15,20 +15,22 @@ The following asset categories are provided for GHDL:
 * macOS x64-64 builds as TAR/GZ file
 * macOS aarch64 builds as TAR/GZ file
 * Ubuntu 24.04 LTS builds as TAR/GZ file
+* Ubuntu 26.04 LTS builds as TAR/GZ file
 * Windows builds for standalone usage (without MSYS2) as ZIP file
 * MSYS2/MinGW64 packages as TAR/ZST file
 * MSYS2/UCRT64 packages as TAR/ZST file
+
 
 ## Docker Images
 
 Latest docker images at pushed to [Docker Hub - ghdl/ghdl:latest](https://hub.docker.com/r/ghdl/ghdl/tags).
 
-| Backend  | Ubuntu 22.04                        | Ubuntu 24.04                        |
-|----------|-------------------------------------|-------------------------------------|
-| mcode    | `ghdl:%ghdl%-mcode-ubuntu-22.04`    | `ghdl:%ghdl%-mcode-ubuntu-24.04`    |
-| llvm     | `ghdl:%ghdl%-llvm-ubuntu-22.04`     | `ghdl:%ghdl%-llvm-ubuntu-24.04`     |
-| llvm-jit | `ghdl:%ghdl%-llvm-jit-ubuntu-22.04` | `ghdl:%ghdl%-llvm-jit-ubuntu-24.04` |
-| gcc      | `ghdl:%ghdl%-gcc-ubuntu-22.04`      | `ghdl:%ghdl%-gcc-ubuntu-24.04`      |
+| Backend  | Ubuntu 22.04                        | Ubuntu 24.04                        | Ubuntu 26.04                        |
+|----------|-------------------------------------|-------------------------------------|-------------------------------------|
+| mcode    | `ghdl:%ghdl%-mcode-ubuntu-22.04`    | `ghdl:%ghdl%-mcode-ubuntu-24.04`    | `ghdl:%ghdl%-mcode-ubuntu-26.04`    |
+| llvm     | `ghdl:%ghdl%-llvm-ubuntu-22.04`     | `ghdl:%ghdl%-llvm-ubuntu-24.04`     | `ghdl:%ghdl%-llvm-ubuntu-26.04`     |
+| llvm-jit | `ghdl:%ghdl%-llvm-jit-ubuntu-22.04` | `ghdl:%ghdl%-llvm-jit-ubuntu-24.04` | `ghdl:%ghdl%-llvm-jit-ubuntu-26.04` |
+| gcc      | `ghdl:%ghdl%-gcc-ubuntu-22.04`      | `ghdl:%ghdl%-gcc-ubuntu-24.04`      | `ghdl:%ghdl%-gcc-ubuntu-26.04`      |
 
 
 # pyGHDL %ghdl%

--- a/.github/workflows/Build-MSYS2.yml
+++ b/.github/workflows/Build-MSYS2.yml
@@ -169,7 +169,7 @@ jobs:
           LLVM_LDFLAGS='\`\$(LLVM_CONFIG) --link-static --ldflags --libs --system-libs\`'
 
           if ${{ startsWith(inputs.backend, 'llvm') }}; then
-            CONFIG_ARGS="--with-llvm-config"
+            CONFIG_ARGS="--with-llvm-config --with-backtrace-lib=${MINGW_PREFIX}/lib/libbacktrace.a"
             if ${{ endsWith(inputs.backend, 'jit') }}; then
               CONFIG_ARGS="$CONFIG_ARGS --with-llvm-jit"
             fi

--- a/.github/workflows/Build-MSYS2.yml
+++ b/.github/workflows/Build-MSYS2.yml
@@ -169,11 +169,12 @@ jobs:
           LLVM_LDFLAGS='\`\$(LLVM_CONFIG) --link-static --ldflags --libs --system-libs\`'
 
           if ${{ startsWith(inputs.backend, 'llvm') }}; then
-            CONFIG_ARGS="--with-llvm-config --with-backtrace-lib=${MINGW_PREFIX}/lib/libbacktrace.a"
+            CONFIG_ARGS="--with-llvm-config CXX=clang++"
             if ${{ endsWith(inputs.backend, 'jit') }}; then
               CONFIG_ARGS="$CONFIG_ARGS --with-llvm-jit"
+            else
+              CONFIG_ARGS="$CONFIG_ARGS --with-backtrace-lib=${MINGW_PREFIX}/lib/libbacktrace.a"
             fi
-            CONFIG_ARGS="$CONFIG_ARGS CXX=clang++"
           fi
           echo "CONFIG_ARGS=$CONFIG_ARGS"
 

--- a/.github/workflows/Build-MSYS2.yml
+++ b/.github/workflows/Build-MSYS2.yml
@@ -115,7 +115,7 @@ jobs:
           # Runtime (and backend) specific packages
           common_packages="python:p python-pip:p gcc:p gcc-ada:p binutils:p diffutils:p zlib:p"
           mcode_packages=""
-          llvm_packages="llvm:p clang:p"
+          llvm_packages="llvm:p clang:p libbacktrace:p"
 
           if ${{ startsWith(inputs.backend, 'mcode') }}; then
             tee -a "${GITHUB_OUTPUT}" <<EOF

--- a/.github/workflows/Build-MacOS.yml
+++ b/.github/workflows/Build-MacOS.yml
@@ -32,7 +32,7 @@ on:
       python_version:
         description: 'Python version for pyGHDL testing.'
         required: false
-        default: '3.12'
+        default: '3.14'
         type: string
       pyunit_testsuites:
         description: 'Name of the pyunit testsuites.'

--- a/.github/workflows/Build-Ubuntu.yml
+++ b/.github/workflows/Build-Ubuntu.yml
@@ -99,7 +99,7 @@ jobs:
           if ${{ startsWith(inputs.ghdl_backend, 'mcode') }}; then
             APT_ARGS="$APT_ARGS"
           elif ${{ startsWith(inputs.ghdl_backend, 'llvm') }}; then
-            APT_ARGS="$APT_ARGS llvm clang"
+            APT_ARGS="$APT_ARGS llvm clang libbacktrace-dev"
           elif ${{ startsWith(inputs.ghdl_backend, 'gcc') }}; then
             APT_ARGS="$APT_ARGS libgmp-dev libmpfr-dev libmpc-dev libgettextpo-dev flex"
           else

--- a/.github/workflows/Build-Ubuntu.yml
+++ b/.github/workflows/Build-Ubuntu.yml
@@ -34,7 +34,7 @@ on:
       python_version:
         description: 'Python version for pyGHDL testing.'
         required: false
-        default: '3.12'
+        default: '3.14'
         type: string
       pyunit_testsuites:
         description: 'Name of the pyunit testsuites.'
@@ -99,7 +99,13 @@ jobs:
           if ${{ startsWith(inputs.ghdl_backend, 'mcode') }}; then
             APT_ARGS="$APT_ARGS"
           elif ${{ startsWith(inputs.ghdl_backend, 'llvm') }}; then
-            APT_ARGS="$APT_ARGS llvm clang libbacktrace-dev"
+            APT_ARGS="$APT_ARGS llvm clang"
+
+            if ${{ contains(fromJson('["22.04", "24.04"]'), inputs.ubuntu_version) }}; then
+              printf "%s\n" "libbacktrace is part of GCC but not a standalone library."
+            else
+              APT_ARGS="$APT_ARGS libbacktrace-dev"
+            fi
           elif ${{ startsWith(inputs.ghdl_backend, 'gcc') }}; then
             APT_ARGS="$APT_ARGS libgmp-dev libmpfr-dev libmpc-dev libgettextpo-dev flex"
           else
@@ -134,11 +140,25 @@ jobs:
           if ${{ startsWith(inputs.ghdl_backend, 'mcode') }}; then
             CONFIG_ARGS=""
           elif ${{ startsWith(inputs.ghdl_backend, 'llvm') }}; then
-            CONFIG_ARGS="--with-llvm-config --with-backtrace-lib=$(dpkg -L libbacktrace-dev | grep "libbacktrace.a")"
+            CONFIG_ARGS="--with-llvm-config CXX=clang++"
             if ${{ endsWith(inputs.ghdl_backend, 'jit') }}; then
               CONFIG_ARGS="$CONFIG_ARGS --with-llvm-jit"
+            else
+              if ${{ contains(fromJson('["22.04", "24.04"]'), inputs.ubuntu_version) }}; then
+                printf "%s\n" "libbacktrace is part of GCC but not a standalone library."
+                GCC_MAJOR=$(gcc -dumpversion | cut -d. -f1)
+                LIBBACKTRACE_PATH="/usr/lib/gcc/x86_64-linux-gnu/${GCC_MAJOR}/libbacktrace.a"
+                if [[ -f "${LIBBACKTRACE_PATH}" ]]; then
+                  printf -- "%s\n" "Found libbacktrace: ${LIBBACKTRACE_PATH}"
+                  CONFIG_ARGS="$CONFIG_ARGS --with-backtrace-lib=${LIBBACKTRACE_PATH}"
+                else
+                  printf -- "%s\n" "libbacktrace not found at '${LIBBACKTRACE_PATH}'."
+                  printf "::warning title=%s::%s\n" "Configure GHDL for LLVM on Ubuntu ${{ inputs.ubuntu_version }}" "libbacktrace not found at '${LIBBACKTRACE_PATH}'."
+                fi
+              else
+                CONFIG_ARGS="$CONFIG_ARGS --with-backtrace-lib=$(dpkg -L libbacktrace-dev | grep "libbacktrace.a")"
+              fi
             fi
-            CONFIG_ARGS="$CONFIG_ARGS CXX=clang++"
           elif ${{ startsWith(inputs.ghdl_backend, 'gcc') }}; then
             CONFIG_ARGS="--with-gcc=../../gcc-srcs"
           else
@@ -303,7 +323,7 @@ jobs:
           retention-days: 7
 
       - name: ✂ Remove binaries, libraries and other files for libghdl (only mcode backend)
-        if: inputs.ubuntu_version == '24.04' && inputs.ghdl_backend == 'mcode'
+        if: contains(fromJson('["24.04", "26.04"]'), inputs.ubuntu_version) && inputs.ghdl_backend == 'mcode'
         run: |
           sudo chown -R runner:docker ./install
           rm -Rf ./install/bin
@@ -316,14 +336,14 @@ jobs:
           rm -Rf ./install/*.requirements
 
       - name: Copy additional dependencies (only mcode backend)
-        if: inputs.ubuntu_version == '24.04' && inputs.ghdl_backend == 'mcode'
+        if: contains(fromJson('["24.04", "26.04"]'), inputs.ubuntu_version) && inputs.ghdl_backend == 'mcode'
         run: |
           # libgnat
           cp -v /lib/x86_64-linux-gnu/libgnat-${{ steps.requirements.outputs.GNAT_MAJOR_VERSION }}.so ./install/lib
 
       - name: 📤 Upload '${{ steps.artifact_name.outputs.libghdl_artifact }}' artifact (only mcode backend)
         uses: pyTooling/upload-artifact@v7
-        if: inputs.ubuntu_version == '24.04' && inputs.ghdl_backend == 'mcode'
+        if: contains(fromJson('["24.04", "26.04"]'), inputs.ubuntu_version) && inputs.ghdl_backend == 'mcode'
         with:
           name: ${{ steps.artifact_name.outputs.libghdl_artifact }}
           working-directory: install

--- a/.github/workflows/Build-Ubuntu.yml
+++ b/.github/workflows/Build-Ubuntu.yml
@@ -134,7 +134,7 @@ jobs:
           if ${{ startsWith(inputs.ghdl_backend, 'mcode') }}; then
             CONFIG_ARGS=""
           elif ${{ startsWith(inputs.ghdl_backend, 'llvm') }}; then
-            CONFIG_ARGS="--with-llvm-config"
+            CONFIG_ARGS="--with-llvm-config --with-backtrace-lib=$(dpkg -L libbacktrace-dev | grep "libbacktrace.a")"
             if ${{ endsWith(inputs.ghdl_backend, 'jit') }}; then
               CONFIG_ARGS="$CONFIG_ARGS --with-llvm-jit"
             fi

--- a/.github/workflows/Check-pyGHDL.yml
+++ b/.github/workflows/Check-pyGHDL.yml
@@ -6,12 +6,12 @@ on:
       ubuntu_image:
         description: 'Name of the Ubuntu image.'
         required: false
-        default: 'ubuntu-24.04'
+        default: 'ubuntu-26.04'
         type: string
       python_version:
         description: 'Use Python version'
         required: false
-        default: '3.12'
+        default: '3.14'
         type: string
       black:
         description: 'Check Python source code using black.'

--- a/.github/workflows/Documentation-Sphinx.yml
+++ b/.github/workflows/Documentation-Sphinx.yml
@@ -6,7 +6,7 @@ on:
       ubuntu_image:
         description: 'Name of the Ubuntu image.'
         required: false
-        default: 'ubuntu-24.04'
+        default: 'ubuntu-26.04'
         type: string
       ghdl_artifact:
         description: 'Name of the GHDL artifact for Ubuntu.'
@@ -15,7 +15,7 @@ on:
       python_version:
         description: 'Python version.'
         required: false
-        default: '3.12'
+        default: '3.14'
         type: string
       requirements:
         description: 'Python dependencies to be installed through pip.'

--- a/.github/workflows/Package-Docker.yml
+++ b/.github/workflows/Package-Docker.yml
@@ -6,7 +6,7 @@ on:
       ubuntu_image:
         description: 'Name of the Ubuntu image.'
         required: false
-        default: 'ubuntu-24.04'
+        default: 'ubuntu-26.04'
         type: string
       ghdl_artifact:
         description: 'Name of the GHDL artifact.'

--- a/.github/workflows/Package-pyGHDL.yml
+++ b/.github/workflows/Package-pyGHDL.yml
@@ -11,6 +11,10 @@ on:
         description: 'Name of the OS image.'
         required: true
         type: string
+      libgnat:
+        description: 'Version of libgnat on Ubuntu.'
+        required: true
+        type: string
       runtime:
         description: 'MSYS2 runtime if MSYS2 is used.'
         required: true
@@ -208,7 +212,7 @@ jobs:
       - name: 🔧 Install dependencies (Ubuntu)
         if: startsWith(inputs.os_image, 'ubuntu')
         run: |
-          sudo apt-get install -y --no-install-recommends libgnat-13
+          sudo apt-get install -y --no-install-recommends libgnat-${{ inputs.libgnat }}
           python -m pip install -v --disable-pip-version-check ./wheels/pyghdl-*.whl
           python -m pip install --disable-pip-version-check -r testsuite/requirements.txt
 

--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -10,7 +10,7 @@ on:
       ubuntu_image:
         description: 'Name of the Ubuntu image.'
         required: false
-        default: 'ubuntu-24.04'
+        default: 'ubuntu-26.04'
         type: string
       # Integrated from pyTooling/Actions::PrepareJob.yml, because GitHub is limited to 20 reusable workflows.
       main_branch:
@@ -162,7 +162,7 @@ jobs:
   # Integrated from pyTooling/Actions::PrepareJob.yml, because GitHub is limited to 20 reusable workflows.
   Prepare:
     name: Extract Information
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       on_default_branch:   ${{ steps.Classify.outputs.on_default_branch }}
       on_main_branch:      ${{ steps.Classify.outputs.on_main_branch }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -74,8 +74,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {icon: '🐧🟨', backend: 'mcode',    ubuntu_version: '22.04', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-          - {icon: '🐧🟩', backend: 'mcode',    ubuntu_version: '24.04', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {icon: '🐧🟧', backend: 'mcode',    ubuntu_version: '22.04', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {icon: '🐧🟨', backend: 'mcode',    ubuntu_version: '24.04', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {icon: '🐧🟩', backend: 'mcode',    ubuntu_version: '26.04', testsuites: '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
     with:
       ubuntu_version:           ${{ matrix.ubuntu_version }}
       ghdl_backend:             ${{ matrix.backend }}
@@ -96,14 +97,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-###       - {'icon': '🐧🟨', 'backend': 'mcode',    'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites     # used by Ubuntu-fast
-          - {'icon': '🐧🟨', 'backend': 'llvm',     'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-          - {'icon': '🐧🟨', 'backend': 'llvm-jit', 'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-          - {'icon': '🐧🟨', 'backend': 'gcc',      'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-###       - {'icon': '🐧🟩', 'backend': 'mcode',    'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites     # used by Ubuntu-fast
-          - {'icon': '🐧🟩', 'backend': 'llvm',     'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-          - {'icon': '🐧🟩', 'backend': 'llvm-jit', 'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
-          - {'icon': '🐧🟩', 'backend': 'gcc',      'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+###       - {'icon': '🐧🟧', 'backend': 'mcode',    'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites     # used by Ubuntu-fast
+          - {'icon': '🐧🟧', 'backend': 'llvm',     'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {'icon': '🐧🟧', 'backend': 'llvm-jit', 'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {'icon': '🐧🟧', 'backend': 'gcc',      'ubuntu_version': '22.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+###       - {'icon': '🐧🟨', 'backend': 'mcode',    'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites     # used by Ubuntu-fast
+          - {'icon': '🐧🟨', 'backend': 'llvm',     'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {'icon': '🐧🟨', 'backend': 'llvm-jit', 'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {'icon': '🐧🟨', 'backend': 'gcc',      'ubuntu_version': '24.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+###       - {'icon': '🐧🟩', 'backend': 'mcode',    'ubuntu_version': '26.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites     # used by Ubuntu-fast
+          - {'icon': '🐧🟩', 'backend': 'llvm',     'ubuntu_version': '26.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {'icon': '🐧🟩', 'backend': 'llvm-jit', 'ubuntu_version': '26.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
+          - {'icon': '🐧🟩', 'backend': 'gcc',      'ubuntu_version': '26.04', 'testsuites': '${{ needs.Params.outputs.testsuites }}'}  # 'all', 'none' or list of testsuites
     with:
       ubuntu_version:           ${{ matrix.ubuntu_version }}
       ghdl_backend:             ${{ matrix.backend }}
@@ -148,7 +153,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-###       - {icon: '🪟', runtime: 'mingw32', backend: 'mcode',    testsuites: '${{ needs.Params.outputs.testsuites }}'}   # No gcc-ada package for MinGW32, support was dropped
           - {icon: '🪟', runtime: 'mingw64', backend: 'mcode',    testsuites: '${{ needs.Params.outputs.testsuites }}'}
           - {icon: '🪟', runtime: 'mingw64', backend: 'llvm',     testsuites: 'sanity gna synth vpi vhpi'}                # no vests (too slow)
           - {icon: '🪟', runtime: 'mingw64', backend: 'llvm-jit', testsuites: 'sanity vpi vhpi'}                          # gna and synth fail (#2726); no vests (too slow)
@@ -198,9 +202,10 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - {icon: '🐧', name: 'Ubuntu',  image: 'ubuntu-24.04', libghdl_artifact: 'ubuntu-24.04-x86_64', pyghdl_artifact: 'Ubuntu-24.04-x86_64'}
-###       - {icon: '🍏', name: 'macOS',   image: 'macos-14',     libghdl_artifact: 'macos-14-aarch64',    pyghdl_artifact: 'macOS-14-aarch64'}
-          - {icon: '🪟', name: 'Windows', image: 'windows-2025', libghdl_artifact: 'MSYS2-ucrt64',        pyghdl_artifact: 'Windows-x86_64'}
+          - {icon: '🐧', name: 'Ubuntu',  image: 'ubuntu-24.04', libgnat: '13', libghdl_artifact: 'ubuntu-24.04-x86_64', pyghdl_artifact: 'Ubuntu-24.04-x86_64'}
+          - {icon: '🐧', name: 'Ubuntu',  image: 'ubuntu-26.04', libgnat: '14', libghdl_artifact: 'ubuntu-26.04-x86_64', pyghdl_artifact: 'Ubuntu-26.04-x86_64'}
+###       - {icon: '🍏', name: 'macOS',   image: 'macos-14',     libgnat: '',   libghdl_artifact: 'macos-14-aarch64',    pyghdl_artifact: 'macOS-14-aarch64'   }
+          - {icon: '🪟', name: 'Windows', image: 'windows-2025', libgnat: '',   libghdl_artifact: 'MSYS2-ucrt64',        pyghdl_artifact: 'Windows-x86_64'     }
         py:
           - {icon: '🟠', version: '3.11'}
           - {icon: '🟡', version: '3.12'}
@@ -209,12 +214,17 @@ jobs:
           - {icon: '🟣', version: '3.15.0-alpha.1'}
         other:
           - {runtime: ''}
+        exclude:
+          - {os: {image: 'ubuntu-26.04'}, py: {version: '3.11'}}
+          - {os: {image: 'ubuntu-26.04'}, py: {version: '3.12'}}
+          - {os: {image: 'ubuntu-26.04'}, py: {version: '3.15.0-alpha.1'}}
         include:
-          - {os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2025', libghdl_artifact: 'MSYS2-mingw64', pyghdl_artifact: 'Windows-mingw64'}, py: {icon: '🟢', version: '3.14'}, other: {runtime: 'mingw64'}}
-          - {os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2025', libghdl_artifact: 'MSYS2-ucrt64',  pyghdl_artifact: 'Windows-ucrt64' }, py: {icon: '🟢', version: '3.14'}, other: {runtime: 'ucrt64' }}
+          - {os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2025', libghdl_artifact: 'MSYS2-mingw64', pyghdl_artifact: 'Windows-mingw64', libgnat: ''}, py: {icon: '🟢', version: '3.14'}, other: {runtime: 'mingw64'}}
+          - {os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2025', libghdl_artifact: 'MSYS2-ucrt64',  pyghdl_artifact: 'Windows-ucrt64',  libgnat: ''}, py: {icon: '🟢', version: '3.14'}, other: {runtime: 'ucrt64' }}
     with:
       os_name:               ${{ matrix.os.name }}
       os_image:              ${{ matrix.os.image }}
+      libgnat:               ${{ matrix.os.libgnat }}
       runtime:               ${{ matrix.other.runtime }}
       python_icon:           ${{ matrix.py.icon }}
       python_version:        ${{ matrix.py.version }}
@@ -277,7 +287,7 @@ jobs:
       - PublishCoverageResults
       - PublishPytestResults
     with:
-      ghdl_artifact:  ${{ needs.Params.outputs.ghdl_basename }}-ubuntu-24.04-x86_64-mcode
+      ghdl_artifact:  ${{ needs.Params.outputs.ghdl_basename }}-ubuntu-26.04-x86_64-mcode
       html_artifact:  'documentation-HTML'
       latex_document: 'ghdl'
       latex_artifact: 'documentation-LaTeX'
@@ -333,6 +343,10 @@ jobs:
         ghdl-ubuntu-24.04-x86_64-llvm:         $ghdl-llvm-%ghdl%-ubuntu24.04-x86_64.tar.gz:                   ghdl,ubuntu,24.04,x86-64,native,llvm:            GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - llvm backend
         ghdl-ubuntu-24.04-x86_64-llvm-jit:     $ghdl-llvm-jit-%ghdl%-ubuntu24.04-x86_64.tar.gz:               ghdl,ubuntu,24.04,x86-64,native,llvm-jit:        GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - llvm-jit backend
         ghdl-ubuntu-24.04-x86_64-mcode:        $ghdl-mcode-%ghdl%-ubuntu24.04-x86_64.tar.gz:                  ghdl,ubuntu,24.04,x86-64,native,mcode:           GHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - mcode backend
+        ghdl-ubuntu-26.04-x86_64-gcc:          $ghdl-gcc-%ghdl%-ubuntu26.04-x86_64.tar.gz:                    ghdl,ubuntu,26.04,x86-64,native,gcc:             GHDL - v%ghdl% - Ubuntu 26.04 (x86-64, LTS) - gcc backend
+        ghdl-ubuntu-26.04-x86_64-llvm:         $ghdl-llvm-%ghdl%-ubuntu26.04-x86_64.tar.gz:                   ghdl,ubuntu,26.04,x86-64,native,llvm:            GHDL - v%ghdl% - Ubuntu 26.04 (x86-64, LTS) - llvm backend
+        ghdl-ubuntu-26.04-x86_64-llvm-jit:     $ghdl-llvm-jit-%ghdl%-ubuntu26.04-x86_64.tar.gz:               ghdl,ubuntu,26.04,x86-64,native,llvm-jit:        GHDL - v%ghdl% - Ubuntu 26.04 (x86-64, LTS) - llvm-jit backend
+        ghdl-ubuntu-26.04-x86_64-mcode:        $ghdl-mcode-%ghdl%-ubuntu26.04-x86_64.tar.gz:                  ghdl,ubuntu,26.04,x86-64,native,mcode:           GHDL - v%ghdl% - Ubuntu 26.04 (x86-64, LTS) - mcode backend
         ghdl-Pacman-mingw64-llvm:               mingw-w64-x86_64-ghdl-llvm-%pacghdl%-any.pkg.tar.zst:         ghdl,windows,2025,x86-64,mingw64,llvm:           GHDL - v%ghdl% - MSYS2/MinGW64 - LLVM backend
         ghdl-Pacman-mingw64-llvm-jit:           mingw-w64-x86_64-ghdl-llvm-jit-%pacghdl%-any.pkg.tar.zst:     ghdl,windows,2025,x86-64,mingw64,llvm-jit:       GHDL - v%ghdl% - MSYS2/MinGW64 - LLVM-JIT backend
         ghdl-Pacman-mingw64-mcode:              mingw-w64-x86_64-ghdl-mcode-%pacghdl%-any.pkg.tar.zst:        ghdl,windows,2025,x86-64,mingw64,mcode:          GHDL - v%ghdl% - MSYS2/MinGW64 - mcode backend
@@ -343,8 +357,12 @@ jobs:
         ghdl-Windows-ucrt64-mcode:             !ghdl-mcode-%ghdl%-ucrt64.zip:                                 ghdl,windows,2025,x86-64,native,mcode:           GHDL - v%ghdl% - Windows (x86-64, UCRT64, standalone) - mcode backend
         pyGHDL-Ubuntu-24.04-x86_64-Python-3.11: pyghdl-%pyghdl%-cp311-cp311-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.11,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.11
         pyGHDL-Ubuntu-24.04-x86_64-Python-3.12: pyghdl-%pyghdl%-cp312-cp312-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.12,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.12
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.13: pyghdl-%pyghdl%-cp313-cp313-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.13,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.13
-        pyGHDL-Ubuntu-24.04-x86_64-Python-3.14: pyghdl-%pyghdl%-cp314-cp314-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.14,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.14
+        # pyGHDL-Ubuntu-24.04-x86_64-Python-3.13: pyghdl-%pyghdl%-cp313-cp313-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.13,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.13
+        # pyGHDL-Ubuntu-24.04-x86_64-Python-3.14: pyghdl-%pyghdl%-cp314-cp314-linux_x86_64.whl:                 pyGHDL,ubuntu,24.04,x86-64,py3.14,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 24.04 (x86-64, LTS) - Wheel for Python 3.14
+        # pyGHDL-Ubuntu-26.04-x86_64-Python-3.11: pyghdl-%pyghdl%-cp311-cp311-linux_x86_64.whl:                 pyGHDL,ubuntu,26.04,x86-64,py3.11,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 26.04 (x86-64, LTS) - Wheel for Python 3.11
+        # pyGHDL-Ubuntu-26.04-x86_64-Python-3.12: pyghdl-%pyghdl%-cp312-cp312-linux_x86_64.whl:                 pyGHDL,ubuntu,26.04,x86-64,py3.12,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 26.04 (x86-64, LTS) - Wheel for Python 3.12
+        pyGHDL-Ubuntu-26.04-x86_64-Python-3.13: pyghdl-%pyghdl%-cp313-cp313-linux_x86_64.whl:                 pyGHDL,ubuntu,26.04,x86-64,py3.13,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 26.04 (x86-64, LTS) - Wheel for Python 3.13
+        pyGHDL-Ubuntu-26.04-x86_64-Python-3.14: pyghdl-%pyghdl%-cp314-cp314-linux_x86_64.whl:                 pyGHDL,ubuntu,26.04,x86-64,py3.14,native,mcode:  pyGHDL - v%ghdl% - Ubuntu 26.04 (x86-64, LTS) - Wheel for Python 3.14
         pyGHDL-Windows-x86_64-Python-3.11:      pyghdl-%pyghdl%-cp311-cp311-win_amd64.whl:                    pyGHDL,windows,2025,x86-64,py3.11,native,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.11
         pyGHDL-Windows-x86_64-Python-3.12:      pyghdl-%pyghdl%-cp312-cp312-win_amd64.whl:                    pyGHDL,windows,2025,x86-64,py3.12,native,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.12
         pyGHDL-Windows-x86_64-Python-3.13:      pyghdl-%pyghdl%-cp313-cp313-win_amd64.whl:                    pyGHDL,windows,2025,x86-64,py3.13,native,mcode:  pyGHDL - v%ghdl% - Windows (x86-64) - Wheel for Python 3.13
@@ -400,12 +418,15 @@ jobs:
           - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'llvm'}
           - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'llvm-jit'}
           - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'gcc'}
+          - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-26.04', runtime: '',        backend: 'mcode'}
+          - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-26.04', runtime: '',        backend: 'llvm'}
+          - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-26.04', runtime: '',        backend: 'llvm-jit'}
+          - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-26.04', runtime: '',        backend: 'gcc'}
           - {icon: '🍏',   name: 'macOS',   image: 'macos-14',     runtime: '',        backend: 'llvm'}
           - {icon: '🍏',   name: 'macOS',   image: 'macos-14',     runtime: '',        backend: 'llvm-jit'}
           - {icon: '🍏',   name: 'macOS',   image: 'macos-15',     runtime: '',        backend: 'llvm'}
           - {icon: '🍏',   name: 'macOS',   image: 'macos-15',     runtime: '',        backend: 'llvm-jit'}
           - {icon: '🪟',   name: 'Windows', image: 'windows-2025', runtime: '',        backend: 'mcode'}
-#         - {icon: '🪟⬛', name: 'Windows', image: 'windows-2025', runtime: 'mingw32', backend: 'mcode'}
           - {icon: '🪟🟦', name: 'Windows', image: 'windows-2025', runtime: 'mingw64', backend: 'mcode'}
           - {icon: '🪟🟦', name: 'Windows', image: 'windows-2025', runtime: 'mingw64', backend: 'llvm'}
           - {icon: '🪟🟦', name: 'Windows', image: 'windows-2025', runtime: 'mingw64', backend: 'llvm-jit'}

--- a/.github/workflows/Publish-GitHubPages.yml
+++ b/.github/workflows/Publish-GitHubPages.yml
@@ -6,7 +6,7 @@ on:
       ubuntu_image:
         description: 'Name of the Ubuntu image.'
         required: false
-        default: 'ubuntu-24.04'
+        default: 'ubuntu-26.04'
         type: string
       documentation:
         description: 'Name of the documentation artifact.'

--- a/.github/workflows/Test-GHDL.yml
+++ b/.github/workflows/Test-GHDL.yml
@@ -6,7 +6,7 @@ on:
       os_image:
         description: 'Name of the OS image.'
         required: false
-        default: 'ubuntu-24.04'
+        default: 'ubuntu-26.04'
         type: string
       runtime:
         description: 'MSYS2 runtime if MSYS2 is used.'

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,8 +5,8 @@ python-dateutil ~= 2.9
 
 # Sphinx Extenstions
 autoapi ~= 2.0
-myst-parser ~= 5.0
-sphinx_autodoc_typehints ~= 3.10
+myst-parser ~= 5.1
+sphinx_autodoc_typehints ~= 3.11
 
 # Theme
 furo >= 2025.12.19

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 120
-target-version = ['py311', 'py312', 'py313']  # , 'py314']
+target-version = ['py311', 'py312', 'py313', 'py314']
 
 [tool.mypy]
 files = ["pyGHDL"]

--- a/testsuite/requirements.txt
+++ b/testsuite/requirements.txt
@@ -5,4 +5,4 @@ pytest ~= 9.0
 pytest-cov ~= 7.1
 
 # Coverage collection
-Coverage ~= 7.13
+Coverage ~= 7.14


### PR DESCRIPTION
# New Features

* Build GHDL for Ubuntu 2022.04 and Ubuntu 2024.04 with libbacktrace support for LLVM backends.  
  * `libbacktrace.a` is taken from GCC installation directory.
* Build GHDL for Ubuntu-2026.04 (newly added to GitHub Actions).
  * Build GHDL for Ubuntu 2026.04 with `libbacktrace` support for LLVM backends.  
    Ubuntu added `libbacktrace-dev` as a package since 2025.10.
* Build GHDL for MinGW64 and UCRT64 with `libbacktrace` support for LLVM backends.


# Changes

* Bumped dependencies.


# CI Pipeline

* Removed last traces of MinGW32 builds.
* Jobs using the GitHub Action Ubuntu 24.04 image have been switched to Ubuntu 26.04.
* Because of Ubuntu 26.04, used Python has been updated from 3.12 to 3.14.  
  (This doesn't influence Python packages provided from 3.11 to 3.15)