### PR TITLE
Add native --flow dataflow database exporter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,8 @@
   (ports/generics/signals and per-process read/drive sets), the elaborated
   hierarchy with real port maps, canonical nets with fan-in/fan-out and
   port/net collapsing, and combinational-vs-clocked cells.  Bare `--flow`
-  writes `ghdl.flow`.
+  writes `ghdl.flow`.  There is also a dedicated `ghdl --flow [--out=FILE]
+  UNIT` command that elaborates and dumps without running a simulation.
 
 ## [2026-03-07] 6.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+- New `--flow[=FILE]` run option: dump a native dataflow database (JSON, with
+  the `.flow` extension) of the elaborated design.  It records modules
+  (ports/generics/signals and per-process read/drive sets), the elaborated
+  hierarchy with real port maps, canonical nets with fan-in/fan-out and
+  port/net collapsing, and combinational-vs-clocked cells.  Bare `--flow`
+  writes `ghdl.flow`.
+
 ## [2026-03-07] 6.0
 
 - Initial support of vhdl2019 (with --std=19)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,16 @@
 ## Unreleased
 
 - New `--flow[=FILE]` run option: dump a native dataflow database (JSON, with
-  the `.flow` extension) of the elaborated design.  It records modules
-  (ports/generics/signals and per-process read/drive sets), the elaborated
-  hierarchy with real port maps, canonical nets with fan-in/fan-out and
-  port/net collapsing, and combinational-vs-clocked cells.  Bare `--flow`
+  the `.flow` extension) of the elaborated design.  It records `entities` and
+  `architectures` (ports/generics/signals and per-process read/drive sets), the
+  elaborated hierarchy with real port maps, canonical nets with fan-in/fan-out
+  and port/net collapsing, and combinational-vs-clocked cells.  Bare `--flow`
   writes `ghdl.flow`.  There is also a dedicated `ghdl --flow [--out=FILE]
-  UNIT` command that elaborates and dumps without running a simulation.
+  UNIT` command that elaborates and dumps without running a simulation.  Every
+  source position is a compact `"start:begin:end"` byte-offset string (the
+  `begin`/`generate` keyword and closing `end`/`;`), and each unit carries its
+  `libraries`/`uses` context linkage, to help source-scanning consumers locate
+  constructs.
 
 ## [2026-03-07] 6.0
 

--- a/doc/using/Simulation.rst
+++ b/doc/using/Simulation.rst
@@ -323,6 +323,38 @@ Export hierarchy and references
   * ``port`` Like ``proc`` but display ports and signals too.
     If `KIND` is not specified, the hierarchy is displayed with the ``port`` mode.
 
+.. option:: --flow[=<FILENAME>]
+
+  .. index:: dataflow database
+
+  .. index:: flow
+
+  Dump a :dfn:`dataflow database` of the elaborated design as a JSON file
+  (extension ``.flow``).  If `FILENAME` is omitted, the file ``ghdl.flow`` is
+  written.  The dump is produced at elaboration time, so a zero-time run
+  (``--stop-time=0ns``) is enough; the option also composes with the waveform
+  options so a single run can produce both a ``.flow`` and, e.g., a ``.vcd``.
+
+  Unlike a waveform, the database records the *structure* of the design rather
+  than signal values over time.  It contains:
+
+  * ``modules`` -- per entity/architecture: ports (with direction and type),
+    generics, signals, and the read-set / drive-set / sensitivity of every
+    process and concurrent assignment, with source locations.
+
+  * ``hierarchy`` -- the elaborated instance tree (generates unrolled), with the
+    real port map binding each formal to its actual net.
+
+  * ``nets`` -- one entry per canonical net, with the signals that collapse into
+    it (a port and the net it binds to share one net), and the driving and
+    reading cells (fan-in / fan-out).
+
+  * ``cells`` -- one entry per elaborated process/assignment, classified as
+    combinational or clocked (with the clock net), and its driven and read nets.
+
+  This is intended for dataflow tracing and netlist-style analysis tools.
+  Only the interpreted / JIT-elaboration run path builds the required model.
+
 .. option:: --xref-html [options] files...
 
   To easily navigate through your sources, you may generate cross-references.

--- a/doc/using/Simulation.rst
+++ b/doc/using/Simulation.rst
@@ -338,9 +338,13 @@ Export hierarchy and references
   Unlike a waveform, the database records the *structure* of the design rather
   than signal values over time.  It contains:
 
-  * ``modules`` -- per entity/architecture: ports (with direction and type),
-    generics, signals, and the read-set / drive-set / sensitivity of every
-    process and concurrent assignment, with source locations.
+  * ``entities`` -- per entity: ports (with direction and type), generics, and
+    the entity's ``library``/``use`` context clauses.
+
+  * ``architectures`` -- per architecture (with an ``entity`` back-reference):
+    signals, constants, the architecture's own context clauses, and the
+    read-set / drive-set / sensitivity of every process, concurrent assignment
+    and instantiation.
 
   * ``hierarchy`` -- the elaborated instance tree (generates unrolled), with the
     real port map binding each formal to its actual net.
@@ -351,6 +355,22 @@ Export hierarchy and references
 
   * ``cells`` -- one entry per elaborated process/assignment, classified as
     combinational or clocked (with the clock net), and its driven and read nets.
+
+  To help source-scanning consumers (such as Perl lexers) locate constructs
+  without re-parsing, every position is a compact string of byte offsets,
+  ``"start:begin:end"``:
+
+  * *start* -- byte offset where the construct begins;
+  * *begin* -- byte offset of the ``begin`` keyword that ends the declarative
+    region (for a generate, its ``generate`` keyword) -- empty when there is
+    none;
+  * *end* -- byte offset of the closing ``end`` keyword or terminating ``;`` --
+    empty for a plain point.
+
+  So a port is ``"start::"``, an entity instantiation is ``"start::end"``, and an
+  architecture or process is ``"start:begin:end"``.  The ``library``/``use``
+  context clauses are reported per unit (on the entity and architecture
+  separately), recording each unit's linkage to the packages it uses.
 
   This is intended for dataflow tracing and netlist-style analysis tools.
   Only the interpreted / JIT-elaboration run path builds the required model.

--- a/doc/using/Simulation.rst
+++ b/doc/using/Simulation.rst
@@ -355,6 +355,14 @@ Export hierarchy and references
   This is intended for dataflow tracing and netlist-style analysis tools.
   Only the interpreted / JIT-elaboration run path builds the required model.
 
+  There is also a dedicated command that elaborates and dumps the database
+  without running a simulation::
+
+    ghdl --flow [--out=FILE] UNIT [ARCH]
+
+  It writes ``ghdl.flow`` by default, or `FILE` with ``--out=FILE``.  It is
+  equivalent to ``ghdl -r UNIT --flow=FILE`` stopped at time zero.
+
 .. option:: --xref-html [options] files...
 
   To easily navigate through your sources, you may generate cross-references.

--- a/src/ghdldrv/ghdlcomp.adb
+++ b/src/ghdldrv/ghdlcomp.adb
@@ -178,6 +178,93 @@ package body Ghdlcomp is
    end Perform_Action;
 
 
+   --  Command --flow: elaborate UNIT and dump the dataflow database,
+   --  then stop (no simulation).
+   type Command_Flow is new Command_Comp with record
+      Flow_File : String_Acc := null;
+   end record;
+   function Decode_Command (Cmd : Command_Flow; Name : String)
+                           return Boolean;
+   function Get_Short_Help (Cmd : Command_Flow) return String;
+   procedure Decode_Option (Cmd : in out Command_Flow;
+                            Option : String;
+                            Arg : String;
+                            Res : out Option_State);
+   procedure Perform_Action (Cmd : in out Command_Flow;
+                             Args : String_Acc_Array;
+                             Success : out Boolean);
+
+   function Decode_Command (Cmd : Command_Flow; Name : String)
+                           return Boolean
+   is
+      pragma Unreferenced (Cmd);
+   begin
+      return Name = "--flow" or else Name = "flow";
+   end Decode_Command;
+
+   function Get_Short_Help (Cmd : Command_Flow) return String
+   is
+      pragma Unreferenced (Cmd);
+   begin
+      return "--flow [--out=FILE] UNIT [ARCH]"
+        & ASCII.LF & "  Elaborate UNIT and dump the dataflow database"
+        & ASCII.LF & "  (default file: ghdl.flow)";
+   end Get_Short_Help;
+
+   procedure Decode_Option (Cmd : in out Command_Flow;
+                            Option : String;
+                            Arg : String;
+                            Res : out Option_State) is
+   begin
+      if Option'Length > 6
+        and then Option (Option'First .. Option'First + 5) = "--out="
+      then
+         Cmd.Flow_File :=
+           new String'(Option (Option'First + 6 .. Option'Last));
+         Res := Option_Ok;
+      else
+         Decode_Option (Command_Comp (Cmd), Option, Arg, Res);
+      end if;
+   end Decode_Option;
+
+   procedure Perform_Action (Cmd : in out Command_Flow;
+                             Args : String_Acc_Array;
+                             Success : out Boolean)
+   is
+      Opt_Arg : Natural;
+      File : constant String :=
+        (if Cmd.Flow_File /= null then Cmd.Flow_File.all else "ghdl.flow");
+      New_Args : String_Acc_Array (1 .. Args'Length + 1);
+   begin
+      Success := False;
+
+      --  Append "--flow=FILE" so the elaboration step writes the
+      --  database (the dump happens after Compute_Sources); the
+      --  simulation itself is skipped.
+      for I in 1 .. Args'Length loop
+         New_Args (I) := Args (Args'First + I - 1);
+      end loop;
+      New_Args (Args'Length + 1) := new String'("--flow=" & File);
+
+      Hooks.Compile_Init.all (False);
+
+      Libraries.Load_Work_Library (False);
+      Flags.Flag_Elaborate_With_Outdated := False;
+      Flags.Flag_Only_Elab_Warnings := True;
+
+      Hooks.Compile_Elab.all ("--flow", New_Args, Opt_Arg);
+
+      --  Opt_Arg indexes the first arg after the unit; the trailing
+      --  entry is the injected "--flow=FILE", so anything at or before
+      --  Args'Length is a user option that is ignored (no simulation).
+      if Opt_Arg <= Args'Length then
+         Error_Msg_Option ("options after unit are ignored by --flow");
+      end if;
+
+      Success := True;
+   end Perform_Action;
+
+
    --  Command -c xx -r/-e
    type Command_Compile is new Command_Comp with null record;
    function Decode_Command (Cmd : Command_Compile; Name : String)
@@ -1063,6 +1150,7 @@ package body Ghdlcomp is
       Register_Command (new Command_Analyze);
       Register_Command (new Command_Elab);
       Register_Command (new Command_Run);
+      Register_Command (new Command_Flow);
       Register_Command (new Command_Compile);
       Register_Command (new Command_Make);
       Register_Command (new Command_Gen_Makefile);

--- a/src/ghdldrv/ghdlrun.adb
+++ b/src/ghdldrv/ghdlrun.adb
@@ -53,6 +53,7 @@ with Trans_Foreign_Jit;
 with Trans.Coverage;
 
 with Simul.Main;
+with Simul.Flow;
 with Simul.Vhdl_Elab;
 with Simul.Vhdl_Simul;
 with Simul.Vhdl_Compile;
@@ -123,6 +124,33 @@ package body Ghdlrun is
             null;
       end case;
    end Compile_Init;
+
+   --  Front-end '--flow[=FILE]' run option: dump the native dataflow
+   --  database (.flow JSON) from the elaborated model.  The dump happens
+   --  at elaboration (in Compile_Elab_Setup), before grt decodes run
+   --  options, so the filename is captured here in the front-end and the
+   --  option is filtered out of the argv handed to grt (Set_Run_Options).
+   Flow_Filename : String_Acc := null;
+
+   Flow_Prefix : constant String := "--flow=";
+
+   function Is_Flow_Option (Arg : String) return Boolean is
+   begin
+      return Arg = "--flow"
+        or else (Arg'Length > Flow_Prefix'Length
+                 and then Arg (Arg'First .. Arg'First + Flow_Prefix'Length - 1)
+                            = Flow_Prefix);
+   end Is_Flow_Option;
+
+   procedure Capture_Flow_Option (Arg : String) is
+   begin
+      if Arg = "--flow" then
+         Flow_Filename := new String'("ghdl.flow");
+      elsif Is_Flow_Option (Arg) then
+         Flow_Filename :=
+           new String'(Arg (Arg'First + Flow_Prefix'Length .. Arg'Last));
+      end if;
+   end Capture_Flow_Option;
 
    function Compile_Elab_Setup (Config : Iir) return Boolean is
    begin
@@ -214,6 +242,13 @@ package body Ghdlrun is
                Simul.Vhdl_Elab.Gather_Processes (Inst);
                Simul.Vhdl_Elab.Elab_Processes;
                Simul.Vhdl_Elab.Compute_Sources;
+
+               --  Native dataflow exporter: if --flow[=FILE] was given,
+               --  dump the elaborated dataflow database now that the
+               --  Processes/Drivers/Sensitivity/Connect tables are built.
+               if Flow_Filename /= null then
+                  Simul.Flow.Dump (Flow_Filename.all);
+               end if;
             end;
       end case;
 
@@ -253,6 +288,8 @@ package body Ghdlrun is
                   Res := Decode_Generic_Override_Option (Arg);
                elsif Arg = "--expect-failure" then
                   Flag_Expect_Failure := True;
+               elsif Is_Flow_Option (Arg) then
+                  Capture_Flow_Option (Arg);
                end if;
             end;
          end loop;
@@ -282,15 +319,30 @@ package body Ghdlrun is
 --           T := new String'(Str & Ghdllocal.Nul);
 --           return To_Ghdl_C_String (T.all'Address);
 --        end Strdup;
+      Nbr : Natural;
+      J : Natural;
    begin
       --  Argc, Argv and Progname are from Grt.Options.
-      Argc := 1 + Args'Length;
+      --  '--flow' is a front-end option (handled at elaboration); filter
+      --  it out so it is not passed to (and rejected by) grt.
+      Nbr := 0;
+      for I in Args'Range loop
+         if not Is_Flow_Option (Args (I).all) then
+            Nbr := Nbr + 1;
+         end if;
+      end loop;
+
+      Argc := 1 + Nbr;
       Argv := Malloc
         (size_t (Argc * (Ghdl_C_String'Size / System.Storage_Unit)));
       Argv (0) := Strdup (Ada.Command_Line.Command_Name & Ghdllocal.Nul);
       Progname := Argv (0);
+      J := 1;
       for I in Args'Range loop
-         Argv (1 + I - Args'First) := Strdup (Args (I).all & Ghdllocal.Nul);
+         if not Is_Flow_Option (Args (I).all) then
+            Argv (J) := Strdup (Args (I).all & Ghdllocal.Nul);
+            J := J + 1;
+         end if;
       end loop;
    end Set_Run_Options;
 

--- a/src/ghdldrv/ghdlrun.adb
+++ b/src/ghdldrv/ghdlrun.adb
@@ -269,6 +269,18 @@ package body Ghdlrun is
    is
       Config : Iir;
    begin
+      --  '--flow' exports begin/end source spans (architecture/process
+      --  'begin', unit 'end', ...) which live in the extended-locations
+      --  table.  That table is only populated by the parser when
+      --  Flag_Elocations is set, and units are (re)parsed during
+      --  Common_Compile_Elab below, so enable it here, before any load.
+      for I in Args'Range loop
+         if Is_Flow_Option (Args (I).all) then
+            Flags.Flag_Elocations := True;
+            exit;
+         end if;
+      end loop;
+
       Common_Compile_Elab (Cmd_Name, Args, True, Opt_Arg, Config);
 
       if Run_Mode /= Run_Elab_Jit then

--- a/src/simul/simul-flow.adb
+++ b/src/simul/simul-flow.adb
@@ -1,0 +1,1792 @@
+--  Native dataflow (.flow) JSON exporter for simulation.
+--  Copyright (C) 2026 Tristan Gingold
+--
+--  This file is part of GHDL.
+--
+--  This program is free software: you can redistribute it and/or modify
+--  it under the terms of the GNU General Public License as published by
+--  the Free Software Foundation, either version 2 of the License, or
+--  (at your option) any later version.
+--
+--  This program is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--  GNU General Public License for more details.
+--
+--  You should have received a copy of the GNU General Public License
+--  along with this program.  If not, see <gnu.org/licenses>.
+
+with Ada.Text_IO; use Ada.Text_IO;
+
+with Types; use Types;
+with Name_Table;
+with Files_Map;
+
+with Vhdl.Nodes; use Vhdl.Nodes;
+with Vhdl.Utils;
+with Vhdl.Canon;
+
+with Libraries;
+
+with Elab.Vhdl_Context; use Elab.Vhdl_Context;
+with Elab.Vhdl_Objtypes; use Elab.Vhdl_Objtypes;
+with Elab.Vhdl_Values; use Elab.Vhdl_Values;
+with Simul.Vhdl_Elab; use Simul.Vhdl_Elab;
+
+with Flags;
+with Version;
+
+package body Simul.Flow is
+
+   --  ------------------------------------------------------------------
+   --  Small helpers.
+   --  ------------------------------------------------------------------
+
+   --  Integer image without the leading space of 'Image.
+   function Img (N : Integer) return String is
+      S : constant String := Integer'Image (N);
+   begin
+      if S (S'First) = ' ' then
+         return S (S'First + 1 .. S'Last);
+      else
+         return S;
+      end if;
+   end Img;
+
+   function Hex1 (V : Natural) return Character is
+      H : constant String := "0123456789abcdef";
+   begin
+      return H (H'First + V);
+   end Hex1;
+
+   --  Emit S as a quoted, escaped JSON string.
+   procedure Put_Str (F : File_Type; S : String) is
+   begin
+      Put (F, '"');
+      for C of S loop
+         case C is
+            when '"' =>
+               Put (F, "\""");
+            when '\' =>
+               Put (F, "\\");
+            when ASCII.LF =>
+               Put (F, "\n");
+            when ASCII.CR =>
+               Put (F, "\r");
+            when ASCII.HT =>
+               Put (F, "\t");
+            when others =>
+               if Character'Pos (C) < 16#20# then
+                  Put (F, "\u00");
+                  Put (F, Hex1 (Character'Pos (C) / 16));
+                  Put (F, Hex1 (Character'Pos (C) mod 16));
+               else
+                  Put (F, C);
+               end if;
+         end case;
+      end loop;
+      Put (F, '"');
+   end Put_Str;
+
+   --  ------------------------------------------------------------------
+   --  File registry (for the top-level "files" array).
+   --  ------------------------------------------------------------------
+
+   Max_Files : constant := 8192;
+   Files_Seen : array (1 .. Max_Files) of Name_Id;
+   N_Files : Natural := 0;
+
+   procedure Note_File (Id : Name_Id) is
+   begin
+      if Id = Null_Identifier then
+         return;
+      end if;
+      for K in 1 .. N_Files loop
+         if Files_Seen (K) = Id then
+            return;
+         end if;
+      end loop;
+      if N_Files < Max_Files then
+         N_Files := N_Files + 1;
+         Files_Seen (N_Files) := Id;
+      end if;
+   end Note_File;
+
+   --  Return the file name of node N (and register it), or "".
+   function Node_File (N : Iir) return String is
+      Loc : Location_Type;
+      Fid : Name_Id;
+      Line : Positive;
+      Col : Natural;
+   begin
+      if N = Null_Iir then
+         return "";
+      end if;
+      Loc := Get_Location (N);
+      if Loc = No_Location then
+         return "";
+      end if;
+      Files_Map.Location_To_Position (Loc, Fid, Line, Col);
+      Note_File (Fid);
+      return Name_Table.Image (Fid);
+   end Node_File;
+
+   --  Emit a {"off","line","col"} position object for node N.
+   procedure Put_Pos (F : File_Type; N : Iir) is
+      Loc : Location_Type;
+      Fid : Name_Id;
+      Line : Positive;
+      Col : Natural;
+   begin
+      if N = Null_Iir then
+         Put (F, "{""off"": 0, ""line"": 0, ""col"": 0}");
+         return;
+      end if;
+      Loc := Get_Location (N);
+      if Loc = No_Location then
+         Put (F, "{""off"": 0, ""line"": 0, ""col"": 0}");
+         return;
+      end if;
+      Files_Map.Location_To_Position (Loc, Fid, Line, Col);
+      Note_File (Fid);
+      Put (F, "{""off"": 0, ""line"": " & Img (Line)
+           & ", ""col"": " & Img (Col) & "}");
+   end Put_Pos;
+
+   --  ------------------------------------------------------------------
+   --  Name / type resolution.
+   --  ------------------------------------------------------------------
+
+   --  Reduce a name (possibly indexed/sliced/selected) to its base
+   --  declaration node.
+   function Resolve_Obj (N : Iir) return Iir is
+      B : Iir := N;
+   begin
+      if B = Null_Iir then
+         return Null_Iir;
+      end if;
+      loop
+         case Get_Kind (B) is
+            when Iir_Kind_Indexed_Name
+               | Iir_Kind_Slice_Name
+               | Iir_Kind_Selected_Element
+               | Iir_Kind_Parenthesis_Name =>
+               B := Get_Prefix (B);
+            when Iir_Kinds_Denoting_Name =>
+               declare
+                  Ne : constant Iir := Get_Named_Entity (B);
+               begin
+                  exit when Ne = Null_Iir;
+                  B := Ne;
+               end;
+            when others =>
+               exit;
+         end case;
+      end loop;
+      return B;
+   end Resolve_Obj;
+
+   --  Identifier image of a declaration node, or "" if it has none.
+   function Decl_Ident (D : Iir) return String is
+   begin
+      if D = Null_Iir then
+         return "";
+      end if;
+      case Get_Kind (D) is
+         when Iir_Kind_Signal_Declaration
+            | Iir_Kind_Interface_Signal_Declaration
+            | Iir_Kind_Guard_Signal_Declaration
+            | Iir_Kind_Constant_Declaration
+            | Iir_Kind_Interface_Constant_Declaration
+            | Iir_Kind_Variable_Declaration
+            | Iir_Kind_Interface_Variable_Declaration
+            | Iir_Kind_File_Declaration
+            | Iir_Kind_Iterator_Declaration
+            | Iir_Kind_Object_Alias_Declaration
+            | Iir_Kind_Type_Declaration
+            | Iir_Kind_Subtype_Declaration
+            | Iir_Kind_Enumeration_Literal
+            | Iir_Kind_Unit_Declaration
+            | Iir_Kind_Entity_Declaration
+            | Iir_Kind_Architecture_Body
+            | Iir_Kind_Component_Declaration
+            | Iir_Kind_Configuration_Declaration
+            | Iir_Kind_Package_Declaration =>
+            return Name_Table.Image (Get_Identifier (D));
+         when others =>
+            return "";
+      end case;
+   end Decl_Ident;
+
+   --  Underlying object name of an expression/name.
+   function Obj_Name (N : Iir) return String is
+   begin
+      return Decl_Ident (Resolve_Obj (N));
+   end Obj_Name;
+
+   --  Best-effort printable type name of a declaration's subtype.
+   function Type_Image (Decl : Iir) return String is
+      Ind : constant Iir := Get_Subtype_Indication (Decl);
+      T, D, B : Iir;
+   begin
+      --  Prefer the written subtype mark (e.g. "std_logic_vector")
+      --  over the resolved base type (e.g. "std_ulogic_vector").
+      if Ind /= Null_Iir then
+         if Get_Kind (Ind) in Iir_Kinds_Denoting_Name then
+            declare
+               Nm : constant String := Decl_Ident (Resolve_Obj (Ind));
+            begin
+               if Nm /= "" then
+                  return Nm;
+               end if;
+            end;
+         else
+            begin
+               declare
+                  TM : constant Iir := Get_Subtype_Type_Mark (Ind);
+               begin
+                  if TM /= Null_Iir then
+                     declare
+                        Nm : constant String :=
+                          Decl_Ident (Resolve_Obj (TM));
+                     begin
+                        if Nm /= "" then
+                           return Nm;
+                        end if;
+                     end;
+                  end if;
+               end;
+            exception
+               when others =>
+                  null;
+            end;
+         end if;
+      end if;
+      T := Get_Type (Decl);
+      if T = Null_Iir then
+         return "";
+      end if;
+      D := Get_Type_Declarator (T);
+      if D /= Null_Iir then
+         return Name_Table.Image (Get_Identifier (D));
+      end if;
+      B := Vhdl.Utils.Get_Base_Type (T);
+      if B /= Null_Iir then
+         D := Get_Type_Declarator (B);
+         if D /= Null_Iir then
+            return Name_Table.Image (Get_Identifier (D));
+         end if;
+      end if;
+      return "";
+   end Type_Image;
+
+   --  ------------------------------------------------------------------
+   --  Name-list emission (reads / drives / sensitivity).
+   --  ------------------------------------------------------------------
+
+   --  Emit a JSON array of object names from an Iir_List, deduplicated
+   --  by resolved declaration.
+   procedure Put_Name_List (F : File_Type; List : Iir_List) is
+      Seen : array (1 .. 8192) of Iir := (others => Null_Iir);
+      N_Seen : Natural := 0;
+      First : Boolean := True;
+      It : List_Iterator;
+   begin
+      Put (F, "[");
+      if List /= Null_Iir_List and then List /= Iir_List_All then
+         It := List_Iterate (List);
+         while Is_Valid (It) loop
+            declare
+               El : constant Iir := Get_Element (It);
+               D : constant Iir := Resolve_Obj (El);
+               Dup : Boolean := False;
+            begin
+               if D /= Null_Iir then
+                  for K in 1 .. N_Seen loop
+                     if Seen (K) = D then
+                        Dup := True;
+                        exit;
+                     end if;
+                  end loop;
+                  if not Dup then
+                     if N_Seen < Seen'Last then
+                        N_Seen := N_Seen + 1;
+                        Seen (N_Seen) := D;
+                     end if;
+                     declare
+                        Nm : constant String := Decl_Ident (D);
+                     begin
+                        if Nm /= "" then
+                           if not First then
+                              Put (F, ", ");
+                           end if;
+                           First := False;
+                           Put_Str (F, Nm);
+                        end if;
+                     end;
+                  end if;
+               end if;
+            end;
+            Next (It);
+         end loop;
+      end if;
+      Put (F, "]");
+   end Put_Name_List;
+
+   --  ------------------------------------------------------------------
+   --  Driver (write) set: walk a sequential statement chain collecting
+   --  signal-assignment targets into LIST.
+   --  ------------------------------------------------------------------
+
+   --  Read (sensitivity) set: walk a sequential statement chain
+   --  collecting signals read into LIST.  Unlike
+   --  Canon_Extract_Sensitivity_Statement (which rejects wait
+   --  statements, as it targets process(all)), this tolerates the full
+   --  sequential grammar by handling control-flow and wait itself and
+   --  delegating only leaf statements to canon.
+   procedure Collect_Reads (Chain : Iir; List : Iir_List) is
+      Stmt : Iir := Chain;
+   begin
+      while Stmt /= Null_Iir loop
+         case Get_Kind (Stmt) is
+            when Iir_Kind_Wait_Statement =>
+               if Get_Condition_Clause (Stmt) /= Null_Iir then
+                  Vhdl.Canon.Canon_Extract_Sensitivity_Expression
+                    (Get_Condition_Clause (Stmt), List);
+               end if;
+               if Get_Timeout_Clause (Stmt) /= Null_Iir then
+                  Vhdl.Canon.Canon_Extract_Sensitivity_Expression
+                    (Get_Timeout_Clause (Stmt), List);
+               end if;
+               declare
+                  SL : constant Iir_List := Get_Sensitivity_List (Stmt);
+                  It : List_Iterator;
+               begin
+                  if SL /= Null_Iir_List and then SL /= Iir_List_All then
+                     It := List_Iterate (SL);
+                     while Is_Valid (It) loop
+                        Append_Element (List, Get_Element (It));
+                        Next (It);
+                     end loop;
+                  end if;
+               end;
+            when Iir_Kind_If_Statement =>
+               declare
+                  Cl : Iir := Stmt;
+               begin
+                  while Cl /= Null_Iir loop
+                     if Get_Condition (Cl) /= Null_Iir then
+                        Vhdl.Canon.Canon_Extract_Sensitivity_Expression
+                          (Get_Condition (Cl), List);
+                     end if;
+                     Collect_Reads
+                       (Get_Sequential_Statement_Chain (Cl), List);
+                     Cl := Get_Else_Clause (Cl);
+                  end loop;
+               end;
+            when Iir_Kind_Case_Statement =>
+               if Get_Expression (Stmt) /= Null_Iir then
+                  Vhdl.Canon.Canon_Extract_Sensitivity_Expression
+                    (Get_Expression (Stmt), List);
+               end if;
+               declare
+                  Alt : Iir := Get_Case_Statement_Alternative_Chain (Stmt);
+               begin
+                  while Alt /= Null_Iir loop
+                     Collect_Reads (Get_Associated_Chain (Alt), List);
+                     Alt := Get_Chain (Alt);
+                  end loop;
+               end;
+            when Iir_Kind_While_Loop_Statement =>
+               if Get_Condition (Stmt) /= Null_Iir then
+                  Vhdl.Canon.Canon_Extract_Sensitivity_Expression
+                    (Get_Condition (Stmt), List);
+               end if;
+               Collect_Reads
+                 (Get_Sequential_Statement_Chain (Stmt), List);
+            when Iir_Kind_For_Loop_Statement =>
+               Collect_Reads
+                 (Get_Sequential_Statement_Chain (Stmt), List);
+            when others =>
+               --  Leaf statement (assignment, procedure call,
+               --  assertion, ...).  Delegate to canon, but degrade
+               --  gracefully on any node kind it cannot handle.
+               begin
+                  Vhdl.Canon.Canon_Extract_Sensitivity_Statement
+                    (Stmt, List);
+               exception
+                  when others =>
+                     null;
+               end;
+         end case;
+         Stmt := Get_Chain (Stmt);
+      end loop;
+   end Collect_Reads;
+
+   procedure Collect_Drivers (Chain : Iir; List : Iir_List) is
+      Stmt : Iir := Chain;
+   begin
+      while Stmt /= Null_Iir loop
+         case Get_Kind (Stmt) is
+            when Iir_Kind_Simple_Signal_Assignment_Statement
+               | Iir_Kind_Conditional_Signal_Assignment_Statement
+               | Iir_Kind_Selected_Waveform_Assignment_Statement
+               | Iir_Kind_Signal_Force_Assignment_Statement
+               | Iir_Kind_Signal_Release_Assignment_Statement =>
+               declare
+                  D : constant Iir := Resolve_Obj (Get_Target (Stmt));
+               begin
+                  if D /= Null_Iir then
+                     Append_Element (List, D);
+                  end if;
+               end;
+            when Iir_Kind_If_Statement =>
+               declare
+                  Cl : Iir := Stmt;
+               begin
+                  while Cl /= Null_Iir loop
+                     Collect_Drivers
+                       (Get_Sequential_Statement_Chain (Cl), List);
+                     Cl := Get_Else_Clause (Cl);
+                  end loop;
+               end;
+            when Iir_Kind_Case_Statement =>
+               declare
+                  Alt : Iir := Get_Case_Statement_Alternative_Chain (Stmt);
+               begin
+                  while Alt /= Null_Iir loop
+                     Collect_Drivers (Get_Associated_Chain (Alt), List);
+                     Alt := Get_Chain (Alt);
+                  end loop;
+               end;
+            when Iir_Kind_For_Loop_Statement
+               | Iir_Kind_While_Loop_Statement =>
+               Collect_Drivers
+                 (Get_Sequential_Statement_Chain (Stmt), List);
+            when others =>
+               null;
+         end case;
+         Stmt := Get_Chain (Stmt);
+      end loop;
+   end Collect_Drivers;
+
+   --  ------------------------------------------------------------------
+   --  Concurrent-statement walkers (each emits one module sub-array).
+   --  Generate bodies are flattened into the enclosing module.
+   --  ------------------------------------------------------------------
+
+   procedure Walk_Processes
+     (F : File_Type; Chain : Iir; First : in out Boolean);
+   procedure Walk_Assignments
+     (F : File_Type; Chain : Iir; First : in out Boolean);
+   procedure Walk_Instances
+     (F : File_Type; Chain : Iir; First : in out Boolean);
+
+   --  Emit a single process object.
+   procedure Emit_Process (F : File_Type; Proc : Iir) is
+      Reads : constant Iir_List := Create_Iir_List;
+      Drives : constant Iir_List := Create_Iir_List;
+      Lbl : constant Name_Id := Get_Label (Proc);
+   begin
+      Put (F, "{""label"": ");
+      if Lbl = Null_Identifier then
+         Put (F, "null");
+      else
+         Put_Str (F, Name_Table.Image (Lbl));
+      end if;
+      Put (F, ", ""pos"": ");
+      Put_Pos (F, Proc);
+
+      Put (F, ", ""sensitivity"": ");
+      if Get_Kind (Proc) = Iir_Kind_Sensitized_Process_Statement then
+         Put_Name_List (F, Get_Sensitivity_List (Proc));
+      else
+         Put (F, "[]");
+      end if;
+
+      Collect_Reads (Get_Sequential_Statement_Chain (Proc), Reads);
+      Collect_Drivers (Get_Sequential_Statement_Chain (Proc), Drives);
+
+      Put (F, ", ""drives"": ");
+      Put_Name_List (F, Drives);
+      Put (F, ", ""reads"": ");
+      Put_Name_List (F, Reads);
+      Put (F, "}");
+   end Emit_Process;
+
+   procedure Walk_Processes
+     (F : File_Type; Chain : Iir; First : in out Boolean)
+   is
+      Stmt : Iir := Chain;
+   begin
+      while Stmt /= Null_Iir loop
+         case Get_Kind (Stmt) is
+            when Iir_Kind_Sensitized_Process_Statement
+               | Iir_Kind_Process_Statement =>
+               if not First then
+                  Put (F, ", ");
+               end if;
+               First := False;
+               Emit_Process (F, Stmt);
+            when Iir_Kind_For_Generate_Statement
+               | Iir_Kind_If_Generate_Statement =>
+               declare
+                  Bod : constant Iir :=
+                    Get_Generate_Statement_Body (Stmt);
+               begin
+                  if Bod /= Null_Iir then
+                     Walk_Processes
+                       (F, Get_Concurrent_Statement_Chain (Bod), First);
+                  end if;
+               end;
+            when others =>
+               null;
+         end case;
+         Stmt := Get_Chain (Stmt);
+      end loop;
+   end Walk_Processes;
+
+   --  Emit a single concurrent-assignment object.
+   procedure Emit_Assignment (F : File_Type; Stmt : Iir) is
+      Reads : constant Iir_List := Create_Iir_List;
+   begin
+      Put (F, "{""target"": ");
+      Put_Str (F, Obj_Name (Get_Target (Stmt)));
+      Put (F, ", ""pos"": ");
+      Put_Pos (F, Stmt);
+
+      begin
+         case Get_Kind (Stmt) is
+            when Iir_Kind_Concurrent_Simple_Signal_Assignment =>
+               Vhdl.Canon.
+                 Canon_Extract_Sensitivity_Simple_Signal_Assignment
+                   (Stmt, Reads);
+            when Iir_Kind_Concurrent_Conditional_Signal_Assignment =>
+               Vhdl.Canon.
+                 Canon_Extract_Sensitivity_Conditional_Signal_Assignment
+                   (Stmt, Reads);
+            when Iir_Kind_Concurrent_Selected_Signal_Assignment =>
+               Vhdl.Canon.
+                 Canon_Extract_Sensitivity_Selected_Signal_Assignment
+                   (Stmt, Reads);
+            when others =>
+               null;
+         end case;
+      exception
+         when others =>
+            null;
+      end;
+
+      Put (F, ", ""drives"": [");
+      declare
+         Tgt : constant String := Obj_Name (Get_Target (Stmt));
+      begin
+         if Tgt /= "" then
+            Put_Str (F, Tgt);
+         end if;
+      end;
+      Put (F, "], ""reads"": ");
+      Put_Name_List (F, Reads);
+      Put (F, "}");
+   end Emit_Assignment;
+
+   procedure Walk_Assignments
+     (F : File_Type; Chain : Iir; First : in out Boolean)
+   is
+      Stmt : Iir := Chain;
+   begin
+      while Stmt /= Null_Iir loop
+         case Get_Kind (Stmt) is
+            when Iir_Kind_Concurrent_Simple_Signal_Assignment
+               | Iir_Kind_Concurrent_Conditional_Signal_Assignment
+               | Iir_Kind_Concurrent_Selected_Signal_Assignment =>
+               if not First then
+                  Put (F, ", ");
+               end if;
+               First := False;
+               Emit_Assignment (F, Stmt);
+            when Iir_Kind_For_Generate_Statement
+               | Iir_Kind_If_Generate_Statement =>
+               declare
+                  Bod : constant Iir :=
+                    Get_Generate_Statement_Body (Stmt);
+               begin
+                  if Bod /= Null_Iir then
+                     Walk_Assignments
+                       (F, Get_Concurrent_Statement_Chain (Bod), First);
+                  end if;
+               end;
+            when others =>
+               null;
+         end case;
+         Stmt := Get_Chain (Stmt);
+      end loop;
+   end Walk_Assignments;
+
+   --  Resolve the module name / arch / entity-flag of an instantiation.
+   procedure Inst_Unit
+     (Stmt : Iir;
+      Mod_Name : out Name_Id;
+      Arch_Name : out Name_Id;
+      Is_Entity : out Boolean)
+   is
+      IU : constant Iir := Get_Instantiated_Unit (Stmt);
+      U : Iir := IU;
+   begin
+      Mod_Name := Null_Identifier;
+      Arch_Name := Null_Identifier;
+      Is_Entity := False;
+      if U = Null_Iir then
+         return;
+      end if;
+      if Get_Kind (U) = Iir_Kind_Entity_Aspect_Entity then
+         Is_Entity := True;
+         declare
+            En : constant Iir := Get_Entity_Name (U);
+            Ar : constant Iir := Get_Architecture (U);
+            Re : Iir;
+         begin
+            if En /= Null_Iir then
+               Re := Get_Named_Entity (En);
+               if Re /= Null_Iir then
+                  Mod_Name := Get_Identifier (Re);
+               else
+                  Mod_Name := Get_Identifier (En);
+               end if;
+            end if;
+            if Ar /= Null_Iir then
+               Arch_Name := Get_Identifier (Ar);
+            end if;
+         end;
+         return;
+      end if;
+      if Get_Kind (U) in Iir_Kinds_Denoting_Name then
+         declare
+            Ne : constant Iir := Get_Named_Entity (U);
+         begin
+            if Ne /= Null_Iir then
+               U := Ne;
+            end if;
+         end;
+      end if;
+      case Get_Kind (U) is
+         when Iir_Kind_Component_Declaration =>
+            Mod_Name := Get_Identifier (U);
+         when Iir_Kind_Entity_Declaration =>
+            Is_Entity := True;
+            Mod_Name := Get_Identifier (U);
+         when others =>
+            if Get_Kind (U) in Iir_Kinds_Denoting_Name then
+               Mod_Name := Get_Identifier (U);
+            end if;
+      end case;
+   end Inst_Unit;
+
+   --  Emit a port_map or generic_map association chain.
+   procedure Emit_Map (F : File_Type; Chain : Iir) is
+      Assoc : Iir := Chain;
+      First : Boolean := True;
+   begin
+      while Assoc /= Null_Iir loop
+         declare
+            Formal : constant Iir := Get_Formal (Assoc);
+            Positional : constant Boolean := Formal = Null_Iir;
+            Actual : Iir := Null_Iir;
+         begin
+            case Get_Kind (Assoc) is
+               when Iir_Kind_Association_Element_By_Expression
+                  | Iir_Kind_Association_Element_By_Name =>
+                  Actual := Get_Actual (Assoc);
+               when others =>
+                  Actual := Null_Iir;
+            end case;
+
+            if not First then
+               Put (F, ", ");
+            end if;
+            First := False;
+            Put (F, "{""formal"": ");
+            if Positional then
+               Put (F, "null");
+            else
+               Put_Str (F, Obj_Name (Formal));
+            end if;
+            if not Positional then
+               Put (F, ", ""fbase"": ");
+               Put_Str (F, Obj_Name (Formal));
+            end if;
+            Put (F, ", ""actual"": ");
+            Put_Str (F, Obj_Name (Actual));
+            Put (F, ", ""actuals"": [");
+            declare
+               A : constant String := Obj_Name (Actual);
+            begin
+               if A /= "" then
+                  Put_Str (F, A);
+               end if;
+            end;
+            Put (F, "]");
+            if Positional then
+               Put (F, ", ""positional"": true");
+            end if;
+            Put (F, "}");
+         end;
+         Assoc := Get_Chain (Assoc);
+      end loop;
+   end Emit_Map;
+
+   --  Emit a single instantiation object.
+   procedure Emit_Instance (F : File_Type; Stmt : Iir) is
+      Mod_Name : Name_Id;
+      Arch_Name : Name_Id;
+      Is_Entity : Boolean;
+      Lbl : constant Name_Id := Get_Label (Stmt);
+   begin
+      Inst_Unit (Stmt, Mod_Name, Arch_Name, Is_Entity);
+      Put (F, "{""label"": ");
+      if Lbl = Null_Identifier then
+         Put (F, "null");
+      else
+         Put_Str (F, Name_Table.Image (Lbl));
+      end if;
+      Put (F, ", ""module"": ");
+      if Mod_Name = Null_Identifier then
+         Put_Str (F, "");
+      else
+         Put_Str (F, Name_Table.Image (Mod_Name));
+      end if;
+      if Arch_Name /= Null_Identifier then
+         Put (F, ", ""arch"": ");
+         Put_Str (F, Name_Table.Image (Arch_Name));
+      end if;
+      Put (F, ", ""is_entity_inst"": ");
+      Put (F, (if Is_Entity then "true" else "false"));
+      Put (F, ", ""pos"": ");
+      Put_Pos (F, Stmt);
+      Put (F, ", ""generic_map"": [");
+      Emit_Map (F, Get_Generic_Map_Aspect_Chain (Stmt));
+      Put (F, "], ""port_map"": [");
+      Emit_Map (F, Get_Port_Map_Aspect_Chain (Stmt));
+      Put (F, "]}");
+   end Emit_Instance;
+
+   procedure Walk_Instances
+     (F : File_Type; Chain : Iir; First : in out Boolean)
+   is
+      Stmt : Iir := Chain;
+   begin
+      while Stmt /= Null_Iir loop
+         case Get_Kind (Stmt) is
+            when Iir_Kind_Component_Instantiation_Statement =>
+               if not First then
+                  Put (F, ", ");
+               end if;
+               First := False;
+               Emit_Instance (F, Stmt);
+            when Iir_Kind_For_Generate_Statement
+               | Iir_Kind_If_Generate_Statement =>
+               declare
+                  Bod : constant Iir :=
+                    Get_Generate_Statement_Body (Stmt);
+               begin
+                  if Bod /= Null_Iir then
+                     Walk_Instances
+                       (F, Get_Concurrent_Statement_Chain (Bod), First);
+                  end if;
+               end;
+            when others =>
+               null;
+         end case;
+         Stmt := Get_Chain (Stmt);
+      end loop;
+   end Walk_Instances;
+
+   --  ------------------------------------------------------------------
+   --  Entity interface (ports / generics).
+   --  ------------------------------------------------------------------
+
+   function Mode_Image (M : Iir_Mode) return String is
+   begin
+      case M is
+         when Iir_In_Mode =>
+            return "in";
+         when Iir_Out_Mode =>
+            return "out";
+         when Iir_Inout_Mode =>
+            return "inout";
+         when Iir_Buffer_Mode =>
+            return "buffer";
+         when Iir_Linkage_Mode =>
+            return "linkage";
+         when others =>
+            return "in";
+      end case;
+   end Mode_Image;
+
+   procedure Emit_Ports (F : File_Type; Ent : Iir) is
+      Port : Iir;
+      First : Boolean := True;
+   begin
+      if Ent = Null_Iir then
+         return;
+      end if;
+      Port := Get_Port_Chain (Ent);
+      while Port /= Null_Iir loop
+         if not First then
+            Put (F, ", ");
+         end if;
+         First := False;
+         Put (F, "{""name"": ");
+         Put_Str (F, Name_Table.Image (Get_Identifier (Port)));
+         Put (F, ", ""dir"": ");
+         Put_Str (F, Mode_Image (Get_Mode (Port)));
+         Put (F, ", ""type"": ");
+         Put_Str (F, Type_Image (Port));
+         Put (F, ", ""pos"": ");
+         Put_Pos (F, Port);
+         Put (F, "}");
+         Port := Get_Chain (Port);
+      end loop;
+   end Emit_Ports;
+
+   procedure Emit_Generics (F : File_Type; Ent : Iir) is
+      Gen : Iir;
+      First : Boolean := True;
+   begin
+      if Ent = Null_Iir then
+         return;
+      end if;
+      Gen := Get_Generic_Chain (Ent);
+      while Gen /= Null_Iir loop
+         if not First then
+            Put (F, ", ");
+         end if;
+         First := False;
+         Put (F, "{""name"": ");
+         Put_Str (F, Name_Table.Image (Get_Identifier (Gen)));
+         Put (F, ", ""type"": ");
+         Put_Str (F, Type_Image (Gen));
+         Put (F, ", ""pos"": ");
+         Put_Pos (F, Gen);
+         Put (F, "}");
+         Gen := Get_Chain (Gen);
+      end loop;
+   end Emit_Generics;
+
+   procedure Emit_Signals (F : File_Type; Arch : Iir) is
+      Decl : Iir;
+      First : Boolean := True;
+   begin
+      Decl := Get_Declaration_Chain (Arch);
+      while Decl /= Null_Iir loop
+         if Get_Kind (Decl) = Iir_Kind_Signal_Declaration then
+            if not First then
+               Put (F, ", ");
+            end if;
+            First := False;
+            Put (F, "{""name"": ");
+            Put_Str (F, Name_Table.Image (Get_Identifier (Decl)));
+            Put (F, ", ""type"": ");
+            Put_Str (F, Type_Image (Decl));
+            Put (F, ", ""skind"": ");
+            Put_Str (F, "signal");
+            Put (F, ", ""pos"": ");
+            Put_Pos (F, Decl);
+            Put (F, "}");
+         end if;
+         Decl := Get_Chain (Decl);
+      end loop;
+   end Emit_Signals;
+
+   --  ------------------------------------------------------------------
+   --  Module emission (one per architecture body).
+   --  ------------------------------------------------------------------
+
+   procedure Emit_Module (F : File_Type; Arch : Iir) is
+      Ent : constant Iir :=
+        Get_Named_Entity (Get_Entity_Name (Arch));
+      Chain : constant Iir := Get_Concurrent_Statement_Chain (Arch);
+      First : Boolean;
+   begin
+      Put (F, "    {""name"": ");
+      if Ent /= Null_Iir then
+         Put_Str (F, Name_Table.Image (Get_Identifier (Ent)));
+      else
+         Put_Str (F, "");
+      end if;
+      Put (F, ", ""kind"": ");
+      Put_Str (F, "entity");
+      Put (F, ", ""lang"": ");
+      Put_Str (F, "vhdl");
+      Put (F, ", ""file"": ");
+      Put_Str (F, Node_File (Arch));
+      Put (F, ", ""pos"": ");
+      Put_Pos (F, Arch);
+      Put (F, ", ""arch"": ");
+      Put_Str (F, Name_Table.Image (Get_Identifier (Arch)));
+      Put (F, ",");
+
+      New_Line (F);
+      Put (F, "      ""ports"": [");
+      Emit_Ports (F, Ent);
+      Put (F, "],");
+      New_Line (F);
+      Put (F, "      ""generics"": [");
+      Emit_Generics (F, Ent);
+      Put (F, "],");
+      New_Line (F);
+      Put (F, "      ""signals"": [");
+      Emit_Signals (F, Arch);
+      Put (F, "],");
+      New_Line (F);
+      Put (F, "      ""constants"": [],");
+      New_Line (F);
+
+      Put (F, "      ""processes"": [");
+      First := True;
+      Walk_Processes (F, Chain, First);
+      Put (F, "],");
+      New_Line (F);
+
+      Put (F, "      ""assignments"": [");
+      First := True;
+      Walk_Assignments (F, Chain, First);
+      Put (F, "],");
+      New_Line (F);
+
+      Put (F, "      ""generates"": [],");
+      New_Line (F);
+
+      Put (F, "      ""instances"": [");
+      First := True;
+      Walk_Instances (F, Chain, First);
+      Put (F, "]}");
+   end Emit_Module;
+
+   --  ------------------------------------------------------------------
+   --  Elaborated hierarchy (hierarchy[] from the instance tree).
+   --  Mirrors the elaborator's own traversal (Gather_Processes_1):
+   --  descend via Get_Sub_Instance / Get_Generate_Sub_Instance.
+   --  ------------------------------------------------------------------
+
+   --  Emit a Name_Id as a JSON string ("" if Null).
+   procedure Put_Name (F : File_Type; Id : Name_Id) is
+   begin
+      if Id = Null_Identifier then
+         Put_Str (F, "");
+      else
+         Put_Str (F, Name_Table.Image (Id));
+      end if;
+   end Put_Name;
+
+   --  Resolve an instance to (entity name, arch name, body instance).
+   --  For a component instantiation the body instance is the inner
+   --  component instance (bound architecture); otherwise it is Inst.
+   procedure Inst_Module_Arch
+     (Inst : Synth_Instance_Acc;
+      Mod_Name : out Name_Id;
+      Arch_Name : out Name_Id;
+      Body_Inst : out Synth_Instance_Acc)
+   is
+      S : Node;
+   begin
+      Mod_Name := Null_Identifier;
+      Arch_Name := Null_Identifier;
+      Body_Inst := Inst;
+      if Inst = null then
+         return;
+      end if;
+      S := Get_Source_Scope (Inst);
+      if S = Null_Node then
+         return;
+      end if;
+      if Get_Kind (S) = Iir_Kind_Component_Declaration then
+         Mod_Name := Get_Identifier (S);
+         declare
+            CI : constant Synth_Instance_Acc :=
+              Get_Component_Instance (Inst);
+         begin
+            if CI = null then
+               return;
+            end if;
+            Body_Inst := CI;
+            S := Get_Source_Scope (CI);
+         end;
+      end if;
+      if Get_Kind (S) = Iir_Kind_Architecture_Body then
+         Arch_Name := Get_Identifier (S);
+         declare
+            Ent : constant Node := Vhdl.Utils.Get_Entity (S);
+         begin
+            if Ent /= Null_Node then
+               Mod_Name := Get_Identifier (Ent);
+            end if;
+         end;
+      end if;
+   end Inst_Module_Arch;
+
+   --  Concurrent statement chain of an instance's elaborated scope.
+   function Scope_Chain (Inst : Synth_Instance_Acc) return Node is
+      S : Node;
+   begin
+      if Inst = null then
+         return Null_Node;
+      end if;
+      S := Get_Source_Scope (Inst);
+      if S = Null_Node then
+         return Null_Node;
+      end if;
+      case Get_Kind (S) is
+         when Iir_Kind_Architecture_Body
+            | Iir_Kind_Generate_Statement_Body
+            | Iir_Kind_Block_Statement =>
+            return Get_Concurrent_Statement_Chain (S);
+         when others =>
+            return Null_Node;
+      end case;
+   end Scope_Chain;
+
+   procedure Emit_Children
+     (F : File_Type; Inst : Synth_Instance_Acc; First : in out Boolean);
+   procedure Emit_Instance_Node
+     (F : File_Type; Inst : Synth_Instance_Acc; Stmt : Node;
+      First : in out Boolean);
+   procedure Emit_Frame_Node
+     (F : File_Type; Inst : Synth_Instance_Acc; Kind : String;
+      Label : Name_Id; Index : Natural; First : in out Boolean);
+
+   procedure Emit_Instance_Node
+     (F : File_Type; Inst : Synth_Instance_Acc; Stmt : Node;
+      First : in out Boolean)
+   is
+      Mod_Name : Name_Id;
+      Arch_Name : Name_Id;
+      Body_Inst : Synth_Instance_Acc;
+      Lbl : Name_Id;
+      Cf : Boolean := True;
+   begin
+      Inst_Module_Arch (Inst, Mod_Name, Arch_Name, Body_Inst);
+      if Stmt /= Null_Node then
+         Lbl := Get_Label (Stmt);
+      else
+         Lbl := Mod_Name;
+      end if;
+
+      if not First then
+         Put (F, ", ");
+      end if;
+      First := False;
+
+      Put (F, "{""name"": ");
+      Put_Name (F, Lbl);
+      Put (F, ", ""module"": ");
+      Put_Name (F, Mod_Name);
+      if Arch_Name /= Null_Identifier then
+         Put (F, ", ""arch"": ");
+         Put_Name (F, Arch_Name);
+      end if;
+      Put (F, ", ""instance_label"": ");
+      Put_Name (F, Lbl);
+      Put (F, ", ""inst_pos"": ");
+      if Stmt /= Null_Node then
+         Put_Pos (F, Stmt);
+      else
+         Put_Pos (F, Get_Source_Scope (Body_Inst));
+      end if;
+      Put (F, ", ""generics"": []");
+      Put (F, ", ""generic_map"": [");
+      if Stmt /= Null_Node then
+         Emit_Map (F, Get_Generic_Map_Aspect_Chain (Stmt));
+      end if;
+      Put (F, "], ""port_map"": [");
+      if Stmt /= Null_Node then
+         Emit_Map (F, Get_Port_Map_Aspect_Chain (Stmt));
+      end if;
+      Put (F, "], ""children"": [");
+      Emit_Children (F, Body_Inst, Cf);
+      Put (F, "]}");
+   end Emit_Instance_Node;
+
+   procedure Emit_Frame_Node
+     (F : File_Type; Inst : Synth_Instance_Acc; Kind : String;
+      Label : Name_Id; Index : Natural; First : in out Boolean)
+   is
+      Cf : Boolean := True;
+   begin
+      if not First then
+         Put (F, ", ");
+      end if;
+      First := False;
+
+      Put (F, "{""name"": ");
+      if Kind = "for" and then Label /= Null_Identifier then
+         Put_Str (F, Name_Table.Image (Label) & "(" & Img (Index) & ")");
+      else
+         Put_Name (F, Label);
+      end if;
+      Put (F, ", ""scope"": true, ""generate"": {""kind"": ");
+      Put_Str (F, Kind);
+      Put (F, ", ""label"": ");
+      Put_Name (F, Label);
+      if Kind = "for" then
+         Put (F, ", ""index"": " & Img (Index));
+      elsif Kind = "if" then
+         Put (F, ", ""arm"": 0");
+      end if;
+      Put (F, "}, ""children"": [");
+      Emit_Children (F, Inst, Cf);
+      Put (F, "]}");
+   end Emit_Frame_Node;
+
+   procedure Emit_Children
+     (F : File_Type; Inst : Synth_Instance_Acc; First : in out Boolean)
+   is
+      Stmt : Node := Scope_Chain (Inst);
+   begin
+      while Stmt /= Null_Node loop
+         case Get_Kind (Stmt) is
+            when Iir_Kind_Component_Instantiation_Statement =>
+               declare
+                  Sub : constant Synth_Instance_Acc :=
+                    Get_Sub_Instance (Inst, Stmt);
+               begin
+                  if Sub /= null then
+                     Emit_Instance_Node (F, Sub, Stmt, First);
+                  end if;
+               end;
+            when Iir_Kind_For_Generate_Statement =>
+               begin
+                  declare
+                     It : constant Node :=
+                       Get_Parameter_Specification (Stmt);
+                     Rng : constant Type_Acc :=
+                       Get_Subtype_Object (Inst, Get_Type (It));
+                     Len : constant Natural :=
+                       Natural (Get_Range_Length (Rng.Drange));
+                     Gen_Inst : constant Synth_Instance_Acc :=
+                       Get_Sub_Instance (Inst, Stmt);
+                  begin
+                     for I in 1 .. Len loop
+                        Emit_Frame_Node
+                          (F, Get_Generate_Sub_Instance (Gen_Inst, I),
+                           "for", Get_Label (Stmt), I, First);
+                     end loop;
+                  end;
+               exception
+                  when others =>
+                     null;
+               end;
+            when Iir_Kind_If_Generate_Statement
+               | Iir_Kind_Case_Generate_Statement =>
+               declare
+                  Sub : constant Synth_Instance_Acc :=
+                    Get_Sub_Instance (Inst, Stmt);
+               begin
+                  if Sub /= null then
+                     Emit_Frame_Node
+                       (F, Sub, "if", Get_Label (Stmt), 0, First);
+                  end if;
+               end;
+            when Iir_Kind_Block_Statement =>
+               declare
+                  Sub : constant Synth_Instance_Acc :=
+                    Get_Sub_Instance (Inst, Stmt);
+               begin
+                  if Sub /= null then
+                     Emit_Frame_Node
+                       (F, Sub, "block", Get_Label (Stmt), 0, First);
+                  end if;
+               end;
+            when others =>
+               null;
+         end case;
+         Stmt := Get_Chain (Stmt);
+      end loop;
+   end Emit_Children;
+
+   --  Hierarchical name of the top unit (its entity), or "".
+   function Top_Name return String is
+      S : Node;
+   begin
+      if Top_Instance = null then
+         return "";
+      end if;
+      S := Get_Source_Scope (Top_Instance);
+      if S /= Null_Node
+        and then Get_Kind (S) = Iir_Kind_Architecture_Body
+      then
+         declare
+            Ent : constant Node := Vhdl.Utils.Get_Entity (S);
+         begin
+            if Ent /= Null_Node then
+               return Name_Table.Image (Get_Identifier (Ent));
+            end if;
+         end;
+      end if;
+      return "";
+   end Top_Name;
+
+   --  ------------------------------------------------------------------
+   --  Industrial polish: canonical net graph (nets[] + cells[]) built
+   --  from the elaborated Drivers/Sensitivity/Connect tables, plus
+   --  comb-vs-clocked classification and provenance.
+   --  ------------------------------------------------------------------
+
+   --  The VHDL standard being elaborated, as a 2-char tag.
+   function Std_Image return String is
+   begin
+      case Flags.Vhdl_Std is
+         when Flags.Vhdl_87 => return "87";
+         when Flags.Vhdl_93 => return "93";
+         when Flags.Vhdl_00 => return "00";
+         when Flags.Vhdl_02 => return "02";
+         when Flags.Vhdl_08 => return "08";
+         when Flags.Vhdl_19 => return "19";
+      end case;
+   end Std_Image;
+
+   --  Canonical net of a signal: follow Collapsed_By to the root.  This
+   --  unifies a port with the actual net it binds to.
+   function Canon_Net (S : Signal_Index_Type) return Signal_Index_Type is
+      R : Signal_Index_Type := S;
+   begin
+      loop
+         exit when Signals_Table.Table (R).Collapsed_By = No_Signal_Index;
+         R := Signals_Table.Table (R).Collapsed_By;
+      end loop;
+      return R;
+   end Canon_Net;
+
+   --  Label of an instantiation/scope statement, or Null.
+   function Stmt_Label (St : Node) return Name_Id is
+   begin
+      if St = Null_Node then
+         return Null_Identifier;
+      end if;
+      case Get_Kind (St) is
+         when Iir_Kind_Component_Instantiation_Statement
+            | Iir_Kind_For_Generate_Statement
+            | Iir_Kind_If_Generate_Statement
+            | Iir_Kind_Case_Generate_Statement
+            | Iir_Kind_Block_Statement =>
+            return Get_Label (St);
+         when others =>
+            return Null_Identifier;
+      end case;
+   end Stmt_Label;
+
+   --  Dotted hierarchical path of an instance ("top.uut").
+   function Inst_Path (Inst : Synth_Instance_Acc) return String is
+   begin
+      if Inst = null then
+         return "";
+      end if;
+      if Inst = Top_Instance then
+         return Top_Name;
+      end if;
+      declare
+         Par : constant Synth_Instance_Acc := Get_Instance_Parent (Inst);
+         Lbl : constant Name_Id :=
+           Stmt_Label (Get_Statement_Scope (Inst));
+         P : constant String := Inst_Path (Par);
+      begin
+         if Lbl = Null_Identifier then
+            return P;
+         elsif P = "" then
+            return Name_Table.Image (Lbl);
+         else
+            return P & "." & Name_Table.Image (Lbl);
+         end if;
+      end;
+   end Inst_Path;
+
+   --  Index of a signal declaration within an instance, or No_Signal_Index.
+   function Find_Signal (Decl : Node; Inst : Synth_Instance_Acc)
+                        return Signal_Index_Type is
+      By_Decl : Signal_Index_Type := No_Signal_Index;
+   begin
+      for I in Signals_Table.First .. Signals_Table.Last loop
+         if Signals_Table.Table (I).Decl = Decl then
+            if Signals_Table.Table (I).Inst = Inst then
+               return I;
+            elsif By_Decl = No_Signal_Index then
+               By_Decl := I;
+            end if;
+         end if;
+      end loop;
+      return By_Decl;
+   end Find_Signal;
+
+   --  Is DEF one of the std edge-detection functions?
+   function Is_Edge_Def (Def : Iir_Predefined_Functions) return Boolean is
+   begin
+      case Def is
+         when Iir_Predefined_Boolean_Rising_Edge
+            | Iir_Predefined_Boolean_Falling_Edge
+            | Iir_Predefined_Bit_Rising_Edge
+            | Iir_Predefined_Bit_Falling_Edge
+            | Iir_Predefined_Ieee_1164_Rising_Edge
+            | Iir_Predefined_Ieee_1164_Falling_Edge =>
+            return True;
+         when others =>
+            return False;
+      end case;
+   end Is_Edge_Def;
+
+   --  If E is an edge expression (rising_edge(clk), clk'event ...) return
+   --  the clock signal declaration, else Null.
+   function Clock_In_Expr (E : Node) return Node is
+   begin
+      if E = Null_Node then
+         return Null_Node;
+      end if;
+      case Get_Kind (E) is
+         when Iir_Kind_Function_Call =>
+            declare
+               Impl : constant Node := Get_Implementation (E);
+            begin
+               if Impl /= Null_Node
+                 and then Is_Edge_Def (Get_Implicit_Definition (Impl))
+               then
+                  declare
+                     Assoc : constant Node :=
+                       Get_Parameter_Association_Chain (E);
+                  begin
+                     if Assoc /= Null_Node then
+                        return Resolve_Obj (Get_Actual (Assoc));
+                     end if;
+                  end;
+               end if;
+            end;
+            return Null_Node;
+         when Iir_Kind_Event_Attribute =>
+            return Resolve_Obj (Get_Prefix (E));
+         when Iir_Kinds_Dyadic_Operator =>
+            declare
+               C : constant Node := Clock_In_Expr (Get_Left (E));
+            begin
+               if C /= Null_Node then
+                  return C;
+               end if;
+               return Clock_In_Expr (Get_Right (E));
+            end;
+         when Iir_Kinds_Monadic_Operator =>
+            return Clock_In_Expr (Get_Operand (E));
+         when Iir_Kind_Parenthesis_Expression =>
+            return Clock_In_Expr (Get_Expression (E));
+         when others =>
+            return Null_Node;
+      end case;
+   end Clock_In_Expr;
+
+   --  Search a process body for an edge clock; return the clock signal
+   --  declaration or Null.
+   function Process_Clock (Chain : Node) return Node is
+      Stmt : Node := Chain;
+      C, R : Node;
+   begin
+      while Stmt /= Null_Node loop
+         case Get_Kind (Stmt) is
+            when Iir_Kind_If_Statement =>
+               declare
+                  Cl : Node := Stmt;
+               begin
+                  while Cl /= Null_Node loop
+                     C := Clock_In_Expr (Get_Condition (Cl));
+                     if C /= Null_Node then
+                        return C;
+                     end if;
+                     R := Process_Clock
+                       (Get_Sequential_Statement_Chain (Cl));
+                     if R /= Null_Node then
+                        return R;
+                     end if;
+                     Cl := Get_Else_Clause (Cl);
+                  end loop;
+               end;
+            when Iir_Kind_Wait_Statement =>
+               C := Clock_In_Expr (Get_Condition_Clause (Stmt));
+               if C /= Null_Node then
+                  return C;
+               end if;
+            when Iir_Kind_Case_Statement =>
+               declare
+                  Alt : Node := Get_Case_Statement_Alternative_Chain (Stmt);
+               begin
+                  while Alt /= Null_Node loop
+                     R := Process_Clock (Get_Associated_Chain (Alt));
+                     if R /= Null_Node then
+                        return R;
+                     end if;
+                     Alt := Get_Chain (Alt);
+                  end loop;
+               end;
+            when Iir_Kind_For_Loop_Statement
+               | Iir_Kind_While_Loop_Statement =>
+               R := Process_Clock (Get_Sequential_Statement_Chain (Stmt));
+               if R /= Null_Node then
+                  return R;
+               end if;
+            when others =>
+               null;
+         end case;
+         Stmt := Get_Chain (Stmt);
+      end loop;
+      return Null_Node;
+   end Process_Clock;
+
+   --  Emit the comma-separated cell (elaborated process/assignment) ids
+   --  that drive (Drivers_Mode) or read a net, aggregated over all the
+   --  signals that collapse into NET.
+   procedure Emit_Net_Procs
+     (F : File_Type; Net : Signal_Index_Type; Drivers_Mode : Boolean)
+   is
+      Fr : Boolean := True;
+      Seen : array (1 .. 8192) of Process_Index_Type :=
+        (others => No_Process_Index);
+      Ns : Natural := 0;
+
+      procedure Add (P : Process_Index_Type) is
+         Dup : Boolean := False;
+      begin
+         if P = No_Process_Index then
+            return;
+         end if;
+         for K in 1 .. Ns loop
+            if Seen (K) = P then
+               Dup := True;
+               exit;
+            end if;
+         end loop;
+         if not Dup then
+            if Ns < Seen'Last then
+               Ns := Ns + 1;
+               Seen (Ns) := P;
+            end if;
+            if not Fr then
+               Put (F, ", ");
+            end if;
+            Fr := False;
+            Put (F, Img (Integer (P)));
+         end if;
+      end Add;
+   begin
+      for J in Signals_Table.First .. Signals_Table.Last loop
+         if Canon_Net (J) = Net then
+            declare
+               Idx : Driver_Index_Type;
+            begin
+               if Drivers_Mode then
+                  if Signals_Table.Table (J).Kind = Signal_User then
+                     Idx := Signals_Table.Table (J).Drivers;
+                  else
+                     Idx := No_Driver_Index;
+                  end if;
+                  while Idx /= No_Driver_Index loop
+                     Add (Drivers_Table.Table (Idx).Proc);
+                     Idx := Drivers_Table.Table (Idx).Prev_Sig;
+                  end loop;
+               else
+                  Idx := Signals_Table.Table (J).Sensitivity;
+                  while Idx /= No_Sensitivity_Index loop
+                     Add (Sensitivity_Table.Table (Idx).Proc);
+                     Idx := Sensitivity_Table.Table (Idx).Prev_Sig;
+                  end loop;
+               end if;
+            end;
+         end if;
+      end loop;
+   end Emit_Net_Procs;
+
+   --  Emit canonical net ids reached by walking a per-process driver or
+   --  sensitivity chain (via Prev_Proc).
+   procedure Emit_Proc_Nets
+     (F : File_Type; Head : Driver_Index_Type; Drivers_Mode : Boolean)
+   is
+      Fr : Boolean := True;
+      Seen : array (1 .. 8192) of Signal_Index_Type :=
+        (others => No_Signal_Index);
+      Ns : Natural := 0;
+      Idx : Driver_Index_Type := Head;
+      Net : Signal_Index_Type;
+      Dup : Boolean;
+   begin
+      while Idx /= No_Driver_Index loop
+         if Drivers_Mode then
+            Net := Canon_Net (Drivers_Table.Table (Idx).Sig.Base);
+         else
+            Net := Canon_Net (Sensitivity_Table.Table (Idx).Sig.Base);
+         end if;
+         Dup := False;
+         for K in 1 .. Ns loop
+            if Seen (K) = Net then
+               Dup := True;
+               exit;
+            end if;
+         end loop;
+         if not Dup then
+            if Ns < Seen'Last then
+               Ns := Ns + 1;
+               Seen (Ns) := Net;
+            end if;
+            if not Fr then
+               Put (F, ", ");
+            end if;
+            Fr := False;
+            Put (F, Img (Integer (Net)));
+         end if;
+         if Drivers_Mode then
+            Idx := Drivers_Table.Table (Idx).Prev_Proc;
+         else
+            Idx := Sensitivity_Table.Table (Idx).Prev_Proc;
+         end if;
+      end loop;
+   end Emit_Proc_Nets;
+
+   procedure Emit_Cells (F : File_Type) is
+      First : Boolean := True;
+   begin
+      for P in Processes_Table.First .. Processes_Table.Last loop
+         declare
+            E : Proc_Record_Type renames Processes_Table.Table (P);
+            Is_Assign : constant Boolean :=
+              Get_Kind (E.Proc) in Iir_Kinds_Concurrent_Signal_Assignment;
+            Clk : Node := Null_Node;
+            Lbl : constant Name_Id := Get_Label (E.Proc);
+         begin
+            if not First then
+               Put (F, ",");
+            end if;
+            First := False;
+            New_Line (F);
+            Put (F, "    {""id"": " & Img (Integer (P)));
+            Put (F, ", ""kind"": ");
+            Put_Str (F, (if Is_Assign then "assign" else "process"));
+            Put (F, ", ""label"": ");
+            if Lbl /= Null_Identifier then
+               Put_Str (F, Name_Table.Image (Lbl));
+            elsif Is_Assign then
+               Put_Str (F, Obj_Name (Get_Target (E.Proc)));
+            else
+               Put (F, "null");
+            end if;
+            Put (F, ", ""path"": ");
+            Put_Str (F, Inst_Path (E.Inst));
+            Put (F, ", ""pos"": ");
+            Put_Pos (F, E.Proc);
+
+            if not Is_Assign then
+               begin
+                  Clk := Process_Clock
+                    (Get_Sequential_Statement_Chain (E.Proc));
+               exception
+                  when others =>
+                     Clk := Null_Node;
+               end;
+            end if;
+            Put (F, ", ""clocked"": ");
+            Put (F, (if Clk /= Null_Node then "true" else "false"));
+            if Clk /= Null_Node then
+               declare
+                  Cn : constant Signal_Index_Type :=
+                    Find_Signal (Clk, E.Inst);
+               begin
+                  if Cn /= No_Signal_Index then
+                     Put (F, ", ""clock_net"": "
+                          & Img (Integer (Canon_Net (Cn))));
+                  end if;
+               end;
+            end if;
+
+            Put (F, ", ""drives"": [");
+            Emit_Proc_Nets (F, E.Drivers, True);
+            Put (F, "], ""reads"": [");
+            Emit_Proc_Nets (F, E.Sensitivity, False);
+            Put (F, "]}");
+         end;
+      end loop;
+   end Emit_Cells;
+
+   procedure Emit_Nets (F : File_Type) is
+      First : Boolean := True;
+      Big : constant Boolean := Natural (Signals_Table.Last) > 20_000;
+   begin
+      for I in Signals_Table.First .. Signals_Table.Last loop
+         declare
+            E : Signal_Entry renames Signals_Table.Table (I);
+         begin
+            if E.Kind = Signal_User
+              and then E.Collapsed_By = No_Signal_Index
+            then
+               if not First then
+                  Put (F, ",");
+               end if;
+               First := False;
+               New_Line (F);
+               Put (F, "    {""id"": " & Img (Integer (I)));
+               Put (F, ", ""name"": ");
+               Put_Str (F, Decl_Ident (E.Decl));
+               Put (F, ", ""path"": ");
+               Put_Str (F, Inst_Path (E.Inst));
+               Put (F, ", ""is_port"": ");
+               Put (F, (if Get_Kind (E.Decl)
+                          = Iir_Kind_Interface_Signal_Declaration
+                        then "true" else "false"));
+
+               Put (F, ", ""aliases"": [");
+               declare
+                  Fr : Boolean := True;
+               begin
+                  for J in Signals_Table.First .. Signals_Table.Last loop
+                     if J /= I
+                       and then Signals_Table.Table (J).Collapsed_By
+                                  /= No_Signal_Index
+                       and then Canon_Net (J) = I
+                     then
+                        declare
+                           Nm : constant String :=
+                             Decl_Ident (Signals_Table.Table (J).Decl);
+                        begin
+                           if Nm /= "" then
+                              if not Fr then
+                                 Put (F, ", ");
+                              end if;
+                              Fr := False;
+                              Put_Str (F, Nm);
+                           end if;
+                        end;
+                     end if;
+                  end loop;
+               end;
+               Put (F, "]");
+
+               if Big then
+                  Put (F, ", ""adjacency"": ""omitted_for_scale""");
+               else
+                  Put (F, ", ""drivers"": [");
+                  Emit_Net_Procs (F, I, True);
+                  Put (F, "], ""loads"": [");
+                  Emit_Net_Procs (F, I, False);
+                  Put (F, "]");
+               end if;
+               Put (F, "}");
+            end if;
+         end;
+      end loop;
+   end Emit_Nets;
+
+   --  ------------------------------------------------------------------
+   --  Top-level dump.
+   --  ------------------------------------------------------------------
+
+   procedure Dump (Filename : String) is
+      F : File_Type;
+      Lib : Iir;
+      File : Iir;
+      Unit : Iir;
+      LU : Iir;
+      Mod_First : Boolean := True;
+   begin
+      N_Files := 0;
+      Create (F, Out_File, Filename);
+
+      Put_Line (F, "{");
+      Put_Line (F, "  ""schema"": ""flowtracer1.merged.v0"",");
+      Put_Line
+        (F, "  ""generated_by"": ""ghdl --flow (native)"",");
+      Put (F, "  ""ghdl"": {""version"": ");
+      Put_Str (F, Version.Ghdl_Ver);
+      Put (F, ", ""hash"": ");
+      Put_Str (F, Version.Ghdl_Hash);
+      Put (F, ", ""std"": ");
+      Put_Str (F, Std_Image);
+      Put_Line (F, "},");
+      Put_Line (F, "  ""lang"": ""vhdl"",");
+      Put_Line (F, "  ""elaborated"": true,");
+      Put_Line (F, "  ""hierarchy_prov"": ""elaborated"",");
+      Put_Line (F, "  ""applied_fallbacks"": [],");
+      Put (F, "  ""top"": ");
+      declare
+         T : constant String := Top_Name;
+      begin
+         if T = "" then
+            Put (F, "null");
+         else
+            Put_Str (F, T);
+         end if;
+      end;
+      Put_Line (F, ",");
+
+      Put (F, "  ""modules"": [");
+      Lib := Libraries.Get_Libraries_Chain;
+      while Lib /= Null_Iir loop
+         declare
+            Lib_Name : constant String :=
+              Name_Table.Image (Get_Identifier (Lib));
+         begin
+            if Lib_Name /= "std" and then Lib_Name /= "ieee" then
+               File := Get_Design_File_Chain (Lib);
+               while File /= Null_Iir loop
+                  Unit := Get_First_Design_Unit (File);
+                  while Unit /= Null_Iir loop
+                     LU := Get_Library_Unit (Unit);
+                     if LU /= Null_Iir
+                       and then Get_Kind (LU) = Iir_Kind_Architecture_Body
+                     then
+                        if not Mod_First then
+                           Put (F, ",");
+                        end if;
+                        Mod_First := False;
+                        New_Line (F);
+                        Emit_Module (F, LU);
+                     end if;
+                     Unit := Get_Chain (Unit);
+                  end loop;
+                  File := Get_Chain (File);
+               end loop;
+            end if;
+         end;
+         Lib := Get_Chain (Lib);
+      end loop;
+      New_Line (F);
+      Put_Line (F, "  ],");
+
+      Put_Line (F, "  ""packages"": [],");
+
+      Put (F, "  ""hierarchy"": [");
+      if Top_Instance /= null then
+         declare
+            Hf : Boolean := True;
+         begin
+            New_Line (F);
+            Put (F, "    ");
+            Emit_Instance_Node (F, Top_Instance, Null_Node, Hf);
+            New_Line (F);
+            Put (F, "  ");
+         end;
+      end if;
+      Put_Line (F, "],");
+
+      Put (F, "  ""nets"": [");
+      Emit_Nets (F);
+      New_Line (F);
+      Put_Line (F, "  ],");
+
+      Put (F, "  ""cells"": [");
+      Emit_Cells (F);
+      New_Line (F);
+      Put_Line (F, "  ],");
+
+      Put (F, "  ""files"": [");
+      for K in 1 .. N_Files loop
+         if K > 1 then
+            Put (F, ", ");
+         end if;
+         Put_Str (F, Name_Table.Image (Files_Seen (K)));
+      end loop;
+      Put_Line (F, "]");
+
+      Put_Line (F, "}");
+      Close (F);
+   end Dump;
+end Simul.Flow;

--- a/src/simul/simul-flow.adb
+++ b/src/simul/simul-flow.adb
@@ -53,6 +53,17 @@ package body Simul.Flow is
       end if;
    end Img;
 
+   --  Int64 image without the leading space of 'Image.
+   function Img64 (N : Int64) return String is
+      S : constant String := Int64'Image (N);
+   begin
+      if S (S'First) = ' ' then
+         return S (S'First + 1 .. S'Last);
+      else
+         return S;
+      end if;
+   end Img64;
+
    function Hex1 (V : Natural) return Character is
       H : constant String := "0123456789abcdef";
    begin
@@ -1055,6 +1066,49 @@ package body Simul.Flow is
      (F : File_Type; Inst : Synth_Instance_Acc; Kind : String;
       Label : Name_Id; Index : Natural; First : in out Boolean);
 
+   --  Emit the resolved generics of an instance: {name, type, value}
+   --  with the elaborated discrete value when available.
+   procedure Emit_Resolved_Generics
+     (F : File_Type; Ent : Node; Inst : Synth_Instance_Acc)
+   is
+      Gen : Node;
+      First : Boolean := True;
+   begin
+      if Ent = Null_Node or else Inst = null then
+         return;
+      end if;
+      Gen := Get_Generic_Chain (Ent);
+      while Gen /= Null_Node loop
+         if Get_Kind (Gen) = Iir_Kind_Interface_Constant_Declaration then
+            declare
+               Has_Val : Boolean := False;
+               V : Int64 := 0;
+            begin
+               begin
+                  V := Read_Discrete (Get_Value (Inst, Gen));
+                  Has_Val := True;
+               exception
+                  when others =>
+                     Has_Val := False;
+               end;
+               if not First then
+                  Put (F, ", ");
+               end if;
+               First := False;
+               Put (F, "{""name"": ");
+               Put_Str (F, Name_Table.Image (Get_Identifier (Gen)));
+               Put (F, ", ""type"": ");
+               Put_Str (F, Type_Image (Gen));
+               if Has_Val then
+                  Put (F, ", ""value"": " & Img64 (V));
+               end if;
+               Put (F, "}");
+            end;
+         end if;
+         Gen := Get_Chain (Gen);
+      end loop;
+   end Emit_Resolved_Generics;
+
    procedure Emit_Instance_Node
      (F : File_Type; Inst : Synth_Instance_Acc; Stmt : Node;
       First : in out Boolean)
@@ -1063,9 +1117,17 @@ package body Simul.Flow is
       Arch_Name : Name_Id;
       Body_Inst : Synth_Instance_Acc;
       Lbl : Name_Id;
+      Ent : Node := Null_Node;
+      Scope : Node;
       Cf : Boolean := True;
    begin
       Inst_Module_Arch (Inst, Mod_Name, Arch_Name, Body_Inst);
+      Scope := Get_Source_Scope (Body_Inst);
+      if Scope /= Null_Node
+        and then Get_Kind (Scope) = Iir_Kind_Architecture_Body
+      then
+         Ent := Vhdl.Utils.Get_Entity (Scope);
+      end if;
       if Stmt /= Null_Node then
          Lbl := Get_Label (Stmt);
       else
@@ -1093,8 +1155,9 @@ package body Simul.Flow is
       else
          Put_Pos (F, Get_Source_Scope (Body_Inst));
       end if;
-      Put (F, ", ""generics"": []");
-      Put (F, ", ""generic_map"": [");
+      Put (F, ", ""generics"": [");
+      Emit_Resolved_Generics (F, Ent, Body_Inst);
+      Put (F, "], ""generic_map"": [");
       if Stmt /= Null_Node then
          Emit_Map (F, Get_Generic_Map_Aspect_Chain (Stmt));
       end if;

--- a/src/simul/simul-flow.adb
+++ b/src/simul/simul-flow.adb
@@ -23,6 +23,7 @@ with Name_Table;
 with Files_Map;
 
 with Vhdl.Nodes; use Vhdl.Nodes;
+with Vhdl.Elocations; use Vhdl.Elocations;
 with Vhdl.Utils;
 with Vhdl.Canon;
 
@@ -142,27 +143,253 @@ package body Simul.Flow is
       return Name_Table.Image (Fid);
    end Node_File;
 
-   --  Emit a {"off","line","col"} position object for node N.
-   procedure Put_Pos (F : File_Type; N : Iir) is
-      Loc : Location_Type;
+   --  The 0-based byte offset of a location within its file, as a string
+   --  ("" for No_Location).  Registers the file as a side effect.
+   function Off_Img (Loc : Location_Type) return String is
       Fid : Name_Id;
       Line : Positive;
       Col : Natural;
+      Sf : Source_File_Entry;
+      Pos : Source_Ptr;
    begin
-      if N = Null_Iir then
-         Put (F, "{""off"": 0, ""line"": 0, ""col"": 0}");
-         return;
-      end if;
-      Loc := Get_Location (N);
       if Loc = No_Location then
-         Put (F, "{""off"": 0, ""line"": 0, ""col"": 0}");
-         return;
+         return "";
       end if;
       Files_Map.Location_To_Position (Loc, Fid, Line, Col);
+      Files_Map.Location_To_File_Pos (Loc, Sf, Pos);
       Note_File (Fid);
-      Put (F, "{""off"": 0, ""line"": " & Img (Line)
-           & ", ""col"": " & Img (Col) & "}");
+      return Img (Integer (Pos));
+   end Off_Img;
+
+   --  Emit a position as the compact string "start:begin:end" of byte
+   --  offsets.  Missing parts are left empty: a plain point is "S::",
+   --  a span with no 'begin' keyword is "S::E".
+   procedure Put_Pos3
+     (F : File_Type; Start_Loc, Begin_Loc, End_Loc : Location_Type) is
+   begin
+      Put (F, '"');
+      Put (F, Off_Img (Start_Loc) & ":"
+           & Off_Img (Begin_Loc) & ":" & Off_Img (End_Loc));
+      Put (F, '"');
+   end Put_Pos3;
+
+   --  Emit the position of node N as a plain point "off::".
+   procedure Put_Pos (F : File_Type; N : Iir) is
+   begin
+      if N = Null_Iir then
+         Put (F, """::""");
+         return;
+      end if;
+      Put_Pos3 (F, Get_Location (N), No_Location, No_Location);
    end Put_Pos;
+
+   --  Safe extended-location reads: return No_Location when N has no
+   --  elocations (canon-synthesized processes, etc.), so the begin/end
+   --  span emitters omit the field instead of reading a garbage slot.
+   function E_Begin (N : Iir) return Location_Type is
+   begin
+      if N /= Null_Iir and then Has_Elocations (N) then
+         return Get_Begin_Location (N);
+      end if;
+      return No_Location;
+   end E_Begin;
+
+   function E_End (N : Iir) return Location_Type is
+   begin
+      if N /= Null_Iir and then Has_Elocations (N) then
+         return Get_End_Location (N);
+      end if;
+      return No_Location;
+   end E_End;
+
+   function E_Start (N : Iir) return Location_Type is
+   begin
+      if N /= Null_Iir and then Has_Elocations (N) then
+         return Get_Start_Location (N);
+      end if;
+      return No_Location;
+   end E_Start;
+
+   --  Component/entity instantiation statements carry no end location,
+   --  so locate their terminating ';' by scanning the source buffer from
+   --  the statement start, skipping comments, string/char literals and
+   --  parenthesised (generic/port map) regions.  Returns the location of
+   --  the ';' (No_Location if not found / no source).
+   function Stmt_Semicolon_Loc (N : Iir) return Location_Type is
+      Loc : constant Location_Type := Get_Location (N);
+      Sf : Source_File_Entry;
+      Pos : Source_Ptr;
+      Buf : File_Buffer_Acc;
+      Len : Source_Ptr;
+      Depth : Integer := 0;
+   begin
+      if Loc = No_Location then
+         return No_Location;
+      end if;
+      Files_Map.Location_To_File_Pos (Loc, Sf, Pos);
+      Buf := Files_Map.Get_File_Source (Sf);
+      Len := Files_Map.Get_File_Length (Sf);
+      while Pos < Len loop
+         case Buf (Pos) is
+            when '-' =>
+               if Pos + 1 < Len and then Buf (Pos + 1) = '-' then
+                  while Pos < Len and then Buf (Pos) /= ASCII.LF loop
+                     Pos := Pos + 1;
+                  end loop;
+               else
+                  Pos := Pos + 1;
+               end if;
+            when '"' =>
+               Pos := Pos + 1;
+               while Pos < Len and then Buf (Pos) /= '"' loop
+                  Pos := Pos + 1;
+               end loop;
+               Pos := Pos + 1;
+            when ''' =>
+               --  Character literal 'x' (tick-quote-tick); anything else
+               --  (e.g. an attribute tick) is just advanced over.
+               if Pos + 2 < Len and then Buf (Pos + 2) = ''' then
+                  Pos := Pos + 3;
+               else
+                  Pos := Pos + 1;
+               end if;
+            when '(' =>
+               Depth := Depth + 1;
+               Pos := Pos + 1;
+            when ')' =>
+               Depth := Depth - 1;
+               Pos := Pos + 1;
+            when ';' =>
+               if Depth <= 0 then
+                  return Files_Map.File_Pos_To_Location (Sf, Pos);
+               end if;
+               Pos := Pos + 1;
+            when others =>
+               Pos := Pos + 1;
+         end case;
+      end loop;
+      return No_Location;
+   exception
+      when others =>
+         return No_Location;
+   end Stmt_Semicolon_Loc;
+
+   --  Span-end of a statement: its 'end' location when available, else
+   --  the terminating ';' (for canon-synthesized processes built from a
+   --  single concurrent assignment, which have no end location).
+   function Stmt_Span_End (N : Iir) return Location_Type is
+      L : constant Location_Type := E_End (N);
+   begin
+      if L /= No_Location then
+         return L;
+      end if;
+      return Stmt_Semicolon_Loc (N);
+   end Stmt_Span_End;
+
+   --  Flatten a (possibly selected) name into its dotted source form,
+   --  e.g. "ieee.std_logic_1164.all".
+   function Flatten_Name (N : Iir) return String is
+   begin
+      if N = Null_Iir then
+         return "";
+      end if;
+      case Get_Kind (N) is
+         when Iir_Kind_Simple_Name
+            | Iir_Kind_Character_Literal =>
+            return Name_Table.Image (Get_Identifier (N));
+         when Iir_Kind_Selected_Name =>
+            declare
+               P : constant String := Flatten_Name (Get_Prefix (N));
+               S : constant String :=
+                 Name_Table.Image (Get_Identifier (N));
+            begin
+               if P = "" then
+                  return S;
+               else
+                  return P & "." & S;
+               end if;
+            end;
+         when Iir_Kind_Selected_By_All_Name =>
+            declare
+               P : constant String := Flatten_Name (Get_Prefix (N));
+            begin
+               if P = "" then
+                  return "all";
+               else
+                  return P & ".all";
+               end if;
+            end;
+         when others =>
+            return "";
+      end case;
+   end Flatten_Name;
+
+   --  Emit  "libraries": [...], "uses": [{name,pos}, ...],  recording the
+   --  package/library linkage of a single design unit (entity OR
+   --  architecture) from the context clauses that precede it in the source.
+   procedure Emit_Context (F : File_Type; Unit : Iir) is
+      Lib_First : Boolean := True;
+      Use_First : Boolean := True;
+      DU : constant Iir :=
+        (if Unit = Null_Iir then Null_Iir else Get_Design_Unit (Unit));
+      It : Iir;
+      UC : Iir;
+   begin
+      Put (F, "      ""libraries"": [");
+      if DU /= Null_Iir then
+         It := Get_Context_Items (DU);
+         while It /= Null_Iir loop
+            if Get_Kind (It) = Iir_Kind_Library_Clause then
+               declare
+                  Id : constant Name_Id := Get_Identifier (It);
+               begin
+                  if Id /= Null_Identifier then
+                     if not Lib_First then
+                        Put (F, ", ");
+                     end if;
+                     Lib_First := False;
+                     Put_Str (F, Name_Table.Image (Id));
+                  end if;
+               end;
+            end if;
+            It := Get_Chain (It);
+         end loop;
+      end if;
+      Put (F, "],");
+      New_Line (F);
+
+      Put (F, "      ""uses"": [");
+      if DU /= Null_Iir then
+         It := Get_Context_Items (DU);
+         while It /= Null_Iir loop
+            if Get_Kind (It) = Iir_Kind_Use_Clause then
+               UC := It;
+               while UC /= Null_Iir loop
+                  declare
+                     S : constant String :=
+                       Flatten_Name (Get_Selected_Name (UC));
+                  begin
+                     if S /= "" then
+                        if not Use_First then
+                           Put (F, ", ");
+                        end if;
+                        Use_First := False;
+                        Put (F, "{""name"": ");
+                        Put_Str (F, S);
+                        Put (F, ", ""pos"": ");
+                        Put_Pos (F, UC);
+                        Put (F, "}");
+                     end if;
+                  end;
+                  UC := Get_Use_Clause_Chain (UC);
+               end loop;
+            end if;
+            It := Get_Chain (It);
+         end loop;
+      end if;
+      Put (F, "],");
+      New_Line (F);
+   end Emit_Context;
 
    --  ------------------------------------------------------------------
    --  Name / type resolution.
@@ -582,8 +809,10 @@ package body Simul.Flow is
       else
          Put_Str (F, Name_Table.Image (Lbl));
       end if;
+      --  pos = "start:begin:end": process keyword : 'begin' (end of the
+      --  declarative part) : 'end process;'.
       Put (F, ", ""pos"": ");
-      Put_Pos (F, Proc);
+      Put_Pos3 (F, Get_Location (Proc), E_Begin (Proc), Stmt_Span_End (Proc));
 
       Put (F, ", ""sensitivity"": ");
       if Get_Kind (Proc) = Iir_Kind_Sensitized_Process_Statement then
@@ -641,7 +870,7 @@ package body Simul.Flow is
       Put (F, "{""target"": ");
       Put_Str (F, Obj_Name (Get_Target (Stmt)));
       Put (F, ", ""pos"": ");
-      Put_Pos (F, Stmt);
+      Put_Pos3 (F, Get_Location (Stmt), No_Location, Stmt_Span_End (Stmt));
 
       begin
          case Get_Kind (Stmt) is
@@ -837,7 +1066,7 @@ package body Simul.Flow is
       else
          Put_Str (F, Name_Table.Image (Lbl));
       end if;
-      Put (F, ", ""module"": ");
+      Put (F, ", ""entity"": ");
       if Mod_Name = Null_Identifier then
          Put_Str (F, "");
       else
@@ -849,8 +1078,12 @@ package body Simul.Flow is
       end if;
       Put (F, ", ""is_entity_inst"": ");
       Put (F, (if Is_Entity then "true" else "false"));
+      --  pos = "start::end": instantiation label .. terminating ';'
+      --  (instantiations have no 'begin' and carry no end location, so
+      --  the ';' is scanned from the source buffer).
       Put (F, ", ""pos"": ");
-      Put_Pos (F, Stmt);
+      Put_Pos3 (F, Get_Location (Stmt), No_Location,
+                Stmt_Semicolon_Loc (Stmt));
       Put (F, ", ""generic_map"": [");
       Emit_Map (F, Get_Generic_Map_Aspect_Chain (Stmt));
       Put (F, "], ""port_map"": [");
@@ -1019,42 +1252,58 @@ package body Simul.Flow is
    end Emit_Signals;
 
    --  ------------------------------------------------------------------
-   --  Module emission (one per architecture body).
+   --  Unit emission: entities[] and architectures[] (kept separate, as
+   --  they are distinct VHDL library units with their own source spans
+   --  and context clauses).
    --  ------------------------------------------------------------------
 
-   procedure Emit_Module (F : File_Type; Arch : Iir) is
-      Ent : constant Iir :=
-        Get_Named_Entity (Get_Entity_Name (Arch));
+   --  One entry in entities[]: ports, generics and the entity's own
+   --  context clause.  pos = "start:begin:end" of the entity declaration
+   --  (a 'begin' only when the entity has a passive statement part).
+   procedure Emit_Entity (F : File_Type; Ent : Iir) is
+   begin
+      Put (F, "    {""name"": ");
+      Put_Str (F, Name_Table.Image (Get_Identifier (Ent)));
+      Put (F, ", ""file"": ");
+      Put_Str (F, Node_File (Ent));
+      Put (F, ", ""pos"": ");
+      Put_Pos3 (F, E_Start (Ent), E_Begin (Ent), E_End (Ent));
+      Put (F, ",");
+      New_Line (F);
+      Emit_Context (F, Ent);
+      Put (F, "      ""generics"": [");
+      Emit_Generics (F, Ent);
+      Put (F, "],");
+      New_Line (F);
+      Put (F, "      ""ports"": [");
+      Emit_Ports (F, Ent);
+      Put (F, "]}");
+   end Emit_Entity;
+
+   --  One entry in architectures[]: signals/constants and the concurrent
+   --  body (processes, assignments, instances), plus a back-reference to
+   --  its entity and the architecture's own context clause.
+   --  pos = "start:begin:end" of "architecture .. begin .. end;".
+   procedure Emit_Architecture (F : File_Type; Arch : Iir) is
+      Ent : constant Iir := Get_Named_Entity (Get_Entity_Name (Arch));
       Chain : constant Iir := Get_Concurrent_Statement_Chain (Arch);
       First : Boolean;
    begin
       Put (F, "    {""name"": ");
+      Put_Str (F, Name_Table.Image (Get_Identifier (Arch)));
+      Put (F, ", ""entity"": ");
       if Ent /= Null_Iir then
          Put_Str (F, Name_Table.Image (Get_Identifier (Ent)));
       else
          Put_Str (F, "");
       end if;
-      Put (F, ", ""kind"": ");
-      Put_Str (F, "entity");
-      Put (F, ", ""lang"": ");
-      Put_Str (F, "vhdl");
       Put (F, ", ""file"": ");
       Put_Str (F, Node_File (Arch));
       Put (F, ", ""pos"": ");
-      Put_Pos (F, Arch);
-      Put (F, ", ""arch"": ");
-      Put_Str (F, Name_Table.Image (Get_Identifier (Arch)));
+      Put_Pos3 (F, E_Start (Arch), E_Begin (Arch), E_End (Arch));
       Put (F, ",");
-
       New_Line (F);
-      Put (F, "      ""ports"": [");
-      Emit_Ports (F, Ent);
-      Put (F, "],");
-      New_Line (F);
-      Put (F, "      ""generics"": [");
-      Emit_Generics (F, Ent);
-      Put (F, "],");
-      New_Line (F);
+      Emit_Context (F, Arch);
       Put (F, "      ""signals"": [");
       Emit_Signals (F, Arch);
       Put (F, "],");
@@ -1083,7 +1332,7 @@ package body Simul.Flow is
       First := True;
       Walk_Instances (F, Chain, First);
       Put (F, "]}");
-   end Emit_Module;
+   end Emit_Architecture;
 
    --  ------------------------------------------------------------------
    --  Elaborated hierarchy (hierarchy[] from the instance tree).
@@ -1174,7 +1423,7 @@ package body Simul.Flow is
      (F : File_Type; Inst : Synth_Instance_Acc; Stmt : Node;
       First : in out Boolean);
    procedure Emit_Frame_Node
-     (F : File_Type; Inst : Synth_Instance_Acc; Kind : String;
+     (F : File_Type; Inst : Synth_Instance_Acc; Stmt : Node; Kind : String;
       Label : Name_Id; Index : Natural; First : in out Boolean);
 
    --  Emit the resolved generics of an instance: {name, type, value}
@@ -1252,7 +1501,7 @@ package body Simul.Flow is
 
       Put (F, "{""name"": ");
       Put_Name (F, Lbl);
-      Put (F, ", ""module"": ");
+      Put (F, ", ""entity"": ");
       Put_Name (F, Mod_Name);
       if Arch_Name /= Null_Identifier then
          Put (F, ", ""arch"": ");
@@ -1262,7 +1511,8 @@ package body Simul.Flow is
       Put_Name (F, Lbl);
       Put (F, ", ""inst_pos"": ");
       if Stmt /= Null_Node then
-         Put_Pos (F, Stmt);
+         Put_Pos3 (F, Get_Location (Stmt), No_Location,
+                   Stmt_Semicolon_Loc (Stmt));
       else
          Put_Pos (F, Get_Source_Scope (Body_Inst));
       end if;
@@ -1282,10 +1532,11 @@ package body Simul.Flow is
    end Emit_Instance_Node;
 
    procedure Emit_Frame_Node
-     (F : File_Type; Inst : Synth_Instance_Acc; Kind : String;
+     (F : File_Type; Inst : Synth_Instance_Acc; Stmt : Node; Kind : String;
       Label : Name_Id; Index : Natural; First : in out Boolean)
    is
       Cf : Boolean := True;
+      Scope : constant Node := Get_Source_Scope (Inst);
    begin
       if not First then
          Put (F, ", ");
@@ -1297,6 +1548,21 @@ package body Simul.Flow is
          Put_Str (F, Name_Table.Image (Label) & "(" & Img (Index) & ")");
       else
          Put_Name (F, Label);
+      end if;
+      --  pos = "start:begin:end" of the frame.  For generates the span
+      --  lives on the generate statement (Generate_Location is the
+      --  'generate' keyword that opens the body); blocks carry begin/end
+      --  on the block statement scope itself.
+      Put (F, ", ""pos"": ");
+      if Stmt /= Null_Node
+        and then Has_Elocations (Stmt)
+        and then (Get_Kind (Stmt) = Iir_Kind_For_Generate_Statement
+                  or else Get_Kind (Stmt) = Iir_Kind_If_Generate_Statement)
+      then
+         Put_Pos3 (F, Get_Start_Location (Stmt),
+                   Get_Generate_Location (Stmt), Get_End_Location (Stmt));
+      else
+         Put_Pos3 (F, E_Start (Scope), E_Begin (Scope), E_End (Scope));
       end if;
       Put (F, ", ""scope"": true, ""generate"": {""kind"": ");
       Put_Str (F, Kind);
@@ -1356,8 +1622,8 @@ package body Simul.Flow is
                                  Idx := I - 1;
                            end;
                            Emit_Frame_Node
-                             (F, GBody, "for", Get_Label (Stmt), Idx,
-                              First);
+                             (F, GBody, Stmt, "for", Get_Label (Stmt),
+                              Idx, First);
                         end;
                      end loop;
                   end;
@@ -1373,7 +1639,7 @@ package body Simul.Flow is
                begin
                   if Sub /= null then
                      Emit_Frame_Node
-                       (F, Sub, "if", Get_Label (Stmt), 0, First);
+                       (F, Sub, Stmt, "if", Get_Label (Stmt), 0, First);
                   end if;
                end;
             when Iir_Kind_Block_Statement =>
@@ -1383,7 +1649,7 @@ package body Simul.Flow is
                begin
                   if Sub /= null then
                      Emit_Frame_Node
-                       (F, Sub, "block", Get_Label (Stmt), 0, First);
+                       (F, Sub, Stmt, "block", Get_Label (Stmt), 0, First);
                   end if;
                end;
             when others =>
@@ -1761,8 +2027,16 @@ package body Simul.Flow is
             end if;
             Put (F, ", ""path"": ");
             Put_Str (F, Inst_Path (E.Inst));
+            --  pos = "start:begin:end" (same as the source process); a
+            --  concurrent assignment has no 'begin'.
             Put (F, ", ""pos"": ");
-            Put_Pos (F, E.Proc);
+            if Is_Assign then
+               Put_Pos3 (F, Get_Location (E.Proc), No_Location,
+                         Stmt_Span_End (E.Proc));
+            else
+               Put_Pos3 (F, Get_Location (E.Proc), E_Begin (E.Proc),
+                         Stmt_Span_End (E.Proc));
+            end if;
 
             if not Is_Assign then
                begin
@@ -1898,7 +2172,7 @@ package body Simul.Flow is
                         Put (F, ", ""file"": ");
                         Put_Str (F, Node_File (LU));
                         Put (F, ", ""pos"": ");
-                        Put_Pos (F, LU);
+                        Put_Pos3 (F, E_Start (LU), No_Location, E_End (LU));
                         Put (F, ", ""constants"": [");
                         Emit_Constant_Decls
                           (F, Get_Declaration_Chain (LU));
@@ -1926,7 +2200,7 @@ package body Simul.Flow is
       Create (F, Out_File, Filename);
 
       Put_Line (F, "{");
-      Put_Line (F, "  ""schema"": ""flowtracer1.merged.v0"",");
+      Put_Line (F, "  ""schema"": ""flowtracer1.vhdl.v0"",");
       Put_Line
         (F, "  ""generated_by"": ""ghdl --flow (native)"",");
       Put (F, "  ""ghdl"": {""version"": ");
@@ -1952,7 +2226,46 @@ package body Simul.Flow is
       end;
       Put_Line (F, ",");
 
-      Put (F, "  ""modules"": [");
+      --  entities[]: one per entity declaration in the work/user libs.
+      Put (F, "  ""entities"": [");
+      Lib := Libraries.Get_Libraries_Chain;
+      while Lib /= Null_Iir loop
+         declare
+            Lib_Name : constant String :=
+              Name_Table.Image (Get_Identifier (Lib));
+         begin
+            if Lib_Name /= "std" and then Lib_Name /= "ieee" then
+               File := Get_Design_File_Chain (Lib);
+               while File /= Null_Iir loop
+                  Unit := Get_First_Design_Unit (File);
+                  while Unit /= Null_Iir loop
+                     LU := Get_Library_Unit (Unit);
+                     if LU /= Null_Iir
+                       and then Get_Kind (LU) = Iir_Kind_Entity_Declaration
+                     then
+                        if not Mod_First then
+                           Put (F, ",");
+                        end if;
+                        Mod_First := False;
+                        New_Line (F);
+                        Emit_Entity (F, LU);
+                     end if;
+                     Unit := Get_Chain (Unit);
+                  end loop;
+                  File := Get_Chain (File);
+               end loop;
+            end if;
+         end;
+         Lib := Get_Chain (Lib);
+      end loop;
+      New_Line (F);
+      Put_Line (F, "  ],");
+
+      --  architectures[]: one per architecture body whose entity resolves
+      --  (others are units present in the library but not loaded for this
+      --  top, which would otherwise emit empty entries).
+      Put (F, "  ""architectures"": [");
+      Mod_First := True;
       Lib := Libraries.Get_Libraries_Chain;
       while Lib /= Null_Iir loop
          declare
@@ -1967,13 +2280,15 @@ package body Simul.Flow is
                      LU := Get_Library_Unit (Unit);
                      if LU /= Null_Iir
                        and then Get_Kind (LU) = Iir_Kind_Architecture_Body
+                       and then Get_Named_Entity (Get_Entity_Name (LU))
+                                  /= Null_Iir
                      then
                         if not Mod_First then
                            Put (F, ",");
                         end if;
                         Mod_First := False;
                         New_Line (F);
-                        Emit_Module (F, LU);
+                        Emit_Architecture (F, LU);
                      end if;
                      Unit := Get_Chain (Unit);
                   end loop;

--- a/src/simul/simul-flow.adb
+++ b/src/simul/simul-flow.adb
@@ -1230,9 +1230,24 @@ package body Simul.Flow is
                        Get_Sub_Instance (Inst, Stmt);
                   begin
                      for I in 1 .. Len loop
-                        Emit_Frame_Node
-                          (F, Get_Generate_Sub_Instance (Gen_Inst, I),
-                           "for", Get_Label (Stmt), I, First);
+                        declare
+                           GBody : constant Synth_Instance_Acc :=
+                             Get_Generate_Sub_Instance (Gen_Inst, I);
+                           --  The actual VHDL loop value (e.g. 0..N-1),
+                           --  not the 1-based iteration ordinal.
+                           Idx : Integer := I - 1;
+                        begin
+                           begin
+                              Idx := Integer
+                                (Read_Discrete (Get_Value (GBody, It)));
+                           exception
+                              when others =>
+                                 Idx := I - 1;
+                           end;
+                           Emit_Frame_Node
+                             (F, GBody, "for", Get_Label (Stmt), Idx,
+                              First);
+                        end;
                      end loop;
                   end;
                exception

--- a/src/simul/simul-flow.adb
+++ b/src/simul/simul-flow.adb
@@ -236,6 +236,83 @@ package body Simul.Flow is
    end Obj_Name;
 
    --  Best-effort printable type name of a declaration's subtype.
+   --  Image of a static integer-literal expression, or "".
+   function Int_Expr_Image (E : Node) return String is
+   begin
+      if E /= Null_Node
+        and then Get_Kind (E) = Iir_Kind_Integer_Literal
+      then
+         return Img64 (Get_Value (E));
+      end if;
+      return "";
+   end Int_Expr_Image;
+
+   --  "L downto R" / "L to R" from a range expression, or "".
+   function Range_Image (Rng : Node) return String is
+   begin
+      if Rng = Null_Node
+        or else Get_Kind (Rng) /= Iir_Kind_Range_Expression
+      then
+         return "";
+      end if;
+      declare
+         L : constant String := Int_Expr_Image (Get_Left_Limit (Rng));
+         R : constant String := Int_Expr_Image (Get_Right_Limit (Rng));
+      begin
+         if L = "" or else R = "" then
+            return "";
+         end if;
+         if Get_Direction (Rng) = Dir_Downto then
+            return L & " downto " & R;
+         else
+            return L & " to " & R;
+         end if;
+      end;
+   end Range_Image;
+
+   --  The range node of an index-constraint element (a range expression
+   --  or an index subtype carrying a range constraint).
+   function Element_Range (E : Node) return Node is
+   begin
+      if E = Null_Node then
+         return Null_Node;
+      end if;
+      if Get_Kind (E) = Iir_Kind_Range_Expression then
+         return E;
+      end if;
+      begin
+         return Get_Range_Constraint (E);
+      exception
+         when others =>
+            return Null_Node;
+      end;
+   end Element_Range;
+
+   --  "(3 downto 0)" for a single-index constrained array subtype, else
+   --  "" (multi-dimensional or non-static constraints are skipped).
+   function Index_Constraint_Image (Ind : Node) return String is
+      Lst : Iir_Flist;
+   begin
+      begin
+         Lst := Get_Index_Constraint_List (Ind);
+      exception
+         when others =>
+            return "";
+      end;
+      if Lst = Null_Iir_Flist or else Flist_Last (Lst) /= 0 then
+         return "";
+      end if;
+      declare
+         R : constant String :=
+           Range_Image (Element_Range (Get_Nth_Element (Lst, 0)));
+      begin
+         if R = "" then
+            return "";
+         end if;
+         return "(" & R & ")";
+      end;
+   end Index_Constraint_Image;
+
    function Type_Image (Decl : Iir) return String is
       Ind : constant Iir := Get_Subtype_Indication (Decl);
       T, D, B : Iir;
@@ -262,7 +339,7 @@ package body Simul.Flow is
                           Decl_Ident (Resolve_Obj (TM));
                      begin
                         if Nm /= "" then
-                           return Nm;
+                           return Nm & Index_Constraint_Image (Ind);
                         end if;
                      end;
                   end if;
@@ -884,6 +961,38 @@ package body Simul.Flow is
       end loop;
    end Emit_Generics;
 
+   --  Emit constant declarations from a declaration chain, with the
+   --  static integer value when the default expression is a literal.
+   procedure Emit_Constant_Decls (F : File_Type; Chain : Node) is
+      Decl : Node := Chain;
+      First : Boolean := True;
+   begin
+      while Decl /= Null_Node loop
+         if Get_Kind (Decl) = Iir_Kind_Constant_Declaration then
+            if not First then
+               Put (F, ", ");
+            end if;
+            First := False;
+            Put (F, "{""name"": ");
+            Put_Str (F, Name_Table.Image (Get_Identifier (Decl)));
+            Put (F, ", ""type"": ");
+            Put_Str (F, Type_Image (Decl));
+            declare
+               IV : constant String :=
+                 Int_Expr_Image (Get_Default_Value (Decl));
+            begin
+               if IV /= "" then
+                  Put (F, ", ""value"": " & IV);
+               end if;
+            end;
+            Put (F, ", ""pos"": ");
+            Put_Pos (F, Decl);
+            Put (F, "}");
+         end if;
+         Decl := Get_Chain (Decl);
+      end loop;
+   end Emit_Constant_Decls;
+
    procedure Emit_Signals (F : File_Type; Arch : Iir) is
       Decl : Iir;
       First : Boolean := True;
@@ -950,7 +1059,9 @@ package body Simul.Flow is
       Emit_Signals (F, Arch);
       Put (F, "],");
       New_Line (F);
-      Put (F, "      ""constants"": [],");
+      Put (F, "      ""constants"": [");
+      Emit_Constant_Decls (F, Get_Declaration_Chain (Arch));
+      Put (F, "],");
       New_Line (F);
 
       Put (F, "      ""processes"": [");
@@ -1757,6 +1868,52 @@ package body Simul.Flow is
    --  Top-level dump.
    --  ------------------------------------------------------------------
 
+   --  Emit packages[] (work/user libraries only) with their constants.
+   procedure Emit_Packages (F : File_Type) is
+      First : Boolean := True;
+      Lib, File, Unit, LU : Node;
+   begin
+      Lib := Libraries.Get_Libraries_Chain;
+      while Lib /= Null_Node loop
+         declare
+            Lib_Name : constant String :=
+              Name_Table.Image (Get_Identifier (Lib));
+         begin
+            if Lib_Name /= "std" and then Lib_Name /= "ieee" then
+               File := Get_Design_File_Chain (Lib);
+               while File /= Null_Node loop
+                  Unit := Get_First_Design_Unit (File);
+                  while Unit /= Null_Node loop
+                     LU := Get_Library_Unit (Unit);
+                     if LU /= Null_Node
+                       and then Get_Kind (LU) = Iir_Kind_Package_Declaration
+                     then
+                        if not First then
+                           Put (F, ",");
+                        end if;
+                        First := False;
+                        New_Line (F);
+                        Put (F, "    {""name"": ");
+                        Put_Str (F, Name_Table.Image (Get_Identifier (LU)));
+                        Put (F, ", ""file"": ");
+                        Put_Str (F, Node_File (LU));
+                        Put (F, ", ""pos"": ");
+                        Put_Pos (F, LU);
+                        Put (F, ", ""constants"": [");
+                        Emit_Constant_Decls
+                          (F, Get_Declaration_Chain (LU));
+                        Put (F, "]}");
+                     end if;
+                     Unit := Get_Chain (Unit);
+                  end loop;
+                  File := Get_Chain (File);
+               end loop;
+            end if;
+         end;
+         Lib := Get_Chain (Lib);
+      end loop;
+   end Emit_Packages;
+
    procedure Dump (Filename : String) is
       F : File_Type;
       Lib : Iir;
@@ -1829,7 +1986,10 @@ package body Simul.Flow is
       New_Line (F);
       Put_Line (F, "  ],");
 
-      Put_Line (F, "  ""packages"": [],");
+      Put (F, "  ""packages"": [");
+      Emit_Packages (F);
+      New_Line (F);
+      Put_Line (F, "  ],");
 
       Put (F, "  ""hierarchy"": [");
       if Top_Instance /= null then

--- a/src/simul/simul-flow.ads
+++ b/src/simul/simul-flow.ads
@@ -1,0 +1,24 @@
+--  Native dataflow (.flow) JSON exporter for simulation.
+--  Copyright (C) 2026 Tristan Gingold
+--
+--  This file is part of GHDL.
+--
+--  This program is free software: you can redistribute it and/or modify
+--  it under the terms of the GNU General Public License as published by
+--  the Free Software Foundation, either version 2 of the License, or
+--  (at your option) any later version.
+--
+--  This program is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--  GNU General Public License for more details.
+--
+--  You should have received a copy of the GNU General Public License
+--  along with this program.  If not, see <gnu.org/licenses>.
+
+package Simul.Flow is
+   --  Phase-0 spike: write a minimal JSON snapshot of the elaborated dataflow
+   --  tables (process/signal/driver/sensitivity/connection counts plus signal
+   --  names) to Filename, to prove the data is reachable from this hook point.
+   procedure Dump (Filename : String);
+end Simul.Flow;

--- a/src/vhdl/vhdl-elocations.adb
+++ b/src/vhdl/vhdl-elocations.adb
@@ -128,6 +128,18 @@ package body Vhdl.Elocations is
       Elocations_Table.Table (Idx .. Idx + Len - 1) := (others => No_Location);
    end Create_Elocations;
 
+   function Has_Elocations (N : Iir) return Boolean
+   is
+      use Vhdl.Nodes_Priv;
+   begin
+      if N < Elocations_Index_Table.First
+        or else N > Elocations_Index_Table.Last
+      then
+         return False;
+      end if;
+      return Elocations_Index_Table.Table (N) /= No_Location_Index;
+   end Has_Elocations;
+
    procedure Delete_Elocations (N : Iir)
    is
       use Vhdl.Nodes_Priv;

--- a/src/vhdl/vhdl-elocations.ads
+++ b/src/vhdl/vhdl-elocations.ads
@@ -741,6 +741,12 @@ package Vhdl.Elocations is
    --  Allocate memory to store elocations for node N.  Must be called once.
    procedure Create_Elocations (N : Iir);
 
+   --  True if extended locations have been allocated for node N.  Nodes
+   --  synthesized after parsing (e.g. concurrent assignments turned into
+   --  processes by canon) have none, so the Get_*_Location accessors would
+   --  read garbage; check this first before calling them on such nodes.
+   function Has_Elocations (N : Iir) return Boolean;
+
    -- General methods.
 
    --  Field: Field1

--- a/testsuite/gna/flow01/dut.vhdl
+++ b/testsuite/gna/flow01/dut.vhdl
@@ -1,0 +1,34 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+--  A small unit exercising in / out / inout ports, scalar and vector,
+--  a clocked process and combinational concurrent assignments, for the
+--  native dataflow (--flow) exporter.
+entity dut is
+  port (
+    clk     : in    std_logic;
+    rst     : in    std_logic;
+    data_in : in    std_logic_vector (3 downto 0);
+    count   : out   std_logic_vector (3 downto 0);
+    ready   : out   std_logic;
+    bus_io  : inout std_logic
+  );
+end dut;
+
+architecture rtl of dut is
+  signal cnt : unsigned (3 downto 0) := (others => '0');
+begin
+  process (clk, rst) is
+  begin
+    if rst = '1' then
+      cnt <= (others => '0');
+    elsif rising_edge (clk) then
+      cnt <= cnt + unsigned (data_in);
+    end if;
+  end process;
+
+  count <= std_logic_vector (cnt);
+  ready <= '1' when cnt /= 0 else '0';
+  bus_io <= cnt (0) when rst = '0' else 'Z';
+end rtl;

--- a/testsuite/gna/flow01/tb.vhdl
+++ b/testsuite/gna/flow01/tb.vhdl
@@ -1,0 +1,30 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity tb is
+end tb;
+
+architecture sim of tb is
+  signal clk     : std_logic := '0';
+  signal rst     : std_logic := '1';
+  signal data_in : std_logic_vector (3 downto 0) := "0001";
+  signal count   : std_logic_vector (3 downto 0);
+  signal ready   : std_logic;
+  signal bus_io  : std_logic;
+begin
+  uut : entity work.dut
+    port map (clk => clk, rst => rst, data_in => data_in,
+              count => count, ready => ready, bus_io => bus_io);
+
+  clk <= not clk after 5 ns;
+
+  stim : process is
+  begin
+    rst     <= '1';
+    data_in <= "0001";
+    wait for 12 ns;
+    rst <= '0';
+    wait for 40 ns;
+    std.env.finish;
+  end process;
+end sim;

--- a/testsuite/gna/flow01/testsuite.sh
+++ b/testsuite/gna/flow01/testsuite.sh
@@ -26,10 +26,10 @@ check ()
 }
 
 #  Top-level provenance and elaborated top unit.
-check '"schema": "flowtracer1.merged.v0"' "merged schema"
+check '"schema": "flowtracer1.vhdl.v0"' "vhdl schema"
 check '"top": "tb"'                        "elaborated top unit"
 
-#  modules[]: process dataflow (read-set / drive-set) from the AST.
+#  architectures[]: process dataflow (read-set / drive-set) from the AST.
 check '"drives": ["cnt"]'                  "clocked process drive set"
 
 #  hierarchy[]: elaborated instance tree with the real port_map.

--- a/testsuite/gna/flow01/testsuite.sh
+++ b/testsuite/gna/flow01/testsuite.sh
@@ -1,0 +1,54 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+export GHDL_STD_FLAGS=--std=08
+
+analyze dut.vhdl tb.vhdl
+elab tb
+
+#  --flow=FILE writes the native dataflow database (.flow JSON).
+#  The dump happens at elaboration, so a zero-time run is enough.
+simulate tb --flow=flow01.flow --stop-time=0ns
+
+#  The file must exist and be non-empty.
+if test ! -s flow01.flow; then
+  echo "FAILED: --flow did not create flow01.flow"
+  exit 1
+fi
+
+check ()
+{
+  if ! grep -qF "$1" flow01.flow; then
+    echo "FAILED: expected $2 in flow01.flow"
+    exit 1
+  fi
+}
+
+#  Top-level provenance and elaborated top unit.
+check '"schema": "flowtracer1.merged.v0"' "merged schema"
+check '"top": "tb"'                        "elaborated top unit"
+
+#  modules[]: process dataflow (read-set / drive-set) from the AST.
+check '"drives": ["cnt"]'                  "clocked process drive set"
+
+#  hierarchy[]: elaborated instance tree with the real port_map.
+check '"instance_label": "uut"'            "elaborated instance"
+check '"actuals": ["clk"]'                 "real port binding"
+
+#  nets[] / cells[]: canonical net graph + comb-vs-clocked.
+#  The dut clk port collapses into the tb clk net (port<->net unification).
+check '"clocked": true'                    "clock classification"
+check '"aliases": ["clk"]'                 "signal collapsing (port<->net)"
+
+#  Bare --flow defaults to ghdl.flow.
+simulate tb --flow --stop-time=0ns
+if test ! -s ghdl.flow; then
+  echo "FAILED: bare --flow did not create ghdl.flow"
+  exit 1
+fi
+
+clean
+rm -f flow01.flow ghdl.flow
+
+echo "Test successful"

--- a/testsuite/gna/flow02/gen.vhdl
+++ b/testsuite/gna/flow02/gen.vhdl
@@ -1,0 +1,44 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity counter is
+  generic (
+    WIDTH : positive := 8;
+    STEP  : natural  := 1
+  );
+  port (
+    clk : in  std_logic;
+    q   : out std_logic_vector (WIDTH - 1 downto 0)
+  );
+end counter;
+
+architecture rtl of counter is
+  signal cnt : unsigned (WIDTH - 1 downto 0) := (others => '0');
+begin
+  process (clk) is
+  begin
+    if rising_edge (clk) then
+      cnt <= cnt + STEP;
+    end if;
+  end process;
+  q <= std_logic_vector (cnt);
+end rtl;
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity gentb is
+end gentb;
+
+architecture sim of gentb is
+  signal clk : std_logic := '0';
+  signal q4  : std_logic_vector (3 downto 0);
+  signal q12 : std_logic_vector (11 downto 0);
+begin
+  u_small : entity work.counter
+    generic map (WIDTH => 4, STEP => 1) port map (clk => clk, q => q4);
+  u_big : entity work.counter
+    generic map (WIDTH => 12, STEP => 3) port map (clk => clk, q => q12);
+  clk <= not clk after 5 ns;
+end sim;

--- a/testsuite/gna/flow02/testsuite.sh
+++ b/testsuite/gna/flow02/testsuite.sh
@@ -1,0 +1,40 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+export GHDL_STD_FLAGS=--std=08
+
+analyze gen.vhdl
+elab gentb
+
+#  Two instances of the same entity with different generics; the .flow
+#  hierarchy must carry the per-instance ELABORATED generic values.
+simulate gentb --flow=flow02.flow --stop-time=0ns
+
+if test ! -s flow02.flow; then
+  echo "FAILED: --flow did not create flow02.flow"
+  exit 1
+fi
+
+check ()
+{
+  if ! grep -qF "$1" flow02.flow; then
+    echo "FAILED: expected $2 in flow02.flow"
+    exit 1
+  fi
+}
+
+#  Same module instantiated twice.
+check '"instance_label": "u_small"' "first instance"
+check '"instance_label": "u_big"'   "second instance"
+
+#  Resolved (elaborated) generic values, distinct per instance.
+check '{"name": "width", "type": "positive", "value": 4}'  "u_small WIDTH=4"
+check '{"name": "step", "type": "natural", "value": 1}'    "u_small STEP=1"
+check '{"name": "width", "type": "positive", "value": 12}' "u_big WIDTH=12"
+check '{"name": "step", "type": "natural", "value": 3}'    "u_big STEP=3"
+
+clean
+rm -f flow02.flow
+
+echo "Test successful"

--- a/testsuite/gna/flow03/genr.vhdl
+++ b/testsuite/gna/flow03/genr.vhdl
@@ -1,0 +1,39 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity cell is
+  port (a : in std_logic; y : out std_logic);
+end cell;
+
+architecture rtl of cell is
+begin
+  y <= not a;
+end rtl;
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity arr is
+  generic (N : positive := 4);
+  port (din : in std_logic_vector (N-1 downto 0);
+        dout : out std_logic_vector (N-1 downto 0));
+end arr;
+
+architecture rtl of arr is
+begin
+  g : for i in 0 to N-1 generate
+    u : entity work.cell port map (a => din (i), y => dout (i));
+  end generate;
+end rtl;
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity gtb is
+end gtb;
+
+architecture sim of gtb is
+  signal di, do : std_logic_vector (2 downto 0);
+begin
+  dut : entity work.arr generic map (N => 3) port map (din => di, dout => do);
+end sim;

--- a/testsuite/gna/flow03/testsuite.sh
+++ b/testsuite/gna/flow03/testsuite.sh
@@ -32,7 +32,7 @@ check '"generate": {"kind": "for", "label": "g", "index": 2}' "generate index 2"
 check '"scope": true' "transparent generate scope"
 
 #  Each unrolled iteration instantiates the cell entity.
-check '"module": "cell"' "generate-internal instance"
+check '"entity": "cell"' "generate-internal instance"
 
 clean
 rm -f flow03.flow

--- a/testsuite/gna/flow03/testsuite.sh
+++ b/testsuite/gna/flow03/testsuite.sh
@@ -1,0 +1,40 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+export GHDL_STD_FLAGS=--std=08
+
+analyze genr.vhdl
+elab gtb
+
+#  A for-generate must be unrolled in the elaborated hierarchy, with the
+#  real loop value as the generate index.
+simulate gtb --flow=flow03.flow --stop-time=0ns
+
+if test ! -s flow03.flow; then
+  echo "FAILED: --flow did not create flow03.flow"
+  exit 1
+fi
+
+check ()
+{
+  if ! grep -qF "$1" flow03.flow; then
+    echo "FAILED: expected $2 in flow03.flow"
+    exit 1
+  fi
+}
+
+#  Generate frames unrolled with the actual VHDL loop values (0..2),
+#  marked as transparent scopes.
+check '"generate": {"kind": "for", "label": "g", "index": 0}' "generate index 0"
+check '"generate": {"kind": "for", "label": "g", "index": 1}' "generate index 1"
+check '"generate": {"kind": "for", "label": "g", "index": 2}' "generate index 2"
+check '"scope": true' "transparent generate scope"
+
+#  Each unrolled iteration instantiates the cell entity.
+check '"module": "cell"' "generate-internal instance"
+
+clean
+rm -f flow03.flow
+
+echo "Test successful"

--- a/testsuite/gna/flow04/comp.vhdl
+++ b/testsuite/gna/flow04/comp.vhdl
@@ -1,0 +1,29 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity leaf is
+  port (a : in std_logic; b : in std_logic; y : out std_logic);
+end leaf;
+
+architecture rtl of leaf is
+begin
+  y <= a and b;
+end rtl;
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity comptop is
+  port (i0, i1, i2 : in std_logic; o : out std_logic);
+end comptop;
+
+architecture rtl of comptop is
+  --  Component declaration + component instantiation (default binding).
+  component leaf is
+    port (a : in std_logic; b : in std_logic; y : out std_logic);
+  end component;
+  signal t : std_logic;
+begin
+  u0 : leaf port map (a => i0, b => i1, y => t);
+  u1 : leaf port map (a => t, b => i2, y => o);
+end rtl;

--- a/testsuite/gna/flow04/testsuite.sh
+++ b/testsuite/gna/flow04/testsuite.sh
@@ -1,0 +1,41 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+export GHDL_STD_FLAGS=--std=08
+
+analyze comp.vhdl
+elab comptop
+
+#  Component instantiation (component declaration + default binding), as
+#  opposed to direct entity instantiation: the hierarchy must resolve the
+#  bound entity/architecture, and the net joining the two cells must unify
+#  the formal/actual ports across the component boundary.
+simulate comptop --flow=comp.flow --stop-time=0ns
+
+if test ! -s comp.flow; then
+  echo "FAILED: --flow did not create comp.flow"
+  exit 1
+fi
+
+check ()
+{
+  if ! grep -qF "$1" comp.flow; then
+    echo "FAILED: expected $2 in comp.flow"
+    exit 1
+  fi
+}
+
+#  Both component instantiations bound to entity leaf(rtl).
+check '"instance_label": "u0"' "first component instance"
+check '"instance_label": "u1"' "second component instance"
+check '"module": "leaf"'       "component bound to entity"
+
+#  The internal net t unifies the collapsed ports of both instances.
+check '"name": "t", "path"'    "internal chaining net"
+check '"aliases": ["y", "y", "a", "a"]' "cross-component net unification"
+
+clean
+rm -f comp.flow
+
+echo "Test successful"

--- a/testsuite/gna/flow04/testsuite.sh
+++ b/testsuite/gna/flow04/testsuite.sh
@@ -29,7 +29,7 @@ check ()
 #  Both component instantiations bound to entity leaf(rtl).
 check '"instance_label": "u0"' "first component instance"
 check '"instance_label": "u1"' "second component instance"
-check '"module": "leaf"'       "component bound to entity"
+check '"entity": "leaf"'       "component bound to entity"
 
 #  The internal net t unifies the collapsed ports of both instances.
 check '"name": "t", "path"'    "internal chaining net"

--- a/testsuite/gna/flow05/ifg.vhdl
+++ b/testsuite/gna/flow05/ifg.vhdl
@@ -1,0 +1,44 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity cell2 is
+  port (a : in std_logic; y : out std_logic);
+end cell2;
+
+architecture rtl of cell2 is
+begin
+  y <= not a;
+end rtl;
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity ifgtop is
+  generic (USE_INV : boolean := true);
+  port (a : in std_logic; y : out std_logic);
+end ifgtop;
+
+architecture rtl of ifgtop is
+begin
+  --  Taken branch: instantiates cell2.
+  g_on : if USE_INV generate
+    u : entity work.cell2 port map (a => a, y => y);
+  end generate;
+  --  Pruned branch: must NOT appear in the elaborated hierarchy.
+  g_off : if not USE_INV generate
+    y <= a;
+  end generate;
+end rtl;
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity ifgtb is
+end ifgtb;
+
+architecture sim of ifgtb is
+  signal a, y : std_logic;
+begin
+  dut : entity work.ifgtop generic map (USE_INV => true)
+    port map (a => a, y => y);
+end sim;

--- a/testsuite/gna/flow05/testsuite.sh
+++ b/testsuite/gna/flow05/testsuite.sh
@@ -21,7 +21,7 @@ if ! grep -qF '"kind": "if", "label": "g_on"' ifg.flow; then
   echo "FAILED: taken if-generate branch g_on missing"
   exit 1
 fi
-if ! grep -qF '"module": "cell2"' ifg.flow; then
+if ! grep -qF '"entity": "cell2"' ifg.flow; then
   echo "FAILED: instance inside taken branch missing"
   exit 1
 fi

--- a/testsuite/gna/flow05/testsuite.sh
+++ b/testsuite/gna/flow05/testsuite.sh
@@ -1,0 +1,38 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+export GHDL_STD_FLAGS=--std=08
+
+analyze ifg.vhdl
+elab ifgtb
+
+#  if-generate: only the taken branch (g_on, USE_INV=true) is elaborated;
+#  the pruned branch (g_off) must not appear in the hierarchy.
+simulate ifgtb --flow=ifg.flow --stop-time=0ns
+
+if test ! -s ifg.flow; then
+  echo "FAILED: --flow did not create ifg.flow"
+  exit 1
+fi
+
+#  Taken branch present, with its instance.
+if ! grep -qF '"kind": "if", "label": "g_on"' ifg.flow; then
+  echo "FAILED: taken if-generate branch g_on missing"
+  exit 1
+fi
+if ! grep -qF '"module": "cell2"' ifg.flow; then
+  echo "FAILED: instance inside taken branch missing"
+  exit 1
+fi
+
+#  Pruned branch absent.
+if grep -qF '"label": "g_off"' ifg.flow; then
+  echo "FAILED: pruned if-generate branch g_off should not appear"
+  exit 1
+fi
+
+clean
+rm -f ifg.flow
+
+echo "Test successful"

--- a/testsuite/gna/flow06/pkg.vhdl
+++ b/testsuite/gna/flow06/pkg.vhdl
@@ -1,0 +1,18 @@
+package myconfig is
+  constant WIDTH : natural := 16;
+  constant DEPTH : natural := 256;
+  constant NAME  : string  := "core";
+end package;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use work.myconfig.all;
+
+entity pkgtop is
+end pkgtop;
+
+architecture rtl of pkgtop is
+  constant LOCAL : natural := WIDTH + 1;
+  signal s : std_logic_vector (WIDTH-1 downto 0);
+begin
+end rtl;

--- a/testsuite/gna/flow06/testsuite.sh
+++ b/testsuite/gna/flow06/testsuite.sh
@@ -1,0 +1,40 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+export GHDL_STD_FLAGS=--std=08
+
+analyze pkg.vhdl
+elab pkgtop
+
+#  Exercise packages[] with constants, architecture constants, and the
+#  type constraint suffix (rendered from folded static expressions).
+simulate pkgtop --flow=pkg.flow --stop-time=0ns
+
+if test ! -s pkg.flow; then
+  echo "FAILED: --flow did not create pkg.flow"
+  exit 1
+fi
+
+check ()
+{
+  if ! grep -qF "$1" pkg.flow; then
+    echo "FAILED: expected $2 in pkg.flow"
+    exit 1
+  fi
+}
+
+#  Package constants with resolved values.
+check '"name": "width", "type": "natural", "value": 16'  "package constant width"
+check '"name": "depth", "type": "natural", "value": 256' "package constant depth"
+
+#  Architecture constant, folded from WIDTH + 1.
+check '"name": "local", "type": "natural", "value": 17'  "folded local constant"
+
+#  Type constraint suffix, folded from WIDTH - 1 downto 0.
+check '"type": "std_logic_vector(15 downto 0)"'          "type constraint suffix"
+
+clean
+rm -f pkg.flow
+
+echo "Test successful"

--- a/testsuite/gna/flow07/dut.vhdl
+++ b/testsuite/gna/flow07/dut.vhdl
@@ -1,0 +1,34 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+--  A small unit exercising in / out / inout ports, scalar and vector,
+--  a clocked process and combinational concurrent assignments, for the
+--  native dataflow (--flow) exporter.
+entity dut is
+  port (
+    clk     : in    std_logic;
+    rst     : in    std_logic;
+    data_in : in    std_logic_vector (3 downto 0);
+    count   : out   std_logic_vector (3 downto 0);
+    ready   : out   std_logic;
+    bus_io  : inout std_logic
+  );
+end dut;
+
+architecture rtl of dut is
+  signal cnt : unsigned (3 downto 0) := (others => '0');
+begin
+  process (clk, rst) is
+  begin
+    if rst = '1' then
+      cnt <= (others => '0');
+    elsif rising_edge (clk) then
+      cnt <= cnt + unsigned (data_in);
+    end if;
+  end process;
+
+  count <= std_logic_vector (cnt);
+  ready <= '1' when cnt /= 0 else '0';
+  bus_io <= cnt (0) when rst = '0' else 'Z';
+end rtl;

--- a/testsuite/gna/flow07/tb.vhdl
+++ b/testsuite/gna/flow07/tb.vhdl
@@ -1,0 +1,30 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity tb is
+end tb;
+
+architecture sim of tb is
+  signal clk     : std_logic := '0';
+  signal rst     : std_logic := '1';
+  signal data_in : std_logic_vector (3 downto 0) := "0001";
+  signal count   : std_logic_vector (3 downto 0);
+  signal ready   : std_logic;
+  signal bus_io  : std_logic;
+begin
+  uut : entity work.dut
+    port map (clk => clk, rst => rst, data_in => data_in,
+              count => count, ready => ready, bus_io => bus_io);
+
+  clk <= not clk after 5 ns;
+
+  stim : process is
+  begin
+    rst     <= '1';
+    data_in <= "0001";
+    wait for 12 ns;
+    rst <= '0';
+    wait for 40 ns;
+    std.env.finish;
+  end process;
+end sim;

--- a/testsuite/gna/flow07/testsuite.sh
+++ b/testsuite/gna/flow07/testsuite.sh
@@ -1,0 +1,35 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+export GHDL_STD_FLAGS=--std=08
+
+analyze dut.vhdl tb.vhdl
+
+#  The dedicated `ghdl --flow` command elaborates UNIT and dumps the
+#  dataflow database, without running a simulation.
+"$GHDL" --flow --std=08 --out=cmd.flow tb
+if test ! -s cmd.flow; then
+  echo "FAILED: ghdl --flow --out= did not create cmd.flow"
+  exit 1
+fi
+if ! grep -qF '"top": "tb"' cmd.flow; then
+  echo "FAILED: cmd.flow missing elaborated top"
+  exit 1
+fi
+if ! grep -qF '"instance_label": "uut"' cmd.flow; then
+  echo "FAILED: cmd.flow missing elaborated hierarchy"
+  exit 1
+fi
+
+#  Bare --flow defaults to ghdl.flow.
+"$GHDL" --flow --std=08 tb
+if test ! -s ghdl.flow; then
+  echo "FAILED: bare ghdl --flow did not create ghdl.flow"
+  exit 1
+fi
+
+clean
+rm -f cmd.flow ghdl.flow
+
+echo "Test successful"

--- a/testsuite/gna/flow08/dut.vhdl
+++ b/testsuite/gna/flow08/dut.vhdl
@@ -1,0 +1,35 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+--  A small unit exercising in / out / inout ports, scalar and vector,
+--  for extended-VCD (--evcd) testing.
+entity dut is
+  port (
+    clk     : in    std_logic;
+    rst     : in    std_logic;
+    data_in : in    std_logic_vector (3 downto 0);
+    count   : out   std_logic_vector (3 downto 0);
+    ready   : out   std_logic;
+    bus_io  : inout std_logic
+  );
+end dut;
+
+architecture rtl of dut is
+  signal cnt : unsigned (3 downto 0) := (others => '0');
+begin
+  process (clk, rst) is
+  begin
+    if rst = '1' then
+      cnt <= (others => '0');
+    elsif rising_edge (clk) then
+      cnt <= cnt + unsigned (data_in);
+    end if;
+  end process;
+
+  count <= std_logic_vector (cnt);
+  ready <= '1' when cnt /= 0 else '0';
+
+  --  Drive the inout for part of the run, release it (high-Z) otherwise.
+  bus_io <= cnt (0) when rst = '0' else 'Z';
+end rtl;

--- a/testsuite/gna/flow08/tb.vhdl
+++ b/testsuite/gna/flow08/tb.vhdl
@@ -1,0 +1,36 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity tb is
+end tb;
+
+architecture sim of tb is
+  signal clk     : std_logic := '0';
+  signal rst     : std_logic := '1';
+  signal data_in : std_logic_vector (3 downto 0) := "0001";
+  signal count   : std_logic_vector (3 downto 0);
+  signal ready   : std_logic;
+  signal bus_io  : std_logic;
+begin
+  uut : entity work.dut
+    port map (
+      clk => clk, rst => rst, data_in => data_in,
+      count => count, ready => ready, bus_io => bus_io);
+
+  --  10 ns clock.
+  clk <= not clk after 5 ns;
+
+  stim : process is
+  begin
+    rst     <= '1';
+    data_in <= "0001";
+    wait for 12 ns;
+    rst <= '0';
+    wait for 40 ns;
+    data_in <= "0011";
+    wait for 40 ns;
+    rst <= '1';
+    wait for 20 ns;
+    std.env.finish;
+  end process;
+end sim;

--- a/testsuite/gna/flow08/testsuite.sh
+++ b/testsuite/gna/flow08/testsuite.sh
@@ -1,0 +1,55 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+export GHDL_STD_FLAGS=--std=08
+
+analyze dut.vhdl tb.vhdl
+elab tb
+
+#  --flow=FILE writes the native dataflow database (.flow JSON).
+#  The dump happens at elaboration, so a zero-time run is enough.
+simulate tb --flow=flow08.flow --stop-time=0ns
+
+if test ! -s flow08.flow; then
+  echo "FAILED: --flow did not create flow08.flow"
+  exit 1
+fi
+
+check ()
+{
+  if ! grep -qF "$1" flow08.flow; then
+    echo "FAILED: expected $2 in flow08.flow"
+    exit 1
+  fi
+}
+
+#  Lexical-position helpers for source-scanning consumers (e.g. Perl
+#  lexers).  Every position is the compact byte-offset string
+#  "start:begin:end" (begin/end empty when not applicable).
+
+#  Entity and architecture are separate units, each with its own span.
+#  dut entity: "entity dut is" .. "end dut;" (no begin).
+check '"name": "dut", "file": "dut.vhdl", "pos": "180::433"' "entity span"
+
+#  dut architecture: "architecture" : 'begin' : final "end;".
+check '"name": "rtl", "entity": "dut", "file": "dut.vhdl", "pos": "443:527:911"' "architecture start:begin:end"
+
+#  Per-unit context linkage: library/use clauses with positions, attached
+#  to the entity (the clauses precede `entity dut`).
+check '"libraries": ["ieee"]'                          "library clause list"
+check '"name": "ieee.numeric_std.all", "pos": "43::"'  "use clause linkage to package"
+
+#  Real process: start : 'begin' (end of declarations) : "end process;".
+check '"label": "P0", "pos": "535:559:703"'            "process start:begin:end"
+
+#  Concurrent assignment becomes a process with no begin: start :: ';'.
+check '"label": "P1", "pos": "719::750"'               "concurrent assignment span"
+
+#  Entity instantiation: start :: terminating ';' (no begin).
+check '"label": "uut", "entity": "dut", "is_entity_inst": true, "pos": "344::486"' "instantiation span"
+
+clean
+rm -f flow08.flow
+
+echo "Test successful"


### PR DESCRIPTION
## What

Adds a `-r --flow[=FILE]` run option (and a dedicated `ghdl --flow` command) that dumps a JSON **dataflow database** (extension `.flow`) directly from GHDL's elaborated model, in a single native pass.

```
ghdl -r tb --flow                 # writes ghdl.flow
ghdl -r tb --flow=design.flow     # writes design.flow
ghdl --flow [--out=FILE] tb       # elaborate + dump, no simulation
```

## Why

Existing external dataflow tracers need three passes (source scan + VPI + merge) only because VPI exposes no dataflow. GHDL already has it all elaborated and resolved, so one native pass replaces them.

## What's in the file

The new `Simul.Flow` package walks the analyzed AST and the elaborated `Simul.Vhdl_Elab` tables (Processes/Drivers/Sensitivity/Connect/Signals), right after `Compute_Sources`, and emits:

- **`modules`** — per entity/architecture: ports (dir/type, incl. constraints like `std_logic_vector(3 downto 0)`), generics, signals, constants, and the read-set / drive-set / sensitivity of every process and concurrent assignment, with source spans.
- **`hierarchy`** — the elaborated instance tree (generates unrolled with the real loop index, component instantiations resolved), with the **real** port map and per-instance resolved generic values.
- **`nets`** — one entry per canonical net, with the signals that collapse into it (port↔net unification) and its fan-in/fan-out cells.
- **`cells`** — one entry per elaborated process/assignment, classified combinational or clocked (with the clock net), and its driven/read nets.
- **`packages`** — package constants with values; plus `ghdl` provenance (version, hash, std).

## Notes

- The option is handled in the front-end (`ghdlrun`): captured in the post-top argument loop, dumped in `Compile_Elab_Setup`, and filtered out of the argv handed to grt (the dump happens at elaboration, before grt decodes run options). The `ghdl --flow` command mirrors `ghdl --synth` (elaborate, dump, stop).
- Only the interpreted / JIT-elaboration run path builds the required model; the compiled-elaboration path is unaffected.

## Tests / docs

- `testsuite/gna/flow01`–`flow07`: base dataflow, resolved generics, for-generate, component instantiation, if-generate pruning, package/architecture constants + type constraints, and the `ghdl --flow` command.
- Documented in `doc/using/Simulation.rst` and `NEWS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)