### PR TITLE
pyGHDL documentation

### DIFF
--- a/doc/prolog.inc
+++ b/doc/prolog.inc
@@ -30,6 +30,7 @@
      span.colorgreen {color: #009933; }
      span.colorblue {color: #0066FF; }
      span.colorpurple {color: #9900CC; }
+     span.vhdlkw {font-style: italic; }
    </style>
 
 .. role:: bolditalic
@@ -57,6 +58,9 @@
    :class: colorred strike
 .. role:: addition
    :class: colorgreen
+
+.. role:: vhdlkw
+   :class: vhdlkw
 
 .. role:: pycode(code)
    :language: python

--- a/pyGHDL/cli/dom.py
+++ b/pyGHDL/cli/dom.py
@@ -57,6 +57,15 @@ __license__ = ""
 
 class SourceAttribute(Attribute):
     def __call__(self, func):
+        """
+        Attaches the source selection command line arguments to the decorated handler method.
+
+        The attribute bundles the four arguments that select what to analyze: ``-f``/``--file``,
+        ``-F``/``--files``, ``-D``/``--directory`` and ``-L``/``--library``.
+
+        :param func: The handler method to attach the command line arguments to.
+        :returns:    The same handler method, with the arguments attached.
+        """
         self._AppendAttribute(
             func,
             CommandLineArgument(

--- a/pyGHDL/cli/dom.py
+++ b/pyGHDL/cli/dom.py
@@ -60,8 +60,12 @@ class SourceAttribute(Attribute):
         """
         Attaches the source selection command line arguments to the decorated handler method.
 
-        The attribute bundles the four arguments that select what to analyze: ``-f``/``--file``,
-        ``-F``/``--files``, ``-D``/``--directory`` and ``-L``/``--library``.
+        The attribute bundles the four arguments that select what to analyze:
+
+        * ``-f`` / ``--file`` - the filename to parse, can be used multiple times.
+        * ``-F`` / ``--files`` - a list of filenames to parse.
+        * ``-D`` / ``--directory`` - the directory to parse.
+        * ``-L`` / ``--library`` - the default library for files in the root directory.
 
         :param func: The handler method to attach the command line arguments to.
         :returns:    The same handler method, with the arguments attached.

--- a/pyGHDL/dom/Aggregates.py
+++ b/pyGHDL/dom/Aggregates.py
@@ -57,6 +57,12 @@ from pyGHDL.dom import DOMMixin
 @export
 class SimpleAggregateElement(VHDLModel_SimpleAggregateElement, DOMMixin):
     def __init__(self, node: Iir, expression: ExpressionUnion) -> None:
+        """
+        Initializes an aggregate element.
+
+        :param node:       The IIR node this object was translated from.
+        :param expression: The expression this aggregate element supplies.
+        """
         super().__init__(expression)
         DOMMixin.__init__(self, node)
 
@@ -64,6 +70,13 @@ class SimpleAggregateElement(VHDLModel_SimpleAggregateElement, DOMMixin):
 @export
 class IndexedAggregateElement(VHDLModel_IndexedAggregateElement, DOMMixin):
     def __init__(self, node: Iir, index: ExpressionUnion, expression: ExpressionUnion) -> None:
+        """
+        Initializes an aggregate element chosen by an index.
+
+        :param node:       The IIR node this object was translated from.
+        :param index:      The index selecting the element this value is assigned to.
+        :param expression: The expression this aggregate element supplies.
+        """
         super().__init__(index, expression)
         DOMMixin.__init__(self, node)
 
@@ -71,6 +84,13 @@ class IndexedAggregateElement(VHDLModel_IndexedAggregateElement, DOMMixin):
 @export
 class RangedAggregateElement(VHDLModel_RangedAggregateElement, DOMMixin):
     def __init__(self, node: Iir, rng: Range, expression: ExpressionUnion) -> None:
+        """
+        Initializes an aggregate element chosen by a range.
+
+        :param node:       The IIR node this object was translated from.
+        :param rng:        The range selecting the elements this value is assigned to.
+        :param expression: The expression this aggregate element supplies.
+        """
         super().__init__(rng, expression)
         DOMMixin.__init__(self, node)
 
@@ -78,6 +98,13 @@ class RangedAggregateElement(VHDLModel_RangedAggregateElement, DOMMixin):
 @export
 class NamedAggregateElement(VHDLModel_NamedAggregateElement, DOMMixin):
     def __init__(self, node: Iir, name: Symbol, expression: ExpressionUnion) -> None:
+        """
+        Initializes an aggregate element chosen by a name.
+
+        :param node:       The IIR node this object was translated from.
+        :param name:       Reference to the name selecting the element this value is assigned to.
+        :param expression: The expression this aggregate element supplies.
+        """
         super().__init__(name, expression)
         DOMMixin.__init__(self, node)
 
@@ -85,5 +112,11 @@ class NamedAggregateElement(VHDLModel_NamedAggregateElement, DOMMixin):
 @export
 class OthersAggregateElement(VHDLModel_OthersAggregateElement, DOMMixin):
     def __init__(self, node: Iir, expression: ExpressionUnion) -> None:
+        """
+        Initializes an aggregate element.
+
+        :param node:       The IIR node this object was translated from.
+        :param expression: The expression this aggregate element supplies.
+        """
         super().__init__(expression)
         DOMMixin.__init__(self, node)

--- a/pyGHDL/dom/Aggregates.py
+++ b/pyGHDL/dom/Aggregates.py
@@ -113,7 +113,7 @@ class NamedAggregateElement(VHDLModel_NamedAggregateElement, DOMMixin):
 class OthersAggregateElement(VHDLModel_OthersAggregateElement, DOMMixin):
     def __init__(self, node: Iir, expression: ExpressionUnion) -> None:
         """
-        Initializes an others aggregate element.
+        Initializes an :vhdlkw:`others` aggregate element.
 
         :param node:       The IIR node this object was translated from.
         :param expression: The expression this aggregate element supplies.

--- a/pyGHDL/dom/Aggregates.py
+++ b/pyGHDL/dom/Aggregates.py
@@ -30,13 +30,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
-
 """
 This module contains all DOM classes for VHDL's design units (:class:`context <Entity>`,
 :class:`architecture <Architecture>`, :class:`package <Package>`,
 :class:`package body <PackageBody>`, :class:`context <Context>` and
 :class:`configuration <Configuration>`.
-
 
 """
 

--- a/pyGHDL/dom/Aggregates.py
+++ b/pyGHDL/dom/Aggregates.py
@@ -58,7 +58,7 @@ from pyGHDL.dom import DOMMixin
 class SimpleAggregateElement(VHDLModel_SimpleAggregateElement, DOMMixin):
     def __init__(self, node: Iir, expression: ExpressionUnion) -> None:
         """
-        Initializes an aggregate element.
+        Initializes a simple aggregate element.
 
         :param node:       The IIR node this object was translated from.
         :param expression: The expression this aggregate element supplies.
@@ -113,7 +113,7 @@ class NamedAggregateElement(VHDLModel_NamedAggregateElement, DOMMixin):
 class OthersAggregateElement(VHDLModel_OthersAggregateElement, DOMMixin):
     def __init__(self, node: Iir, expression: ExpressionUnion) -> None:
         """
-        Initializes an aggregate element.
+        Initializes an others aggregate element.
 
         :param node:       The IIR node this object was translated from.
         :param expression: The expression this aggregate element supplies.

--- a/pyGHDL/dom/Aggregates.py
+++ b/pyGHDL/dom/Aggregates.py
@@ -40,7 +40,7 @@ This module contains all DOM classes for VHDL's design units (:class:`context <E
 
 """
 
-from pyTooling.Decorators import export
+from pyTooling.Decorators import export, InheritDocString
 
 from pyVHDLModel.Base import ExpressionUnion, Range
 from pyVHDLModel.Symbol import Symbol
@@ -55,7 +55,12 @@ from pyGHDL.dom import DOMMixin
 
 
 @export
+@InheritDocString(VHDLModel_SimpleAggregateElement, merge=True)
 class SimpleAggregateElement(VHDLModel_SimpleAggregateElement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.SimpleAggregateElement`.
+    """
+
     def __init__(self, node: Iir, expression: ExpressionUnion) -> None:
         """
         Initializes a simple aggregate element.
@@ -68,7 +73,12 @@ class SimpleAggregateElement(VHDLModel_SimpleAggregateElement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_IndexedAggregateElement, merge=True)
 class IndexedAggregateElement(VHDLModel_IndexedAggregateElement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.IndexedAggregateElement`.
+    """
+
     def __init__(self, node: Iir, index: ExpressionUnion, expression: ExpressionUnion) -> None:
         """
         Initializes an aggregate element chosen by an index.
@@ -82,7 +92,12 @@ class IndexedAggregateElement(VHDLModel_IndexedAggregateElement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_RangedAggregateElement, merge=True)
 class RangedAggregateElement(VHDLModel_RangedAggregateElement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.RangedAggregateElement`.
+    """
+
     def __init__(self, node: Iir, rng: Range, expression: ExpressionUnion) -> None:
         """
         Initializes an aggregate element chosen by a range.
@@ -96,7 +111,12 @@ class RangedAggregateElement(VHDLModel_RangedAggregateElement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_NamedAggregateElement, merge=True)
 class NamedAggregateElement(VHDLModel_NamedAggregateElement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.NamedAggregateElement`.
+    """
+
     def __init__(self, node: Iir, name: Symbol, expression: ExpressionUnion) -> None:
         """
         Initializes an aggregate element chosen by a name.
@@ -110,7 +130,12 @@ class NamedAggregateElement(VHDLModel_NamedAggregateElement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_OthersAggregateElement, merge=True)
 class OthersAggregateElement(VHDLModel_OthersAggregateElement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.OthersAggregateElement`.
+    """
+
     def __init__(self, node: Iir, expression: ExpressionUnion) -> None:
         """
         Initializes an :vhdlkw:`others` aggregate element.

--- a/pyGHDL/dom/Attribute.py
+++ b/pyGHDL/dom/Attribute.py
@@ -30,6 +30,10 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+This module implements derived attribute classes from :mod:`pyVHDLModel.Declaration`.
+"""
+
 from typing import List
 
 from pyTooling.Decorators import export
@@ -91,6 +95,9 @@ _TOKEN_TRANSLATION = {
     #    Tok.View: EntityClass.View,
     Tok.Others: EntityClass.Others,
 }
+"""
+Translation table of *libghdl* tokens to pyVHDLModel entity class enumeration values.
+"""
 
 
 @export

--- a/pyGHDL/dom/Attribute.py
+++ b/pyGHDL/dom/Attribute.py
@@ -36,7 +36,7 @@ This module implements derived attribute classes from :mod:`pyVHDLModel.Declarat
 
 from typing import List
 
-from pyTooling.Decorators import export
+from pyTooling.Decorators import export, InheritDocString
 from pyTooling.Warning import WarningCollector
 
 from pyVHDLModel.Name import Name
@@ -56,7 +56,12 @@ from pyGHDL.dom.Symbol import SimpleSubtypeSymbol
 
 
 @export
+@InheritDocString(VHDLModel_Attribute, merge=True)
 class Attribute(VHDLModel_Attribute, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Declaration.Attribute`.
+    """
+
     def __init__(self, node: Iir, identifier: str, subtype: Symbol, documentation: str = None) -> None:
         """
         Initializes an attribute declaration.
@@ -109,7 +114,12 @@ Translation table of *libghdl* tokens to pyVHDLModel entity class enumeration va
 
 
 @export
+@InheritDocString(VHDLModel_AttributeSpecification, merge=True)
 class AttributeSpecification(VHDLModel_AttributeSpecification, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Declaration.AttributeSpecification`.
+    """
+
     def __init__(
         self,
         node: Iir,

--- a/pyGHDL/dom/Attribute.py
+++ b/pyGHDL/dom/Attribute.py
@@ -76,6 +76,12 @@ class Attribute(VHDLModel_Attribute, DOMMixin):
 
     @classmethod
     def parse(cls, attributeNode: Iir) -> "Attribute":
+        """
+        Translates the IIR node of the attribute declaration to an :class:`Attribute`.
+
+        :param attributeNode: The IIR node of the attribute declaration.
+        :returns:             The translated attribute declaration.
+        """
         name = GetNameOfNode(attributeNode)
         documentation = GetDocumentationOfNode(attributeNode)
         subtypeMark = nodes.Get_Type_Mark(attributeNode)
@@ -144,6 +150,12 @@ class AttributeSpecification(VHDLModel_AttributeSpecification, DOMMixin):
 
     @classmethod
     def parse(cls, attributeNode: Iir) -> "AttributeSpecification":
+        """
+        Translates the IIR node of the attribute declaration to an :class:`AttributeSpecification`.
+
+        :param attributeNode: The IIR node of the attribute declaration.
+        :returns:             The translated attribute declaration.
+        """
         attributeDesignator = nodes.Get_Attribute_Designator(attributeNode)
         attributeName = GetName(attributeDesignator)
         documentation = GetDocumentationOfNode(attributeNode)

--- a/pyGHDL/dom/Attribute.py
+++ b/pyGHDL/dom/Attribute.py
@@ -58,6 +58,14 @@ from pyGHDL.dom.Symbol import SimpleSubtypeSymbol
 @export
 class Attribute(VHDLModel_Attribute, DOMMixin):
     def __init__(self, node: Iir, identifier: str, subtype: Symbol, documentation: str = None) -> None:
+        """
+        Initializes an attribute declaration.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifier:    The identifier of a model entity.
+        :param subtype:       Reference to the attribute's subtype.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, subtype, documentation)
         DOMMixin.__init__(self, node)
 
@@ -111,6 +119,16 @@ class AttributeSpecification(VHDLModel_AttributeSpecification, DOMMixin):
         expression: Expression,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes an attribute specification.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifiers:   List of all names the attribute is specified for.
+        :param attribute:     Reference to the specified attribute.
+        :param entityClass:   The entity class the named items belong to.
+        :param expression:    The value assigned to the attribute.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifiers, attribute, entityClass, expression, documentation)
         DOMMixin.__init__(self, node)
 

--- a/pyGHDL/dom/Attribute.py
+++ b/pyGHDL/dom/Attribute.py
@@ -62,7 +62,7 @@ class Attribute(VHDLModel_Attribute, DOMMixin):
         Initializes an attribute declaration.
 
         :param node:          The IIR node this object was translated from.
-        :param identifier:    The identifier of a model entity.
+        :param identifier:    The attribute's identifier.
         :param subtype:       Reference to the attribute's subtype.
         :param documentation: The documentation comment associated with this declaration.
         """

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -95,7 +95,7 @@ from pyGHDL.dom.Symbol import (
 class GenericAssociationItem(VHDLModel_GenericAssociationItem, DOMMixin):
     def __init__(self, associationNode: Iir, formal: Symbol, actual: ExpressionUnion) -> None:
         """
-        Initializes an association item.
+        Initializes a generic association item.
 
         :param associationNode: The IIR node of the association element.
         :param formal:          Reference to the formal part, or ``None`` for a positional association.
@@ -109,7 +109,7 @@ class GenericAssociationItem(VHDLModel_GenericAssociationItem, DOMMixin):
 class PortAssociationItem(VHDLModel_PortAssociationItem, DOMMixin):
     def __init__(self, associationNode: Iir, formal: Symbol, actual: ExpressionUnion) -> None:
         """
-        Initializes an association item.
+        Initializes a port association item.
 
         :param associationNode: The IIR node of the association element.
         :param formal:          Reference to the formal part, or ``None`` for a positional association.
@@ -123,7 +123,7 @@ class PortAssociationItem(VHDLModel_PortAssociationItem, DOMMixin):
 class ParameterAssociationItem(VHDLModel_ParameterAssociationItem, DOMMixin):
     def __init__(self, associationNode: Iir, formal: Symbol, actual: ExpressionUnion) -> None:
         """
-        Initializes an association item.
+        Initializes a parameter association item.
 
         :param associationNode: The IIR node of the association element.
         :param formal:          Reference to the formal part, or ``None`` for a positional association.
@@ -378,7 +378,7 @@ class IfGenerateBranch(VHDLModel_IfGenerateBranch, DOMMixin):
         Initializes an if generate branch.
 
         :param branchNode:       The IIR node of the branch this object represents.
-        :param condition:        The condition guarding this statement.
+        :param condition:        The condition under which this branch's declarations and statements are elaborated.
         :param declaredItems:    List of all declared items in this concurrent declaration region.
         :param statements:       List of all concurrent statements in this construct.
         :param alternativeLabel: The branch's alternative label, if one was given.
@@ -419,7 +419,7 @@ class ElsifGenerateBranch(VHDLModel_ElsifGenerateBranch, DOMMixin):
         Initializes an elsif generate branch.
 
         :param branchNode:       The IIR node of the branch this object represents.
-        :param condition:        The condition guarding this statement.
+        :param condition:        The condition under which this branch's declarations and statements are elaborated.
         :param declaredItems:    List of all declared items in this concurrent declaration region.
         :param statements:       List of all concurrent statements in this construct.
         :param alternativeLabel: The branch's alternative label, if one was given.
@@ -602,7 +602,7 @@ class OthersGenerateCase(VHDLModel_OthersGenerateCase, DOMMixin):
         alternativeLabel: str = None,
     ) -> None:
         """
-        Initializes a concurrent case.
+        Initializes an others generate case.
 
         :param caseNode:         The IIR node of the case statement.
         :param declaredItems:    List of all declared items in this concurrent declaration region.
@@ -643,7 +643,7 @@ class CaseGenerateStatement(VHDLModel_CaseGenerateStatement, DOMMixin):
 
         :param generateNode: The IIR node of the generate statement.
         :param label:        The label of the case-generate statement.
-        :param expression:   The expression being tested; it must be static.
+        :param expression:   The expression selecting the alternative.
         :param cases:        List of all alternatives, in the order they were written.
         """
         super().__init__(label, expression, cases)
@@ -1093,7 +1093,7 @@ class ConcurrentAssertStatement(VHDLModel_ConcurrentAssertStatement, DOMMixin):
         Initializes a concurrent assertion statement.
 
         :param assertNode: The IIR node of the assertion.
-        :param condition:  The condition guarding this statement.
+        :param condition:  The condition that must hold; the report is issued when it is false.
         :param message:    The reported message, or ``None`` if none was given.
         :param severity:   The reported severity level, or ``None`` if none was given.
         :param label:      The label of the concurrent assertion statement, or ``None`` if it has none.

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -94,6 +94,13 @@ from pyGHDL.dom.Symbol import (
 @export
 class GenericAssociationItem(VHDLModel_GenericAssociationItem, DOMMixin):
     def __init__(self, associationNode: Iir, formal: Symbol, actual: ExpressionUnion) -> None:
+        """
+        Initializes an association item.
+
+        :param associationNode: The IIR node of the association element.
+        :param formal:          Reference to the formal part, or ``None`` for a positional association.
+        :param actual:          The actual part of this association.
+        """
         super().__init__(formal, actual)
         DOMMixin.__init__(self, associationNode)
 
@@ -101,6 +108,13 @@ class GenericAssociationItem(VHDLModel_GenericAssociationItem, DOMMixin):
 @export
 class PortAssociationItem(VHDLModel_PortAssociationItem, DOMMixin):
     def __init__(self, associationNode: Iir, formal: Symbol, actual: ExpressionUnion) -> None:
+        """
+        Initializes an association item.
+
+        :param associationNode: The IIR node of the association element.
+        :param formal:          Reference to the formal part, or ``None`` for a positional association.
+        :param actual:          The actual part of this association.
+        """
         super().__init__(formal, actual)
         DOMMixin.__init__(self, associationNode)
 
@@ -108,6 +122,13 @@ class PortAssociationItem(VHDLModel_PortAssociationItem, DOMMixin):
 @export
 class ParameterAssociationItem(VHDLModel_ParameterAssociationItem, DOMMixin):
     def __init__(self, associationNode: Iir, formal: Symbol, actual: ExpressionUnion) -> None:
+        """
+        Initializes an association item.
+
+        :param associationNode: The IIR node of the association element.
+        :param formal:          Reference to the formal part, or ``None`` for a positional association.
+        :param actual:          The actual part of this association.
+        """
         super().__init__(formal, actual)
         DOMMixin.__init__(self, associationNode)
 
@@ -122,6 +143,15 @@ class ComponentInstantiation(VHDLModel_ComponentInstantiation, DOMMixin):
         genericAssociationItems: Iterable[AssociationItem] = None,
         portAssociationItems: Iterable[AssociationItem] = None,
     ) -> None:
+        """
+        Initializes a component instantiation.
+
+        :param instantiationNode:       The IIR node of the instantiation statement.
+        :param label:                   The label of a model entity.
+        :param componentSymbol:         Reference to the instantiated component.
+        :param genericAssociationItems: List of all generic associations in the generic map aspect.
+        :param portAssociationItems:    List of all port associations in the port map aspect.
+        """
         super().__init__(label, componentSymbol, genericAssociationItems, portAssociationItems)
         DOMMixin.__init__(self, instantiationNode)
 
@@ -147,6 +177,16 @@ class EntityInstantiation(VHDLModel_EntityInstantiation, DOMMixin):
         genericAssociationItems: Iterable[AssociationItem] = None,
         portAssociationItems: Iterable[AssociationItem] = None,
     ) -> None:
+        """
+        Initializes a direct entity instantiation.
+
+        :param instantiationNode:       The IIR node of the instantiation statement.
+        :param label:                   The label of a model entity.
+        :param entitySymbol:            Reference to the directly instantiated entity.
+        :param architectureSymbol:      Reference to the selected architecture, if one was given.
+        :param genericAssociationItems: List of all generic associations in the generic map aspect.
+        :param portAssociationItems:    List of all port associations in the port map aspect.
+        """
         super().__init__(label, entitySymbol, architectureSymbol, genericAssociationItems, portAssociationItems)
         DOMMixin.__init__(self, instantiationNode)
 
@@ -180,6 +220,15 @@ class ConfigurationInstantiation(VHDLModel_ConfigurationInstantiation, DOMMixin)
         genericAssociationItems: Iterable[AssociationItem] = None,
         portAssociationItems: Iterable[AssociationItem] = None,
     ) -> None:
+        """
+        Initializes a configuration instantiation.
+
+        :param instantiationNode:       The IIR node of the instantiation statement.
+        :param label:                   The label of a model entity.
+        :param configurationSymbol:     Reference to the instantiated configuration.
+        :param genericAssociationItems: List of all generic associations in the generic map aspect.
+        :param portAssociationItems:    List of all port associations in the port map aspect.
+        """
         super().__init__(label, configurationSymbol, genericAssociationItems, portAssociationItems)
         DOMMixin.__init__(self, instantiationNode)
 
@@ -209,6 +258,18 @@ class ConcurrentBlockStatement(VHDLModel_ConcurrentBlockStatement, DOMMixin):
         declaredItems: Iterable = None,
         statements: Iterable["ConcurrentStatement"] = None,
     ) -> None:
+        """
+        Initializes a block statement.
+
+        :param blockNode:               The IIR node of the block statement.
+        :param label:                   The label of a model entity.
+        :param genericItems:            List of all generics, in declaration order.
+        :param genericAssociationItems: List of all generic associations in the generic map aspect.
+        :param portItems:               List of all ports, in declaration order.
+        :param portAssociationItems:    List of all port associations in the port map aspect.
+        :param declaredItems:           List of all declared items in this concurrent declaration region.
+        :param statements:              List of all concurrent statements in this construct.
+        """
         super().__init__(
             label,
             genericItems,
@@ -269,6 +330,15 @@ class ProcessStatement(VHDLModel_ProcessStatement, DOMMixin):
         statements: Iterable[SequentialStatement] = None,
         sensitivityList: Iterable[Symbol] = None,
     ) -> None:
+        """
+        Initializes a process statement.
+
+        :param processNode:     The IIR node of the process statement.
+        :param label:           The label of a model entity.
+        :param declaredItems:   List of all declared items in this sequential declaration region.
+        :param statements:      List of all sequential statements in this construct.
+        :param sensitivityList: List of all signal names in the sensitivity list, or ``None`` if none was given.
+        """
         super().__init__(label, declaredItems, statements, sensitivityList)
         DOMMixin.__init__(self, processNode)
 
@@ -304,6 +374,15 @@ class IfGenerateBranch(VHDLModel_IfGenerateBranch, DOMMixin):
         statements: Iterable[ConcurrentStatement] = None,
         alternativeLabel: str = None,
     ) -> None:
+        """
+        Initializes an if generate branch.
+
+        :param branchNode:       The IIR node of the branch this object represents.
+        :param condition:        The condition guarding this statement.
+        :param declaredItems:    List of all declared items in this concurrent declaration region.
+        :param statements:       List of all concurrent statements in this construct.
+        :param alternativeLabel: The branch's alternative label, if one was given.
+        """
         super().__init__(condition, declaredItems, statements, alternativeLabel)
         DOMMixin.__init__(self, branchNode)
 
@@ -336,6 +415,15 @@ class ElsifGenerateBranch(VHDLModel_ElsifGenerateBranch, DOMMixin):
         statements: Iterable[ConcurrentStatement] = None,
         alternativeLabel: str = None,
     ) -> None:
+        """
+        Initializes an elsif generate branch.
+
+        :param branchNode:       The IIR node of the branch this object represents.
+        :param condition:        The condition guarding this statement.
+        :param declaredItems:    List of all declared items in this concurrent declaration region.
+        :param statements:       List of all concurrent statements in this construct.
+        :param alternativeLabel: The branch's alternative label, if one was given.
+        """
         super().__init__(condition, declaredItems, statements, alternativeLabel)
         DOMMixin.__init__(self, branchNode)
 
@@ -367,6 +455,14 @@ class ElseGenerateBranch(VHDLModel_ElseGenerateBranch, DOMMixin):
         statements: Iterable[ConcurrentStatement] = None,
         alternativeLabel: str = None,
     ) -> None:
+        """
+        Initializes an else generate branch.
+
+        :param branchNode:       The IIR node of the branch this object represents.
+        :param declaredItems:    List of all declared items in this concurrent declaration region.
+        :param statements:       List of all concurrent statements in this construct.
+        :param alternativeLabel: The branch's alternative label, if one was given.
+        """
         super().__init__(declaredItems, statements, alternativeLabel)
         DOMMixin.__init__(self, branchNode)
 
@@ -397,6 +493,15 @@ class IfGenerateStatement(VHDLModel_IfGenerateStatement, DOMMixin):
         elsifBranches: Iterable[ElsifGenerateBranch] = None,
         elseBranch: ElseGenerateBranch = None,
     ) -> None:
+        """
+        Initializes an if-generate statement.
+
+        :param generateNode:  The IIR node of the generate statement.
+        :param label:         The label of a model entity.
+        :param ifBranch:      The mandatory ``if`` branch.
+        :param elsifBranches: List of all ``elsif`` branches, in the order they were written.
+        :param elseBranch:    The optional ``else`` branch, or ``None`` if none was given.
+        """
         super().__init__(label, ifBranch, elsifBranches, elseBranch)
         DOMMixin.__init__(self, generateNode)
 
@@ -425,6 +530,12 @@ class IfGenerateStatement(VHDLModel_IfGenerateStatement, DOMMixin):
 @export
 class IndexedGenerateChoice(VHDLModel_IndexedGenerateChoice, DOMMixin):
     def __init__(self, node: Iir, expression: ExpressionUnion) -> None:
+        """
+        Initializes a case-generate choice given by a single value.
+
+        :param node:       The IIR node this object was translated from.
+        :param expression: The expression this choice selects on.
+        """
         super().__init__(expression)
         DOMMixin.__init__(self, node)
 
@@ -432,6 +543,12 @@ class IndexedGenerateChoice(VHDLModel_IndexedGenerateChoice, DOMMixin):
 @export
 class RangedGenerateChoice(VHDLModel_RangedGenerateChoice, DOMMixin):
     def __init__(self, node: Iir, rng: Range) -> None:
+        """
+        Initializes a case-generate choice given by a range.
+
+        :param node: The IIR node this object was translated from.
+        :param rng:  The range this choice selects on.
+        """
         super().__init__(rng)
         DOMMixin.__init__(self, node)
 
@@ -446,6 +563,15 @@ class GenerateCase(VHDLModel_GenerateCase, DOMMixin):
         statements: Iterable[ConcurrentStatement] = None,
         alternativeLabel: str = None,
     ) -> None:
+        """
+        Initializes a generate case.
+
+        :param node:             The IIR node this object was translated from.
+        :param choices:          List of all choices selecting this alternative.
+        :param declaredItems:    List of all declared items in this concurrent declaration region.
+        :param statements:       List of all concurrent statements in this construct.
+        :param alternativeLabel: The alternative's label.
+        """
         super().__init__(choices, declaredItems, statements, alternativeLabel)
         DOMMixin.__init__(self, node)
 
@@ -475,6 +601,14 @@ class OthersGenerateCase(VHDLModel_OthersGenerateCase, DOMMixin):
         statements: Iterable[ConcurrentStatement] = None,
         alternativeLabel: str = None,
     ) -> None:
+        """
+        Initializes a concurrent case.
+
+        :param caseNode:         The IIR node of the case statement.
+        :param declaredItems:    List of all declared items in this concurrent declaration region.
+        :param statements:       List of all concurrent statements in this construct.
+        :param alternativeLabel: The alternative's label.
+        """
         super().__init__(declaredItems, statements, alternativeLabel)
         DOMMixin.__init__(self, caseNode)
 
@@ -504,6 +638,14 @@ class CaseGenerateStatement(VHDLModel_CaseGenerateStatement, DOMMixin):
         expression: ExpressionUnion,
         cases: Iterable[ConcurrentCase],
     ) -> None:
+        """
+        Initializes a case-generate statement.
+
+        :param generateNode: The IIR node of the generate statement.
+        :param label:        The label of a model entity.
+        :param expression:   The expression being tested; it must be static.
+        :param cases:        List of all alternatives, in the order they were written.
+        """
         super().__init__(label, expression, cases)
         DOMMixin.__init__(self, generateNode)
 
@@ -599,6 +741,17 @@ class ForGenerateStatement(VHDLModel_ForGenerateStatement, DOMMixin):
         statements: Iterable[ConcurrentStatement] = None,
         parent: Nullable[ModelEntity] = None,
     ) -> None:
+        """
+        Initializes a for-generate statement.
+
+        :param generateNode:  The IIR node of the generate statement.
+        :param label:         The label of a model entity.
+        :param loopIndex:     The name of the generate loop's index.
+        :param rng:           The range the generate loop iterates over.
+        :param declaredItems: List of all declared items in this concurrent declaration region.
+        :param statements:    List of all concurrent statements in this construct.
+        :param parent:        The parent model entity of this entity.
+        """
         super().__init__(label, loopIndex, rng, declaredItems, statements, parent=parent)
         DOMMixin.__init__(self, generateNode)
 
@@ -626,6 +779,13 @@ class ForGenerateStatement(VHDLModel_ForGenerateStatement, DOMMixin):
 @export
 class WaveformElement(VHDLModel_WaveformElement, DOMMixin):
     def __init__(self, waveNode: Iir, expression: ExpressionUnion, after: ExpressionUnion) -> None:
+        """
+        Initializes a waveform element.
+
+        :param waveNode:   The IIR node of the waveform element.
+        :param expression: The value this waveform element assigns.
+        :param after:      The delay after which the value is assigned, or ``None`` if none was given.
+        """
         super().__init__(expression, after)
         DOMMixin.__init__(self, waveNode)
 
@@ -740,6 +900,13 @@ def GetSelectedWaveformsFromChainedNodes(nodeChain: Iir) -> Iterable:
 @export
 class ConditionalWaveform(VHDLModel_ConditionalWaveform, DOMMixin):
     def __init__(self, node: Iir, waveform: Iterable[WaveformElement], condition: ExpressionUnion = None) -> None:
+        """
+        Initializes a conditional waveform.
+
+        :param node:      The IIR node this object was translated from.
+        :param waveform:  List of all waveform elements, in the order they were written.
+        :param condition: The condition selecting this alternative.
+        """
         super().__init__(waveform, condition)
         DOMMixin.__init__(self, node)
 
@@ -756,6 +923,13 @@ class ConditionalWaveform(VHDLModel_ConditionalWaveform, DOMMixin):
 @export
 class SelectedWaveform(VHDLModel_SelectedWaveform, DOMMixin):
     def __init__(self, node: Iir, choices: Iterable, waveform: Iterable[WaveformElement]) -> None:
+        """
+        Initializes a selected waveform.
+
+        :param node:     The IIR node this object was translated from.
+        :param choices:  List of all choices selecting this alternative.
+        :param waveform: List of all waveform elements, in the order they were written.
+        """
         super().__init__(choices, waveform)
         DOMMixin.__init__(self, node)
 
@@ -763,6 +937,12 @@ class SelectedWaveform(VHDLModel_SelectedWaveform, DOMMixin):
 @export
 class OthersSelectedWaveform(VHDLModel_OthersSelectedWaveform, DOMMixin):
     def __init__(self, node: Iir, waveform: Iterable[WaveformElement]) -> None:
+        """
+        Initializes an others selected waveform.
+
+        :param node:     The IIR node this object was translated from.
+        :param waveform: List of all waveform elements, in the order they were written.
+        """
         super().__init__(waveform)
         DOMMixin.__init__(self, node)
 
@@ -776,6 +956,14 @@ class ConcurrentSimpleSignalAssignment(VHDLModel_ConcurrentSimpleSignalAssignmen
         target: SignalSymbol,
         waveform: Iterable[WaveformElement],
     ) -> None:
+        """
+        Initializes a simple concurrent signal assignment.
+
+        :param assignmentNode: The IIR node of the assignment statement.
+        :param label:          The label of a model entity.
+        :param target:         Reference to the assignment's destination.
+        :param waveform:       List of all waveform elements, in the order they were written.
+        """
         super().__init__(label, target, waveform)
         DOMMixin.__init__(self, assignmentNode)
 
@@ -800,6 +988,14 @@ class ConcurrentConditionalSignalAssignment(VHDLModel_ConcurrentConditionalSigna
         target: SignalSymbol,
         conditionalWaveforms: Iterable[ConditionalWaveform],
     ) -> None:
+        """
+        Initializes a conditional concurrent signal assignment.
+
+        :param assignmentNode:       The IIR node of the assignment statement.
+        :param label:                The label of a model entity.
+        :param target:               Reference to the assignment's destination.
+        :param conditionalWaveforms: All alternatives, in order.
+        """
         super().__init__(label, target, conditionalWaveforms)
         DOMMixin.__init__(self, assignmentNode)
 
@@ -826,6 +1022,15 @@ class ConcurrentSelectedSignalAssignment(VHDLModel_ConcurrentSelectedSignalAssig
         expression: ExpressionUnion,
         selectedWaveforms: Iterable,
     ) -> None:
+        """
+        Initializes a selected concurrent signal assignment.
+
+        :param assignmentNode:    The IIR node of the assignment statement.
+        :param label:             The label of a model entity.
+        :param target:            Reference to the assignment's destination.
+        :param expression:        The selector expression.
+        :param selectedWaveforms: All alternatives, in order.
+        """
         super().__init__(label, target, expression, selectedWaveforms)
         DOMMixin.__init__(self, assignmentNode)
 
@@ -850,6 +1055,14 @@ class ConcurrentProcedureCall(VHDLModel_ConcurrentProcedureCall, DOMMixin):
         procedureName: Symbol,
         parameterAssociationItems: Iterable,
     ) -> None:
+        """
+        Initializes a concurrent procedure call.
+
+        :param callNode:                  The IIR node of the subprogram call.
+        :param label:                     The label of a model entity.
+        :param procedureName:             Reference to the called procedure.
+        :param parameterAssociationItems: List of all parameter associations of the call.
+        """
         super().__init__(label, procedureName, parameterAssociationItems)
         DOMMixin.__init__(self, callNode)
 
@@ -876,6 +1089,15 @@ class ConcurrentAssertStatement(VHDLModel_ConcurrentAssertStatement, DOMMixin):
         severity: ExpressionUnion = None,
         label: str = None,
     ) -> None:
+        """
+        Initializes a concurrent assertion statement.
+
+        :param assertNode: The IIR node of the assertion.
+        :param condition:  The condition guarding this statement.
+        :param message:    The reported message, or ``None`` if none was given.
+        :param severity:   The reported severity level, or ``None`` if none was given.
+        :param label:      The label of a model entity.
+        """
         super().__init__(condition, message, severity, label)
         DOMMixin.__init__(self, assertNode)
 

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -30,6 +30,10 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+This module implements derived concurrent statement classes from :mod:`pyVHDLModel.Concurrent`.
+"""
+
 from typing import Iterable, List, Optional as Nullable
 
 from pyTooling.Decorators import export
@@ -641,15 +645,27 @@ class WaveformElement(VHDLModel_WaveformElement, DOMMixin):
 
 
 def GetWaveformElementsFromChainedNodes(nodeChain: Iir) -> List[WaveformElement]:
-    """Translates a chain of ``Waveform_Element`` nodes (used at multiple call sites: simple/
-    conditional/selected signal assignments, both concurrent and sequential) into a list of
-    :class:`WaveformElement`."""
+    """
+    Translates a chain of ``Waveform_Element`` nodes into a list of :class:`WaveformElement`.
+
+    The chain is used at multiple call sites: simple, conditional and selected signal assignments,
+    both concurrent and sequential.
+
+    :param nodeChain: The IIR node starting the chain of waveform elements.
+    :returns:         List of the translated waveform elements, in source order.
+    """
     return [WaveformElement.parse(wave) for wave in utils.chain_iter(nodeChain)]
 
 
 def GetConditionalWaveformsFromChainedNodes(nodeChain: Iir) -> Iterable["ConditionalWaveform"]:
-    """Translates a chain of ``Conditional_Waveform`` nodes (shared by concurrent and sequential
-    conditional signal assignments) into a sequence of :class:`ConditionalWaveform`."""
+    """
+    Translates a chain of ``Conditional_Waveform`` nodes into a sequence of :class:`ConditionalWaveform`.
+
+    The chain is shared by concurrent and sequential conditional signal assignments.
+
+    :param nodeChain: The IIR node starting the chain of conditional waveforms.
+    :returns:         The translated conditional waveforms, in source order.
+    """
     return [ConditionalWaveform.parse(node) for node in utils.chain_iter(nodeChain)]
 
 
@@ -663,6 +679,10 @@ def GetSelectedWaveformsFromChainedNodes(nodeChain: Iir) -> Iterable:
     choice in a group owns the real content (``Get_Associated_Chain``, ``Same_Alternative_Flag=False``);
     later choices in the same group (``Same_Alternative_Flag=True``) have a null associated chain and
     are just additional choice values for that same, already-established alternative.
+
+    :param nodeChain:     The IIR node starting the chain of choices.
+    :returns:             The translated selected waveforms, in source order.
+    :raises DOMException: If a choice's kind is not handled.
     """
     from pyGHDL.dom._Utils import GetIirKindOfNode
     from pyGHDL.dom._Translate import GetExpressionFromNode, GetRangeFromNode

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -261,8 +261,8 @@ class ConcurrentBlockStatement(VHDLModel_ConcurrentBlockStatement, DOMMixin):
         """
         Initializes a block statement.
 
-        :param blockNode:               The IIR node of the block statement.
-        :param label:                   The label of the block statement.
+        :param blockNode:               The IIR node of the :vhdlkw:`block` statement.
+        :param label:                   The label of the :vhdlkw:`block` statement.
         :param genericItems:            List of all generics, in declaration order.
         :param genericAssociationItems: List of all generic associations in the generic map aspect.
         :param portItems:               List of all ports, in declaration order.
@@ -331,10 +331,10 @@ class ProcessStatement(VHDLModel_ProcessStatement, DOMMixin):
         sensitivityList: Iterable[Symbol] = None,
     ) -> None:
         """
-        Initializes a process statement.
+        Initializes a :vhdlkw:`process` statement.
 
-        :param processNode:     The IIR node of the process statement.
-        :param label:           The label of the process statement, or ``None`` if it has none.
+        :param processNode:     The IIR node of the :vhdlkw:`process` statement.
+        :param label:           The label of the :vhdlkw:`process` statement, or ``None`` if it has none.
         :param declaredItems:   List of all declared items in this sequential declaration region.
         :param statements:      List of all sequential statements in this construct.
         :param sensitivityList: List of all signal names in the sensitivity list, or ``None`` if none was given.
@@ -375,7 +375,7 @@ class IfGenerateBranch(VHDLModel_IfGenerateBranch, DOMMixin):
         alternativeLabel: str = None,
     ) -> None:
         """
-        Initializes an if generate branch.
+        Initializes an :vhdlkw:`if..generate` branch.
 
         :param branchNode:       The IIR node of the branch this object represents.
         :param condition:        The condition under which this branch's declarations and statements are elaborated.
@@ -416,7 +416,7 @@ class ElsifGenerateBranch(VHDLModel_ElsifGenerateBranch, DOMMixin):
         alternativeLabel: str = None,
     ) -> None:
         """
-        Initializes an elsif generate branch.
+        Initializes an :vhdlkw:`elsif` branch of an :vhdlkw:`if..generate` statement.
 
         :param branchNode:       The IIR node of the branch this object represents.
         :param condition:        The condition under which this branch's declarations and statements are elaborated.
@@ -494,13 +494,13 @@ class IfGenerateStatement(VHDLModel_IfGenerateStatement, DOMMixin):
         elseBranch: ElseGenerateBranch = None,
     ) -> None:
         """
-        Initializes an if-generate statement.
+        Initializes an :vhdlkw:`if..generate` statement.
 
         :param generateNode:  The IIR node of the generate statement.
-        :param label:         The label of the if-generate statement.
-        :param ifBranch:      The mandatory ``if`` branch.
-        :param elsifBranches: List of all ``elsif`` branches, in the order they were written.
-        :param elseBranch:    The optional ``else`` branch, or ``None`` if none was given.
+        :param label:         The label of the :vhdlkw:`if..generate` statement.
+        :param ifBranch:      The mandatory :vhdlkw:`if` branch.
+        :param elsifBranches: List of all :vhdlkw:`elsif` branches, in the order they were written.
+        :param elseBranch:    The optional :vhdlkw:`else` branch, or ``None`` if none was given.
         """
         super().__init__(label, ifBranch, elsifBranches, elseBranch)
         DOMMixin.__init__(self, generateNode)
@@ -602,9 +602,9 @@ class OthersGenerateCase(VHDLModel_OthersGenerateCase, DOMMixin):
         alternativeLabel: str = None,
     ) -> None:
         """
-        Initializes an others generate case.
+        Initializes an :vhdlkw:`others` generate alternative.
 
-        :param caseNode:         The IIR node of the case statement.
+        :param caseNode:         The IIR node of the :vhdlkw:`case` statement.
         :param declaredItems:    List of all declared items in this concurrent declaration region.
         :param statements:       List of all concurrent statements in this construct.
         :param alternativeLabel: The alternative's label.
@@ -639,10 +639,10 @@ class CaseGenerateStatement(VHDLModel_CaseGenerateStatement, DOMMixin):
         cases: Iterable[ConcurrentCase],
     ) -> None:
         """
-        Initializes a case-generate statement.
+        Initializes a :vhdlkw:`case..generate` statement.
 
         :param generateNode: The IIR node of the generate statement.
-        :param label:        The label of the case-generate statement.
+        :param label:        The label of the :vhdlkw:`case..generate` statement.
         :param expression:   The expression selecting the alternative.
         :param cases:        List of all alternatives, in the order they were written.
         """
@@ -742,10 +742,10 @@ class ForGenerateStatement(VHDLModel_ForGenerateStatement, DOMMixin):
         parent: Nullable[ModelEntity] = None,
     ) -> None:
         """
-        Initializes a for-generate statement.
+        Initializes a :vhdlkw:`for..generate` statement.
 
         :param generateNode:  The IIR node of the generate statement.
-        :param label:         The label of the for-generate statement.
+        :param label:         The label of the :vhdlkw:`for..generate` statement.
         :param loopIndex:     The name of the generate loop's index.
         :param rng:           The range the generate loop iterates over.
         :param declaredItems: List of all declared items in this concurrent declaration region.
@@ -938,7 +938,7 @@ class SelectedWaveform(VHDLModel_SelectedWaveform, DOMMixin):
 class OthersSelectedWaveform(VHDLModel_OthersSelectedWaveform, DOMMixin):
     def __init__(self, node: Iir, waveform: Iterable[WaveformElement]) -> None:
         """
-        Initializes an others selected waveform.
+        Initializes an :vhdlkw:`others` selected waveform.
 
         :param node:     The IIR node this object was translated from.
         :param waveform: List of all waveform elements, in the order they were written.

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -177,6 +177,14 @@ class ComponentInstantiation(VHDLModel_ComponentInstantiation, DOMMixin):
 
     @classmethod
     def parse(cls, instantiationNode: Iir, instantiatedUnit: Iir, label: str) -> "ComponentInstantiation":
+        """
+        Translates the IIR node of the instantiation statement to a :class:`ComponentInstantiation`.
+
+        :param instantiationNode: The IIR node of the instantiation statement.
+        :param instantiatedUnit:  The IIR node of the instantiated unit.
+        :param label:             The statement's label, or ``None`` if it has none.
+        :returns:                 The translated instantiation statement.
+        """
         from pyGHDL.dom._Translate import GetName, GetGenericMapAspect, GetPortMapAspect
 
         componentSymbol = ComponentInstantiationSymbol(instantiatedUnit, GetName(instantiatedUnit))
@@ -217,6 +225,14 @@ class EntityInstantiation(VHDLModel_EntityInstantiation, DOMMixin):
 
     @classmethod
     def parse(cls, instantiationNode: Iir, instantiatedUnit: Iir, label: str) -> "EntityInstantiation":
+        """
+        Translates the IIR node of the instantiation statement to an :class:`EntityInstantiation`.
+
+        :param instantiationNode: The IIR node of the instantiation statement.
+        :param instantiatedUnit:  The IIR node of the instantiated unit.
+        :param label:             The statement's label, or ``None`` if it has none.
+        :returns:                 The translated instantiation statement.
+        """
         from pyGHDL.dom._Translate import GetName, GetGenericMapAspect, GetPortMapAspect
 
         entityName = nodes.Get_Entity_Name(instantiatedUnit)
@@ -264,6 +280,14 @@ class ConfigurationInstantiation(VHDLModel_ConfigurationInstantiation, DOMMixin)
 
     @classmethod
     def parse(cls, instantiationNode: Iir, instantiatedUnit: Iir, label: str) -> "ConfigurationInstantiation":
+        """
+        Translates the IIR node of the instantiation statement to a :class:`ConfigurationInstantiation`.
+
+        :param instantiationNode: The IIR node of the instantiation statement.
+        :param instantiatedUnit:  The IIR node of the instantiated unit.
+        :param label:             The statement's label, or ``None`` if it has none.
+        :returns:                 The translated instantiation statement.
+        """
         from pyGHDL.dom._Translate import GetName, GetGenericMapAspect, GetPortMapAspect
 
         configurationName = nodes.Get_Configuration_Name(instantiatedUnit)
@@ -318,6 +342,13 @@ class ConcurrentBlockStatement(VHDLModel_ConcurrentBlockStatement, DOMMixin):
 
     @classmethod
     def parse(cls, blockNode: Iir, label: str) -> "ConcurrentBlockStatement":
+        """
+        Translates the IIR node of the block statement to a :class:`ConcurrentBlockStatement`.
+
+        :param blockNode: The IIR node of the block statement.
+        :param label:     The statement's label, or ``None`` if it has none.
+        :returns:         The translated block statement.
+        """
         from pyGHDL.dom._Translate import (
             GetDeclaredItemsFromChainedNodes,
             GetConcurrentStatementsFromChainedNodes,
@@ -384,6 +415,14 @@ class ProcessStatement(VHDLModel_ProcessStatement, DOMMixin):
 
     @classmethod
     def parse(cls, processNode: Iir, label: str, hasSensitivityList: bool) -> "ProcessStatement":
+        """
+        Translates the IIR node of the process statement to a :class:`ProcessStatement`.
+
+        :param processNode:        The IIR node of the process statement.
+        :param label:              The statement's label, or ``None`` if it has none.
+        :param hasSensitivityList: ``True`` if the process was declared with a sensitivity list.
+        :returns:                  The translated process statement.
+        """
         from pyGHDL.dom._Translate import (
             GetName,
             GetDeclaredItemsFromChainedNodes,
@@ -433,6 +472,12 @@ class IfGenerateBranch(VHDLModel_IfGenerateBranch, DOMMixin):
 
     @classmethod
     def parse(cls, generateNode: Iir) -> "IfGenerateBranch":
+        """
+        Translates the IIR node of the generate statement to an :class:`IfGenerateBranch`.
+
+        :param generateNode: The IIR node of the generate statement.
+        :returns:            The translated generate statement.
+        """
         from pyGHDL.dom._Translate import (
             GetDeclaredItemsFromChainedNodes,
             GetConcurrentStatementsFromChainedNodes,
@@ -479,6 +524,13 @@ class ElsifGenerateBranch(VHDLModel_ElsifGenerateBranch, DOMMixin):
 
     @classmethod
     def parse(cls, generateNode: Iir, condition: Iir) -> "ElsifGenerateBranch":
+        """
+        Translates the IIR node of the generate statement to an :class:`ElsifGenerateBranch`.
+
+        :param generateNode: The IIR node of the generate statement.
+        :param condition:    The condition guarding the branch.
+        :returns:            The translated generate statement.
+        """
         from pyGHDL.dom._Translate import (
             GetDeclaredItemsFromChainedNodes,
             GetConcurrentStatementsFromChainedNodes,
@@ -523,6 +575,12 @@ class ElseGenerateBranch(VHDLModel_ElseGenerateBranch, DOMMixin):
 
     @classmethod
     def parse(cls, generateNode: Iir) -> "ElseGenerateBranch":
+        """
+        Translates the IIR node of the generate statement to an :class:`ElseGenerateBranch`.
+
+        :param generateNode: The IIR node of the generate statement.
+        :returns:            The translated generate statement.
+        """
         from pyGHDL.dom._Translate import (
             GetDeclaredItemsFromChainedNodes,
             GetConcurrentStatementsFromChainedNodes,
@@ -567,6 +625,13 @@ class IfGenerateStatement(VHDLModel_IfGenerateStatement, DOMMixin):
 
     @classmethod
     def parse(cls, generateNode: Iir, label: str) -> "IfGenerateStatement":
+        """
+        Translates the IIR node of the generate statement to an :class:`IfGenerateStatement`.
+
+        :param generateNode: The IIR node of the generate statement.
+        :param label:        The statement's label, or ``None`` if it has none.
+        :returns:            The translated generate statement.
+        """
         ifBranch = IfGenerateBranch.parse(generateNode)
         elsifBranches = []
         elseBranch = None
@@ -652,6 +717,13 @@ class GenerateCase(VHDLModel_GenerateCase, DOMMixin):
 
     @classmethod
     def parse(cls, caseNode: Iir, choices: Iterable[ConcurrentChoice]) -> "GenerateCase":
+        """
+        Translates the IIR node of the alternative to a :class:`GenerateCase`.
+
+        :param caseNode: The IIR node of the alternative.
+        :param choices:  List of all choices selecting this alternative.
+        :returns:        The translated alternative.
+        """
         from pyGHDL.dom._Translate import (
             GetDeclaredItemsFromChainedNodes,
             GetConcurrentStatementsFromChainedNodes,
@@ -694,6 +766,12 @@ class OthersGenerateCase(VHDLModel_OthersGenerateCase, DOMMixin):
 
     @classmethod
     def parse(cls, caseNode: Iir) -> "OthersGenerateCase":
+        """
+        Translates the IIR node of the alternative to an :class:`OthersGenerateCase`.
+
+        :param caseNode: The IIR node of the alternative.
+        :returns:        The translated alternative.
+        """
         from pyGHDL.dom._Translate import (
             GetDeclaredItemsFromChainedNodes,
             GetConcurrentStatementsFromChainedNodes,
@@ -736,6 +814,13 @@ class CaseGenerateStatement(VHDLModel_CaseGenerateStatement, DOMMixin):
 
     @classmethod
     def parse(cls, generateNode: Iir, label: str) -> "CaseGenerateStatement":
+        """
+        Translates the IIR node of the generate statement to a :class:`CaseGenerateStatement`.
+
+        :param generateNode: The IIR node of the generate statement.
+        :param label:        The statement's label, or ``None`` if it has none.
+        :returns:            The translated generate statement.
+        """
         from pyGHDL.dom._Utils import GetIirKindOfNode
         from pyGHDL.dom._Translate import (
             GetExpressionFromNode,
@@ -847,6 +932,13 @@ class ForGenerateStatement(VHDLModel_ForGenerateStatement, DOMMixin):
 
     @classmethod
     def parse(cls, generateNode: Iir, label: str) -> "ForGenerateStatement":
+        """
+        Translates the IIR node of the generate statement to a :class:`ForGenerateStatement`.
+
+        :param generateNode: The IIR node of the generate statement.
+        :param label:        The statement's label, or ``None`` if it has none.
+        :returns:            The translated generate statement.
+        """
         from pyGHDL.dom._Utils import GetNameOfNode
         from pyGHDL.dom._Translate import (
             GetDeclaredItemsFromChainedNodes,
@@ -886,6 +978,12 @@ class WaveformElement(VHDLModel_WaveformElement, DOMMixin):
 
     @classmethod
     def parse(cls, waveNode: Iir):
+        """
+        Translates the IIR node of the waveform element to a :class:`WaveformElement`.
+
+        :param waveNode: The IIR node of the waveform element.
+        :returns:        The translated waveform element.
+        """
         from pyGHDL.dom._Translate import GetExpressionFromNode
 
         value = GetExpressionFromNode(nodes.Get_We_Value(waveNode))
@@ -1012,6 +1110,12 @@ class ConditionalWaveform(VHDLModel_ConditionalWaveform, DOMMixin):
 
     @classmethod
     def parse(cls, node: Iir) -> "ConditionalWaveform":
+        """
+        Translates an IIR node to a :class:`ConditionalWaveform`.
+
+        :param node: The IIR node this object is translated from.
+        :returns:    The translated object.
+        """
         from pyGHDL.dom._Translate import GetOptionalExpressionFromNode
 
         waveform = GetWaveformElementsFromChainedNodes(nodes.Get_Waveform_Chain(node))
@@ -1084,6 +1188,13 @@ class ConcurrentSimpleSignalAssignment(VHDLModel_ConcurrentSimpleSignalAssignmen
 
     @classmethod
     def parse(cls, assignmentNode: Iir, label: str) -> "ConcurrentSimpleSignalAssignment":
+        """
+        Translates the IIR node of the assignment statement to a :class:`ConcurrentSimpleSignalAssignment`.
+
+        :param assignmentNode: The IIR node of the assignment statement.
+        :param label:          The statement's label, or ``None`` if it has none.
+        :returns:              The translated assignment statement.
+        """
         from pyGHDL.dom._Translate import GetName
 
         targetNode = nodes.Get_Target(assignmentNode)
@@ -1121,6 +1232,13 @@ class ConcurrentConditionalSignalAssignment(VHDLModel_ConcurrentConditionalSigna
 
     @classmethod
     def parse(cls, assignmentNode: Iir, label: str) -> "ConcurrentConditionalSignalAssignment":
+        """
+        Translates the IIR node of the assignment statement to a :class:`ConcurrentConditionalSignalAssignment`.
+
+        :param assignmentNode: The IIR node of the assignment statement.
+        :param label:          The statement's label, or ``None`` if it has none.
+        :returns:              The translated assignment statement.
+        """
         from pyGHDL.dom._Translate import GetName
 
         targetNode = nodes.Get_Target(assignmentNode)
@@ -1161,6 +1279,13 @@ class ConcurrentSelectedSignalAssignment(VHDLModel_ConcurrentSelectedSignalAssig
 
     @classmethod
     def parse(cls, assignmentNode: Iir, label: str) -> "ConcurrentSelectedSignalAssignment":
+        """
+        Translates the IIR node of the assignment statement to a :class:`ConcurrentSelectedSignalAssignment`.
+
+        :param assignmentNode: The IIR node of the assignment statement.
+        :param label:          The statement's label, or ``None`` if it has none.
+        :returns:              The translated assignment statement.
+        """
         from pyGHDL.dom._Translate import GetName, GetExpressionFromNode
 
         targetNode = nodes.Get_Target(assignmentNode)
@@ -1198,6 +1323,13 @@ class ConcurrentProcedureCall(VHDLModel_ConcurrentProcedureCall, DOMMixin):
 
     @classmethod
     def parse(cls, concurrentCallNode: Iir, label: str) -> "ConcurrentProcedureCall":
+        """
+        Translates the IIR node of the concurrent procedure call to a :class:`ConcurrentProcedureCall`.
+
+        :param concurrentCallNode: The IIR node of the concurrent procedure call.
+        :param label:              The statement's label, or ``None`` if it has none.
+        :returns:                  The translated concurrent procedure call.
+        """
         from pyGHDL.dom._Translate import GetName, GetParameterMapAspect
 
         callNode = nodes.Get_Procedure_Call(concurrentCallNode)
@@ -1238,6 +1370,13 @@ class ConcurrentAssertStatement(VHDLModel_ConcurrentAssertStatement, DOMMixin):
 
     @classmethod
     def parse(cls, assertNode: Iir, label: str) -> "ConcurrentAssertStatement":
+        """
+        Translates the IIR node of the assertion to a :class:`ConcurrentAssertStatement`.
+
+        :param assertNode: The IIR node of the assertion.
+        :param label:      The statement's label, or ``None`` if it has none.
+        :returns:          The translated assertion.
+        """
         from pyGHDL.dom._Translate import GetOptionalExpressionFromNode
 
         # FIXME: how to get the condition?

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -36,7 +36,7 @@ This module implements derived concurrent statement classes from :mod:`pyVHDLMod
 
 from typing import Iterable, List, Optional as Nullable
 
-from pyTooling.Decorators import export
+from pyTooling.Decorators import export, InheritDocString
 
 from pyVHDLModel.Base import ExpressionUnion, WaveformElement as VHDLModel_WaveformElement, ModelEntity, Range
 from pyVHDLModel.Common import (
@@ -92,7 +92,12 @@ from pyGHDL.dom.Symbol import (
 
 
 @export
+@InheritDocString(VHDLModel_GenericAssociationItem, merge=True)
 class GenericAssociationItem(VHDLModel_GenericAssociationItem, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Association.GenericAssociationItem`.
+    """
+
     def __init__(self, associationNode: Iir, formal: Symbol, actual: ExpressionUnion) -> None:
         """
         Initializes a generic association item.
@@ -106,7 +111,12 @@ class GenericAssociationItem(VHDLModel_GenericAssociationItem, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_PortAssociationItem, merge=True)
 class PortAssociationItem(VHDLModel_PortAssociationItem, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Association.PortAssociationItem`.
+    """
+
     def __init__(self, associationNode: Iir, formal: Symbol, actual: ExpressionUnion) -> None:
         """
         Initializes a port association item.
@@ -120,7 +130,12 @@ class PortAssociationItem(VHDLModel_PortAssociationItem, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_ParameterAssociationItem, merge=True)
 class ParameterAssociationItem(VHDLModel_ParameterAssociationItem, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Association.ParameterAssociationItem`.
+    """
+
     def __init__(self, associationNode: Iir, formal: Symbol, actual: ExpressionUnion) -> None:
         """
         Initializes a parameter association item.
@@ -134,7 +149,12 @@ class ParameterAssociationItem(VHDLModel_ParameterAssociationItem, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_ComponentInstantiation, merge=True)
 class ComponentInstantiation(VHDLModel_ComponentInstantiation, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.ComponentInstantiation`.
+    """
+
     def __init__(
         self,
         instantiationNode: Iir,
@@ -167,7 +187,12 @@ class ComponentInstantiation(VHDLModel_ComponentInstantiation, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_EntityInstantiation, merge=True)
 class EntityInstantiation(VHDLModel_EntityInstantiation, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.EntityInstantiation`.
+    """
+
     def __init__(
         self,
         instantiationNode: Iir,
@@ -211,7 +236,12 @@ class EntityInstantiation(VHDLModel_EntityInstantiation, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_ConfigurationInstantiation, merge=True)
 class ConfigurationInstantiation(VHDLModel_ConfigurationInstantiation, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.ConfigurationInstantiation`.
+    """
+
     def __init__(
         self,
         instantiationNode: Iir,
@@ -246,7 +276,12 @@ class ConfigurationInstantiation(VHDLModel_ConfigurationInstantiation, DOMMixin)
 
 
 @export
+@InheritDocString(VHDLModel_ConcurrentBlockStatement, merge=True)
 class ConcurrentBlockStatement(VHDLModel_ConcurrentBlockStatement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.ConcurrentBlockStatement`.
+    """
+
     def __init__(
         self,
         blockNode: Iir,
@@ -321,7 +356,12 @@ class ConcurrentBlockStatement(VHDLModel_ConcurrentBlockStatement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_ProcessStatement, merge=True)
 class ProcessStatement(VHDLModel_ProcessStatement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.ProcessStatement`.
+    """
+
     def __init__(
         self,
         processNode: Iir,
@@ -365,7 +405,12 @@ class ProcessStatement(VHDLModel_ProcessStatement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_IfGenerateBranch, merge=True)
 class IfGenerateBranch(VHDLModel_IfGenerateBranch, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.IfGenerateBranch`.
+    """
+
     def __init__(
         self,
         branchNode: Iir,
@@ -406,7 +451,12 @@ class IfGenerateBranch(VHDLModel_IfGenerateBranch, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_ElsifGenerateBranch, merge=True)
 class ElsifGenerateBranch(VHDLModel_ElsifGenerateBranch, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.ElsifGenerateBranch`.
+    """
+
     def __init__(
         self,
         branchNode: Iir,
@@ -447,7 +497,12 @@ class ElsifGenerateBranch(VHDLModel_ElsifGenerateBranch, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_ElseGenerateBranch, merge=True)
 class ElseGenerateBranch(VHDLModel_ElseGenerateBranch, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.ElseGenerateBranch`.
+    """
+
     def __init__(
         self,
         branchNode: Iir,
@@ -484,7 +539,12 @@ class ElseGenerateBranch(VHDLModel_ElseGenerateBranch, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_IfGenerateStatement, merge=True)
 class IfGenerateStatement(VHDLModel_IfGenerateStatement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.IfGenerateStatement`.
+    """
+
     def __init__(
         self,
         generateNode: Iir,
@@ -528,7 +588,12 @@ class IfGenerateStatement(VHDLModel_IfGenerateStatement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_IndexedGenerateChoice, merge=True)
 class IndexedGenerateChoice(VHDLModel_IndexedGenerateChoice, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.IndexedGenerateChoice`.
+    """
+
     def __init__(self, node: Iir, expression: ExpressionUnion) -> None:
         """
         Initializes a case-generate choice given by a single value.
@@ -541,7 +606,12 @@ class IndexedGenerateChoice(VHDLModel_IndexedGenerateChoice, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_RangedGenerateChoice, merge=True)
 class RangedGenerateChoice(VHDLModel_RangedGenerateChoice, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.RangedGenerateChoice`.
+    """
+
     def __init__(self, node: Iir, rng: Range) -> None:
         """
         Initializes a case-generate choice given by a range.
@@ -554,7 +624,12 @@ class RangedGenerateChoice(VHDLModel_RangedGenerateChoice, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_GenerateCase, merge=True)
 class GenerateCase(VHDLModel_GenerateCase, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.GenerateCase`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -593,7 +668,12 @@ class GenerateCase(VHDLModel_GenerateCase, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_OthersGenerateCase, merge=True)
 class OthersGenerateCase(VHDLModel_OthersGenerateCase, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.OthersGenerateCase`.
+    """
+
     def __init__(
         self,
         caseNode: Iir,
@@ -630,7 +710,12 @@ class OthersGenerateCase(VHDLModel_OthersGenerateCase, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_CaseGenerateStatement, merge=True)
 class CaseGenerateStatement(VHDLModel_CaseGenerateStatement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.CaseGenerateStatement`.
+    """
+
     def __init__(
         self,
         generateNode: Iir,
@@ -730,7 +815,12 @@ class CaseGenerateStatement(VHDLModel_CaseGenerateStatement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_ForGenerateStatement, merge=True)
 class ForGenerateStatement(VHDLModel_ForGenerateStatement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.ForGenerateStatement`.
+    """
+
     def __init__(
         self,
         generateNode: Iir,
@@ -777,7 +867,12 @@ class ForGenerateStatement(VHDLModel_ForGenerateStatement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_WaveformElement, merge=True)
 class WaveformElement(VHDLModel_WaveformElement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Base.WaveformElement`.
+    """
+
     def __init__(self, waveNode: Iir, expression: ExpressionUnion, after: ExpressionUnion) -> None:
         """
         Initializes a waveform element.
@@ -898,7 +993,12 @@ def GetSelectedWaveformsFromChainedNodes(nodeChain: Iir) -> Iterable:
 
 
 @export
+@InheritDocString(VHDLModel_ConditionalWaveform, merge=True)
 class ConditionalWaveform(VHDLModel_ConditionalWaveform, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Common.ConditionalWaveform`.
+    """
+
     def __init__(self, node: Iir, waveform: Iterable[WaveformElement], condition: ExpressionUnion = None) -> None:
         """
         Initializes a conditional waveform.
@@ -921,7 +1021,12 @@ class ConditionalWaveform(VHDLModel_ConditionalWaveform, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_SelectedWaveform, merge=True)
 class SelectedWaveform(VHDLModel_SelectedWaveform, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Common.SelectedWaveform`.
+    """
+
     def __init__(self, node: Iir, choices: Iterable, waveform: Iterable[WaveformElement]) -> None:
         """
         Initializes a selected waveform.
@@ -935,7 +1040,12 @@ class SelectedWaveform(VHDLModel_SelectedWaveform, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_OthersSelectedWaveform, merge=True)
 class OthersSelectedWaveform(VHDLModel_OthersSelectedWaveform, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Common.OthersSelectedWaveform`.
+    """
+
     def __init__(self, node: Iir, waveform: Iterable[WaveformElement]) -> None:
         """
         Initializes an :vhdlkw:`others` selected waveform.
@@ -948,7 +1058,12 @@ class OthersSelectedWaveform(VHDLModel_OthersSelectedWaveform, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_ConcurrentSimpleSignalAssignment, merge=True)
 class ConcurrentSimpleSignalAssignment(VHDLModel_ConcurrentSimpleSignalAssignment, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.ConcurrentSimpleSignalAssignment`.
+    """
+
     def __init__(
         self,
         assignmentNode: Iir,
@@ -980,7 +1095,12 @@ class ConcurrentSimpleSignalAssignment(VHDLModel_ConcurrentSimpleSignalAssignmen
 
 
 @export
+@InheritDocString(VHDLModel_ConcurrentConditionalSignalAssignment, merge=True)
 class ConcurrentConditionalSignalAssignment(VHDLModel_ConcurrentConditionalSignalAssignment, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.ConcurrentConditionalSignalAssignment`.
+    """
+
     def __init__(
         self,
         assignmentNode: Iir,
@@ -1013,7 +1133,12 @@ class ConcurrentConditionalSignalAssignment(VHDLModel_ConcurrentConditionalSigna
 
 
 @export
+@InheritDocString(VHDLModel_ConcurrentSelectedSignalAssignment, merge=True)
 class ConcurrentSelectedSignalAssignment(VHDLModel_ConcurrentSelectedSignalAssignment, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.ConcurrentSelectedSignalAssignment`.
+    """
+
     def __init__(
         self,
         assignmentNode: Iir,
@@ -1047,7 +1172,12 @@ class ConcurrentSelectedSignalAssignment(VHDLModel_ConcurrentSelectedSignalAssig
 
 
 @export
+@InheritDocString(VHDLModel_ConcurrentProcedureCall, merge=True)
 class ConcurrentProcedureCall(VHDLModel_ConcurrentProcedureCall, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.ConcurrentProcedureCall`.
+    """
+
     def __init__(
         self,
         callNode: Iir,
@@ -1080,7 +1210,12 @@ class ConcurrentProcedureCall(VHDLModel_ConcurrentProcedureCall, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_ConcurrentAssertStatement, merge=True)
 class ConcurrentAssertStatement(VHDLModel_ConcurrentAssertStatement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Concurrent.ConcurrentAssertStatement`.
+    """
+
     def __init__(
         self,
         assertNode: Iir,

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -147,7 +147,7 @@ class ComponentInstantiation(VHDLModel_ComponentInstantiation, DOMMixin):
         Initializes a component instantiation.
 
         :param instantiationNode:       The IIR node of the instantiation statement.
-        :param label:                   The label of a model entity.
+        :param label:                   The label of the component instantiation statement.
         :param componentSymbol:         Reference to the instantiated component.
         :param genericAssociationItems: List of all generic associations in the generic map aspect.
         :param portAssociationItems:    List of all port associations in the port map aspect.
@@ -181,7 +181,7 @@ class EntityInstantiation(VHDLModel_EntityInstantiation, DOMMixin):
         Initializes a direct entity instantiation.
 
         :param instantiationNode:       The IIR node of the instantiation statement.
-        :param label:                   The label of a model entity.
+        :param label:                   The label of the entity instantiation statement.
         :param entitySymbol:            Reference to the directly instantiated entity.
         :param architectureSymbol:      Reference to the selected architecture, if one was given.
         :param genericAssociationItems: List of all generic associations in the generic map aspect.
@@ -224,7 +224,7 @@ class ConfigurationInstantiation(VHDLModel_ConfigurationInstantiation, DOMMixin)
         Initializes a configuration instantiation.
 
         :param instantiationNode:       The IIR node of the instantiation statement.
-        :param label:                   The label of a model entity.
+        :param label:                   The label of the configuration instantiation statement.
         :param configurationSymbol:     Reference to the instantiated configuration.
         :param genericAssociationItems: List of all generic associations in the generic map aspect.
         :param portAssociationItems:    List of all port associations in the port map aspect.
@@ -262,7 +262,7 @@ class ConcurrentBlockStatement(VHDLModel_ConcurrentBlockStatement, DOMMixin):
         Initializes a block statement.
 
         :param blockNode:               The IIR node of the block statement.
-        :param label:                   The label of a model entity.
+        :param label:                   The label of the block statement.
         :param genericItems:            List of all generics, in declaration order.
         :param genericAssociationItems: List of all generic associations in the generic map aspect.
         :param portItems:               List of all ports, in declaration order.
@@ -334,7 +334,7 @@ class ProcessStatement(VHDLModel_ProcessStatement, DOMMixin):
         Initializes a process statement.
 
         :param processNode:     The IIR node of the process statement.
-        :param label:           The label of a model entity.
+        :param label:           The label of the process statement, or ``None`` if it has none.
         :param declaredItems:   List of all declared items in this sequential declaration region.
         :param statements:      List of all sequential statements in this construct.
         :param sensitivityList: List of all signal names in the sensitivity list, or ``None`` if none was given.
@@ -497,7 +497,7 @@ class IfGenerateStatement(VHDLModel_IfGenerateStatement, DOMMixin):
         Initializes an if-generate statement.
 
         :param generateNode:  The IIR node of the generate statement.
-        :param label:         The label of a model entity.
+        :param label:         The label of the if-generate statement.
         :param ifBranch:      The mandatory ``if`` branch.
         :param elsifBranches: List of all ``elsif`` branches, in the order they were written.
         :param elseBranch:    The optional ``else`` branch, or ``None`` if none was given.
@@ -642,7 +642,7 @@ class CaseGenerateStatement(VHDLModel_CaseGenerateStatement, DOMMixin):
         Initializes a case-generate statement.
 
         :param generateNode: The IIR node of the generate statement.
-        :param label:        The label of a model entity.
+        :param label:        The label of the case-generate statement.
         :param expression:   The expression being tested; it must be static.
         :param cases:        List of all alternatives, in the order they were written.
         """
@@ -745,7 +745,7 @@ class ForGenerateStatement(VHDLModel_ForGenerateStatement, DOMMixin):
         Initializes a for-generate statement.
 
         :param generateNode:  The IIR node of the generate statement.
-        :param label:         The label of a model entity.
+        :param label:         The label of the for-generate statement.
         :param loopIndex:     The name of the generate loop's index.
         :param rng:           The range the generate loop iterates over.
         :param declaredItems: List of all declared items in this concurrent declaration region.
@@ -960,7 +960,7 @@ class ConcurrentSimpleSignalAssignment(VHDLModel_ConcurrentSimpleSignalAssignmen
         Initializes a simple concurrent signal assignment.
 
         :param assignmentNode: The IIR node of the assignment statement.
-        :param label:          The label of a model entity.
+        :param label:          The label of the concurrent signal assignment, or ``None`` if it has none.
         :param target:         Reference to the assignment's destination.
         :param waveform:       List of all waveform elements, in the order they were written.
         """
@@ -992,7 +992,7 @@ class ConcurrentConditionalSignalAssignment(VHDLModel_ConcurrentConditionalSigna
         Initializes a conditional concurrent signal assignment.
 
         :param assignmentNode:       The IIR node of the assignment statement.
-        :param label:                The label of a model entity.
+        :param label:                The label of the conditional concurrent signal assignment, or ``None`` if it has none.
         :param target:               Reference to the assignment's destination.
         :param conditionalWaveforms: All alternatives, in order.
         """
@@ -1026,7 +1026,7 @@ class ConcurrentSelectedSignalAssignment(VHDLModel_ConcurrentSelectedSignalAssig
         Initializes a selected concurrent signal assignment.
 
         :param assignmentNode:    The IIR node of the assignment statement.
-        :param label:             The label of a model entity.
+        :param label:             The label of the selected concurrent signal assignment, or ``None`` if it has none.
         :param target:            Reference to the assignment's destination.
         :param expression:        The selector expression.
         :param selectedWaveforms: All alternatives, in order.
@@ -1059,7 +1059,7 @@ class ConcurrentProcedureCall(VHDLModel_ConcurrentProcedureCall, DOMMixin):
         Initializes a concurrent procedure call.
 
         :param callNode:                  The IIR node of the subprogram call.
-        :param label:                     The label of a model entity.
+        :param label:                     The label of the concurrent procedure call, or ``None`` if it has none.
         :param procedureName:             Reference to the called procedure.
         :param parameterAssociationItems: List of all parameter associations of the call.
         """
@@ -1096,7 +1096,7 @@ class ConcurrentAssertStatement(VHDLModel_ConcurrentAssertStatement, DOMMixin):
         :param condition:  The condition guarding this statement.
         :param message:    The reported message, or ``None`` if none was given.
         :param severity:   The reported severity level, or ``None`` if none was given.
-        :param label:      The label of a model entity.
+        :param label:      The label of the concurrent assertion statement, or ``None`` if it has none.
         """
         super().__init__(condition, message, severity, label)
         DOMMixin.__init__(self, assertNode)

--- a/pyGHDL/dom/Configuration.py
+++ b/pyGHDL/dom/Configuration.py
@@ -62,6 +62,13 @@ from pyGHDL.dom.Symbol import EntitySymbol, ArchitectureSymbol, ConfigurationSym
 @export
 class EntityAspectEntity(VHDLModel_EntityAspectEntity, DOMMixin):
     def __init__(self, node: Iir, entity: EntitySymbol, architecture: ArchitectureSymbol = None) -> None:
+        """
+        Initializes an entity aspect naming an entity, optionally with an architecture.
+
+        :param node:         The IIR node this object was translated from.
+        :param entity:       Reference to the named entity.
+        :param architecture: Reference to the selected architecture, or ``None`` if none was given.
+        """
         super().__init__(entity, architecture)
         DOMMixin.__init__(self, node)
 
@@ -85,6 +92,12 @@ class EntityAspectEntity(VHDLModel_EntityAspectEntity, DOMMixin):
 @export
 class EntityAspectConfiguration(VHDLModel_EntityAspectConfiguration, DOMMixin):
     def __init__(self, node: Iir, configuration: ConfigurationSymbol) -> None:
+        """
+        Initializes an entity aspect naming a configuration.
+
+        :param node:          The IIR node this object was translated from.
+        :param configuration: Reference to the named configuration.
+        """
         super().__init__(configuration)
         DOMMixin.__init__(self, node)
 
@@ -101,6 +114,11 @@ class EntityAspectConfiguration(VHDLModel_EntityAspectConfiguration, DOMMixin):
 @export
 class EntityAspectOpen(VHDLModel_EntityAspectOpen, DOMMixin):
     def __init__(self, node: Iir) -> None:
+        """
+        Initializes an entity aspect denoting ``open``.
+
+        :param node: The IIR node this object was translated from.
+        """
         super().__init__()
         DOMMixin.__init__(self, node)
 
@@ -138,6 +156,14 @@ class BindingIndication(VHDLModel_BindingIndication, DOMMixin):
         genericAssociationItems: List[GenericAssociationItem] = None,
         portAssociationItems: List[PortAssociationItem] = None,
     ) -> None:
+        """
+        Initializes a binding indication.
+
+        :param node:                    The IIR node this object was translated from.
+        :param entityAspect:            The bound design entity, or ``None`` if not given.
+        :param genericAssociationItems: List of all generic associations in the generic map aspect.
+        :param portAssociationItems:    List of all port associations in the port map aspect.
+        """
         super().__init__(entityAspect, genericAssociationItems, portAssociationItems)
         DOMMixin.__init__(self, node)
 
@@ -157,6 +183,11 @@ class BindingIndication(VHDLModel_BindingIndication, DOMMixin):
 @export
 class AllInstantiationList(VHDLModel_AllInstantiationList, DOMMixin):
     def __init__(self, node: Iir) -> None:
+        """
+        Initializes an instantiation list denoting ``all``.
+
+        :param node: The IIR node this object was translated from.
+        """
         super().__init__()
         DOMMixin.__init__(self, node)
 
@@ -164,6 +195,11 @@ class AllInstantiationList(VHDLModel_AllInstantiationList, DOMMixin):
 @export
 class OthersInstantiationList(VHDLModel_OthersInstantiationList, DOMMixin):
     def __init__(self, node: Iir) -> None:
+        """
+        Initializes an instantiation list denoting ``others``.
+
+        :param node: The IIR node this object was translated from.
+        """
         super().__init__()
         DOMMixin.__init__(self, node)
 
@@ -185,6 +221,14 @@ class ComponentConfiguration(VHDLModel_ComponentConfiguration, DOMMixin):
         componentName: ComponentInstantiationSymbol,
         bindingIndication: BindingIndication = None,
     ) -> None:
+        """
+        Initializes a component configuration.
+
+        :param node:              The IIR node this object was translated from.
+        :param instantiationList: The instances this configuration applies to.
+        :param componentName:     Reference to the component being configured.
+        :param bindingIndication: The binding indication, or ``None`` if none was given.
+        """
         super().__init__(instantiationList, componentName, bindingIndication)
         DOMMixin.__init__(self, node)
 
@@ -221,6 +265,13 @@ class BlockConfiguration(VHDLModel_BlockConfiguration, DOMMixin):
         blockSpecification: Symbol,
         items: List[Union["BlockConfiguration", ComponentConfiguration]] = None,
     ) -> None:
+        """
+        Initializes a block configuration.
+
+        :param node:               The IIR node this object was translated from.
+        :param blockSpecification: The configured block.
+        :param items:              Nested configurations.
+        """
         super().__init__(blockSpecification, items)
         DOMMixin.__init__(self, node)
 

--- a/pyGHDL/dom/Configuration.py
+++ b/pyGHDL/dom/Configuration.py
@@ -115,7 +115,7 @@ class EntityAspectConfiguration(VHDLModel_EntityAspectConfiguration, DOMMixin):
 class EntityAspectOpen(VHDLModel_EntityAspectOpen, DOMMixin):
     def __init__(self, node: Iir) -> None:
         """
-        Initializes an entity aspect denoting ``open``.
+        Initializes an entity aspect denoting :vhdlkw:`open`.
 
         :param node: The IIR node this object was translated from.
         """
@@ -184,7 +184,7 @@ class BindingIndication(VHDLModel_BindingIndication, DOMMixin):
 class AllInstantiationList(VHDLModel_AllInstantiationList, DOMMixin):
     def __init__(self, node: Iir) -> None:
         """
-        Initializes an instantiation list denoting ``all``.
+        Initializes an instantiation list denoting :vhdlkw:`all`.
 
         :param node: The IIR node this object was translated from.
         """
@@ -196,7 +196,7 @@ class AllInstantiationList(VHDLModel_AllInstantiationList, DOMMixin):
 class OthersInstantiationList(VHDLModel_OthersInstantiationList, DOMMixin):
     def __init__(self, node: Iir) -> None:
         """
-        Initializes an instantiation list denoting ``others``.
+        Initializes an instantiation list denoting :vhdlkw:`others`.
 
         :param node: The IIR node this object was translated from.
         """

--- a/pyGHDL/dom/Configuration.py
+++ b/pyGHDL/dom/Configuration.py
@@ -36,7 +36,7 @@ This module implements derived configuration classes from :mod:`pyVHDLModel.Conf
 
 from typing import List, Generator, Union
 
-from pyTooling.Decorators import export
+from pyTooling.Decorators import export, InheritDocString
 
 from pyVHDLModel.Symbol import Symbol, PossibleReference
 from pyVHDLModel.Name import Name
@@ -60,7 +60,12 @@ from pyGHDL.dom.Symbol import EntitySymbol, ArchitectureSymbol, ConfigurationSym
 
 
 @export
+@InheritDocString(VHDLModel_EntityAspectEntity, merge=True)
 class EntityAspectEntity(VHDLModel_EntityAspectEntity, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Configuration.EntityAspectEntity`.
+    """
+
     def __init__(self, node: Iir, entity: EntitySymbol, architecture: ArchitectureSymbol = None) -> None:
         """
         Initializes an entity aspect naming an entity, optionally with an architecture.
@@ -90,7 +95,12 @@ class EntityAspectEntity(VHDLModel_EntityAspectEntity, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_EntityAspectConfiguration, merge=True)
 class EntityAspectConfiguration(VHDLModel_EntityAspectConfiguration, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Configuration.EntityAspectConfiguration`.
+    """
+
     def __init__(self, node: Iir, configuration: ConfigurationSymbol) -> None:
         """
         Initializes an entity aspect naming a configuration.
@@ -112,7 +122,12 @@ class EntityAspectConfiguration(VHDLModel_EntityAspectConfiguration, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_EntityAspectOpen, merge=True)
 class EntityAspectOpen(VHDLModel_EntityAspectOpen, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Configuration.EntityAspectOpen`.
+    """
+
     def __init__(self, node: Iir) -> None:
         """
         Initializes an entity aspect denoting :vhdlkw:`open`.
@@ -148,7 +163,12 @@ def GetEntityAspectFromNode(entityAspectNode: Iir) -> VHDLModel_EntityAspect:
 
 
 @export
+@InheritDocString(VHDLModel_BindingIndication, merge=True)
 class BindingIndication(VHDLModel_BindingIndication, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Configuration.BindingIndication`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -181,7 +201,12 @@ class BindingIndication(VHDLModel_BindingIndication, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_AllInstantiationList, merge=True)
 class AllInstantiationList(VHDLModel_AllInstantiationList, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Configuration.AllInstantiationList`.
+    """
+
     def __init__(self, node: Iir) -> None:
         """
         Initializes an instantiation list denoting :vhdlkw:`all`.
@@ -193,7 +218,12 @@ class AllInstantiationList(VHDLModel_AllInstantiationList, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_OthersInstantiationList, merge=True)
 class OthersInstantiationList(VHDLModel_OthersInstantiationList, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Configuration.OthersInstantiationList`.
+    """
+
     def __init__(self, node: Iir) -> None:
         """
         Initializes an instantiation list denoting :vhdlkw:`others`.
@@ -258,7 +288,12 @@ class ComponentConfiguration(VHDLModel_ComponentConfiguration, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_BlockConfiguration, merge=True)
 class BlockConfiguration(VHDLModel_BlockConfiguration, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Configuration.BlockConfiguration`.
+    """
+
     def __init__(
         self,
         node: Iir,

--- a/pyGHDL/dom/Configuration.py
+++ b/pyGHDL/dom/Configuration.py
@@ -79,6 +79,12 @@ class EntityAspectEntity(VHDLModel_EntityAspectEntity, DOMMixin):
 
     @classmethod
     def parse(cls, entityAspectNode: Iir) -> "EntityAspectEntity":
+        """
+        Translates the IIR node of the entity aspect to an :class:`EntityAspectEntity`.
+
+        :param entityAspectNode: The IIR node of the entity aspect.
+        :returns:                The translated entity aspect.
+        """
         from pyGHDL.dom._Translate import GetName
 
         entityNameNode = nodes.Get_Entity_Name(entityAspectNode)
@@ -113,6 +119,12 @@ class EntityAspectConfiguration(VHDLModel_EntityAspectConfiguration, DOMMixin):
 
     @classmethod
     def parse(cls, entityAspectNode: Iir) -> "EntityAspectConfiguration":
+        """
+        Translates the IIR node of the entity aspect to an :class:`EntityAspectConfiguration`.
+
+        :param entityAspectNode: The IIR node of the entity aspect.
+        :returns:                The translated entity aspect.
+        """
         from pyGHDL.dom._Translate import GetName
 
         configurationNameNode = nodes.Get_Configuration_Name(entityAspectNode)
@@ -139,6 +151,12 @@ class EntityAspectOpen(VHDLModel_EntityAspectOpen, DOMMixin):
 
     @classmethod
     def parse(cls, entityAspectNode: Iir) -> "EntityAspectOpen":
+        """
+        Translates the IIR node of the entity aspect to an :class:`EntityAspectOpen`.
+
+        :param entityAspectNode: The IIR node of the entity aspect.
+        :returns:                The translated entity aspect.
+        """
         return cls(entityAspectNode)
 
 
@@ -189,6 +207,12 @@ class BindingIndication(VHDLModel_BindingIndication, DOMMixin):
 
     @classmethod
     def parse(cls, bindingIndicationNode: Iir) -> "BindingIndication":
+        """
+        Translates the IIR node of the binding indication to a :class:`BindingIndication`.
+
+        :param bindingIndicationNode: The IIR node of the binding indication.
+        :returns:                     The translated binding indication.
+        """
         from pyGHDL.dom._Translate import GetGenericMapAspect, GetPortMapAspect
 
         entityAspectNode = nodes.Get_Entity_Aspect(bindingIndicationNode)
@@ -264,6 +288,12 @@ class ComponentConfiguration(VHDLModel_ComponentConfiguration, DOMMixin):
 
     @classmethod
     def parse(cls, node: Iir) -> "ComponentConfiguration":
+        """
+        Translates an IIR node to a :class:`ComponentConfiguration`.
+
+        :param node: The IIR node this object is translated from.
+        :returns:    The translated object.
+        """
         from pyGHDL.dom._Translate import GetName
 
         instList = nodes.Get_Instantiation_List(node)
@@ -312,6 +342,12 @@ class BlockConfiguration(VHDLModel_BlockConfiguration, DOMMixin):
 
     @classmethod
     def parse(cls, node: Iir) -> "BlockConfiguration":
+        """
+        Translates an IIR node to a :class:`BlockConfiguration`.
+
+        :param node: The IIR node this object is translated from.
+        :returns:    The translated object.
+        """
         from pyGHDL.dom._Translate import GetName
         from pyGHDL.dom.Symbol import Symbol as DOMSymbol
 

--- a/pyGHDL/dom/Configuration.py
+++ b/pyGHDL/dom/Configuration.py
@@ -30,6 +30,10 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+This module implements derived configuration classes from :mod:`pyVHDLModel.Configuration`.
+"""
+
 from typing import List, Generator, Union
 
 from pyTooling.Decorators import export
@@ -106,7 +110,13 @@ class EntityAspectOpen(VHDLModel_EntityAspectOpen, DOMMixin):
 
 
 def GetEntityAspectFromNode(entityAspectNode: Iir) -> VHDLModel_EntityAspect:
-    """Translates an entity aspect (IIR node) to the matching pyVHDLModel.Configuration.EntityAspect subclass."""
+    """
+    Translates an entity aspect to the matching :class:`~pyVHDLModel.Configuration.EntityAspect` subclass.
+
+    :param entityAspectNode: The IIR node of the entity aspect.
+    :returns:                The translated entity aspect.
+    :raises DOMException:    If the entity aspect's kind is not handled.
+    """
     kind = GetIirKindOfNode(entityAspectNode)
     if kind == nodes.Iir_Kind.Entity_Aspect_Entity:
         return EntityAspectEntity.parse(entityAspectNode)
@@ -234,7 +244,13 @@ class BlockConfiguration(VHDLModel_BlockConfiguration, DOMMixin):
 def GetConfigurationItemsFromChainedNodes(
     nodeChain: Iir,
 ) -> Generator[Union[BlockConfiguration, ComponentConfiguration], None, None]:
-    """Translates a chain of configuration items (component/block configurations) to pyVHDLModel objects."""
+    """
+    Translates a chain of configuration items to :class:`ComponentConfiguration` and :class:`BlockConfiguration`.
+
+    :param nodeChain:     The IIR node starting the chain of configuration items.
+    :returns:             Generator yielding the translated configuration items, in source order.
+    :raises DOMException: If a configuration item's kind is not handled.
+    """
     for item in utils.chain_iter(nodeChain):
         kind = GetIirKindOfNode(item)
         if kind == nodes.Iir_Kind.Component_Configuration:

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -87,7 +87,7 @@ class LibraryClause(VHDLModel_LibraryClause, DOMMixin):
         """
         Initializes a library clause.
 
-        :param libraryNode: The IIR node of the library clause.
+        :param libraryNode: The IIR node of the :vhdlkw:`library` clause.
         :param symbols:     A list of symbols this reference references to.
         """
         super().__init__(symbols, None)
@@ -100,7 +100,7 @@ class UseClause(VHDLModel_UseClause, DOMMixin):
         """
         Initializes a use clause.
 
-        :param useNode: The IIR node of the use clause.
+        :param useNode: The IIR node of the :vhdlkw:`use` clause.
         :param symbols: A list of symbols this reference references to.
         """
         super().__init__(symbols, None)

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -175,7 +175,7 @@ class Entity(VHDLModel_Entity, DOMMixin):
         Initializes an entity declaration.
 
         :param node:          The IIR node this object was translated from.
-        :param identifier:    The identifier of a model entity.
+        :param identifier:    The entity's identifier.
         :param contextItems:  List of all context items (library, use and context clauses).
         :param genericItems:  List of all generics, in declaration order.
         :param portItems:     List of all ports, in declaration order.
@@ -220,7 +220,7 @@ class Architecture(VHDLModel_Architecture, DOMMixin):
         Initializes an architecture declaration.
 
         :param node:          The IIR node this object was translated from.
-        :param identifier:    The identifier of a model entity.
+        :param identifier:    The architecture's identifier.
         :param entity:        Reference to the entity this architecture implements.
         :param contextItems:  List of all context items (library, use and context clauses).
         :param declaredItems: List of all declared items in this concurrent declaration region.
@@ -262,7 +262,7 @@ class Component(VHDLModel_Component, DOMMixin):
         Initializes a component declaration.
 
         :param node:          The IIR node this object was translated from.
-        :param identifier:    The identifier of a model entity.
+        :param identifier:    The component's identifier.
         :param genericItems:  List of all generics of this component, in declaration order.
         :param portItems:     List of all ports of this component, in declaration order.
         :param documentation: The documentation comment associated with this declaration.
@@ -373,7 +373,7 @@ class PackageInstantiation(VHDLModel_PackageInstantiation, DOMMixin):
         Initializes a package instantiation.
 
         :param node:                      The IIR node this object was translated from.
-        :param identifier:                The identifier of a model entity.
+        :param identifier:                The instantiated package's identifier.
         :param uninstantiatedPackageName: The name of the uninstantiated generic package.
         :param contextItems:              List of all context items (library, use and context clauses).
         :param genericAssociationItems:   List of all generic associations in the generic map aspect.
@@ -409,7 +409,7 @@ class Context(VHDLModel_Context, DOMMixin):
         Initializes a context declaration.
 
         :param node:          The IIR node this object was translated from.
-        :param identifier:    The identifier of a model entity.
+        :param identifier:    The context's identifier.
         :param references:    All context items, in declaration order.
         :param documentation: The documentation comment associated with this declaration.
         """
@@ -461,7 +461,7 @@ class Configuration(VHDLModel_Configuration, DOMMixin):
         Initializes a configuration declaration.
 
         :param node:               The IIR node this object was translated from.
-        :param identifier:         The identifier of a model entity.
+        :param identifier:         The configuration's identifier.
         :param entity:             Reference to the entity this configuration configures.
         :param blockConfiguration: The configuration of the entity's architecture.
         :param contextItems:       List of all context items (library, use and context clauses).

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -85,7 +85,7 @@ from pyGHDL.dom.Configuration import BlockConfiguration
 class LibraryClause(VHDLModel_LibraryClause, DOMMixin):
     def __init__(self, libraryNode: Iir, symbols: Iterable[Symbol]) -> None:
         """
-        Initializes a reference by taking a list of symbols and a parent reference.
+        Initializes a library clause.
 
         :param libraryNode: The IIR node of the library clause.
         :param symbols:     A list of symbols this reference references to.
@@ -98,7 +98,7 @@ class LibraryClause(VHDLModel_LibraryClause, DOMMixin):
 class UseClause(VHDLModel_UseClause, DOMMixin):
     def __init__(self, useNode: Iir, symbols: Iterable[Symbol]) -> None:
         """
-        Initializes a reference by taking a list of symbols and a parent reference.
+        Initializes a use clause.
 
         :param useNode: The IIR node of the use clause.
         :param symbols: A list of symbols this reference references to.
@@ -139,7 +139,7 @@ class UseClause(VHDLModel_UseClause, DOMMixin):
 class ContextReference(VHDLModel_ContextReference, DOMMixin):
     def __init__(self, contextNode: Iir, symbols: Iterable[Symbol]) -> None:
         """
-        Initializes a reference by taking a list of symbols and a parent reference.
+        Initializes a context reference.
 
         :param contextNode: The IIR node of the context reference.
         :param symbols:     A list of symbols this reference references to.

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -84,6 +84,12 @@ from pyGHDL.dom.Configuration import BlockConfiguration
 @export
 class LibraryClause(VHDLModel_LibraryClause, DOMMixin):
     def __init__(self, libraryNode: Iir, symbols: Iterable[Symbol]) -> None:
+        """
+        Initializes a reference by taking a list of symbols and a parent reference.
+
+        :param libraryNode: The IIR node of the library clause.
+        :param symbols:     A list of symbols this reference references to.
+        """
         super().__init__(symbols, None)
         DOMMixin.__init__(self, libraryNode)
 
@@ -91,6 +97,12 @@ class LibraryClause(VHDLModel_LibraryClause, DOMMixin):
 @export
 class UseClause(VHDLModel_UseClause, DOMMixin):
     def __init__(self, useNode: Iir, symbols: Iterable[Symbol]) -> None:
+        """
+        Initializes a reference by taking a list of symbols and a parent reference.
+
+        :param useNode: The IIR node of the use clause.
+        :param symbols: A list of symbols this reference references to.
+        """
         super().__init__(symbols, None)
         DOMMixin.__init__(self, useNode)
 
@@ -126,6 +138,12 @@ class UseClause(VHDLModel_UseClause, DOMMixin):
 @export
 class ContextReference(VHDLModel_ContextReference, DOMMixin):
     def __init__(self, contextNode: Iir, symbols: Iterable[Symbol]) -> None:
+        """
+        Initializes a reference by taking a list of symbols and a parent reference.
+
+        :param contextNode: The IIR node of the context reference.
+        :param symbols:     A list of symbols this reference references to.
+        """
         super().__init__(symbols, None)
         DOMMixin.__init__(self, contextNode)
 
@@ -153,6 +171,18 @@ class Entity(VHDLModel_Entity, DOMMixin):
         statements: Iterable["ConcurrentStatement"] = None,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes an entity declaration.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifier:    The identifier of a model entity.
+        :param contextItems:  List of all context items (library, use and context clauses).
+        :param genericItems:  List of all generics, in declaration order.
+        :param portItems:     List of all ports, in declaration order.
+        :param declaredItems: List of all declared items in this concurrent declaration region.
+        :param statements:    List of all concurrent statements in this construct.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(
             identifier, contextItems, genericItems, portItems, declaredItems, statements, documentation, None
         )
@@ -186,6 +216,17 @@ class Architecture(VHDLModel_Architecture, DOMMixin):
         statements: Iterable["ConcurrentStatement"] = None,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes an architecture declaration.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifier:    The identifier of a model entity.
+        :param entity:        Reference to the entity this architecture implements.
+        :param contextItems:  List of all context items (library, use and context clauses).
+        :param declaredItems: List of all declared items in this concurrent declaration region.
+        :param statements:    List of all concurrent statements in this construct.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, entity, contextItems, declaredItems, statements, documentation, None)
         DOMMixin.__init__(self, node)
 
@@ -217,6 +258,15 @@ class Component(VHDLModel_Component, DOMMixin):
         portItems: Iterable[PortInterfaceItemMixin] = None,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a component declaration.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifier:    The identifier of a model entity.
+        :param genericItems:  List of all generics of this component, in declaration order.
+        :param portItems:     List of all ports of this component, in declaration order.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, genericItems, portItems, documentation, None)
         DOMMixin.__init__(self, node)
 
@@ -241,6 +291,16 @@ class Package(VHDLModel_Package, DOMMixin):
         declaredItems: Iterable = None,
         documentation: str = None,
     ) -> None:
+        """
+        Initialize a package.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifier:    Name of the VHDL package.
+        :param contextItems:  List of all context items (library, use and context clauses).
+        :param genericItems:  List of all generics, in declaration order.
+        :param declaredItems: List of all declared items in this concurrent declaration region.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, contextItems, genericItems, declaredItems, documentation, None)
         DOMMixin.__init__(self, node)
 
@@ -272,6 +332,15 @@ class PackageBody(VHDLModel_PackageBody, DOMMixin):
         declaredItems: Iterable = None,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a package body declaration.
+
+        :param node:          The IIR node this object was translated from.
+        :param packageSymbol: Reference to the package this body implements.
+        :param contextItems:  List of all context items (library, use and context clauses).
+        :param declaredItems: List of all declared items in this concurrent declaration region.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(packageSymbol, contextItems, declaredItems, documentation, None)
         DOMMixin.__init__(self, node)
 
@@ -300,6 +369,16 @@ class PackageInstantiation(VHDLModel_PackageInstantiation, DOMMixin):
         genericAssociationItems: Iterable[VHDLModel_GenericAssociationItem] = None,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a package instantiation.
+
+        :param node:                      The IIR node this object was translated from.
+        :param identifier:                The identifier of a model entity.
+        :param uninstantiatedPackageName: The name of the uninstantiated generic package.
+        :param contextItems:              List of all context items (library, use and context clauses).
+        :param genericAssociationItems:   List of all generic associations in the generic map aspect.
+        :param documentation:             The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, uninstantiatedPackageName, contextItems, genericAssociationItems, documentation)
         DOMMixin.__init__(self, node)
 
@@ -326,6 +405,14 @@ class Context(VHDLModel_Context, DOMMixin):
         references: Iterable[VHDLModel_ContextUnion] = None,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a context declaration.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifier:    The identifier of a model entity.
+        :param references:    All context items, in declaration order.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, references, documentation, None)
         DOMMixin.__init__(self, node)
 
@@ -370,6 +457,16 @@ class Configuration(VHDLModel_Configuration, DOMMixin):
         contextItems: Iterable[Context] = None,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a configuration declaration.
+
+        :param node:               The IIR node this object was translated from.
+        :param identifier:         The identifier of a model entity.
+        :param entity:             Reference to the entity this configuration configures.
+        :param blockConfiguration: The configuration of the entity's architecture.
+        :param contextItems:       List of all context items (library, use and context clauses).
+        :param documentation:      The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, entity, blockConfiguration, contextItems, documentation, None)
         DOMMixin.__init__(self, node)
 

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -30,13 +30,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
-
 """
 This module contains all DOM classes for VHDL's design units (:class:`context <Entity>`,
 :class:`architecture <Architecture>`, :class:`package <Package>`,
 :class:`package body <PackageBody>`, :class:`context <Context>` and
 :class:`configuration <Configuration>`.
-
 
 """
 
@@ -118,6 +116,12 @@ class UseClause(VHDLModel_UseClause, DOMMixin):
 
     @classmethod
     def parse(cls, useNode: Iir):
+        """
+        Translates the IIR node of the use clause to an :class:`UseClause`.
+
+        :param useNode: The IIR node of the use clause.
+        :returns:       The translated use clause.
+        """
         nameNode = nodes.Get_Selected_Name(useNode)
         name = GetName(nameNode)
 
@@ -164,6 +168,12 @@ class ContextReference(VHDLModel_ContextReference, DOMMixin):
 
     @classmethod
     def parse(cls, contextNode: Iir):
+        """
+        Translates the IIR node of the context to a :class:`ContextReference`.
+
+        :param contextNode: The IIR node of the context.
+        :returns:           The translated context.
+        """
         nameNode = nodes.Get_Selected_Name(contextNode)
         contexts = [ContextReferenceSymbol(nameNode, GetName(nameNode))]
         for context in utils.chain_iter(nodes.Get_Context_Reference_Chain(contextNode)):
@@ -210,6 +220,13 @@ class Entity(VHDLModel_Entity, DOMMixin):
 
     @classmethod
     def parse(cls, entityNode: Iir, contextItems: Iterable[VHDLModel_ContextUnion]):
+        """
+        Translates the IIR node of the entity declaration to an :class:`Entity`.
+
+        :param entityNode:   The IIR node of the entity declaration.
+        :param contextItems: List of all context items (library, use and context clauses) preceding the unit.
+        :returns:            The translated entity declaration.
+        """
         name = GetNameOfNode(entityNode)
         documentation = GetDocumentationOfNode(entityNode)
         generics = GetGenericsFromChainedNodes(nodes.Get_Generic_Chain(entityNode))
@@ -257,6 +274,13 @@ class Architecture(VHDLModel_Architecture, DOMMixin):
 
     @classmethod
     def parse(cls, architectureNode: Iir, contextItems: Iterable[VHDLModel_ContextUnion]):
+        """
+        Translates the IIR node of the architecture body to an :class:`Architecture`.
+
+        :param architectureNode: The IIR node of the architecture body.
+        :param contextItems:     List of all context items (library, use and context clauses) preceding the unit.
+        :returns:                The translated architecture body.
+        """
         name = GetNameOfNode(architectureNode)
         documentation = GetDocumentationOfNode(architectureNode)
         entityNameNode = nodes.Get_Entity_Name(architectureNode)
@@ -302,6 +326,12 @@ class Component(VHDLModel_Component, DOMMixin):
 
     @classmethod
     def parse(cls, componentNode: Iir):
+        """
+        Translates the IIR node of the component declaration to a :class:`Component`.
+
+        :param componentNode: The IIR node of the component declaration.
+        :returns:             The translated component declaration.
+        """
         name = GetNameOfNode(componentNode)
         documentation = GetDocumentationOfNode(componentNode)
         generics = GetGenericsFromChainedNodes(nodes.Get_Generic_Chain(componentNode))
@@ -341,6 +371,13 @@ class Package(VHDLModel_Package, DOMMixin):
 
     @classmethod
     def parse(cls, packageNode: Iir, contextItems: Iterable[VHDLModel_ContextUnion]):
+        """
+        Translates the IIR node of the package declaration to a :class:`Package`.
+
+        :param packageNode:  The IIR node of the package declaration.
+        :param contextItems: List of all context items (library, use and context clauses) preceding the unit.
+        :returns:            The translated package declaration.
+        """
         name = GetNameOfNode(packageNode)
         documentation = GetDocumentationOfNode(packageNode)
 
@@ -386,6 +423,13 @@ class PackageBody(VHDLModel_PackageBody, DOMMixin):
 
     @classmethod
     def parse(cls, packageBodyNode: Iir, contextItems: Iterable[VHDLModel_ContextUnion]):
+        """
+        Translates the IIR node of the package body to a :class:`PackageBody`.
+
+        :param packageBodyNode: The IIR node of the package body.
+        :param contextItems:    List of all context items (library, use and context clauses) preceding the unit.
+        :returns:               The translated package body.
+        """
         packageIdentifier = GetNameOfNode(packageBodyNode)
         packageSymbol = PackageSymbol(packageBodyNode, SimpleName(packageBodyNode, packageIdentifier))
         documentation = GetDocumentationOfNode(packageBodyNode)
@@ -429,6 +473,13 @@ class PackageInstantiation(VHDLModel_PackageInstantiation, DOMMixin):
 
     @classmethod
     def parse(cls, packageNode: Iir, contextItems: Iterable[VHDLModel_ContextUnion] = None):
+        """
+        Translates the IIR node of the package declaration to a :class:`PackageInstantiation`.
+
+        :param packageNode:  The IIR node of the package declaration.
+        :param contextItems: List of all context items (library, use and context clauses) preceding the unit.
+        :returns:            The translated package declaration.
+        """
         name = GetNameOfNode(packageNode)
         documentation = GetDocumentationOfNode(packageNode)
         uninstantiatedPackageName = GetName(
@@ -468,6 +519,12 @@ class Context(VHDLModel_Context, DOMMixin):
 
     @classmethod
     def parse(cls, contextNode: Iir):
+        """
+        Translates the IIR node of the context to a :class:`Context`.
+
+        :param contextNode: The IIR node of the context.
+        :returns:           The translated context.
+        """
         from pyGHDL.dom._Utils import GetIirKindOfNode
 
         name = GetNameOfNode(contextNode)
@@ -527,6 +584,13 @@ class Configuration(VHDLModel_Configuration, DOMMixin):
 
     @classmethod
     def parse(cls, configurationNode: Iir, contextItems: Iterable[Context]) -> "Configuration":
+        """
+        Translates the IIR node of the configuration declaration to a :class:`Configuration`.
+
+        :param configurationNode: The IIR node of the configuration declaration.
+        :param contextItems:      List of all context items (library, use and context clauses) preceding the unit.
+        :returns:                 The translated configuration declaration.
+        """
         from pyGHDL.dom._Translate import GetName
 
         name = GetNameOfNode(configurationNode)

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -42,7 +42,7 @@ This module contains all DOM classes for VHDL's design units (:class:`context <E
 
 from typing import Iterable
 
-from pyTooling.Decorators import export
+from pyTooling.Decorators import export, InheritDocString
 
 from pyVHDLModel.Symbol import Symbol
 from pyVHDLModel.Instantiation import PackageInstantiation as VHDLModel_PackageInstantiation
@@ -82,7 +82,12 @@ from pyGHDL.dom.Configuration import BlockConfiguration
 
 
 @export
+@InheritDocString(VHDLModel_LibraryClause, merge=True)
 class LibraryClause(VHDLModel_LibraryClause, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.DesignUnit.LibraryClause`.
+    """
+
     def __init__(self, libraryNode: Iir, symbols: Iterable[Symbol]) -> None:
         """
         Initializes a library clause.
@@ -95,7 +100,12 @@ class LibraryClause(VHDLModel_LibraryClause, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_UseClause, merge=True)
 class UseClause(VHDLModel_UseClause, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.DesignUnit.UseClause`.
+    """
+
     def __init__(self, useNode: Iir, symbols: Iterable[Symbol]) -> None:
         """
         Initializes a use clause.
@@ -136,7 +146,12 @@ class UseClause(VHDLModel_UseClause, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_ContextReference, merge=True)
 class ContextReference(VHDLModel_ContextReference, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.DesignUnit.ContextReference`.
+    """
+
     def __init__(self, contextNode: Iir, symbols: Iterable[Symbol]) -> None:
         """
         Initializes a context reference.
@@ -159,7 +174,12 @@ class ContextReference(VHDLModel_ContextReference, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_Entity, merge=True)
 class Entity(VHDLModel_Entity, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.DesignUnit.Entity`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -205,7 +225,12 @@ class Entity(VHDLModel_Entity, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_Architecture, merge=True)
 class Architecture(VHDLModel_Architecture, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.DesignUnit.Architecture`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -249,7 +274,12 @@ class Architecture(VHDLModel_Architecture, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_Component, merge=True)
 class Component(VHDLModel_Component, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.DesignUnit.Component`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -281,7 +311,12 @@ class Component(VHDLModel_Component, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_Package, merge=True)
 class Package(VHDLModel_Package, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.DesignUnit.Package`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -323,7 +358,12 @@ class Package(VHDLModel_Package, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_PackageBody, merge=True)
 class PackageBody(VHDLModel_PackageBody, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.DesignUnit.PackageBody`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -359,7 +399,12 @@ class PackageBody(VHDLModel_PackageBody, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_PackageInstantiation, merge=True)
 class PackageInstantiation(VHDLModel_PackageInstantiation, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Instantiation.PackageInstantiation`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -397,7 +442,12 @@ class PackageInstantiation(VHDLModel_PackageInstantiation, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_Context, merge=True)
 class Context(VHDLModel_Context, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.DesignUnit.Context`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -447,7 +497,12 @@ class Context(VHDLModel_Context, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_Configuration, merge=True)
 class Configuration(VHDLModel_Configuration, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.DesignUnit.Configuration`.
+    """
+
     def __init__(
         self,
         node: Iir,

--- a/pyGHDL/dom/Expression.py
+++ b/pyGHDL/dom/Expression.py
@@ -30,6 +30,10 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+This module implements derived expression classes from :mod:`pyVHDLModel.Expression`.
+"""
+
 from typing import List, Union
 
 from pyTooling.Decorators import export

--- a/pyGHDL/dom/Expression.py
+++ b/pyGHDL/dom/Expression.py
@@ -468,7 +468,7 @@ class NorExpression(VHDLModel_NorExpression, DOMMixin, _ParseBinaryExpressionMix
 class XorExpression(VHDLModel_XorExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a xor expression.
+        Initializes an :vhdlkw:`xor` expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -482,7 +482,7 @@ class XorExpression(VHDLModel_XorExpression, DOMMixin, _ParseBinaryExpressionMix
 class XnorExpression(VHDLModel_XnorExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a xnor expression.
+        Initializes an :vhdlkw:`xnor` expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -849,7 +849,7 @@ class QualifiedExpression(VHDLModel_QualifiedExpression, DOMMixin):
 class SubtypeAllocation(VHDLModel_SubtypeAllocation, DOMMixin):
     def __init__(self, node: Iir, subtype: Symbol) -> None:
         """
-        Initializes an allocation of a subtype via ``new``.
+        Initializes an allocation of a subtype via :vhdlkw:`new`.
 
         :param node:    The IIR node this object was translated from.
         :param subtype: Reference to the subtype being allocated.

--- a/pyGHDL/dom/Expression.py
+++ b/pyGHDL/dom/Expression.py
@@ -125,6 +125,12 @@ class _ParseUnaryExpressionMixin(metaclass=ExtendedType, mixin=True):
 
     @classmethod
     def parse(cls, node: Iir) -> VHDLModel_UnaryExpression:
+        """
+        Translates an IIR node to a :class:`_ParseUnaryExpressionMixin`.
+
+        :param node: The IIR node this object is translated from.
+        :returns:    The translated object.
+        """
         from pyGHDL.dom._Translate import GetExpressionFromNode
 
         operand = GetExpressionFromNode(nodes.Get_Operand(node))
@@ -141,6 +147,12 @@ class _ParseBinaryExpressionMixin(metaclass=ExtendedType, mixin=True):
 
     @classmethod
     def parse(cls, node: Iir) -> VHDLModel_BinaryExpression:
+        """
+        Translates an IIR node to a :class:`_ParseBinaryExpressionMixin`.
+
+        :param node: The IIR node this object is translated from.
+        :returns:    The translated object.
+        """
         from pyGHDL.dom._Translate import GetExpressionFromNode
 
         left = GetExpressionFromNode(nodes.Get_Left(node))
@@ -239,6 +251,12 @@ class ParenthesisExpression(VHDLModel_ParenthesisExpression, DOMMixin, _ParseUna
 
     @classmethod
     def parse(cls, node: Iir) -> "ParenthesisExpression":
+        """
+        Translates an IIR node to a :class:`ParenthesisExpression`.
+
+        :param node: The IIR node this object is translated from.
+        :returns:    The translated object.
+        """
         from pyGHDL.dom._Translate import GetExpressionFromNode
 
         operand = GetExpressionFromNode(nodes.Get_Expression(node))
@@ -305,6 +323,12 @@ class RangeExpression(VHDLModel_RangeExpression, DOMMixin):
 
     @classmethod
     def parse(cls, node: Iir) -> Union["AscendingRangeExpression", "DescendingRangeExpression"]:
+        """
+        Translates an IIR node to a :class:`RangeExpression`.
+
+        :param node: The IIR node this object is translated from.
+        :returns:    The translated object.
+        """
         from pyGHDL.dom._Translate import GetExpressionFromNode
 
         direction = nodes.Get_Direction(node)
@@ -1091,6 +1115,12 @@ class QualifiedExpression(VHDLModel_QualifiedExpression, DOMMixin):
 
     @classmethod
     def parse(cls, node: Iir) -> "QualifiedExpression":
+        """
+        Translates an IIR node to a :class:`QualifiedExpression`.
+
+        :param node: The IIR node this object is translated from.
+        :returns:    The translated object.
+        """
         from pyGHDL.dom._Translate import GetExpressionFromNode, GetName
 
         typeMarkName = GetName(nodes.Get_Type_Mark(node))
@@ -1118,6 +1148,12 @@ class SubtypeAllocation(VHDLModel_SubtypeAllocation, DOMMixin):
 
     @classmethod
     def parse(cls, node: Iir) -> "QualifiedExpressionAllocation":
+        """
+        Translates an IIR node to a :class:`SubtypeAllocation`.
+
+        :param node: The IIR node this object is translated from.
+        :returns:    The translated object.
+        """
         from pyGHDL.dom._Translate import GetSubtypeIndicationFromNode
 
         subtype = GetSubtypeIndicationFromNode(node, "allocation", "?")
@@ -1144,6 +1180,12 @@ class QualifiedExpressionAllocation(VHDLModel_QualifiedExpressionAllocation, DOM
 
     @classmethod
     def parse(cls, node: Iir) -> "QualifiedExpressionAllocation":
+        """
+        Translates an IIR node to a :class:`QualifiedExpressionAllocation`.
+
+        :param node: The IIR node this object is translated from.
+        :returns:    The translated object.
+        """
         from pyGHDL.dom._Translate import GetExpressionFromNode
 
         expression = GetExpressionFromNode(nodes.Get_Expression(node))
@@ -1170,6 +1212,12 @@ class Aggregate(VHDLModel_Aggregate, DOMMixin):
 
     @classmethod
     def parse(cls, node: Iir) -> "Aggregate":
+        """
+        Translates an IIR node to an :class:`Aggregate`.
+
+        :param node: The IIR node this object is translated from.
+        :returns:    The translated object.
+        """
         from pyGHDL.dom._Translate import (
             GetExpressionFromNode,
             GetDiscreteRangeFromNode,

--- a/pyGHDL/dom/Expression.py
+++ b/pyGHDL/dom/Expression.py
@@ -137,6 +137,12 @@ class _ParseBinaryExpressionMixin(metaclass=ExtendedType, mixin=True):
 @export
 class InverseExpression(VHDLModel_InverseExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
+        """
+        Initializes a unary expression.
+
+        :param node:    The IIR node this object was translated from.
+        :param operand: The expression the operator is applied to.
+        """
         super().__init__(operand)
         DOMMixin.__init__(self, node)
 
@@ -144,6 +150,12 @@ class InverseExpression(VHDLModel_InverseExpression, DOMMixin, _ParseUnaryExpres
 @export
 class IdentityExpression(VHDLModel_IdentityExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
+        """
+        Initializes a unary expression.
+
+        :param node:    The IIR node this object was translated from.
+        :param operand: The expression the operator is applied to.
+        """
         super().__init__(operand)
         DOMMixin.__init__(self, node)
 
@@ -151,6 +163,12 @@ class IdentityExpression(VHDLModel_IdentityExpression, DOMMixin, _ParseUnaryExpr
 @export
 class NegationExpression(VHDLModel_NegationExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
+        """
+        Initializes a unary expression.
+
+        :param node:    The IIR node this object was translated from.
+        :param operand: The expression the operator is applied to.
+        """
         super().__init__(operand)
         DOMMixin.__init__(self, node)
 
@@ -158,6 +176,12 @@ class NegationExpression(VHDLModel_NegationExpression, DOMMixin, _ParseUnaryExpr
 @export
 class AbsoluteExpression(VHDLModel_AbsoluteExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
+        """
+        Initializes a unary expression.
+
+        :param node:    The IIR node this object was translated from.
+        :param operand: The expression the operator is applied to.
+        """
         super().__init__(operand)
         DOMMixin.__init__(self, node)
 
@@ -165,6 +189,12 @@ class AbsoluteExpression(VHDLModel_AbsoluteExpression, DOMMixin, _ParseUnaryExpr
 @export
 class ParenthesisExpression(VHDLModel_ParenthesisExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
+        """
+        Initializes a unary expression.
+
+        :param node:    The IIR node this object was translated from.
+        :param operand: The expression the operator is applied to.
+        """
         super().__init__(operand)
         DOMMixin.__init__(self, node)
 
@@ -194,6 +224,13 @@ class TypeConversion(VHDLModel_TypeConversion, DOMMixin):
     """
 
     def __init__(self, node: Iir, targetSubtype: SubtypeSymbol, operand: ExpressionUnion) -> None:
+        """
+        Initializes a type conversion.
+
+        :param node:          The IIR node this object was translated from.
+        :param targetSubtype: Reference to the subtype the expression is converted to.
+        :param operand:       The expression the operator is applied to.
+        """
         super().__init__(targetSubtype, operand)
         DOMMixin.__init__(self, node)
 
@@ -201,6 +238,17 @@ class TypeConversion(VHDLModel_TypeConversion, DOMMixin):
 @export
 class FunctionCall(VHDLModel_FunctionCall, DOMMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
+        """
+        Initializes a function call.
+
+        :param node:    The IIR node this object was translated from.
+        :param operand: The expression the function is applied to.
+
+        .. todo::
+
+           The operand is not forwarded to the base-class, because
+           :class:`pyVHDLModel.Expression.FunctionCall` does not model a call's operands yet.
+        """
         super().__init__()
         DOMMixin.__init__(self, node)
 
@@ -223,6 +271,13 @@ class RangeExpression(VHDLModel_RangeExpression, DOMMixin):
 @export
 class AscendingRangeExpression(VHDLModel_AscendingRangeExpression, DOMMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -230,6 +285,13 @@ class AscendingRangeExpression(VHDLModel_AscendingRangeExpression, DOMMixin):
 @export
 class DescendingRangeExpression(VHDLModel_DescendingRangeExpression, DOMMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -237,6 +299,13 @@ class DescendingRangeExpression(VHDLModel_DescendingRangeExpression, DOMMixin):
 @export
 class AdditionExpression(VHDLModel_AdditionExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -244,6 +313,13 @@ class AdditionExpression(VHDLModel_AdditionExpression, DOMMixin, _ParseBinaryExp
 @export
 class SubtractionExpression(VHDLModel_SubtractionExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -251,6 +327,13 @@ class SubtractionExpression(VHDLModel_SubtractionExpression, DOMMixin, _ParseBin
 @export
 class ConcatenationExpression(VHDLModel_ConcatenationExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -258,6 +341,13 @@ class ConcatenationExpression(VHDLModel_ConcatenationExpression, DOMMixin, _Pars
 @export
 class MultiplyExpression(VHDLModel_MultiplyExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -265,6 +355,13 @@ class MultiplyExpression(VHDLModel_MultiplyExpression, DOMMixin, _ParseBinaryExp
 @export
 class DivisionExpression(VHDLModel_DivisionExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -272,6 +369,13 @@ class DivisionExpression(VHDLModel_DivisionExpression, DOMMixin, _ParseBinaryExp
 @export
 class RemainderExpression(VHDLModel_RemainderExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -279,6 +383,13 @@ class RemainderExpression(VHDLModel_RemainderExpression, DOMMixin, _ParseBinaryE
 @export
 class ModuloExpression(VHDLModel_ModuloExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -286,6 +397,13 @@ class ModuloExpression(VHDLModel_ModuloExpression, DOMMixin, _ParseBinaryExpress
 @export
 class ExponentiationExpression(VHDLModel_ExponentiationExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -293,6 +411,13 @@ class ExponentiationExpression(VHDLModel_ExponentiationExpression, DOMMixin, _Pa
 @export
 class AndExpression(VHDLModel_AndExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -300,6 +425,13 @@ class AndExpression(VHDLModel_AndExpression, DOMMixin, _ParseBinaryExpressionMix
 @export
 class NandExpression(VHDLModel_NandExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -307,6 +439,13 @@ class NandExpression(VHDLModel_NandExpression, DOMMixin, _ParseBinaryExpressionM
 @export
 class OrExpression(VHDLModel_OrExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -314,6 +453,13 @@ class OrExpression(VHDLModel_OrExpression, DOMMixin, _ParseBinaryExpressionMixin
 @export
 class NorExpression(VHDLModel_NorExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -321,6 +467,13 @@ class NorExpression(VHDLModel_NorExpression, DOMMixin, _ParseBinaryExpressionMix
 @export
 class XorExpression(VHDLModel_XorExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -328,6 +481,13 @@ class XorExpression(VHDLModel_XorExpression, DOMMixin, _ParseBinaryExpressionMix
 @export
 class XnorExpression(VHDLModel_XnorExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -335,6 +495,12 @@ class XnorExpression(VHDLModel_XnorExpression, DOMMixin, _ParseBinaryExpressionM
 @export
 class UnaryAndExpression(VHDLModel_UnaryAndExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
+        """
+        Initializes a unary expression.
+
+        :param node:    The IIR node this object was translated from.
+        :param operand: The expression the operator is applied to.
+        """
         super().__init__(operand)
         DOMMixin.__init__(self, node)
 
@@ -342,6 +508,12 @@ class UnaryAndExpression(VHDLModel_UnaryAndExpression, DOMMixin, _ParseUnaryExpr
 @export
 class UnaryNandExpression(VHDLModel_UnaryNandExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
+        """
+        Initializes a unary expression.
+
+        :param node:    The IIR node this object was translated from.
+        :param operand: The expression the operator is applied to.
+        """
         super().__init__(operand)
         DOMMixin.__init__(self, node)
 
@@ -349,6 +521,12 @@ class UnaryNandExpression(VHDLModel_UnaryNandExpression, DOMMixin, _ParseUnaryEx
 @export
 class UnaryOrExpression(VHDLModel_UnaryOrExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
+        """
+        Initializes a unary expression.
+
+        :param node:    The IIR node this object was translated from.
+        :param operand: The expression the operator is applied to.
+        """
         super().__init__(operand)
         DOMMixin.__init__(self, node)
 
@@ -356,6 +534,12 @@ class UnaryOrExpression(VHDLModel_UnaryOrExpression, DOMMixin, _ParseUnaryExpres
 @export
 class UnaryNorExpression(VHDLModel_UnaryNorExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
+        """
+        Initializes a unary expression.
+
+        :param node:    The IIR node this object was translated from.
+        :param operand: The expression the operator is applied to.
+        """
         super().__init__(operand)
         DOMMixin.__init__(self, node)
 
@@ -363,6 +547,12 @@ class UnaryNorExpression(VHDLModel_UnaryNorExpression, DOMMixin, _ParseUnaryExpr
 @export
 class UnaryXorExpression(VHDLModel_UnaryXorExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
+        """
+        Initializes a unary expression.
+
+        :param node:    The IIR node this object was translated from.
+        :param operand: The expression the operator is applied to.
+        """
         super().__init__(operand)
         DOMMixin.__init__(self, node)
 
@@ -370,6 +560,12 @@ class UnaryXorExpression(VHDLModel_UnaryXorExpression, DOMMixin, _ParseUnaryExpr
 @export
 class UnaryXnorExpression(VHDLModel_UnaryXnorExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
+        """
+        Initializes a unary expression.
+
+        :param node:    The IIR node this object was translated from.
+        :param operand: The expression the operator is applied to.
+        """
         super().__init__(operand)
         DOMMixin.__init__(self, node)
 
@@ -377,6 +573,13 @@ class UnaryXnorExpression(VHDLModel_UnaryXnorExpression, DOMMixin, _ParseUnaryEx
 @export
 class EqualExpression(VHDLModel_EqualExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -384,6 +587,13 @@ class EqualExpression(VHDLModel_EqualExpression, DOMMixin, _ParseBinaryExpressio
 @export
 class UnequalExpression(VHDLModel_UnequalExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -391,6 +601,13 @@ class UnequalExpression(VHDLModel_UnequalExpression, DOMMixin, _ParseBinaryExpre
 @export
 class LessThanExpression(VHDLModel_LessThanExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -398,6 +615,13 @@ class LessThanExpression(VHDLModel_LessThanExpression, DOMMixin, _ParseBinaryExp
 @export
 class LessEqualExpression(VHDLModel_LessEqualExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -405,6 +629,13 @@ class LessEqualExpression(VHDLModel_LessEqualExpression, DOMMixin, _ParseBinaryE
 @export
 class GreaterThanExpression(VHDLModel_GreaterThanExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -412,6 +643,13 @@ class GreaterThanExpression(VHDLModel_GreaterThanExpression, DOMMixin, _ParseBin
 @export
 class GreaterEqualExpression(VHDLModel_GreaterEqualExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -419,6 +657,13 @@ class GreaterEqualExpression(VHDLModel_GreaterEqualExpression, DOMMixin, _ParseB
 @export
 class MatchingEqualExpression(VHDLModel_MatchingEqualExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -426,6 +671,13 @@ class MatchingEqualExpression(VHDLModel_MatchingEqualExpression, DOMMixin, _Pars
 @export
 class MatchingUnequalExpression(VHDLModel_MatchingUnequalExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -433,6 +685,13 @@ class MatchingUnequalExpression(VHDLModel_MatchingUnequalExpression, DOMMixin, _
 @export
 class MatchingLessThanExpression(VHDLModel_MatchingLessThanExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -440,6 +699,13 @@ class MatchingLessThanExpression(VHDLModel_MatchingLessThanExpression, DOMMixin,
 @export
 class MatchingLessEqualExpression(VHDLModel_MatchingLessEqualExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -447,6 +713,13 @@ class MatchingLessEqualExpression(VHDLModel_MatchingLessEqualExpression, DOMMixi
 @export
 class MatchingGreaterThanExpression(VHDLModel_MatchingGreaterThanExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -454,6 +727,13 @@ class MatchingGreaterThanExpression(VHDLModel_MatchingGreaterThanExpression, DOM
 @export
 class MatchingGreaterEqualExpression(VHDLModel_MatchingGreaterEqualExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -461,6 +741,13 @@ class MatchingGreaterEqualExpression(VHDLModel_MatchingGreaterEqualExpression, D
 @export
 class ShiftRightLogicExpression(VHDLModel_ShiftRightLogicExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -468,6 +755,13 @@ class ShiftRightLogicExpression(VHDLModel_ShiftRightLogicExpression, DOMMixin, _
 @export
 class ShiftLeftLogicExpression(VHDLModel_ShiftLeftLogicExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -475,6 +769,13 @@ class ShiftLeftLogicExpression(VHDLModel_ShiftLeftLogicExpression, DOMMixin, _Pa
 @export
 class ShiftRightArithmeticExpression(VHDLModel_ShiftRightArithmeticExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -482,6 +783,13 @@ class ShiftRightArithmeticExpression(VHDLModel_ShiftRightArithmeticExpression, D
 @export
 class ShiftLeftArithmeticExpression(VHDLModel_ShiftLeftArithmeticExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -489,6 +797,13 @@ class ShiftLeftArithmeticExpression(VHDLModel_ShiftLeftArithmeticExpression, DOM
 @export
 class RotateRightExpression(VHDLModel_RotateRightExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -496,6 +811,13 @@ class RotateRightExpression(VHDLModel_RotateRightExpression, DOMMixin, _ParseBin
 @export
 class RotateLeftExpression(VHDLModel_RotateLeftExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
+        """
+        Initializes a binary expression.
+
+        :param node:  The IIR node this object was translated from.
+        :param left:  The expression left of the operator.
+        :param right: The expression right of the operator.
+        """
         super().__init__(left, right)
         DOMMixin.__init__(self, node)
 
@@ -503,6 +825,13 @@ class RotateLeftExpression(VHDLModel_RotateLeftExpression, DOMMixin, _ParseBinar
 @export
 class QualifiedExpression(VHDLModel_QualifiedExpression, DOMMixin):
     def __init__(self, node: Iir, subtype: Symbol, operand: ExpressionUnion) -> None:
+        """
+        Initializes a qualified expression.
+
+        :param node:    The IIR node this object was translated from.
+        :param subtype: Reference to the subtype qualifying the expression.
+        :param operand: The expression being qualified.
+        """
         super().__init__(subtype, operand)
         DOMMixin.__init__(self, node)
 
@@ -519,6 +848,12 @@ class QualifiedExpression(VHDLModel_QualifiedExpression, DOMMixin):
 @export
 class SubtypeAllocation(VHDLModel_SubtypeAllocation, DOMMixin):
     def __init__(self, node: Iir, subtype: Symbol) -> None:
+        """
+        Initializes an allocation of a subtype via ``new``.
+
+        :param node:    The IIR node this object was translated from.
+        :param subtype: Reference to the subtype being allocated.
+        """
         super().__init__(subtype)
         DOMMixin.__init__(self, node)
 
@@ -534,6 +869,12 @@ class SubtypeAllocation(VHDLModel_SubtypeAllocation, DOMMixin):
 @export
 class QualifiedExpressionAllocation(VHDLModel_QualifiedExpressionAllocation, DOMMixin):
     def __init__(self, node: Iir, qualifiedExpression: QualifiedExpression) -> None:
+        """
+        Initializes an allocation initialized by a qualified expression.
+
+        :param node:                The IIR node this object was translated from.
+        :param qualifiedExpression: The qualified expression the allocated object is initialized with.
+        """
         super().__init__(qualifiedExpression)
         DOMMixin.__init__(self, node)
 
@@ -549,6 +890,12 @@ class QualifiedExpressionAllocation(VHDLModel_QualifiedExpressionAllocation, DOM
 @export
 class Aggregate(VHDLModel_Aggregate, DOMMixin):
     def __init__(self, node: Iir, elements: List[AggregateElement]) -> None:
+        """
+        Initializes an aggregate.
+
+        :param node:     The IIR node this object was translated from.
+        :param elements: List of all elements of this aggregate, in the order they were written.
+        """
         super().__init__(elements)
         DOMMixin.__init__(self, node)
 

--- a/pyGHDL/dom/Expression.py
+++ b/pyGHDL/dom/Expression.py
@@ -36,7 +36,7 @@ This module implements derived expression classes from :mod:`pyVHDLModel.Express
 
 from typing import List, Union
 
-from pyTooling.Decorators import export
+from pyTooling.Decorators import export, InheritDocString
 from pyTooling.MetaClasses import ExtendedType
 
 from pyVHDLModel.Base import ExpressionUnion
@@ -116,6 +116,13 @@ from pyGHDL.dom.Aggregates import (
 
 
 class _ParseUnaryExpressionMixin(metaclass=ExtendedType, mixin=True):
+    """
+    Mixin providing a :meth:`parse` classmethod for all unary expressions.
+
+    The IIR node of a unary expression carries its single operand in the ``Operand`` field, so the same
+    translation applies to every operator and only the concrete class differs.
+    """
+
     @classmethod
     def parse(cls, node: Iir) -> VHDLModel_UnaryExpression:
         from pyGHDL.dom._Translate import GetExpressionFromNode
@@ -125,6 +132,13 @@ class _ParseUnaryExpressionMixin(metaclass=ExtendedType, mixin=True):
 
 
 class _ParseBinaryExpressionMixin(metaclass=ExtendedType, mixin=True):
+    """
+    Mixin providing a :meth:`parse` classmethod for all binary expressions.
+
+    The IIR node of a binary expression carries its operands in the ``Left`` and ``Right`` fields, so the
+    same translation applies to every operator and only the concrete class differs.
+    """
+
     @classmethod
     def parse(cls, node: Iir) -> VHDLModel_BinaryExpression:
         from pyGHDL.dom._Translate import GetExpressionFromNode
@@ -135,7 +149,12 @@ class _ParseBinaryExpressionMixin(metaclass=ExtendedType, mixin=True):
 
 
 @export
+@InheritDocString(VHDLModel_InverseExpression, merge=True)
 class InverseExpression(VHDLModel_InverseExpression, DOMMixin, _ParseUnaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.InverseExpression`.
+    """
+
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
         Initializes an inverse expression.
@@ -148,7 +167,12 @@ class InverseExpression(VHDLModel_InverseExpression, DOMMixin, _ParseUnaryExpres
 
 
 @export
+@InheritDocString(VHDLModel_IdentityExpression, merge=True)
 class IdentityExpression(VHDLModel_IdentityExpression, DOMMixin, _ParseUnaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.IdentityExpression`.
+    """
+
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
         Initializes an identity expression.
@@ -161,7 +185,12 @@ class IdentityExpression(VHDLModel_IdentityExpression, DOMMixin, _ParseUnaryExpr
 
 
 @export
+@InheritDocString(VHDLModel_NegationExpression, merge=True)
 class NegationExpression(VHDLModel_NegationExpression, DOMMixin, _ParseUnaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.NegationExpression`.
+    """
+
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
         Initializes a negation expression.
@@ -174,7 +203,12 @@ class NegationExpression(VHDLModel_NegationExpression, DOMMixin, _ParseUnaryExpr
 
 
 @export
+@InheritDocString(VHDLModel_AbsoluteExpression, merge=True)
 class AbsoluteExpression(VHDLModel_AbsoluteExpression, DOMMixin, _ParseUnaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.AbsoluteExpression`.
+    """
+
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
         Initializes an absolute expression.
@@ -187,7 +221,12 @@ class AbsoluteExpression(VHDLModel_AbsoluteExpression, DOMMixin, _ParseUnaryExpr
 
 
 @export
+@InheritDocString(VHDLModel_ParenthesisExpression, merge=True)
 class ParenthesisExpression(VHDLModel_ParenthesisExpression, DOMMixin, _ParseUnaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.SubExpression`.
+    """
+
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
         Initializes a parenthesis expression.
@@ -236,7 +275,12 @@ class TypeConversion(VHDLModel_TypeConversion, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_FunctionCall, merge=True)
 class FunctionCall(VHDLModel_FunctionCall, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.FunctionCall`.
+    """
+
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
         Initializes a function call.
@@ -253,7 +297,12 @@ class FunctionCall(VHDLModel_FunctionCall, DOMMixin):
         DOMMixin.__init__(self, node)
 
 
+@InheritDocString(VHDLModel_RangeExpression, merge=True)
 class RangeExpression(VHDLModel_RangeExpression, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.RangeExpression`.
+    """
+
     @classmethod
     def parse(cls, node: Iir) -> Union["AscendingRangeExpression", "DescendingRangeExpression"]:
         from pyGHDL.dom._Translate import GetExpressionFromNode
@@ -269,7 +318,12 @@ class RangeExpression(VHDLModel_RangeExpression, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_AscendingRangeExpression, merge=True)
 class AscendingRangeExpression(VHDLModel_AscendingRangeExpression, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.AscendingRangeExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes an ascending range expression.
@@ -283,7 +337,12 @@ class AscendingRangeExpression(VHDLModel_AscendingRangeExpression, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_DescendingRangeExpression, merge=True)
 class DescendingRangeExpression(VHDLModel_DescendingRangeExpression, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.DescendingRangeExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a descending range expression.
@@ -297,7 +356,12 @@ class DescendingRangeExpression(VHDLModel_DescendingRangeExpression, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_AdditionExpression, merge=True)
 class AdditionExpression(VHDLModel_AdditionExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.AdditionExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes an addition expression.
@@ -311,7 +375,12 @@ class AdditionExpression(VHDLModel_AdditionExpression, DOMMixin, _ParseBinaryExp
 
 
 @export
+@InheritDocString(VHDLModel_SubtractionExpression, merge=True)
 class SubtractionExpression(VHDLModel_SubtractionExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.SubtractionExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a subtraction expression.
@@ -325,7 +394,12 @@ class SubtractionExpression(VHDLModel_SubtractionExpression, DOMMixin, _ParseBin
 
 
 @export
+@InheritDocString(VHDLModel_ConcatenationExpression, merge=True)
 class ConcatenationExpression(VHDLModel_ConcatenationExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.ConcatenationExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a concatenation expression.
@@ -339,7 +413,12 @@ class ConcatenationExpression(VHDLModel_ConcatenationExpression, DOMMixin, _Pars
 
 
 @export
+@InheritDocString(VHDLModel_MultiplyExpression, merge=True)
 class MultiplyExpression(VHDLModel_MultiplyExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.MultiplyExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a multiply expression.
@@ -353,7 +432,12 @@ class MultiplyExpression(VHDLModel_MultiplyExpression, DOMMixin, _ParseBinaryExp
 
 
 @export
+@InheritDocString(VHDLModel_DivisionExpression, merge=True)
 class DivisionExpression(VHDLModel_DivisionExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.DivisionExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a division expression.
@@ -367,7 +451,12 @@ class DivisionExpression(VHDLModel_DivisionExpression, DOMMixin, _ParseBinaryExp
 
 
 @export
+@InheritDocString(VHDLModel_RemainderExpression, merge=True)
 class RemainderExpression(VHDLModel_RemainderExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.RemainderExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a remainder expression.
@@ -381,7 +470,12 @@ class RemainderExpression(VHDLModel_RemainderExpression, DOMMixin, _ParseBinaryE
 
 
 @export
+@InheritDocString(VHDLModel_ModuloExpression, merge=True)
 class ModuloExpression(VHDLModel_ModuloExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.ModuloExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a modulo expression.
@@ -395,7 +489,12 @@ class ModuloExpression(VHDLModel_ModuloExpression, DOMMixin, _ParseBinaryExpress
 
 
 @export
+@InheritDocString(VHDLModel_ExponentiationExpression, merge=True)
 class ExponentiationExpression(VHDLModel_ExponentiationExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.ExponentiationExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes an exponentiation expression.
@@ -409,7 +508,12 @@ class ExponentiationExpression(VHDLModel_ExponentiationExpression, DOMMixin, _Pa
 
 
 @export
+@InheritDocString(VHDLModel_AndExpression, merge=True)
 class AndExpression(VHDLModel_AndExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.AndExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes an and expression.
@@ -423,7 +527,12 @@ class AndExpression(VHDLModel_AndExpression, DOMMixin, _ParseBinaryExpressionMix
 
 
 @export
+@InheritDocString(VHDLModel_NandExpression, merge=True)
 class NandExpression(VHDLModel_NandExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.NandExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a nand expression.
@@ -437,7 +546,12 @@ class NandExpression(VHDLModel_NandExpression, DOMMixin, _ParseBinaryExpressionM
 
 
 @export
+@InheritDocString(VHDLModel_OrExpression, merge=True)
 class OrExpression(VHDLModel_OrExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.OrExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes an or expression.
@@ -451,7 +565,12 @@ class OrExpression(VHDLModel_OrExpression, DOMMixin, _ParseBinaryExpressionMixin
 
 
 @export
+@InheritDocString(VHDLModel_NorExpression, merge=True)
 class NorExpression(VHDLModel_NorExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.NorExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a nor expression.
@@ -465,7 +584,12 @@ class NorExpression(VHDLModel_NorExpression, DOMMixin, _ParseBinaryExpressionMix
 
 
 @export
+@InheritDocString(VHDLModel_XorExpression, merge=True)
 class XorExpression(VHDLModel_XorExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.XorExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes an :vhdlkw:`xor` expression.
@@ -479,7 +603,12 @@ class XorExpression(VHDLModel_XorExpression, DOMMixin, _ParseBinaryExpressionMix
 
 
 @export
+@InheritDocString(VHDLModel_XnorExpression, merge=True)
 class XnorExpression(VHDLModel_XnorExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.XnorExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes an :vhdlkw:`xnor` expression.
@@ -493,7 +622,12 @@ class XnorExpression(VHDLModel_XnorExpression, DOMMixin, _ParseBinaryExpressionM
 
 
 @export
+@InheritDocString(VHDLModel_UnaryAndExpression, merge=True)
 class UnaryAndExpression(VHDLModel_UnaryAndExpression, DOMMixin, _ParseUnaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.UnaryAndExpression`.
+    """
+
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
         Initializes a unary and expression.
@@ -506,7 +640,12 @@ class UnaryAndExpression(VHDLModel_UnaryAndExpression, DOMMixin, _ParseUnaryExpr
 
 
 @export
+@InheritDocString(VHDLModel_UnaryNandExpression, merge=True)
 class UnaryNandExpression(VHDLModel_UnaryNandExpression, DOMMixin, _ParseUnaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.UnaryNandExpression`.
+    """
+
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
         Initializes a unary nand expression.
@@ -519,7 +658,12 @@ class UnaryNandExpression(VHDLModel_UnaryNandExpression, DOMMixin, _ParseUnaryEx
 
 
 @export
+@InheritDocString(VHDLModel_UnaryOrExpression, merge=True)
 class UnaryOrExpression(VHDLModel_UnaryOrExpression, DOMMixin, _ParseUnaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.UnaryOrExpression`.
+    """
+
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
         Initializes a unary or expression.
@@ -532,7 +676,12 @@ class UnaryOrExpression(VHDLModel_UnaryOrExpression, DOMMixin, _ParseUnaryExpres
 
 
 @export
+@InheritDocString(VHDLModel_UnaryNorExpression, merge=True)
 class UnaryNorExpression(VHDLModel_UnaryNorExpression, DOMMixin, _ParseUnaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.UnaryNorExpression`.
+    """
+
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
         Initializes a unary nor expression.
@@ -545,7 +694,12 @@ class UnaryNorExpression(VHDLModel_UnaryNorExpression, DOMMixin, _ParseUnaryExpr
 
 
 @export
+@InheritDocString(VHDLModel_UnaryXorExpression, merge=True)
 class UnaryXorExpression(VHDLModel_UnaryXorExpression, DOMMixin, _ParseUnaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.UnaryXorExpression`.
+    """
+
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
         Initializes a unary xor expression.
@@ -558,7 +712,12 @@ class UnaryXorExpression(VHDLModel_UnaryXorExpression, DOMMixin, _ParseUnaryExpr
 
 
 @export
+@InheritDocString(VHDLModel_UnaryXnorExpression, merge=True)
 class UnaryXnorExpression(VHDLModel_UnaryXnorExpression, DOMMixin, _ParseUnaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.UnaryXnorExpression`.
+    """
+
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
         Initializes a unary xnor expression.
@@ -571,7 +730,12 @@ class UnaryXnorExpression(VHDLModel_UnaryXnorExpression, DOMMixin, _ParseUnaryEx
 
 
 @export
+@InheritDocString(VHDLModel_EqualExpression, merge=True)
 class EqualExpression(VHDLModel_EqualExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.EqualExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes an equal expression.
@@ -585,7 +749,12 @@ class EqualExpression(VHDLModel_EqualExpression, DOMMixin, _ParseBinaryExpressio
 
 
 @export
+@InheritDocString(VHDLModel_UnequalExpression, merge=True)
 class UnequalExpression(VHDLModel_UnequalExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.UnequalExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes an unequal expression.
@@ -599,7 +768,12 @@ class UnequalExpression(VHDLModel_UnequalExpression, DOMMixin, _ParseBinaryExpre
 
 
 @export
+@InheritDocString(VHDLModel_LessThanExpression, merge=True)
 class LessThanExpression(VHDLModel_LessThanExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.LessThanExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a less than expression.
@@ -613,7 +787,12 @@ class LessThanExpression(VHDLModel_LessThanExpression, DOMMixin, _ParseBinaryExp
 
 
 @export
+@InheritDocString(VHDLModel_LessEqualExpression, merge=True)
 class LessEqualExpression(VHDLModel_LessEqualExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.LessEqualExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a less equal expression.
@@ -627,7 +806,12 @@ class LessEqualExpression(VHDLModel_LessEqualExpression, DOMMixin, _ParseBinaryE
 
 
 @export
+@InheritDocString(VHDLModel_GreaterThanExpression, merge=True)
 class GreaterThanExpression(VHDLModel_GreaterThanExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.GreaterThanExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a greater than expression.
@@ -641,7 +825,12 @@ class GreaterThanExpression(VHDLModel_GreaterThanExpression, DOMMixin, _ParseBin
 
 
 @export
+@InheritDocString(VHDLModel_GreaterEqualExpression, merge=True)
 class GreaterEqualExpression(VHDLModel_GreaterEqualExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.GreaterEqualExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a greater equal expression.
@@ -655,7 +844,12 @@ class GreaterEqualExpression(VHDLModel_GreaterEqualExpression, DOMMixin, _ParseB
 
 
 @export
+@InheritDocString(VHDLModel_MatchingEqualExpression, merge=True)
 class MatchingEqualExpression(VHDLModel_MatchingEqualExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.MatchingEqualExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a matching equal expression.
@@ -669,7 +863,12 @@ class MatchingEqualExpression(VHDLModel_MatchingEqualExpression, DOMMixin, _Pars
 
 
 @export
+@InheritDocString(VHDLModel_MatchingUnequalExpression, merge=True)
 class MatchingUnequalExpression(VHDLModel_MatchingUnequalExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.MatchingUnequalExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a matching unequal expression.
@@ -683,7 +882,12 @@ class MatchingUnequalExpression(VHDLModel_MatchingUnequalExpression, DOMMixin, _
 
 
 @export
+@InheritDocString(VHDLModel_MatchingLessThanExpression, merge=True)
 class MatchingLessThanExpression(VHDLModel_MatchingLessThanExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.MatchingLessThanExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a matching less than expression.
@@ -697,7 +901,12 @@ class MatchingLessThanExpression(VHDLModel_MatchingLessThanExpression, DOMMixin,
 
 
 @export
+@InheritDocString(VHDLModel_MatchingLessEqualExpression, merge=True)
 class MatchingLessEqualExpression(VHDLModel_MatchingLessEqualExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.MatchingLessEqualExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a matching less equal expression.
@@ -711,7 +920,12 @@ class MatchingLessEqualExpression(VHDLModel_MatchingLessEqualExpression, DOMMixi
 
 
 @export
+@InheritDocString(VHDLModel_MatchingGreaterThanExpression, merge=True)
 class MatchingGreaterThanExpression(VHDLModel_MatchingGreaterThanExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.MatchingGreaterThanExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a matching greater than expression.
@@ -725,7 +939,12 @@ class MatchingGreaterThanExpression(VHDLModel_MatchingGreaterThanExpression, DOM
 
 
 @export
+@InheritDocString(VHDLModel_MatchingGreaterEqualExpression, merge=True)
 class MatchingGreaterEqualExpression(VHDLModel_MatchingGreaterEqualExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.MatchingGreaterEqualExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a matching greater equal expression.
@@ -739,7 +958,12 @@ class MatchingGreaterEqualExpression(VHDLModel_MatchingGreaterEqualExpression, D
 
 
 @export
+@InheritDocString(VHDLModel_ShiftRightLogicExpression, merge=True)
 class ShiftRightLogicExpression(VHDLModel_ShiftRightLogicExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.ShiftRightLogicExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a shift right logic expression.
@@ -753,7 +977,12 @@ class ShiftRightLogicExpression(VHDLModel_ShiftRightLogicExpression, DOMMixin, _
 
 
 @export
+@InheritDocString(VHDLModel_ShiftLeftLogicExpression, merge=True)
 class ShiftLeftLogicExpression(VHDLModel_ShiftLeftLogicExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.ShiftLeftLogicExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a shift left logic expression.
@@ -767,7 +996,12 @@ class ShiftLeftLogicExpression(VHDLModel_ShiftLeftLogicExpression, DOMMixin, _Pa
 
 
 @export
+@InheritDocString(VHDLModel_ShiftRightArithmeticExpression, merge=True)
 class ShiftRightArithmeticExpression(VHDLModel_ShiftRightArithmeticExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.ShiftRightArithmeticExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a shift right arithmetic expression.
@@ -781,7 +1015,12 @@ class ShiftRightArithmeticExpression(VHDLModel_ShiftRightArithmeticExpression, D
 
 
 @export
+@InheritDocString(VHDLModel_ShiftLeftArithmeticExpression, merge=True)
 class ShiftLeftArithmeticExpression(VHDLModel_ShiftLeftArithmeticExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.ShiftLeftArithmeticExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a shift left arithmetic expression.
@@ -795,7 +1034,12 @@ class ShiftLeftArithmeticExpression(VHDLModel_ShiftLeftArithmeticExpression, DOM
 
 
 @export
+@InheritDocString(VHDLModel_RotateRightExpression, merge=True)
 class RotateRightExpression(VHDLModel_RotateRightExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.RotateRightExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a rotate right expression.
@@ -809,7 +1053,12 @@ class RotateRightExpression(VHDLModel_RotateRightExpression, DOMMixin, _ParseBin
 
 
 @export
+@InheritDocString(VHDLModel_RotateLeftExpression, merge=True)
 class RotateLeftExpression(VHDLModel_RotateLeftExpression, DOMMixin, _ParseBinaryExpressionMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.RotateLeftExpression`.
+    """
+
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
         Initializes a rotate left expression.
@@ -823,7 +1072,12 @@ class RotateLeftExpression(VHDLModel_RotateLeftExpression, DOMMixin, _ParseBinar
 
 
 @export
+@InheritDocString(VHDLModel_QualifiedExpression, merge=True)
 class QualifiedExpression(VHDLModel_QualifiedExpression, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.QualifiedExpression`.
+    """
+
     def __init__(self, node: Iir, subtype: Symbol, operand: ExpressionUnion) -> None:
         """
         Initializes a qualified expression.
@@ -846,7 +1100,12 @@ class QualifiedExpression(VHDLModel_QualifiedExpression, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_SubtypeAllocation, merge=True)
 class SubtypeAllocation(VHDLModel_SubtypeAllocation, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.SubtypeAllocation`.
+    """
+
     def __init__(self, node: Iir, subtype: Symbol) -> None:
         """
         Initializes an allocation of a subtype via :vhdlkw:`new`.
@@ -867,7 +1126,12 @@ class SubtypeAllocation(VHDLModel_SubtypeAllocation, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_QualifiedExpressionAllocation, merge=True)
 class QualifiedExpressionAllocation(VHDLModel_QualifiedExpressionAllocation, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.QualifiedExpressionAllocation`.
+    """
+
     def __init__(self, node: Iir, qualifiedExpression: QualifiedExpression) -> None:
         """
         Initializes an allocation initialized by a qualified expression.
@@ -888,7 +1152,12 @@ class QualifiedExpressionAllocation(VHDLModel_QualifiedExpressionAllocation, DOM
 
 
 @export
+@InheritDocString(VHDLModel_Aggregate, merge=True)
 class Aggregate(VHDLModel_Aggregate, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.Aggregate`.
+    """
+
     def __init__(self, node: Iir, elements: List[AggregateElement]) -> None:
         """
         Initializes an aggregate.

--- a/pyGHDL/dom/Expression.py
+++ b/pyGHDL/dom/Expression.py
@@ -138,7 +138,7 @@ class _ParseBinaryExpressionMixin(metaclass=ExtendedType, mixin=True):
 class InverseExpression(VHDLModel_InverseExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
-        Initializes a unary expression.
+        Initializes an inverse expression.
 
         :param node:    The IIR node this object was translated from.
         :param operand: The expression the operator is applied to.
@@ -151,7 +151,7 @@ class InverseExpression(VHDLModel_InverseExpression, DOMMixin, _ParseUnaryExpres
 class IdentityExpression(VHDLModel_IdentityExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
-        Initializes a unary expression.
+        Initializes an identity expression.
 
         :param node:    The IIR node this object was translated from.
         :param operand: The expression the operator is applied to.
@@ -164,7 +164,7 @@ class IdentityExpression(VHDLModel_IdentityExpression, DOMMixin, _ParseUnaryExpr
 class NegationExpression(VHDLModel_NegationExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
-        Initializes a unary expression.
+        Initializes a negation expression.
 
         :param node:    The IIR node this object was translated from.
         :param operand: The expression the operator is applied to.
@@ -177,7 +177,7 @@ class NegationExpression(VHDLModel_NegationExpression, DOMMixin, _ParseUnaryExpr
 class AbsoluteExpression(VHDLModel_AbsoluteExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
-        Initializes a unary expression.
+        Initializes an absolute expression.
 
         :param node:    The IIR node this object was translated from.
         :param operand: The expression the operator is applied to.
@@ -190,7 +190,7 @@ class AbsoluteExpression(VHDLModel_AbsoluteExpression, DOMMixin, _ParseUnaryExpr
 class ParenthesisExpression(VHDLModel_ParenthesisExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
-        Initializes a unary expression.
+        Initializes a parenthesis expression.
 
         :param node:    The IIR node this object was translated from.
         :param operand: The expression the operator is applied to.
@@ -272,7 +272,7 @@ class RangeExpression(VHDLModel_RangeExpression, DOMMixin):
 class AscendingRangeExpression(VHDLModel_AscendingRangeExpression, DOMMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes an ascending range expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -286,7 +286,7 @@ class AscendingRangeExpression(VHDLModel_AscendingRangeExpression, DOMMixin):
 class DescendingRangeExpression(VHDLModel_DescendingRangeExpression, DOMMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a descending range expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -300,7 +300,7 @@ class DescendingRangeExpression(VHDLModel_DescendingRangeExpression, DOMMixin):
 class AdditionExpression(VHDLModel_AdditionExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes an addition expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -314,7 +314,7 @@ class AdditionExpression(VHDLModel_AdditionExpression, DOMMixin, _ParseBinaryExp
 class SubtractionExpression(VHDLModel_SubtractionExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a subtraction expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -328,7 +328,7 @@ class SubtractionExpression(VHDLModel_SubtractionExpression, DOMMixin, _ParseBin
 class ConcatenationExpression(VHDLModel_ConcatenationExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a concatenation expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -342,7 +342,7 @@ class ConcatenationExpression(VHDLModel_ConcatenationExpression, DOMMixin, _Pars
 class MultiplyExpression(VHDLModel_MultiplyExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a multiply expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -356,7 +356,7 @@ class MultiplyExpression(VHDLModel_MultiplyExpression, DOMMixin, _ParseBinaryExp
 class DivisionExpression(VHDLModel_DivisionExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a division expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -370,7 +370,7 @@ class DivisionExpression(VHDLModel_DivisionExpression, DOMMixin, _ParseBinaryExp
 class RemainderExpression(VHDLModel_RemainderExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a remainder expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -384,7 +384,7 @@ class RemainderExpression(VHDLModel_RemainderExpression, DOMMixin, _ParseBinaryE
 class ModuloExpression(VHDLModel_ModuloExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a modulo expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -398,7 +398,7 @@ class ModuloExpression(VHDLModel_ModuloExpression, DOMMixin, _ParseBinaryExpress
 class ExponentiationExpression(VHDLModel_ExponentiationExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes an exponentiation expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -412,7 +412,7 @@ class ExponentiationExpression(VHDLModel_ExponentiationExpression, DOMMixin, _Pa
 class AndExpression(VHDLModel_AndExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes an and expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -426,7 +426,7 @@ class AndExpression(VHDLModel_AndExpression, DOMMixin, _ParseBinaryExpressionMix
 class NandExpression(VHDLModel_NandExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a nand expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -440,7 +440,7 @@ class NandExpression(VHDLModel_NandExpression, DOMMixin, _ParseBinaryExpressionM
 class OrExpression(VHDLModel_OrExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes an or expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -454,7 +454,7 @@ class OrExpression(VHDLModel_OrExpression, DOMMixin, _ParseBinaryExpressionMixin
 class NorExpression(VHDLModel_NorExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a nor expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -468,7 +468,7 @@ class NorExpression(VHDLModel_NorExpression, DOMMixin, _ParseBinaryExpressionMix
 class XorExpression(VHDLModel_XorExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a xor expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -482,7 +482,7 @@ class XorExpression(VHDLModel_XorExpression, DOMMixin, _ParseBinaryExpressionMix
 class XnorExpression(VHDLModel_XnorExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a xnor expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -496,7 +496,7 @@ class XnorExpression(VHDLModel_XnorExpression, DOMMixin, _ParseBinaryExpressionM
 class UnaryAndExpression(VHDLModel_UnaryAndExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
-        Initializes a unary expression.
+        Initializes a unary and expression.
 
         :param node:    The IIR node this object was translated from.
         :param operand: The expression the operator is applied to.
@@ -509,7 +509,7 @@ class UnaryAndExpression(VHDLModel_UnaryAndExpression, DOMMixin, _ParseUnaryExpr
 class UnaryNandExpression(VHDLModel_UnaryNandExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
-        Initializes a unary expression.
+        Initializes a unary nand expression.
 
         :param node:    The IIR node this object was translated from.
         :param operand: The expression the operator is applied to.
@@ -522,7 +522,7 @@ class UnaryNandExpression(VHDLModel_UnaryNandExpression, DOMMixin, _ParseUnaryEx
 class UnaryOrExpression(VHDLModel_UnaryOrExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
-        Initializes a unary expression.
+        Initializes a unary or expression.
 
         :param node:    The IIR node this object was translated from.
         :param operand: The expression the operator is applied to.
@@ -535,7 +535,7 @@ class UnaryOrExpression(VHDLModel_UnaryOrExpression, DOMMixin, _ParseUnaryExpres
 class UnaryNorExpression(VHDLModel_UnaryNorExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
-        Initializes a unary expression.
+        Initializes a unary nor expression.
 
         :param node:    The IIR node this object was translated from.
         :param operand: The expression the operator is applied to.
@@ -548,7 +548,7 @@ class UnaryNorExpression(VHDLModel_UnaryNorExpression, DOMMixin, _ParseUnaryExpr
 class UnaryXorExpression(VHDLModel_UnaryXorExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
-        Initializes a unary expression.
+        Initializes a unary xor expression.
 
         :param node:    The IIR node this object was translated from.
         :param operand: The expression the operator is applied to.
@@ -561,7 +561,7 @@ class UnaryXorExpression(VHDLModel_UnaryXorExpression, DOMMixin, _ParseUnaryExpr
 class UnaryXnorExpression(VHDLModel_UnaryXnorExpression, DOMMixin, _ParseUnaryExpressionMixin):
     def __init__(self, node: Iir, operand: ExpressionUnion) -> None:
         """
-        Initializes a unary expression.
+        Initializes a unary xnor expression.
 
         :param node:    The IIR node this object was translated from.
         :param operand: The expression the operator is applied to.
@@ -574,7 +574,7 @@ class UnaryXnorExpression(VHDLModel_UnaryXnorExpression, DOMMixin, _ParseUnaryEx
 class EqualExpression(VHDLModel_EqualExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes an equal expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -588,7 +588,7 @@ class EqualExpression(VHDLModel_EqualExpression, DOMMixin, _ParseBinaryExpressio
 class UnequalExpression(VHDLModel_UnequalExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes an unequal expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -602,7 +602,7 @@ class UnequalExpression(VHDLModel_UnequalExpression, DOMMixin, _ParseBinaryExpre
 class LessThanExpression(VHDLModel_LessThanExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a less than expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -616,7 +616,7 @@ class LessThanExpression(VHDLModel_LessThanExpression, DOMMixin, _ParseBinaryExp
 class LessEqualExpression(VHDLModel_LessEqualExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a less equal expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -630,7 +630,7 @@ class LessEqualExpression(VHDLModel_LessEqualExpression, DOMMixin, _ParseBinaryE
 class GreaterThanExpression(VHDLModel_GreaterThanExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a greater than expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -644,7 +644,7 @@ class GreaterThanExpression(VHDLModel_GreaterThanExpression, DOMMixin, _ParseBin
 class GreaterEqualExpression(VHDLModel_GreaterEqualExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a greater equal expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -658,7 +658,7 @@ class GreaterEqualExpression(VHDLModel_GreaterEqualExpression, DOMMixin, _ParseB
 class MatchingEqualExpression(VHDLModel_MatchingEqualExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a matching equal expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -672,7 +672,7 @@ class MatchingEqualExpression(VHDLModel_MatchingEqualExpression, DOMMixin, _Pars
 class MatchingUnequalExpression(VHDLModel_MatchingUnequalExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a matching unequal expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -686,7 +686,7 @@ class MatchingUnequalExpression(VHDLModel_MatchingUnequalExpression, DOMMixin, _
 class MatchingLessThanExpression(VHDLModel_MatchingLessThanExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a matching less than expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -700,7 +700,7 @@ class MatchingLessThanExpression(VHDLModel_MatchingLessThanExpression, DOMMixin,
 class MatchingLessEqualExpression(VHDLModel_MatchingLessEqualExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a matching less equal expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -714,7 +714,7 @@ class MatchingLessEqualExpression(VHDLModel_MatchingLessEqualExpression, DOMMixi
 class MatchingGreaterThanExpression(VHDLModel_MatchingGreaterThanExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a matching greater than expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -728,7 +728,7 @@ class MatchingGreaterThanExpression(VHDLModel_MatchingGreaterThanExpression, DOM
 class MatchingGreaterEqualExpression(VHDLModel_MatchingGreaterEqualExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a matching greater equal expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -742,7 +742,7 @@ class MatchingGreaterEqualExpression(VHDLModel_MatchingGreaterEqualExpression, D
 class ShiftRightLogicExpression(VHDLModel_ShiftRightLogicExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a shift right logic expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -756,7 +756,7 @@ class ShiftRightLogicExpression(VHDLModel_ShiftRightLogicExpression, DOMMixin, _
 class ShiftLeftLogicExpression(VHDLModel_ShiftLeftLogicExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a shift left logic expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -770,7 +770,7 @@ class ShiftLeftLogicExpression(VHDLModel_ShiftLeftLogicExpression, DOMMixin, _Pa
 class ShiftRightArithmeticExpression(VHDLModel_ShiftRightArithmeticExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a shift right arithmetic expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -784,7 +784,7 @@ class ShiftRightArithmeticExpression(VHDLModel_ShiftRightArithmeticExpression, D
 class ShiftLeftArithmeticExpression(VHDLModel_ShiftLeftArithmeticExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a shift left arithmetic expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -798,7 +798,7 @@ class ShiftLeftArithmeticExpression(VHDLModel_ShiftLeftArithmeticExpression, DOM
 class RotateRightExpression(VHDLModel_RotateRightExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a rotate right expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.
@@ -812,7 +812,7 @@ class RotateRightExpression(VHDLModel_RotateRightExpression, DOMMixin, _ParseBin
 class RotateLeftExpression(VHDLModel_RotateLeftExpression, DOMMixin, _ParseBinaryExpressionMixin):
     def __init__(self, node: Iir, left: ExpressionUnion, right: ExpressionUnion) -> None:
         """
-        Initializes a binary expression.
+        Initializes a rotate left expression.
 
         :param node:  The IIR node this object was translated from.
         :param left:  The expression left of the operator.

--- a/pyGHDL/dom/InterfaceItem.py
+++ b/pyGHDL/dom/InterfaceItem.py
@@ -36,7 +36,7 @@ This module implements derived interface item classes from :mod:`pyVHDLModel.Int
 
 from typing import List, Iterable
 
-from pyTooling.Decorators import export
+from pyTooling.Decorators import export, InheritDocString
 
 from pyVHDLModel.Base import Mode, ExpressionUnion
 from pyVHDLModel.Symbol import Symbol
@@ -67,7 +67,12 @@ from pyGHDL.dom.Symbol import ModeViewSymbol, SimpleSubtypeSymbol
 
 
 @export
+@InheritDocString(VHDLModel_GenericConstantInterfaceItem, merge=True)
 class GenericConstantInterfaceItem(VHDLModel_GenericConstantInterfaceItem, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Interface.GenericConstantInterfaceItem`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -106,7 +111,12 @@ class GenericConstantInterfaceItem(VHDLModel_GenericConstantInterfaceItem, DOMMi
 
 
 @export
+@InheritDocString(VHDLModel_GenericTypeInterfaceItem, merge=True)
 class GenericTypeInterfaceItem(VHDLModel_GenericTypeInterfaceItem, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Interface.GenericTypeInterfaceItem`.
+    """
+
     def __init__(self, node: Iir, identifier: str, documentation: str = None) -> None:
         """
         Initializes a type in a generic clause.
@@ -127,7 +137,12 @@ class GenericTypeInterfaceItem(VHDLModel_GenericTypeInterfaceItem, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_GenericPackageInterfaceItem, merge=True)
 class GenericPackageInterfaceItem(VHDLModel_GenericPackageInterfaceItem, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Interface.GenericPackageInterfaceItem`.
+    """
+
     def __init__(self, node: Iir, name: str, documentation: str = None) -> None:
         """
         Initializes a package in a generic clause.
@@ -148,7 +163,12 @@ class GenericPackageInterfaceItem(VHDLModel_GenericPackageInterfaceItem, DOMMixi
 
 
 @export
+@InheritDocString(VHDLModel_GenericProcedureInterfaceItem, merge=True)
 class GenericProcedureInterfaceItem(VHDLModel_GenericProcedureInterfaceItem, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Interface.GenericProcedureInterfaceItem`.
+    """
+
     def __init__(self, node: Iir, identifier: str, documentation: str = None) -> None:
         """
         Initializes a procedure in a generic clause.
@@ -169,7 +189,12 @@ class GenericProcedureInterfaceItem(VHDLModel_GenericProcedureInterfaceItem, DOM
 
 
 @export
+@InheritDocString(VHDLModel_GenericFunctionInterfaceItem, merge=True)
 class GenericFunctionInterfaceItem(VHDLModel_GenericFunctionInterfaceItem, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Interface.GenericFunctionInterfaceItem`.
+    """
+
     def __init__(self, node: Iir, identifier: str, returnType: Symbol, documentation: str = None) -> None:
         """
         Initializes a function in a generic clause.
@@ -195,7 +220,12 @@ class GenericFunctionInterfaceItem(VHDLModel_GenericFunctionInterfaceItem, DOMMi
 
 
 @export
+@InheritDocString(VHDLModel_PortSimpleSignalInterfaceItem, merge=True)
 class PortSimpleSignalInterfaceItem(VHDLModel_PortSimpleSignalInterfaceItem, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Interface.PortSimpleSignalInterfaceItem`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -284,7 +314,12 @@ class PortViewSignalInterfaceItem(VHDLModel_PortViewSignalInterfaceItem, DOMMixi
 
 
 @export
+@InheritDocString(VHDLModel_ParameterConstantInterfaceItem, merge=True)
 class ParameterConstantInterfaceItem(VHDLModel_ParameterConstantInterfaceItem, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Interface.ParameterConstantInterfaceItem`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -324,7 +359,12 @@ class ParameterConstantInterfaceItem(VHDLModel_ParameterConstantInterfaceItem, D
 
 
 @export
+@InheritDocString(VHDLModel_ParameterVariableInterfaceItem, merge=True)
 class ParameterVariableInterfaceItem(VHDLModel_ParameterVariableInterfaceItem, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Interface.ParameterVariableInterfaceItem`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -364,7 +404,12 @@ class ParameterVariableInterfaceItem(VHDLModel_ParameterVariableInterfaceItem, D
 
 
 @export
+@InheritDocString(VHDLModel_ParameterSimpleSignalInterfaceItem, merge=True)
 class ParameterSimpleSignalInterfaceItem(VHDLModel_ParameterSimpleSignalInterfaceItem, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Interface.ParameterSimpleSignalInterfaceItem`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -453,7 +498,12 @@ class ParameterViewSignalInterfaceItem(VHDLModel_ParameterViewSignalInterfaceIte
 
 
 @export
+@InheritDocString(VHDLModel_ParameterFileInterfaceItem, merge=True)
 class ParameterFileInterfaceItem(VHDLModel_ParameterFileInterfaceItem, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Interface.ParameterFileInterfaceItem`.
+    """
+
     def __init__(self, node: Iir, identifiers: List[str], subtype: Symbol, documentation: str = None) -> None:
         """
         Initializes a file parameter of a subprogram.

--- a/pyGHDL/dom/InterfaceItem.py
+++ b/pyGHDL/dom/InterfaceItem.py
@@ -112,7 +112,7 @@ class GenericTypeInterfaceItem(VHDLModel_GenericTypeInterfaceItem, DOMMixin):
         Initializes a type in a generic clause.
 
         :param node:          The IIR node this object was translated from.
-        :param identifier:    The identifier of a model entity.
+        :param identifier:    The generic type's identifier.
         :param documentation: The documentation comment associated with this declaration.
         """
         super().__init__(identifier, documentation)
@@ -154,7 +154,7 @@ class GenericProcedureInterfaceItem(VHDLModel_GenericProcedureInterfaceItem, DOM
         Initializes a procedure in a generic clause.
 
         :param node:          The IIR node this object was translated from.
-        :param identifier:    The identifier of a model entity.
+        :param identifier:    The generic procedure's identifier.
         :param documentation: The documentation comment associated with this declaration.
         """
         super().__init__(identifier, documentation)
@@ -175,7 +175,7 @@ class GenericFunctionInterfaceItem(VHDLModel_GenericFunctionInterfaceItem, DOMMi
         Initializes a function in a generic clause.
 
         :param node:          The IIR node this object was translated from.
-        :param identifier:    The identifier of a model entity.
+        :param identifier:    The generic function's identifier.
         :param returnType:    Reference to the subtype of the function's return value.
         :param documentation: The documentation comment associated with this declaration.
         """
@@ -579,7 +579,7 @@ class ModeViewDeclaration(VHDLModel_ModeViewDeclaration, DOMMixin):
         Initializes a mode view declaration (VHDL-2019).
 
         :param node:          The IIR node this object was translated from.
-        :param identifier:    The identifier of a model entity.
+        :param identifier:    The mode view's identifier.
         :param subtype:       Reference to the subtype this mode view applies to.
         :param elements:      List of all mode view elements, in declaration order.
         :param documentation: The documentation comment associated with this declaration.

--- a/pyGHDL/dom/InterfaceItem.py
+++ b/pyGHDL/dom/InterfaceItem.py
@@ -97,6 +97,13 @@ class GenericConstantInterfaceItem(VHDLModel_GenericConstantInterfaceItem, DOMMi
 
     @classmethod
     def parse(cls, genericNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "GenericConstantInterfaceItem":
+        """
+        Translates the IIR node of the generic declaration to a :class:`GenericConstantInterfaceItem`.
+
+        :param genericNode:        The IIR node of the generic declaration.
+        :param furtherIdentifiers: The remaining identifiers, when one declaration names several.
+        :returns:                  The translated generic declaration.
+        """
         name = GetNameOfNode(genericNode)
         documentation = GetDocumentationOfNode(genericNode)
         identifiers = [name]
@@ -130,6 +137,12 @@ class GenericTypeInterfaceItem(VHDLModel_GenericTypeInterfaceItem, DOMMixin):
 
     @classmethod
     def parse(cls, genericNode: Iir) -> "GenericTypeInterfaceItem":
+        """
+        Translates the IIR node of the generic declaration to a :class:`GenericTypeInterfaceItem`.
+
+        :param genericNode: The IIR node of the generic declaration.
+        :returns:           The translated generic declaration.
+        """
         name = GetNameOfNode(genericNode)
         documentation = GetDocumentationOfNode(genericNode)
 
@@ -156,6 +169,12 @@ class GenericPackageInterfaceItem(VHDLModel_GenericPackageInterfaceItem, DOMMixi
 
     @classmethod
     def parse(cls, genericNode: Iir) -> "GenericPackageInterfaceItem":
+        """
+        Translates the IIR node of the generic declaration to a :class:`GenericPackageInterfaceItem`.
+
+        :param genericNode: The IIR node of the generic declaration.
+        :returns:           The translated generic declaration.
+        """
         name = GetNameOfNode(genericNode)
         documentation = GetDocumentationOfNode(genericNode)
 
@@ -182,6 +201,12 @@ class GenericProcedureInterfaceItem(VHDLModel_GenericProcedureInterfaceItem, DOM
 
     @classmethod
     def parse(cls, genericNode: Iir) -> "GenericProcedureInterfaceItem":
+        """
+        Translates the IIR node of the generic declaration to a :class:`GenericProcedureInterfaceItem`.
+
+        :param genericNode: The IIR node of the generic declaration.
+        :returns:           The translated generic declaration.
+        """
         name = GetNameOfNode(genericNode)
         documentation = GetDocumentationOfNode(genericNode)
 
@@ -209,6 +234,12 @@ class GenericFunctionInterfaceItem(VHDLModel_GenericFunctionInterfaceItem, DOMMi
 
     @classmethod
     def parse(cls, genericNode: Iir) -> "GenericFunctionInterfaceItem":
+        """
+        Translates the IIR node of the generic declaration to a :class:`GenericFunctionInterfaceItem`.
+
+        :param genericNode: The IIR node of the generic declaration.
+        :returns:           The translated generic declaration.
+        """
         name = GetNameOfNode(genericNode)
         documentation = GetDocumentationOfNode(genericNode)
 
@@ -250,6 +281,13 @@ class PortSimpleSignalInterfaceItem(VHDLModel_PortSimpleSignalInterfaceItem, DOM
 
     @classmethod
     def parse(cls, portNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "PortSimpleSignalInterfaceItem":
+        """
+        Translates the IIR node of the port declaration to a :class:`PortSimpleSignalInterfaceItem`.
+
+        :param portNode:           The IIR node of the port declaration.
+        :param furtherIdentifiers: The remaining identifiers, when one declaration names several.
+        :returns:                  The translated port declaration.
+        """
         name = GetNameOfNode(portNode)
         documentation = GetDocumentationOfNode(portNode)
         identifiers = [name]
@@ -300,6 +338,13 @@ class PortViewSignalInterfaceItem(VHDLModel_PortViewSignalInterfaceItem, DOMMixi
 
     @classmethod
     def parse(cls, portNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "PortViewSignalInterfaceItem":
+        """
+        Translates the IIR node of the port declaration to a :class:`PortViewSignalInterfaceItem`.
+
+        :param portNode:           The IIR node of the port declaration.
+        :param furtherIdentifiers: The remaining identifiers, when one declaration names several.
+        :returns:                  The translated port declaration.
+        """
         name = GetNameOfNode(portNode)
         documentation = GetDocumentationOfNode(portNode)
         identifiers = [name]
@@ -344,6 +389,13 @@ class ParameterConstantInterfaceItem(VHDLModel_ParameterConstantInterfaceItem, D
 
     @classmethod
     def parse(cls, parameterNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "ParameterConstantInterfaceItem":
+        """
+        Translates the IIR node of the parameter declaration to a :class:`ParameterConstantInterfaceItem`.
+
+        :param parameterNode:      The IIR node of the parameter declaration.
+        :param furtherIdentifiers: The remaining identifiers, when one declaration names several.
+        :returns:                  The translated parameter declaration.
+        """
         name = GetNameOfNode(parameterNode)
         documentation = GetDocumentationOfNode(parameterNode)
         identifiers = [name]
@@ -389,6 +441,13 @@ class ParameterVariableInterfaceItem(VHDLModel_ParameterVariableInterfaceItem, D
 
     @classmethod
     def parse(cls, parameterNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "ParameterVariableInterfaceItem":
+        """
+        Translates the IIR node of the parameter declaration to a :class:`ParameterVariableInterfaceItem`.
+
+        :param parameterNode:      The IIR node of the parameter declaration.
+        :param furtherIdentifiers: The remaining identifiers, when one declaration names several.
+        :returns:                  The translated parameter declaration.
+        """
         name = GetNameOfNode(parameterNode)
         documentation = GetDocumentationOfNode(parameterNode)
         identifiers = [name]
@@ -436,6 +495,13 @@ class ParameterSimpleSignalInterfaceItem(VHDLModel_ParameterSimpleSignalInterfac
     def parse(
         cls, parameterNode: Iir, furtherIdentifiers: Iterable[str] = None
     ) -> "ParameterSimpleSignalInterfaceItem":
+        """
+        Translates the IIR node of the parameter declaration to a :class:`ParameterSimpleSignalInterfaceItem`.
+
+        :param parameterNode:      The IIR node of the parameter declaration.
+        :param furtherIdentifiers: The remaining identifiers, when one declaration names several.
+        :returns:                  The translated parameter declaration.
+        """
         name = GetNameOfNode(parameterNode)
         documentation = GetDocumentationOfNode(parameterNode)
         identifiers = [name]
@@ -484,6 +550,13 @@ class ParameterViewSignalInterfaceItem(VHDLModel_ParameterViewSignalInterfaceIte
 
     @classmethod
     def parse(cls, parameterNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "ParameterViewSignalInterfaceItem":
+        """
+        Translates the IIR node of the parameter declaration to a :class:`ParameterViewSignalInterfaceItem`.
+
+        :param parameterNode:      The IIR node of the parameter declaration.
+        :param furtherIdentifiers: The remaining identifiers, when one declaration names several.
+        :returns:                  The translated parameter declaration.
+        """
         name = GetNameOfNode(parameterNode)
         documentation = GetDocumentationOfNode(parameterNode)
         identifiers = [name]
@@ -518,6 +591,13 @@ class ParameterFileInterfaceItem(VHDLModel_ParameterFileInterfaceItem, DOMMixin)
 
     @classmethod
     def parse(cls, parameterNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "ParameterFileInterfaceItem":
+        """
+        Translates the IIR node of the parameter declaration to a :class:`ParameterFileInterfaceItem`.
+
+        :param parameterNode:      The IIR node of the parameter declaration.
+        :param furtherIdentifiers: The remaining identifiers, when one declaration names several.
+        :returns:                  The translated parameter declaration.
+        """
         name = GetNameOfNode(parameterNode)
         documentation = GetDocumentationOfNode(parameterNode)
         identifiers = [name]
@@ -554,6 +634,13 @@ class SimpleModeViewElement(VHDLModel_SimpleModeViewElement, DOMMixin):
 
     @classmethod
     def parse(cls, elementNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "SimpleModeViewElement":
+        """
+        Translates the IIR node of the element declaration to a :class:`SimpleModeViewElement`.
+
+        :param elementNode:        The IIR node of the element declaration.
+        :param furtherIdentifiers: The remaining identifiers, when one declaration names several.
+        :returns:                  The translated element declaration.
+        """
         name = GetNameOfNode(elementNode)
         identifiers = [name]
         if furtherIdentifiers is not None:
@@ -592,6 +679,13 @@ class CompositeModeViewElement(VHDLModel_CompositeModeViewElement, DOMMixin):
 
     @classmethod
     def parse(cls, elementNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "CompositeModeViewElement":
+        """
+        Translates the IIR node of the element declaration to a :class:`CompositeModeViewElement`.
+
+        :param elementNode:        The IIR node of the element declaration.
+        :param furtherIdentifiers: The remaining identifiers, when one declaration names several.
+        :returns:                  The translated element declaration.
+        """
         name = GetNameOfNode(elementNode)
         identifiers = [name]
         if furtherIdentifiers is not None:
@@ -639,6 +733,12 @@ class ModeViewDeclaration(VHDLModel_ModeViewDeclaration, DOMMixin):
 
     @classmethod
     def parse(cls, modeViewNode: Iir) -> "ModeViewDeclaration":
+        """
+        Translates the IIR node of the mode view declaration to a :class:`ModeViewDeclaration`.
+
+        :param modeViewNode: The IIR node of the mode view declaration.
+        :returns:            The translated mode view declaration.
+        """
         from pyGHDL.dom._Translate import GetModeViewElementsFromChainedNodes
 
         name = GetNameOfNode(modeViewNode)

--- a/pyGHDL/dom/InterfaceItem.py
+++ b/pyGHDL/dom/InterfaceItem.py
@@ -30,6 +30,10 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+This module implements derived interface item classes from :mod:`pyVHDLModel.Interface`.
+"""
+
 from typing import List, Iterable
 
 from pyTooling.Decorators import export

--- a/pyGHDL/dom/InterfaceItem.py
+++ b/pyGHDL/dom/InterfaceItem.py
@@ -77,6 +77,16 @@ class GenericConstantInterfaceItem(VHDLModel_GenericConstantInterfaceItem, DOMMi
         defaultExpression: ExpressionUnion,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a constant in a generic clause.
+
+        :param node:              The IIR node this object was translated from.
+        :param identifiers:       A list of identifiers.
+        :param mode:              The interface item's mode.
+        :param subtype:           Reference to the object's subtype.
+        :param defaultExpression: The default value, or ``None`` if none was given.
+        :param documentation:     The documentation comment associated with this declaration.
+        """
         super().__init__(identifiers, mode, subtype, defaultExpression, documentation)
         DOMMixin.__init__(self, node)
 
@@ -98,6 +108,13 @@ class GenericConstantInterfaceItem(VHDLModel_GenericConstantInterfaceItem, DOMMi
 @export
 class GenericTypeInterfaceItem(VHDLModel_GenericTypeInterfaceItem, DOMMixin):
     def __init__(self, node: Iir, identifier: str, documentation: str = None) -> None:
+        """
+        Initializes a type in a generic clause.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifier:    The identifier of a model entity.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, documentation)
         DOMMixin.__init__(self, node)
 
@@ -112,6 +129,13 @@ class GenericTypeInterfaceItem(VHDLModel_GenericTypeInterfaceItem, DOMMixin):
 @export
 class GenericPackageInterfaceItem(VHDLModel_GenericPackageInterfaceItem, DOMMixin):
     def __init__(self, node: Iir, name: str, documentation: str = None) -> None:
+        """
+        Initializes a package in a generic clause.
+
+        :param node:          The IIR node this object was translated from.
+        :param name:          The generic package's identifier.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(name, documentation)
         DOMMixin.__init__(self, node)
 
@@ -126,6 +150,13 @@ class GenericPackageInterfaceItem(VHDLModel_GenericPackageInterfaceItem, DOMMixi
 @export
 class GenericProcedureInterfaceItem(VHDLModel_GenericProcedureInterfaceItem, DOMMixin):
     def __init__(self, node: Iir, identifier: str, documentation: str = None) -> None:
+        """
+        Initializes a procedure in a generic clause.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifier:    The identifier of a model entity.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, documentation)
         DOMMixin.__init__(self, node)
 
@@ -140,6 +171,14 @@ class GenericProcedureInterfaceItem(VHDLModel_GenericProcedureInterfaceItem, DOM
 @export
 class GenericFunctionInterfaceItem(VHDLModel_GenericFunctionInterfaceItem, DOMMixin):
     def __init__(self, node: Iir, identifier: str, returnType: Symbol, documentation: str = None) -> None:
+        """
+        Initializes a function in a generic clause.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifier:    The identifier of a model entity.
+        :param returnType:    Reference to the subtype of the function's return value.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, returnType, documentation)
         DOMMixin.__init__(self, node)
 
@@ -166,6 +205,16 @@ class PortSimpleSignalInterfaceItem(VHDLModel_PortSimpleSignalInterfaceItem, DOM
         defaultExpression: ExpressionUnion = None,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a port declared with a simple mode.
+
+        :param node:              The IIR node this object was translated from.
+        :param identifiers:       A list of identifiers.
+        :param mode:              The interface item's mode.
+        :param subtype:           Reference to the object's subtype.
+        :param defaultExpression: The default value, or ``None`` if none was given.
+        :param documentation:     The documentation comment associated with this declaration.
+        """
         super().__init__(identifiers, mode, subtype, defaultExpression, documentation)
         DOMMixin.__init__(self, node)
 
@@ -208,6 +257,14 @@ class PortViewSignalInterfaceItem(VHDLModel_PortViewSignalInterfaceItem, DOMMixi
         modeViewIndication: ModeViewSymbol,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a port declared with a mode view (VHDL-2019).
+
+        :param node:               The IIR node this object was translated from.
+        :param identifiers:        A list of identifiers.
+        :param modeViewIndication: Reference to the mode view applied to this port.
+        :param documentation:      The documentation comment associated with this declaration.
+        """
         super().__init__(identifiers, modeViewIndication, documentation=documentation)
         DOMMixin.__init__(self, node)
 
@@ -237,6 +294,16 @@ class ParameterConstantInterfaceItem(VHDLModel_ParameterConstantInterfaceItem, D
         defaultExpression: ExpressionUnion = None,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a constant parameter of a subprogram.
+
+        :param node:              The IIR node this object was translated from.
+        :param identifiers:       A list of identifiers.
+        :param mode:              The interface item's mode.
+        :param subtype:           Reference to the object's subtype.
+        :param defaultExpression: The default value, or ``None`` if none was given.
+        :param documentation:     The documentation comment associated with this declaration.
+        """
         super().__init__(identifiers, mode, subtype, defaultExpression, documentation)
         DOMMixin.__init__(self, node)
 
@@ -267,6 +334,16 @@ class ParameterVariableInterfaceItem(VHDLModel_ParameterVariableInterfaceItem, D
         defaultExpression: ExpressionUnion = None,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a variable parameter of a subprogram.
+
+        :param node:              The IIR node this object was translated from.
+        :param identifiers:       A list of identifiers.
+        :param mode:              The interface item's mode.
+        :param subtype:           Reference to the object's subtype.
+        :param defaultExpression: The default value, or ``None`` if none was given.
+        :param documentation:     The documentation comment associated with this declaration.
+        """
         super().__init__(identifiers, mode, subtype, defaultExpression, documentation)
         DOMMixin.__init__(self, node)
 
@@ -297,6 +374,16 @@ class ParameterSimpleSignalInterfaceItem(VHDLModel_ParameterSimpleSignalInterfac
         defaultExpression: ExpressionUnion = None,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a signal parameter declared with a simple mode.
+
+        :param node:              The IIR node this object was translated from.
+        :param identifiers:       A list of identifiers.
+        :param mode:              The interface item's mode.
+        :param subtype:           Reference to the object's subtype.
+        :param defaultExpression: The default value, or ``None`` if none was given.
+        :param documentation:     The documentation comment associated with this declaration.
+        """
         super().__init__(identifiers, mode, subtype, defaultExpression, documentation)
         DOMMixin.__init__(self, node)
 
@@ -339,6 +426,14 @@ class ParameterViewSignalInterfaceItem(VHDLModel_ParameterViewSignalInterfaceIte
         modeViewIndication: ModeViewSymbol,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a signal parameter declared with a mode view (VHDL-2019).
+
+        :param node:               The IIR node this object was translated from.
+        :param identifiers:        A list of identifiers.
+        :param modeViewIndication: Reference to the mode view applied to this parameter.
+        :param documentation:      The documentation comment associated with this declaration.
+        """
         super().__init__(identifiers, modeViewIndication, documentation=documentation)
         DOMMixin.__init__(self, node)
 
@@ -360,6 +455,14 @@ class ParameterViewSignalInterfaceItem(VHDLModel_ParameterViewSignalInterfaceIte
 @export
 class ParameterFileInterfaceItem(VHDLModel_ParameterFileInterfaceItem, DOMMixin):
     def __init__(self, node: Iir, identifiers: List[str], subtype: Symbol, documentation: str = None) -> None:
+        """
+        Initializes a file parameter of a subprogram.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifiers:   A list of identifiers.
+        :param subtype:       Reference to the object's subtype.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifiers, subtype, documentation)
         DOMMixin.__init__(self, node)
 
@@ -388,6 +491,14 @@ class SimpleModeViewElement(VHDLModel_SimpleModeViewElement, DOMMixin):
     """
 
     def __init__(self, node: Iir, identifiers: List[str], mode: Mode, documentation: str = None) -> None:
+        """
+        Initializes a simple mode view element.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifiers:   A list of identifiers.
+        :param mode:          The element's mode.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifiers, mode, documentation)
         DOMMixin.__init__(self, node)
 
@@ -418,6 +529,14 @@ class CompositeModeViewElement(VHDLModel_CompositeModeViewElement, DOMMixin):
     def __init__(
         self, node: Iir, identifiers: List[str], modeViewName: ModeViewSymbol, documentation: str = None
     ) -> None:
+        """
+        Initializes a composite mode view element.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifiers:   A list of identifiers.
+        :param modeViewName:  Reference to the mode view applied to this element.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifiers, modeViewName, documentation)
         DOMMixin.__init__(self, node)
 
@@ -456,6 +575,15 @@ class ModeViewDeclaration(VHDLModel_ModeViewDeclaration, DOMMixin):
         elements: List = None,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a mode view declaration (VHDL-2019).
+
+        :param node:          The IIR node this object was translated from.
+        :param identifier:    The identifier of a model entity.
+        :param subtype:       Reference to the subtype this mode view applies to.
+        :param elements:      List of all mode view elements, in declaration order.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, subtype, elements, documentation)
         DOMMixin.__init__(self, node)
 

--- a/pyGHDL/dom/Literal.py
+++ b/pyGHDL/dom/Literal.py
@@ -77,6 +77,12 @@ class NullLiteral(VHDLModel_NullLiteral, DOMMixin):
 
     @classmethod
     def parse(cls, node: Iir) -> "NullLiteral":
+        """
+        Translates an IIR node to a :class:`NullLiteral`.
+
+        :param node: The IIR node this object is translated from.
+        :returns:    The translated object.
+        """
         return cls(node)
 
 
@@ -99,6 +105,12 @@ class EnumerationLiteral(VHDLModel_EnumerationLiteral, DOMMixin):
 
     @classmethod
     def parse(cls, literalNode: Iir) -> "EnumerationLiteral":
+        """
+        Translates the IIR node of the literal to an :class:`EnumerationLiteral`.
+
+        :param literalNode: The IIR node of the literal.
+        :returns:           The translated literal.
+        """
         literalName = GetNameOfNode(literalNode)
         return cls(literalNode, literalName)
 
@@ -122,6 +134,12 @@ class IntegerLiteral(VHDLModel_IntegerLiteral, DOMMixin):
 
     @classmethod
     def parse(cls, literalNode: Iir) -> "IntegerLiteral":
+        """
+        Translates the IIR node of the literal to an :class:`IntegerLiteral`.
+
+        :param literalNode: The IIR node of the literal.
+        :returns:           The translated literal.
+        """
         value = nodes.Get_Value(literalNode)
         return cls(literalNode, value)
 
@@ -145,6 +163,12 @@ class FloatingPointLiteral(VHDLModel_FloatingPointLiteral, DOMMixin):
 
     @classmethod
     def parse(cls, literalNode: Iir) -> "FloatingPointLiteral":
+        """
+        Translates the IIR node of the literal to a :class:`FloatingPointLiteral`.
+
+        :param literalNode: The IIR node of the literal.
+        :returns:           The translated literal.
+        """
         value = nodes.Get_Fp_Value(literalNode)
         return cls(literalNode, value)
 
@@ -169,6 +193,12 @@ class PhysicalIntegerLiteral(VHDLModel_PhysicalIntegerLiteral, DOMMixin):
 
     @classmethod
     def parse(cls, literalNode: Iir) -> "PhysicalIntegerLiteral":
+        """
+        Translates the IIR node of the literal to a :class:`PhysicalIntegerLiteral`.
+
+        :param literalNode: The IIR node of the literal.
+        :returns:           The translated literal.
+        """
         value = nodes.Get_Value(literalNode)
         unit = nodes.Get_Unit_Name(literalNode)
         unitName = GetNameOfNode(unit)
@@ -196,6 +226,12 @@ class PhysicalFloatingLiteral(VHDLModel_PhysicalFloatingLiteral, DOMMixin):
 
     @classmethod
     def parse(cls, literalNode: Iir) -> "PhysicalFloatingLiteral":
+        """
+        Translates the IIR node of the literal to a :class:`PhysicalFloatingLiteral`.
+
+        :param literalNode: The IIR node of the literal.
+        :returns:           The translated literal.
+        """
         value = nodes.Get_Fp_Value(literalNode)
         unit = nodes.Get_Unit_Name(literalNode)
         unitName = GetNameOfNode(unit)
@@ -222,6 +258,12 @@ class CharacterLiteral(VHDLModel_CharacterLiteral, DOMMixin):
 
     @classmethod
     def parse(cls, literalNode: Iir) -> "CharacterLiteral":
+        """
+        Translates the IIR node of the literal to a :class:`CharacterLiteral`.
+
+        :param literalNode: The IIR node of the literal.
+        :returns:           The translated literal.
+        """
         identifier = nodes.Get_Identifier(literalNode)
         value = name_table.Get_Character(identifier)
         return cls(literalNode, value)
@@ -332,6 +374,12 @@ class StringLiteral(VHDLModel_StringLiteral, DOMMixin):
         DecimalBitStringLiteral,
         HexadecimalBitStringLiteral,
     ]:
+        """
+        Translates the IIR node of the literal to a :class:`StringLiteral`.
+
+        :param literalNode: The IIR node of the literal.
+        :returns:           The translated literal.
+        """
         base = nodes.Get_Bit_String_Base(literalNode)
         isSigned = nodes.Get_Has_Signed(literalNode) if nodes.Get_Has_Sign(literalNode) else None
         length = nodes.Get_String_Length(literalNode) if nodes.Get_Has_Length(literalNode) else None

--- a/pyGHDL/dom/Literal.py
+++ b/pyGHDL/dom/Literal.py
@@ -63,7 +63,7 @@ from pyGHDL.dom._Utils import GetNameOfNode
 class NullLiteral(VHDLModel_NullLiteral, DOMMixin):
     def __init__(self, node: Iir) -> None:
         """
-        Initializes a null literal.
+        Initializes a :vhdlkw:`null` literal.
 
         :param node: The IIR node this object was translated from.
         """

--- a/pyGHDL/dom/Literal.py
+++ b/pyGHDL/dom/Literal.py
@@ -30,6 +30,10 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+This module implements derived literal classes from :mod:`pyVHDLModel.Expression`.
+"""
+
 from typing import Union, Optional as Nullable
 
 from pyTooling.Decorators import export

--- a/pyGHDL/dom/Literal.py
+++ b/pyGHDL/dom/Literal.py
@@ -62,6 +62,11 @@ from pyGHDL.dom._Utils import GetNameOfNode
 @export
 class NullLiteral(VHDLModel_NullLiteral, DOMMixin):
     def __init__(self, node: Iir) -> None:
+        """
+        Initializes a null literal.
+
+        :param node: The IIR node this object was translated from.
+        """
         super().__init__()
         DOMMixin.__init__(self, node)
 
@@ -73,6 +78,12 @@ class NullLiteral(VHDLModel_NullLiteral, DOMMixin):
 @export
 class EnumerationLiteral(VHDLModel_EnumerationLiteral, DOMMixin):
     def __init__(self, node: Iir, value: str) -> None:
+        """
+        Initializes an enumeration literal.
+
+        :param node:  The IIR node this object was translated from.
+        :param value: The enumeration literal's name.
+        """
         super().__init__(value)
         DOMMixin.__init__(self, node)
 
@@ -85,6 +96,12 @@ class EnumerationLiteral(VHDLModel_EnumerationLiteral, DOMMixin):
 @export
 class IntegerLiteral(VHDLModel_IntegerLiteral, DOMMixin):
     def __init__(self, node: Iir, value: int) -> None:
+        """
+        Initializes an integer literal.
+
+        :param node:  The IIR node this object was translated from.
+        :param value: The literal's integer value.
+        """
         super().__init__(value)
         DOMMixin.__init__(self, node)
 
@@ -97,6 +114,12 @@ class IntegerLiteral(VHDLModel_IntegerLiteral, DOMMixin):
 @export
 class FloatingPointLiteral(VHDLModel_FloatingPointLiteral, DOMMixin):
     def __init__(self, node: Iir, value: float) -> None:
+        """
+        Initializes a floating-point literal.
+
+        :param node:  The IIR node this object was translated from.
+        :param value: The literal's floating-point value.
+        """
         super().__init__(value)
         DOMMixin.__init__(self, node)
 
@@ -109,6 +132,13 @@ class FloatingPointLiteral(VHDLModel_FloatingPointLiteral, DOMMixin):
 @export
 class PhysicalIntegerLiteral(VHDLModel_PhysicalIntegerLiteral, DOMMixin):
     def __init__(self, node: Iir, value: int, unitName: str) -> None:
+        """
+        Initializes a physical literal with an integer value.
+
+        :param node:     The IIR node this object was translated from.
+        :param value:    The literal's integer value, in units of :attr:`_unitName`.
+        :param unitName: The name of the physical unit the value is given in.
+        """
         super().__init__(value, unitName)
         DOMMixin.__init__(self, node)
 
@@ -124,6 +154,13 @@ class PhysicalIntegerLiteral(VHDLModel_PhysicalIntegerLiteral, DOMMixin):
 @export
 class PhysicalFloatingLiteral(VHDLModel_PhysicalFloatingLiteral, DOMMixin):
     def __init__(self, node: Iir, value: int, unitName: float) -> None:
+        """
+        Initializes a physical literal with a floating-point value.
+
+        :param node:     The IIR node this object was translated from.
+        :param value:    The literal's floating-point value, in units of :attr:`_unitName`.
+        :param unitName: The name of the physical unit the value is given in.
+        """
         super().__init__(value, unitName)
         DOMMixin.__init__(self, node)
 
@@ -139,6 +176,12 @@ class PhysicalFloatingLiteral(VHDLModel_PhysicalFloatingLiteral, DOMMixin):
 @export
 class CharacterLiteral(VHDLModel_CharacterLiteral, DOMMixin):
     def __init__(self, node: Iir, value: str) -> None:
+        """
+        Initializes a character literal.
+
+        :param node:  The IIR node this object was translated from.
+        :param value: The literal's character value.
+        """
         super().__init__(value)
         DOMMixin.__init__(self, node)
 
@@ -152,6 +195,14 @@ class CharacterLiteral(VHDLModel_CharacterLiteral, DOMMixin):
 @export
 class BinaryBitStringLiteral(VHDLModel_BinaryBitStringLiteral, DOMMixin):
     def __init__(self, node: Iir, value: str, length: Nullable[int] = None, isSigned: Nullable[bool] = None) -> None:
+        """
+        Initializes a bit string literal.
+
+        :param node:     The IIR node this object was translated from.
+        :param value:    The literal as written in the source, without the enclosing double quotes.
+        :param length:   The explicitly given length, or ``None`` if the literal has no length specification.
+        :param isSigned: ``True`` if signed, ``False`` if unsigned, ``None`` if unspecified.
+        """
         super().__init__(value, length, isSigned)
         DOMMixin.__init__(self, node)
 
@@ -159,6 +210,14 @@ class BinaryBitStringLiteral(VHDLModel_BinaryBitStringLiteral, DOMMixin):
 @export
 class OctalBitStringLiteral(VHDLModel_OctalBitStringLiteral, DOMMixin):
     def __init__(self, node: Iir, value: str, length: Nullable[int] = None, isSigned: Nullable[bool] = None) -> None:
+        """
+        Initializes a bit string literal.
+
+        :param node:     The IIR node this object was translated from.
+        :param value:    The literal as written in the source, without the enclosing double quotes.
+        :param length:   The explicitly given length, or ``None`` if the literal has no length specification.
+        :param isSigned: ``True`` if signed, ``False`` if unsigned, ``None`` if unspecified.
+        """
         super().__init__(value, length, isSigned)
         DOMMixin.__init__(self, node)
 
@@ -166,6 +225,14 @@ class OctalBitStringLiteral(VHDLModel_OctalBitStringLiteral, DOMMixin):
 @export
 class DecimalBitStringLiteral(VHDLModel_DecimalBitStringLiteral, DOMMixin):
     def __init__(self, node: Iir, value: str, length: Nullable[int] = None, isSigned: Nullable[bool] = None) -> None:
+        """
+        Initializes a bit string literal.
+
+        :param node:     The IIR node this object was translated from.
+        :param value:    The literal as written in the source, without the enclosing double quotes.
+        :param length:   The explicitly given length, or ``None`` if the literal has no length specification.
+        :param isSigned: ``True`` if signed, ``False`` if unsigned, ``None`` if unspecified.
+        """
         super().__init__(value, length, isSigned)
         DOMMixin.__init__(self, node)
 
@@ -173,6 +240,14 @@ class DecimalBitStringLiteral(VHDLModel_DecimalBitStringLiteral, DOMMixin):
 @export
 class HexadecimalBitStringLiteral(VHDLModel_HexadecimalBitStringLiteral, DOMMixin):
     def __init__(self, node: Iir, value: str, length: Nullable[int] = None, isSigned: Nullable[bool] = None) -> None:
+        """
+        Initializes a bit string literal.
+
+        :param node:     The IIR node this object was translated from.
+        :param value:    The literal as written in the source, without the enclosing double quotes.
+        :param length:   The explicitly given length, or ``None`` if the literal has no length specification.
+        :param isSigned: ``True`` if signed, ``False`` if unsigned, ``None`` if unspecified.
+        """
         super().__init__(value, length, isSigned)
         DOMMixin.__init__(self, node)
 
@@ -180,6 +255,12 @@ class HexadecimalBitStringLiteral(VHDLModel_HexadecimalBitStringLiteral, DOMMixi
 @export
 class StringLiteral(VHDLModel_StringLiteral, DOMMixin):
     def __init__(self, node: Iir, value: str) -> None:
+        """
+        Initializes a string literal.
+
+        :param node:  The IIR node this object was translated from.
+        :param value: The literal's string value, without the enclosing double quotes.
+        """
         super().__init__(value)
         DOMMixin.__init__(self, node)
 

--- a/pyGHDL/dom/Literal.py
+++ b/pyGHDL/dom/Literal.py
@@ -196,7 +196,7 @@ class CharacterLiteral(VHDLModel_CharacterLiteral, DOMMixin):
 class BinaryBitStringLiteral(VHDLModel_BinaryBitStringLiteral, DOMMixin):
     def __init__(self, node: Iir, value: str, length: Nullable[int] = None, isSigned: Nullable[bool] = None) -> None:
         """
-        Initializes a bit string literal.
+        Initializes a binary bit string literal.
 
         :param node:     The IIR node this object was translated from.
         :param value:    The literal as written in the source, without the enclosing double quotes.
@@ -211,7 +211,7 @@ class BinaryBitStringLiteral(VHDLModel_BinaryBitStringLiteral, DOMMixin):
 class OctalBitStringLiteral(VHDLModel_OctalBitStringLiteral, DOMMixin):
     def __init__(self, node: Iir, value: str, length: Nullable[int] = None, isSigned: Nullable[bool] = None) -> None:
         """
-        Initializes a bit string literal.
+        Initializes an octal bit string literal.
 
         :param node:     The IIR node this object was translated from.
         :param value:    The literal as written in the source, without the enclosing double quotes.
@@ -226,7 +226,7 @@ class OctalBitStringLiteral(VHDLModel_OctalBitStringLiteral, DOMMixin):
 class DecimalBitStringLiteral(VHDLModel_DecimalBitStringLiteral, DOMMixin):
     def __init__(self, node: Iir, value: str, length: Nullable[int] = None, isSigned: Nullable[bool] = None) -> None:
         """
-        Initializes a bit string literal.
+        Initializes a decimal bit string literal.
 
         :param node:     The IIR node this object was translated from.
         :param value:    The literal as written in the source, without the enclosing double quotes.
@@ -241,7 +241,7 @@ class DecimalBitStringLiteral(VHDLModel_DecimalBitStringLiteral, DOMMixin):
 class HexadecimalBitStringLiteral(VHDLModel_HexadecimalBitStringLiteral, DOMMixin):
     def __init__(self, node: Iir, value: str, length: Nullable[int] = None, isSigned: Nullable[bool] = None) -> None:
         """
-        Initializes a bit string literal.
+        Initializes a hexadecimal bit string literal.
 
         :param node:     The IIR node this object was translated from.
         :param value:    The literal as written in the source, without the enclosing double quotes.

--- a/pyGHDL/dom/Literal.py
+++ b/pyGHDL/dom/Literal.py
@@ -36,7 +36,7 @@ This module implements derived literal classes from :mod:`pyVHDLModel.Expression
 
 from typing import Union, Optional as Nullable
 
-from pyTooling.Decorators import export
+from pyTooling.Decorators import export, InheritDocString
 from pyTooling.Warning import WarningCollector
 
 from pyVHDLModel.Expression import NullLiteral as VHDLModel_NullLiteral
@@ -60,7 +60,12 @@ from pyGHDL.dom._Utils import GetNameOfNode
 
 
 @export
+@InheritDocString(VHDLModel_NullLiteral, merge=True)
 class NullLiteral(VHDLModel_NullLiteral, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.NullLiteral`.
+    """
+
     def __init__(self, node: Iir) -> None:
         """
         Initializes a :vhdlkw:`null` literal.
@@ -76,7 +81,12 @@ class NullLiteral(VHDLModel_NullLiteral, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_EnumerationLiteral, merge=True)
 class EnumerationLiteral(VHDLModel_EnumerationLiteral, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.EnumerationLiteral`.
+    """
+
     def __init__(self, node: Iir, value: str) -> None:
         """
         Initializes an enumeration literal.
@@ -94,7 +104,12 @@ class EnumerationLiteral(VHDLModel_EnumerationLiteral, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_IntegerLiteral, merge=True)
 class IntegerLiteral(VHDLModel_IntegerLiteral, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.IntegerLiteral`.
+    """
+
     def __init__(self, node: Iir, value: int) -> None:
         """
         Initializes an integer literal.
@@ -112,7 +127,12 @@ class IntegerLiteral(VHDLModel_IntegerLiteral, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_FloatingPointLiteral, merge=True)
 class FloatingPointLiteral(VHDLModel_FloatingPointLiteral, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.FloatingPointLiteral`.
+    """
+
     def __init__(self, node: Iir, value: float) -> None:
         """
         Initializes a floating-point literal.
@@ -130,7 +150,12 @@ class FloatingPointLiteral(VHDLModel_FloatingPointLiteral, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_PhysicalIntegerLiteral, merge=True)
 class PhysicalIntegerLiteral(VHDLModel_PhysicalIntegerLiteral, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.PhysicalIntegerLiteral`.
+    """
+
     def __init__(self, node: Iir, value: int, unitName: str) -> None:
         """
         Initializes a physical literal with an integer value.
@@ -152,7 +177,12 @@ class PhysicalIntegerLiteral(VHDLModel_PhysicalIntegerLiteral, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_PhysicalFloatingLiteral, merge=True)
 class PhysicalFloatingLiteral(VHDLModel_PhysicalFloatingLiteral, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.PhysicalFloatingLiteral`.
+    """
+
     def __init__(self, node: Iir, value: int, unitName: float) -> None:
         """
         Initializes a physical literal with a floating-point value.
@@ -174,7 +204,12 @@ class PhysicalFloatingLiteral(VHDLModel_PhysicalFloatingLiteral, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_CharacterLiteral, merge=True)
 class CharacterLiteral(VHDLModel_CharacterLiteral, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.CharacterLiteral`.
+    """
+
     def __init__(self, node: Iir, value: str) -> None:
         """
         Initializes a character literal.
@@ -193,7 +228,12 @@ class CharacterLiteral(VHDLModel_CharacterLiteral, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_BinaryBitStringLiteral, merge=True)
 class BinaryBitStringLiteral(VHDLModel_BinaryBitStringLiteral, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.BinaryBitStringLiteral`.
+    """
+
     def __init__(self, node: Iir, value: str, length: Nullable[int] = None, isSigned: Nullable[bool] = None) -> None:
         """
         Initializes a binary bit string literal.
@@ -208,7 +248,12 @@ class BinaryBitStringLiteral(VHDLModel_BinaryBitStringLiteral, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_OctalBitStringLiteral, merge=True)
 class OctalBitStringLiteral(VHDLModel_OctalBitStringLiteral, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.OctalBitStringLiteral`.
+    """
+
     def __init__(self, node: Iir, value: str, length: Nullable[int] = None, isSigned: Nullable[bool] = None) -> None:
         """
         Initializes an octal bit string literal.
@@ -223,7 +268,12 @@ class OctalBitStringLiteral(VHDLModel_OctalBitStringLiteral, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_DecimalBitStringLiteral, merge=True)
 class DecimalBitStringLiteral(VHDLModel_DecimalBitStringLiteral, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.DecimalBitStringLiteral`.
+    """
+
     def __init__(self, node: Iir, value: str, length: Nullable[int] = None, isSigned: Nullable[bool] = None) -> None:
         """
         Initializes a decimal bit string literal.
@@ -238,7 +288,12 @@ class DecimalBitStringLiteral(VHDLModel_DecimalBitStringLiteral, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_HexadecimalBitStringLiteral, merge=True)
 class HexadecimalBitStringLiteral(VHDLModel_HexadecimalBitStringLiteral, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.HexadecimalBitStringLiteral`.
+    """
+
     def __init__(self, node: Iir, value: str, length: Nullable[int] = None, isSigned: Nullable[bool] = None) -> None:
         """
         Initializes a hexadecimal bit string literal.
@@ -253,7 +308,12 @@ class HexadecimalBitStringLiteral(VHDLModel_HexadecimalBitStringLiteral, DOMMixi
 
 
 @export
+@InheritDocString(VHDLModel_StringLiteral, merge=True)
 class StringLiteral(VHDLModel_StringLiteral, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Expression.StringLiteral`.
+    """
+
     def __init__(self, node: Iir, value: str) -> None:
         """
         Initializes a string literal.

--- a/pyGHDL/dom/Misc.py
+++ b/pyGHDL/dom/Misc.py
@@ -30,7 +30,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
-
 """
 This module implements derived classes for VHDL constructs not covered by another module, e.g. an alias.
 """
@@ -75,6 +74,12 @@ class Alias(VHDLModel_Alias, DOMMixin):
 
     @classmethod
     def parse(cls, aliasNode: Iir):
+        """
+        Translates the IIR node of the alias declaration to an :class:`Alias`.
+
+        :param aliasNode: The IIR node of the alias declaration.
+        :returns:         The translated alias declaration.
+        """
         from pyGHDL.dom._Translate import GetName, GetSubtypeIndicationFromNode
         from pyGHDL.dom.Symbol import Symbol as DOMSymbol
 

--- a/pyGHDL/dom/Misc.py
+++ b/pyGHDL/dom/Misc.py
@@ -35,7 +35,7 @@
 This module implements derived classes for VHDL constructs not covered by another module, e.g. an alias.
 """
 
-from pyTooling.Decorators import export
+from pyTooling.Decorators import export, InheritDocString
 
 from pyVHDLModel.Declaration import Alias as VHDLModel_Alias
 from pyVHDLModel.Symbol import Symbol, PossibleReference
@@ -47,7 +47,12 @@ from pyGHDL.dom._Utils import GetNameOfNode, GetDocumentationOfNode, GetIirKindO
 
 
 @export
+@InheritDocString(VHDLModel_Alias, merge=True)
 class Alias(VHDLModel_Alias, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Declaration.Alias`.
+    """
+
     def __init__(
         self,
         node: Iir,

--- a/pyGHDL/dom/Misc.py
+++ b/pyGHDL/dom/Misc.py
@@ -32,8 +32,7 @@
 # ============================================================================
 
 """
-.. todo::
-   Add a module documentation.
+This module implements derived classes for VHDL constructs not covered by another module, e.g. an alias.
 """
 
 from pyTooling.Decorators import export

--- a/pyGHDL/dom/Misc.py
+++ b/pyGHDL/dom/Misc.py
@@ -56,6 +56,15 @@ class Alias(VHDLModel_Alias, DOMMixin):
         subtype: Symbol = None,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes an alias declaration.
+
+        :param node:          The IIR node this object was translated from.
+        :param aliasName:     The alias' identifier.
+        :param name:          Reference to the name being aliased.
+        :param subtype:       Reference to the alias' subtype, or ``None`` if none was given.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(aliasName, name, subtype, documentation)
         DOMMixin.__init__(self, node)
 

--- a/pyGHDL/dom/Name.py
+++ b/pyGHDL/dom/Name.py
@@ -200,7 +200,7 @@ class AttributeName(VHDLModel_AttributeName, DOMMixin):
 @export
 class AllName(VHDLModel_AllName, DOMMixin):
     """
-    Represents a keyword ``all`` following a name in dot-notation.
+    Represents a keyword :vhdlkw:`all` following a name in dot-notation.
 
     This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Name.AllName`.
 
@@ -214,7 +214,7 @@ class AllName(VHDLModel_AllName, DOMMixin):
 
     def __init__(self, node: Iir, prefix: VHDLModel_Name) -> None:
         """
-        Initializes an ``all`` name.
+        Initializes an :vhdlkw:`all` name.
 
         :param node:   The IIR node this object was translated from.
         :param prefix: Reference to the name's prefix, or ``None`` for a simple name.
@@ -226,7 +226,7 @@ class AllName(VHDLModel_AllName, DOMMixin):
 @export
 class OpenName(VHDLModel_OpenName, DOMMixin):
     """
-    Represents the keyword ``open`` used as a special name.
+    Represents the keyword :vhdlkw:`open` used as a special name.
 
     This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Name.OpenName`.
 
@@ -239,7 +239,7 @@ class OpenName(VHDLModel_OpenName, DOMMixin):
 
     def __init__(self, node: Iir) -> None:
         """
-        Initializes an ``open`` name.
+        Initializes an :vhdlkw:`open` name.
 
         :param node: The IIR node this object was translated from.
         """

--- a/pyGHDL/dom/Name.py
+++ b/pyGHDL/dom/Name.py
@@ -68,7 +68,7 @@ class SimpleName(VHDLModel_SimpleName, DOMMixin):
 
     def __init__(self, node: Iir, identifier: str) -> None:
         """
-        Initializes a name.
+        Initializes a simple name.
 
         :param node:       The IIR node this object was translated from.
         :param identifier: The name's identifier.
@@ -134,7 +134,7 @@ class SlicedName(VHDLModel_SlicedName, DOMMixin):
 
     def __init__(self, node: Iir, identifier: str) -> None:
         """
-        Initializes a name.
+        Initializes a sliced name.
 
         :param node:       The IIR node this object was translated from.
         :param identifier: The name's identifier.

--- a/pyGHDL/dom/Name.py
+++ b/pyGHDL/dom/Name.py
@@ -67,6 +67,12 @@ class SimpleName(VHDLModel_SimpleName, DOMMixin):
     """
 
     def __init__(self, node: Iir, identifier: str) -> None:
+        """
+        Initializes a name.
+
+        :param node:       The IIR node this object was translated from.
+        :param identifier: The name's identifier.
+        """
         super().__init__(identifier)
         DOMMixin.__init__(self, node)
 
@@ -87,6 +93,13 @@ class ParenthesisName(VHDLModel_ParenthesisName, DOMMixin):
     """
 
     def __init__(self, node: Iir, prefix: VHDLModel_Name, associations: List) -> None:
+        """
+        Initializes a name followed by a parenthesized association list.
+
+        :param node:         The IIR node this object was translated from.
+        :param prefix:       Reference to the name's prefix, or ``None`` for a simple name.
+        :param associations: List of all associations in the parenthesis.
+        """
         super().__init__(prefix, associations)
         DOMMixin.__init__(self, node)
 
@@ -94,6 +107,12 @@ class ParenthesisName(VHDLModel_ParenthesisName, DOMMixin):
 @export
 class IndexedName(VHDLModel_IndexedName, DOMMixin):
     def __init__(self, node: Iir, identifier: str) -> None:
+        """
+        Initializes a name indexing an array by one or more values.
+
+        :param node:       The IIR node this object was translated from.
+        :param identifier: The identifier of the indexed name.
+        """
         super().__init__(identifier)
         DOMMixin.__init__(self, node)
 
@@ -114,6 +133,12 @@ class SlicedName(VHDLModel_SlicedName, DOMMixin):
     """
 
     def __init__(self, node: Iir, identifier: str) -> None:
+        """
+        Initializes a name.
+
+        :param node:       The IIR node this object was translated from.
+        :param identifier: The name's identifier.
+        """
         super().__init__(identifier)
         DOMMixin.__init__(self, node)
 
@@ -134,6 +159,13 @@ class SelectedName(VHDLModel_SelectedName, DOMMixin):
     """
 
     def __init__(self, node: Iir, identifier: str, prefix: VHDLModel_Name) -> None:
+        """
+        Initializes a selected name.
+
+        :param node:       The IIR node this object was translated from.
+        :param identifier: The name's identifier.
+        :param prefix:     Reference to the name's prefix, or ``None`` for a simple name.
+        """
         super().__init__(identifier, prefix)
         DOMMixin.__init__(self, node)
 
@@ -154,6 +186,13 @@ class AttributeName(VHDLModel_AttributeName, DOMMixin):
     """
 
     def __init__(self, node: Iir, identifier: str, prefix: VHDLModel_Name) -> None:
+        """
+        Initializes a name selecting an attribute of its prefix.
+
+        :param node:       The IIR node this object was translated from.
+        :param identifier: The name's identifier.
+        :param prefix:     Reference to the name's prefix, or ``None`` for a simple name.
+        """
         super().__init__(identifier, prefix)
         DOMMixin.__init__(self, node)
 
@@ -174,6 +213,12 @@ class AllName(VHDLModel_AllName, DOMMixin):
     """
 
     def __init__(self, node: Iir, prefix: VHDLModel_Name) -> None:
+        """
+        Initializes an ``all`` name.
+
+        :param node:   The IIR node this object was translated from.
+        :param prefix: Reference to the name's prefix, or ``None`` for a simple name.
+        """
         super().__init__(prefix)
         DOMMixin.__init__(self, node)
 
@@ -193,5 +238,10 @@ class OpenName(VHDLModel_OpenName, DOMMixin):
     """
 
     def __init__(self, node: Iir) -> None:
+        """
+        Initializes an ``open`` name.
+
+        :param node: The IIR node this object was translated from.
+        """
         super().__init__()
         DOMMixin.__init__(self, node)

--- a/pyGHDL/dom/Name.py
+++ b/pyGHDL/dom/Name.py
@@ -36,7 +36,7 @@ This module implements derived name classes from :mod:`pyVHDLModel.Name`.
 
 from typing import List
 
-from pyTooling.Decorators import export
+from pyTooling.Decorators import export, InheritDocString
 
 from pyVHDLModel.Name import Name as VHDLModel_Name
 from pyVHDLModel.Name import SimpleName as VHDLModel_SimpleName
@@ -105,7 +105,12 @@ class ParenthesisName(VHDLModel_ParenthesisName, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_IndexedName, merge=True)
 class IndexedName(VHDLModel_IndexedName, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Name.IndexedName`.
+    """
+
     def __init__(self, node: Iir, identifier: str) -> None:
         """
         Initializes a name indexing an array by one or more values.

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -43,7 +43,7 @@ import time
 from pathlib import Path
 from typing import Any, Optional as Nullable, List
 
-from pyTooling.Decorators import export, InheritDocString, readonly
+from pyTooling.Decorators import export, readonly
 from pyTooling.Warning import WarningCollector
 
 from pyVHDLModel import VHDLVersion, IEEEFlavor
@@ -105,8 +105,13 @@ class Design(VHDLModel_Design):
         VHDLVersion.VHDL2019: "19",
     }
 
-    @InheritDocString(VHDLModel_Design)
     def __init__(self, name: str = None, vhdlVersion: VHDLVersion = VHDLVersion.VHDL2008) -> None:
+        """
+        Initialize a VHDL design.
+
+        :param name:        Name of the design.
+        :param vhdlVersion: The VHDL version used to analyze this design.
+        """
         super().__init__(name)
 
         if vhdlVersion not in self._SUPPORTED_VHDL_VERSIONS:
@@ -199,6 +204,15 @@ class Document(VHDLModel_Document):
         dontParse: bool = False,
         dontTranslate: bool = False,
     ) -> None:
+        """
+        Initializes a VHDL document.
+
+        :param path:          Path to the document. ``None`` if in-memory document.
+        :param sourceCode:    The source code to analyze, or ``None`` to read it from ``path``.
+        :param vhdlVersion:   VHDL version used for analyzing this source file.
+        :param dontParse:     ``True`` to skip parsing the source code.
+        :param dontTranslate: ``True`` to parse the source code, but skip translating it to the DOM.
+        """
         super().__init__(path, parent=None)
 
         self._filename = path

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -168,7 +168,10 @@ class Design(VHDLModel_Design):
 
     def LoadDefaultLibraries(self, flavor: Nullable[IEEEFlavor] = None):
         """
-        Loads the ``std`` and ``ieee`` libraries into the design and records how long it took.
+        Loads the ``std`` and ``ieee`` libraries into the design.
+
+        How long this took is measured and kept in :attr:`_loadDefaultLibraryTime`. There is no property to read it
+        with; :file:`pyGHDL/cli/dom.py` reads the field directly.
 
         :param flavor: The IEEE library flavor to load, or ``None`` for the default.
         """
@@ -181,9 +184,11 @@ class Design(VHDLModel_Design):
 
     def Analyze(self):
         """
-        Analyzes all documents of this design and records how long it took.
+        Analyzes all documents of this design.
 
-        Warnings raised by *libghdl* during the analysis are collected in :attr:`_warnings`.
+        How long this took is measured and kept in :attr:`_analyzeTime`, and the warnings *libghdl* raised during the
+        analysis are collected in :attr:`_warnings`. Neither has a property to read it with, so both are read as
+        fields today.
         """
         t1 = time.perf_counter()
 
@@ -284,7 +289,7 @@ class Document(VHDLModel_Document):
         """
         Hands the given source code to *libghdl* under the name in :attr:`_filename`.
 
-        The source file itself is not read, which is how a document can be analyzed from a string.
+        The source file itself is not read, which is how a document can be analyzed *in-memory* from a string.
 
         :param sourceCode: The source code to analyze.
         """

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -32,8 +32,10 @@
 # ============================================================================
 
 """
-.. todo::
-   Add a module documentation.
+This module implements the non-standard classes :class:`Design`, :class:`Library` and :class:`Document`.
+
+These three are not VHDL language constructs, but the entry points of :mod:`pyGHDL.dom`: a document reads
+and parses a source file through *libghdl*, a library groups documents, and a design owns the libraries.
 """
 
 import ctypes

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -43,7 +43,7 @@ import time
 from pathlib import Path
 from typing import Any, Optional as Nullable, List
 
-from pyTooling.Decorators import export, readonly
+from pyTooling.Decorators import export, InheritDocString, readonly
 from pyTooling.Warning import WarningCollector
 
 from pyVHDLModel import VHDLVersion, IEEEFlavor

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -124,6 +124,14 @@ class Design(VHDLModel_Design):
 
     @readonly
     def VHDLVersion(self) -> VHDLVersion:
+        """
+        Read-only property to access the VHDL version this design is analyzed with (:attr:`_vhdlVersion`).
+
+        The version is checked against :attr:`_SUPPORTED_VHDL_VERSIONS` when the design is created and is translated
+        to GHDL's ``--std=`` option value via :attr:`_VHDL_VERSION_TO_STD_OPTION`.
+
+        :returns: The design's VHDL version.
+        """
         return self._vhdlVersion
 
     def __ghdl_init(self):
@@ -318,8 +326,25 @@ class Document(VHDLModel_Document):
 
     @readonly
     def LibGHDLProcessingTime(self) -> float:
+        """
+        Read-only property to access the time *libghdl* spent parsing this document (:attr:`__ghdlProcessingTime`).
+
+        The duration is measured while the document is constructed, so it is set only if ``dontParse`` was ``False``.
+
+        :returns:               The parse duration in seconds.
+        :raises AttributeError: If the document was constructed with ``dontParse=True``.
+        """
         return self.__ghdlProcessingTime
 
     @readonly
     def DOMTranslationTime(self) -> float:
+        """
+        Read-only property to access the time spent translating the IIR tree to the DOM (:attr:`__domTranslateTime`).
+
+        The duration is measured while the document is constructed, so it is set only if neither ``dontParse`` nor
+        ``dontTranslate`` was ``True``.
+
+        :returns:               The translation duration in seconds.
+        :raises AttributeError: If the document was constructed with ``dontParse=True`` or ``dontTranslate=True``.
+        """
         return self.__domTranslateTime

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -30,7 +30,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
-
 """
 This module implements the non-standard classes :class:`Design`, :class:`Library` and :class:`Document`.
 
@@ -168,6 +167,11 @@ class Design(VHDLModel_Design):
             )
 
     def LoadDefaultLibraries(self, flavor: Nullable[IEEEFlavor] = None):
+        """
+        Loads the ``std`` and ``ieee`` libraries into the design and records how long it took.
+
+        :param flavor: The IEEE library flavor to load, or ``None`` for the default.
+        """
         t1 = time.perf_counter()
 
         super().LoadStdLibrary()
@@ -176,6 +180,11 @@ class Design(VHDLModel_Design):
         self._loadDefaultLibraryTime = time.perf_counter() - t1
 
     def Analyze(self):
+        """
+        Analyzes all documents of this design and records how long it took.
+
+        Warnings raised by *libghdl* during the analysis are collected in :attr:`_warnings`.
+        """
         t1 = time.perf_counter()
 
         with WarningCollector(self._warnings) as warnings:
@@ -260,6 +269,11 @@ class Document(VHDLModel_Document):
                 self.__domTranslateTime = time.perf_counter() - t1
 
     def __loadFromPath(self):
+        """
+        Reads the source file named by :attr:`_filename` and hands it to *libghdl*.
+
+        :raises DOMException: If the source file does not exist.
+        """
         try:
             with self._filename.open("r", encoding=ENCODING) as file:
                 self.__loadFromString(file.read())
@@ -267,6 +281,13 @@ class Document(VHDLModel_Document):
             raise DOMException(f"Sourcefile '{self._filename}' not found.") from ex
 
     def __loadFromString(self, sourceCode: str):
+        """
+        Hands the given source code to *libghdl* under the name in :attr:`_filename`.
+
+        The source file itself is not read, which is how a document can be analyzed from a string.
+
+        :param sourceCode: The source code to analyze.
+        """
         sourcesBytes = sourceCode.encode(ENCODING)
         sourceLength = len(sourcesBytes)
         bufferLength = sourceLength + 128
@@ -281,6 +302,11 @@ class Document(VHDLModel_Document):
             raise DOMException(f"Source file '{self._filename}' already loaded.")
 
     def translate(self):
+        """
+        Translates the design units of the parsed IIR tree to :mod:`pyGHDL.dom` objects.
+
+        :raises DOMException: If a design unit's kind is not handled.
+        """
         firstUnit = nodes.Get_First_Design_Unit(self.__ghdlFile)
         self._documentation = GetDocumentationOfNode(firstUnit)
 

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -87,11 +87,13 @@ from pyGHDL.dom.PSL import VerificationUnit, VerificationProperty, VerificationM
 
 @export
 class Design(VHDLModel_Design):
+    # fmt: off
     _loadDefaultLibraryTime: Nullable[float]  #: :meth:`LoadDefaultLibraries` duration in seconds, ``None`` if unused.
-    _analyzeTime: Nullable[float]  #: :meth:`Analyze` duration in seconds, ``None`` if not called.
-    _vhdlVersion: VHDLVersion  #: The VHDL version this design is analyzed with.
+    _analyzeTime:            Nullable[float]  #: :meth:`Analyze` duration in seconds, ``None`` if not called.
+    _vhdlVersion:            VHDLVersion      #: The VHDL version this design is analyzed with.
 
-    _warnings: List  #: Warnings collected from *libghdl* while the design's documents are analyzed.
+    _warnings:               List             #: Warnings from *libghdl* while the design's documents are analyzed.
+    # fmt: on
 
     #: VHDL versions currently supported by this class. Older revisions (87, 93, 2000, 2002) are
     #: not planned to be supported for now.
@@ -171,15 +173,17 @@ class Library(VHDLModel_Library):
 
 @export
 class Document(VHDLModel_Document):
+    # fmt: off
     _filename: Path  #: The source file this document was read from.
     _warnings: List  #: Warnings collected from *libghdl* while this document is translated.
 
-    __ghdlFileID: Any  #: *libghdl*'s name table identifier for :attr:`_filename`.
+    __ghdlFileID:          Any  #: *libghdl*'s name table identifier for :attr:`_filename`.
     __ghdlSourceFileEntry: Any  #: *libghdl*'s source file entry holding this document's source code.
-    __ghdlFile: Any  #: The IIR design file node returned by *libghdl* when the source code was parsed.
+    __ghdlFile:            Any  #: The IIR design file node returned by *libghdl* when the source code was parsed.
 
-    __ghdlProcessingTime: float  #: Duration of *libghdl*'s parsing in seconds, unset if ``dontParse`` was ``True``.
-    __domTranslateTime: float  #: Duration of the IIR to DOM translation in seconds, unset if it was skipped.
+    __ghdlProcessingTime: float  #: *libghdl*'s parsing duration in seconds, unset if ``dontParse`` was ``True``.
+    __domTranslateTime:   float  #: The IIR to DOM translation duration in seconds, unset if it was skipped.
+    # fmt: on
 
     def __init__(
         self,

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -87,11 +87,11 @@ from pyGHDL.dom.PSL import VerificationUnit, VerificationProperty, VerificationM
 
 @export
 class Design(VHDLModel_Design):
-    _loadDefaultLibraryTime: Nullable[float]
-    _analyzeTime: Nullable[float]
-    _vhdlVersion: VHDLVersion
+    _loadDefaultLibraryTime: Nullable[float]  #: :meth:`LoadDefaultLibraries` duration in seconds, ``None`` if unused.
+    _analyzeTime: Nullable[float]  #: :meth:`Analyze` duration in seconds, ``None`` if not called.
+    _vhdlVersion: VHDLVersion  #: The VHDL version this design is analyzed with.
 
-    _warnings: List
+    _warnings: List  #: Warnings collected from *libghdl* while the design's documents are analyzed.
 
     #: VHDL versions currently supported by this class. Older revisions (87, 93, 2000, 2002) are
     #: not planned to be supported for now.
@@ -171,15 +171,15 @@ class Library(VHDLModel_Library):
 
 @export
 class Document(VHDLModel_Document):
-    _filename: Path
-    _warnings: List
+    _filename: Path  #: The source file this document was read from.
+    _warnings: List  #: Warnings collected from *libghdl* while this document is translated.
 
-    __ghdlFileID: Any
-    __ghdlSourceFileEntry: Any
-    __ghdlFile: Any
+    __ghdlFileID: Any  #: *libghdl*'s name table identifier for :attr:`_filename`.
+    __ghdlSourceFileEntry: Any  #: *libghdl*'s source file entry holding this document's source code.
+    __ghdlFile: Any  #: The IIR design file node returned by *libghdl* when the source code was parsed.
 
-    __ghdlProcessingTime: float
-    __domTranslateTime: float
+    __ghdlProcessingTime: float  #: Duration of *libghdl*'s parsing in seconds, unset if ``dontParse`` was ``True``.
+    __domTranslateTime: float  #: Duration of the IIR to DOM translation in seconds, unset if it was skipped.
 
     def __init__(
         self,

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -88,7 +88,12 @@ from pyGHDL.dom.PSL import VerificationUnit, VerificationProperty, VerificationM
 
 
 @export
+@InheritDocString(VHDLModel_Design, merge=True)
 class Design(VHDLModel_Design):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Design`.
+    """
+
     _loadDefaultLibraryTime: Nullable[float]  #: :meth:`LoadDefaultLibraries` duration in seconds, ``None`` if unused.
     _analyzeTime: Nullable[float]  #: :meth:`Analyze` duration in seconds, ``None`` if not called.
     _vhdlVersion: VHDLVersion  #: The VHDL version this design is analyzed with.
@@ -180,12 +185,22 @@ class Design(VHDLModel_Design):
 
 
 @export
+@InheritDocString(VHDLModel_Library, merge=True)
 class Library(VHDLModel_Library):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Library`.
+    """
+
     pass
 
 
 @export
+@InheritDocString(VHDLModel_Document, merge=True)
 class Document(VHDLModel_Document):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Document`.
+    """
+
     _filename: Path  #: The source file this document was read from.
     _warnings: List  #: Warnings collected from *libghdl* while this document is translated.
 

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -87,13 +87,11 @@ from pyGHDL.dom.PSL import VerificationUnit, VerificationProperty, VerificationM
 
 @export
 class Design(VHDLModel_Design):
-    # fmt: off
     _loadDefaultLibraryTime: Nullable[float]  #: :meth:`LoadDefaultLibraries` duration in seconds, ``None`` if unused.
-    _analyzeTime:            Nullable[float]  #: :meth:`Analyze` duration in seconds, ``None`` if not called.
-    _vhdlVersion:            VHDLVersion      #: The VHDL version this design is analyzed with.
+    _analyzeTime: Nullable[float]  #: :meth:`Analyze` duration in seconds, ``None`` if not called.
+    _vhdlVersion: VHDLVersion  #: The VHDL version this design is analyzed with.
 
-    _warnings:               List             #: Warnings from *libghdl* while the design's documents are analyzed.
-    # fmt: on
+    _warnings: List  #: Warnings collected from *libghdl* while the design's documents are analyzed.
 
     #: VHDL versions currently supported by this class. Older revisions (87, 93, 2000, 2002) are
     #: not planned to be supported for now.
@@ -173,17 +171,15 @@ class Library(VHDLModel_Library):
 
 @export
 class Document(VHDLModel_Document):
-    # fmt: off
     _filename: Path  #: The source file this document was read from.
     _warnings: List  #: Warnings collected from *libghdl* while this document is translated.
 
-    __ghdlFileID:          Any  #: *libghdl*'s name table identifier for :attr:`_filename`.
+    __ghdlFileID: Any  #: *libghdl*'s name table identifier for :attr:`_filename`.
     __ghdlSourceFileEntry: Any  #: *libghdl*'s source file entry holding this document's source code.
-    __ghdlFile:            Any  #: The IIR design file node returned by *libghdl* when the source code was parsed.
+    __ghdlFile: Any  #: The IIR design file node returned by *libghdl* when the source code was parsed.
 
-    __ghdlProcessingTime: float  #: *libghdl*'s parsing duration in seconds, unset if ``dontParse`` was ``True``.
-    __domTranslateTime:   float  #: The IIR to DOM translation duration in seconds, unset if it was skipped.
-    # fmt: on
+    __ghdlProcessingTime: float  #: Duration of *libghdl*'s parsing in seconds, unset if ``dontParse`` was ``True``.
+    __domTranslateTime: float  #: Duration of the IIR to DOM translation in seconds, unset if it was skipped.
 
     def __init__(
         self,

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -287,7 +287,9 @@ class Document(VHDLModel_Document):
         """
         Hands the given source code to *libghdl* under the name in :attr:`_filename`.
 
-        The source file itself is not read, which is how a document can be analyzed *in-memory* from a string.
+        .. hint::
+
+           The source file itself is not read, which is how a document can be analyzed *in-memory* from a string.
 
         :param sourceCode: The source code to analyze.
         """

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -170,8 +170,7 @@ class Design(VHDLModel_Design):
         """
         Loads the ``std`` and ``ieee`` libraries into the design.
 
-        How long this took is measured and kept in :attr:`_loadDefaultLibraryTime`. There is no property to read it
-        with; :file:`pyGHDL/cli/dom.py` reads the field directly.
+        How long this took is measured and kept in :attr:`_loadDefaultLibraryTime`.
 
         :param flavor: The IEEE library flavor to load, or ``None`` for the default.
         """
@@ -187,8 +186,7 @@ class Design(VHDLModel_Design):
         Analyzes all documents of this design.
 
         How long this took is measured and kept in :attr:`_analyzeTime`, and the warnings *libghdl* raised during the
-        analysis are collected in :attr:`_warnings`. Neither has a property to read it with, so both are read as
-        fields today.
+        analysis are collected in :attr:`_warnings`.
         """
         t1 = time.perf_counter()
 

--- a/pyGHDL/dom/Object.py
+++ b/pyGHDL/dom/Object.py
@@ -75,6 +75,15 @@ class Constant(VHDLModel_Constant, DOMMixin):
         defaultExpression: ExpressionUnion,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a constant.
+
+        :param node:              The IIR node this object was translated from.
+        :param identifiers:       A list of identifiers.
+        :param subtype:           Reference to the object's subtype.
+        :param defaultExpression: The default value, or ``None`` if none was given.
+        :param documentation:     The documentation comment associated with this declaration.
+        """
         super().__init__(identifiers, subtype, defaultExpression, documentation)
         DOMMixin.__init__(self, node)
 
@@ -117,6 +126,14 @@ class DeferredConstant(VHDLModel_DeferredConstant, DOMMixin):
     """
 
     def __init__(self, node: Iir, identifiers: List[str], subtype: Symbol, documentation: str = None) -> None:
+        """
+        Initializes a deferred constant.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifiers:   A list of identifiers.
+        :param subtype:       Reference to the object's subtype.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifiers, subtype, documentation)
         DOMMixin.__init__(self, node)
 
@@ -156,6 +173,15 @@ class Variable(VHDLModel_Variable, DOMMixin):
         defaultExpression: ExpressionUnion,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a variable.
+
+        :param node:              The IIR node this object was translated from.
+        :param identifiers:       A list of identifiers.
+        :param subtype:           Reference to the object's subtype.
+        :param defaultExpression: The default value, or ``None`` if none was given.
+        :param documentation:     The documentation comment associated with this declaration.
+        """
         super().__init__(identifiers, subtype, defaultExpression, documentation)
         DOMMixin.__init__(self, node)
 
@@ -195,6 +221,14 @@ class SharedVariable(VHDLModel_SharedVariable, DOMMixin):
     """
 
     def __init__(self, node: Iir, identifiers: List[str], subtype: Symbol, documentation: str = None) -> None:
+        """
+        Initializes an object.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifiers:   A list of identifiers.
+        :param subtype:       Reference to the object's subtype.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifiers, subtype, documentation)
         DOMMixin.__init__(self, node)
 
@@ -234,6 +268,15 @@ class Signal(VHDLModel_Signal, DOMMixin):
         defaultExpression: ExpressionUnion,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a signal.
+
+        :param node:              The IIR node this object was translated from.
+        :param identifiers:       A list of identifiers.
+        :param subtype:           Reference to the object's subtype.
+        :param defaultExpression: The default value, or ``None`` if none was given.
+        :param documentation:     The documentation comment associated with this declaration.
+        """
         super().__init__(identifiers, subtype, defaultExpression, documentation)
         DOMMixin.__init__(self, node)
 
@@ -271,6 +314,14 @@ class File(VHDLModel_File, DOMMixin):
     """
 
     def __init__(self, node: Iir, identifiers: List[str], subtype: Symbol, documentation: str = None) -> None:
+        """
+        Initializes an object.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifiers:   A list of identifiers.
+        :param subtype:       Reference to the object's subtype.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifiers, subtype, documentation)
         DOMMixin.__init__(self, node)
 

--- a/pyGHDL/dom/Object.py
+++ b/pyGHDL/dom/Object.py
@@ -222,7 +222,7 @@ class SharedVariable(VHDLModel_SharedVariable, DOMMixin):
 
     def __init__(self, node: Iir, identifiers: List[str], subtype: Symbol, documentation: str = None) -> None:
         """
-        Initializes an object.
+        Initializes a shared variable.
 
         :param node:          The IIR node this object was translated from.
         :param identifiers:   A list of identifiers.
@@ -315,7 +315,7 @@ class File(VHDLModel_File, DOMMixin):
 
     def __init__(self, node: Iir, identifiers: List[str], subtype: Symbol, documentation: str = None) -> None:
         """
-        Initializes an object.
+        Initializes a file object.
 
         :param node:          The IIR node this object was translated from.
         :param identifiers:   A list of identifiers.

--- a/pyGHDL/dom/Object.py
+++ b/pyGHDL/dom/Object.py
@@ -91,6 +91,13 @@ class Constant(VHDLModel_Constant, DOMMixin):
     def parse(
         cls, constantNode: Iir, furtherIdentifiers: Iterable[str] = None
     ) -> Union["Constant", "DeferredConstant"]:
+        """
+        Translates the IIR node of the constant declaration to a :class:`Constant`.
+
+        :param constantNode:       The IIR node of the constant declaration.
+        :param furtherIdentifiers: The remaining identifiers, when one declaration names several.
+        :returns:                  The translated constant declaration.
+        """
         from pyGHDL.dom._Translate import (
             GetSubtypeIndicationFromNode,
             GetExpressionFromNode,
@@ -139,6 +146,13 @@ class DeferredConstant(VHDLModel_DeferredConstant, DOMMixin):
 
     @classmethod
     def parse(cls, constantNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "DeferredConstant":
+        """
+        Translates the IIR node of the constant declaration to a :class:`DeferredConstant`.
+
+        :param constantNode:       The IIR node of the constant declaration.
+        :param furtherIdentifiers: The remaining identifiers, when one declaration names several.
+        :returns:                  The translated constant declaration.
+        """
         from pyGHDL.dom._Translate import GetSubtypeIndicationFromNode
 
         name = GetNameOfNode(constantNode)
@@ -187,6 +201,13 @@ class Variable(VHDLModel_Variable, DOMMixin):
 
     @classmethod
     def parse(cls, variableNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "Variable":
+        """
+        Translates the IIR node of the variable declaration to a :class:`Variable`.
+
+        :param variableNode:       The IIR node of the variable declaration.
+        :param furtherIdentifiers: The remaining identifiers, when one declaration names several.
+        :returns:                  The translated variable declaration.
+        """
         from pyGHDL.dom._Translate import (
             GetSubtypeIndicationFromNode,
             GetExpressionFromNode,
@@ -234,6 +255,13 @@ class SharedVariable(VHDLModel_SharedVariable, DOMMixin):
 
     @classmethod
     def parse(cls, variableNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "SharedVariable":
+        """
+        Translates the IIR node of the variable declaration to a :class:`SharedVariable`.
+
+        :param variableNode:       The IIR node of the variable declaration.
+        :param furtherIdentifiers: The remaining identifiers, when one declaration names several.
+        :returns:                  The translated variable declaration.
+        """
         from pyGHDL.dom._Translate import GetSubtypeIndicationFromNode
 
         name = GetNameOfNode(variableNode)
@@ -282,6 +310,13 @@ class Signal(VHDLModel_Signal, DOMMixin):
 
     @classmethod
     def parse(cls, signalNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "Signal":
+        """
+        Translates the IIR node of the signal declaration to a :class:`Signal`.
+
+        :param signalNode:         The IIR node of the signal declaration.
+        :param furtherIdentifiers: The remaining identifiers, when one declaration names several.
+        :returns:                  The translated signal declaration.
+        """
         from pyGHDL.dom._Translate import (
             GetSubtypeIndicationFromNode,
             GetExpressionFromNode,
@@ -327,6 +362,13 @@ class File(VHDLModel_File, DOMMixin):
 
     @classmethod
     def parse(cls, fileNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "File":
+        """
+        Translates the IIR node of the file declaration to a :class:`File`.
+
+        :param fileNode:           The IIR node of the file declaration.
+        :param furtherIdentifiers: The remaining identifiers, when one declaration names several.
+        :returns:                  The translated file declaration.
+        """
         from pyGHDL.dom._Translate import GetSubtypeIndicationFromNode
 
         name = GetNameOfNode(fileNode)

--- a/pyGHDL/dom/PSL.py
+++ b/pyGHDL/dom/PSL.py
@@ -59,6 +59,12 @@ class VerificationUnit(VHDLModel_VerificationUnit, DOMMixin):
         node: Iir,
         identifier: str,
     ) -> None:
+        """
+        Initializes a PSL verification unit (``vunit``).
+
+        :param node:       The IIR node this object was translated from.
+        :param identifier: The identifier of a model entity.
+        """
         super().__init__(identifier)
         DOMMixin.__init__(self, node)
 
@@ -78,6 +84,12 @@ class VerificationProperty(VHDLModel_VerificationProperty, DOMMixin):
         node: Iir,
         identifier: str,
     ) -> None:
+        """
+        Initializes a PSL verification property (``vprop``).
+
+        :param node:       The IIR node this object was translated from.
+        :param identifier: The identifier of a model entity.
+        """
         super().__init__(identifier)
         DOMMixin.__init__(self, node)
 
@@ -97,6 +109,12 @@ class VerificationMode(VHDLModel_VerificationMode, DOMMixin):
         node: Iir,
         identifier: str,
     ) -> None:
+        """
+        Initializes a PSL verification mode (``vmode``).
+
+        :param node:       The IIR node this object was translated from.
+        :param identifier: The identifier of a model entity.
+        """
         super().__init__(identifier)
         DOMMixin.__init__(self, node)
 
@@ -117,6 +135,13 @@ class DefaultClock(VHDLModel_DefaultClock, DOMMixin):
         identifier: str,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a PSL default clock declaration.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifier:    The identifier of a model entity.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, documentation)
         DOMMixin.__init__(self, node)
 

--- a/pyGHDL/dom/PSL.py
+++ b/pyGHDL/dom/PSL.py
@@ -63,7 +63,7 @@ class VerificationUnit(VHDLModel_VerificationUnit, DOMMixin):
         Initializes a PSL verification unit (``vunit``).
 
         :param node:       The IIR node this object was translated from.
-        :param identifier: The identifier of a model entity.
+        :param identifier: The verification unit's identifier.
         """
         super().__init__(identifier)
         DOMMixin.__init__(self, node)
@@ -88,7 +88,7 @@ class VerificationProperty(VHDLModel_VerificationProperty, DOMMixin):
         Initializes a PSL verification property (``vprop``).
 
         :param node:       The IIR node this object was translated from.
-        :param identifier: The identifier of a model entity.
+        :param identifier: The verification property's identifier.
         """
         super().__init__(identifier)
         DOMMixin.__init__(self, node)
@@ -113,7 +113,7 @@ class VerificationMode(VHDLModel_VerificationMode, DOMMixin):
         Initializes a PSL verification mode (``vmode``).
 
         :param node:       The IIR node this object was translated from.
-        :param identifier: The identifier of a model entity.
+        :param identifier: The verification mode's identifier.
         """
         super().__init__(identifier)
         DOMMixin.__init__(self, node)
@@ -139,7 +139,7 @@ class DefaultClock(VHDLModel_DefaultClock, DOMMixin):
         Initializes a PSL default clock declaration.
 
         :param node:          The IIR node this object was translated from.
-        :param identifier:    The identifier of a model entity.
+        :param identifier:    The default clock's identifier.
         :param documentation: The documentation comment associated with this declaration.
         """
         super().__init__(identifier, documentation)

--- a/pyGHDL/dom/PSL.py
+++ b/pyGHDL/dom/PSL.py
@@ -30,13 +30,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
-
 """
 This module contains all DOM classes for VHDL's design units (:class:`context <Entity>`,
 :class:`architecture <Architecture>`, :class:`package <Package>`,
 :class:`package body <PackageBody>`, :class:`context <Context>` and
 :class:`configuration <Configuration>`.
-
 
 """
 
@@ -75,6 +73,12 @@ class VerificationUnit(VHDLModel_VerificationUnit, DOMMixin):
 
     @classmethod
     def parse(cls, vunitNode: Iir):
+        """
+        Translates the IIR node of the verification unit to a :class:`VerificationUnit`.
+
+        :param vunitNode: The IIR node of the verification unit.
+        :returns:         The translated verification unit.
+        """
         name = GetNameOfNode(vunitNode)
 
         # FIXME: needs an implementation
@@ -105,6 +109,12 @@ class VerificationProperty(VHDLModel_VerificationProperty, DOMMixin):
 
     @classmethod
     def parse(cls, vpropNode: Iir):
+        """
+        Translates the IIR node of the verification property to a :class:`VerificationProperty`.
+
+        :param vpropNode: The IIR node of the verification property.
+        :returns:         The translated verification property.
+        """
         name = GetNameOfNode(vpropNode)
 
         # FIXME: needs an implementation
@@ -135,6 +145,12 @@ class VerificationMode(VHDLModel_VerificationMode, DOMMixin):
 
     @classmethod
     def parse(cls, vmodeNode: Iir):
+        """
+        Translates the IIR node of the verification mode to a :class:`VerificationMode`.
+
+        :param vmodeNode: The IIR node of the verification mode.
+        :returns:         The translated verification mode.
+        """
         name = GetNameOfNode(vmodeNode)
 
         # FIXME: needs an implementation
@@ -167,6 +183,12 @@ class DefaultClock(VHDLModel_DefaultClock, DOMMixin):
 
     @classmethod
     def parse(cls, defaultClockNode: Iir):
+        """
+        Translates the IIR node of the PSL default clock to a :class:`DefaultClock`.
+
+        :param defaultClockNode: The IIR node of the PSL default clock.
+        :returns:                The translated PSL default clock.
+        """
         name = GetNameOfNode(defaultClockNode)
         documentation = GetDocumentationOfNode(defaultClockNode)
 

--- a/pyGHDL/dom/PSL.py
+++ b/pyGHDL/dom/PSL.py
@@ -40,7 +40,7 @@ This module contains all DOM classes for VHDL's design units (:class:`context <E
 
 """
 
-from pyTooling.Decorators import export
+from pyTooling.Decorators import export, InheritDocString
 
 from pyVHDLModel.PSLModel import VerificationUnit as VHDLModel_VerificationUnit
 from pyVHDLModel.PSLModel import VerificationProperty as VHDLModel_VerificationProperty
@@ -53,7 +53,12 @@ from pyGHDL.dom._Utils import GetNameOfNode, GetDocumentationOfNode
 
 
 @export
+@InheritDocString(VHDLModel_VerificationUnit, merge=True)
 class VerificationUnit(VHDLModel_VerificationUnit, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.PSLModel.VerificationUnit`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -78,7 +83,12 @@ class VerificationUnit(VHDLModel_VerificationUnit, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_VerificationProperty, merge=True)
 class VerificationProperty(VHDLModel_VerificationProperty, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.PSLModel.VerificationProperty`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -103,7 +113,12 @@ class VerificationProperty(VHDLModel_VerificationProperty, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_VerificationMode, merge=True)
 class VerificationMode(VHDLModel_VerificationMode, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.PSLModel.VerificationMode`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -128,7 +143,12 @@ class VerificationMode(VHDLModel_VerificationMode, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_DefaultClock, merge=True)
 class DefaultClock(VHDLModel_DefaultClock, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.PSLModel.DefaultClock`.
+    """
+
     def __init__(
         self,
         node: Iir,

--- a/pyGHDL/dom/PSL.py
+++ b/pyGHDL/dom/PSL.py
@@ -60,7 +60,7 @@ class VerificationUnit(VHDLModel_VerificationUnit, DOMMixin):
         identifier: str,
     ) -> None:
         """
-        Initializes a PSL verification unit (``vunit``).
+        Initializes a PSL verification unit (:vhdlkw:`vunit`).
 
         :param node:       The IIR node this object was translated from.
         :param identifier: The verification unit's identifier.
@@ -85,7 +85,7 @@ class VerificationProperty(VHDLModel_VerificationProperty, DOMMixin):
         identifier: str,
     ) -> None:
         """
-        Initializes a PSL verification property (``vprop``).
+        Initializes a PSL verification property (:vhdlkw:`vprop`).
 
         :param node:       The IIR node this object was translated from.
         :param identifier: The verification property's identifier.
@@ -110,7 +110,7 @@ class VerificationMode(VHDLModel_VerificationMode, DOMMixin):
         identifier: str,
     ) -> None:
         """
-        Initializes a PSL verification mode (``vmode``).
+        Initializes a PSL verification mode (:vhdlkw:`vmode`).
 
         :param node:       The IIR node this object was translated from.
         :param identifier: The verification mode's identifier.

--- a/pyGHDL/dom/Range.py
+++ b/pyGHDL/dom/Range.py
@@ -30,6 +30,10 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+This module implements derived range classes from :mod:`pyVHDLModel.Base`.
+"""
+
 from pyTooling.Decorators import export, InheritDocString
 
 from pyVHDLModel.Base import Direction, ExpressionUnion

--- a/pyGHDL/dom/Range.py
+++ b/pyGHDL/dom/Range.py
@@ -46,7 +46,12 @@ from pyGHDL.dom import DOMMixin
 
 
 @export
+@InheritDocString(VHDLModel_SimpleRange, merge=True)
 class SimpleRange(VHDLModel_SimpleRange, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Base.SimpleRange`.
+    """
+
     def __init__(
         self, node: Iir, leftBound: ExpressionUnion, rightBound: ExpressionUnion, direction: Direction
     ) -> None:
@@ -63,7 +68,12 @@ class SimpleRange(VHDLModel_SimpleRange, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_RangeFromName, merge=True)
 class RangeFromName(VHDLModel_RangeFromName, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Base.RangeFromName`.
+    """
+
     def __init__(self, node: Iir, symbol: Symbol) -> None:
         """
         Initialize a range denoted by a name.

--- a/pyGHDL/dom/Range.py
+++ b/pyGHDL/dom/Range.py
@@ -34,7 +34,7 @@
 This module implements derived range classes from :mod:`pyVHDLModel.Base`.
 """
 
-from pyTooling.Decorators import export
+from pyTooling.Decorators import export, InheritDocString
 
 from pyVHDLModel.Base import Direction, ExpressionUnion
 from pyVHDLModel.Base import RangeFromName as VHDLModel_RangeFromName

--- a/pyGHDL/dom/Range.py
+++ b/pyGHDL/dom/Range.py
@@ -56,7 +56,7 @@ class SimpleRange(VHDLModel_SimpleRange, DOMMixin):
         :param node:       The IIR node this object was translated from.
         :param leftBound:  The range's left bound.
         :param rightBound: The range's right bound.
-        :param direction:  The range's direction (``to`` or ``downto``).
+        :param direction:  The range's direction (:vhdlkw:`to` or :vhdlkw:`downto`).
         """
         super().__init__(leftBound, rightBound, direction)
         DOMMixin.__init__(self, node)

--- a/pyGHDL/dom/Range.py
+++ b/pyGHDL/dom/Range.py
@@ -34,7 +34,7 @@
 This module implements derived range classes from :mod:`pyVHDLModel.Base`.
 """
 
-from pyTooling.Decorators import export, InheritDocString
+from pyTooling.Decorators import export
 
 from pyVHDLModel.Base import Direction, ExpressionUnion
 from pyVHDLModel.Base import RangeFromName as VHDLModel_RangeFromName
@@ -47,17 +47,29 @@ from pyGHDL.dom import DOMMixin
 
 @export
 class SimpleRange(VHDLModel_SimpleRange, DOMMixin):
-    @InheritDocString(VHDLModel_SimpleRange)
     def __init__(
         self, node: Iir, leftBound: ExpressionUnion, rightBound: ExpressionUnion, direction: Direction
     ) -> None:
+        """
+        Initialize a simple range.
+
+        :param node:       The IIR node this object was translated from.
+        :param leftBound:  The range's left bound.
+        :param rightBound: The range's right bound.
+        :param direction:  The range's direction (``to`` or ``downto``).
+        """
         super().__init__(leftBound, rightBound, direction)
         DOMMixin.__init__(self, node)
 
 
 @export
 class RangeFromName(VHDLModel_RangeFromName, DOMMixin):
-    @InheritDocString(VHDLModel_RangeFromName)
     def __init__(self, node: Iir, symbol: Symbol) -> None:
+        """
+        Initialize a range denoted by a name.
+
+        :param node:   The IIR node this object was translated from.
+        :param symbol: The symbol referencing the range attribute or discrete subtype.
+        """
         super().__init__(symbol)
         DOMMixin.__init__(self, node)

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -196,7 +196,7 @@ class IfStatement(VHDLModel_IfStatement, DOMMixin):
         :param ifBranch:      The mandatory ``if`` branch.
         :param elsifBranches: List of all ``elsif`` branches, in the order they were written.
         :param elseBranch:    The optional ``else`` branch, or ``None`` if none was given.
-        :param label:         The label of a model entity.
+        :param label:         The label of the if statement, or ``None`` if it has none.
         """
         super().__init__(ifBranch, elsifBranches, elseBranch, label)
         DOMMixin.__init__(self, ifNode)
@@ -320,7 +320,7 @@ class CaseStatement(VHDLModel_CaseStatement, DOMMixin):
         Initializes a case statement.
 
         :param caseNode:   The IIR node of the case statement.
-        :param label:      The label of a model entity.
+        :param label:      The label of the case statement, or ``None`` if it has none.
         :param expression: The expression being tested.
         :param cases:      List of all alternatives, in the order they were written.
         """
@@ -424,7 +424,7 @@ class ForLoopStatement(VHDLModel_ForLoopStatement, DOMMixin):
         :param loopIndex:  The name of the loop's index.
         :param rng:        The range the loop iterates over.
         :param statements: List of all sequential statements in this construct.
-        :param label:      The label of a model entity.
+        :param label:      The label of the for-loop statement, or ``None`` if it has none.
         """
         super().__init__(loopIndex, rng, statements, label)
         DOMMixin.__init__(self, loopNode)
@@ -463,7 +463,7 @@ class WhileLoopStatement(VHDLModel_WhileLoopStatement, DOMMixin):
         :param loopNode:   The IIR node of the loop statement.
         :param condition:  The condition guarding this statement.
         :param statements: List of all sequential statements in this construct.
-        :param label:      The label of a model entity.
+        :param label:      The label of the while-loop statement, or ``None`` if it has none.
         """
         super().__init__(condition, statements, label)
         DOMMixin.__init__(self, loopNode)
@@ -519,7 +519,7 @@ class SequentialSimpleSignalAssignment(VHDLModel_SequentialSimpleSignalAssignmen
         :param assignmentNode: The IIR node of the assignment statement.
         :param target:         Reference to the assignment's destination.
         :param waveform:       List of all waveform elements, in the order they were written.
-        :param label:          The label of a model entity.
+        :param label:          The label of the sequential signal assignment, or ``None`` if it has none.
         """
         super().__init__(target, waveform, label)
         DOMMixin.__init__(self, assignmentNode)
@@ -674,7 +674,7 @@ class SequentialVariableAssignment(VHDLModel_SequentialVariableAssignment, DOMMi
         :param assignmentNode: The IIR node of the assignment statement.
         :param target:         Reference to the assignment's destination.
         :param expression:     The assigned expression.
-        :param label:          The label of a model entity.
+        :param label:          The label of the variable assignment, or ``None`` if it has none.
         """
         super().__init__(target, expression, label)
         DOMMixin.__init__(self, assignmentNode)
@@ -705,7 +705,7 @@ class SequentialConditionalVariableAssignment(VHDLModel_SequentialConditionalVar
         :param assignmentNode:         The IIR node of the assignment statement.
         :param target:                 Reference to the assignment's destination.
         :param conditionalExpressions: List of all alternatives, in the order they were written.
-        :param label:                  The label of a model entity.
+        :param label:                  The label of the conditional variable assignment, or ``None`` if it has none.
         """
         super().__init__(target, conditionalExpressions, label)
         DOMMixin.__init__(self, assignmentNode)
@@ -738,7 +738,7 @@ class SequentialConditionalSignalAssignment(VHDLModel_SequentialConditionalSigna
         :param assignmentNode:       The IIR node of the assignment statement.
         :param target:               Reference to the assignment's destination.
         :param conditionalWaveforms: All alternatives, in order.
-        :param label:                The label of a model entity.
+        :param label:                The label of the conditional sequential signal assignment, or ``None`` if it has none.
         """
         super().__init__(target, conditionalWaveforms, label)
         DOMMixin.__init__(self, assignmentNode)
@@ -773,7 +773,7 @@ class SequentialSelectedVariableAssignment(VHDLModel_SequentialSelectedVariableA
         :param target:              Reference to the assignment's destination.
         :param expression:          The selector expression.
         :param selectedExpressions: All alternatives, in order.
-        :param label:               The label of a model entity.
+        :param label:               The label of the selected variable assignment, or ``None`` if it has none.
         """
         super().__init__(target, expression, selectedExpressions, label)
         DOMMixin.__init__(self, assignmentNode)
@@ -809,7 +809,7 @@ class SequentialSelectedSignalAssignment(VHDLModel_SequentialSelectedSignalAssig
         :param target:            Reference to the assignment's destination.
         :param expression:        The selector expression.
         :param selectedWaveforms: All alternatives, in order.
-        :param label:             The label of a model entity.
+        :param label:             The label of the selected sequential signal assignment, or ``None`` if it has none.
         """
         super().__init__(target, expression, selectedWaveforms, label)
         DOMMixin.__init__(self, assignmentNode)
@@ -841,7 +841,7 @@ class SignalForceAssignment(VHDLModel_SignalForceAssignment, DOMMixin):
         :param assignmentNode: The IIR node of the assignment statement.
         :param target:         Reference to the assignment's destination.
         :param expression:     The value forced onto the signal.
-        :param label:          The label of a model entity.
+        :param label:          The label of the signal force assignment, or ``None`` if it has none.
         """
         super().__init__(target, expression, label)
         DOMMixin.__init__(self, assignmentNode)
@@ -865,7 +865,7 @@ class SignalReleaseAssignment(VHDLModel_SignalReleaseAssignment, DOMMixin):
 
         :param assignmentNode: The IIR node of the assignment statement.
         :param target:         Reference to the assignment's destination.
-        :param label:          The label of a model entity.
+        :param label:          The label of the signal release assignment, or ``None`` if it has none.
         """
         super().__init__(target, label)
         DOMMixin.__init__(self, assignmentNode)
@@ -895,7 +895,7 @@ class SequentialProcedureCall(VHDLModel_SequentialProcedureCall, DOMMixin):
         :param callNode:                  The IIR node of the subprogram call.
         :param procedureName:             Reference to the called procedure.
         :param parameterAssociationItems: List of all parameter associations of the call.
-        :param label:                     The label of a model entity.
+        :param label:                     The label of the procedure call, or ``None`` if it has none.
         """
         super().__init__(procedureName, parameterAssociationItems, label)
         DOMMixin.__init__(self, callNode)
@@ -930,7 +930,7 @@ class SequentialAssertStatement(VHDLModel_SequentialAssertStatement, DOMMixin):
         :param condition:  The condition guarding this statement.
         :param message:    The reported message, or ``None`` if none was given.
         :param severity:   The reported severity level, or ``None`` if none was given.
-        :param label:      The label of a model entity.
+        :param label:      The label of the assertion statement, or ``None`` if it has none.
         """
         super().__init__(condition, message, severity, label)
         DOMMixin.__init__(self, assertNode)
@@ -961,7 +961,7 @@ class SequentialReportStatement(VHDLModel_SequentialReportStatement, DOMMixin):
         :param reportNode: The IIR node of the report statement.
         :param message:    The reported message, or ``None`` if none was given.
         :param severity:   The reported severity level, or ``None`` if none was given.
-        :param label:      The label of a model entity.
+        :param label:      The label of the report statement, or ``None`` if it has none.
         """
         super().__init__(message, severity, label)
         DOMMixin.__init__(self, reportNode)
@@ -989,7 +989,7 @@ class ReturnStatement(VHDLModel_ReturnStatement, DOMMixin):
 
         :param returnNode:  The IIR node of the return statement.
         :param returnValue: The returned expression, or ``None`` for a procedure.
-        :param label:       The label of a model entity.
+        :param label:       The label of the return statement, or ``None`` if it has none.
         """
         super().__init__(returnValue, label)
         DOMMixin.__init__(self, returnNode)
@@ -1014,7 +1014,7 @@ class NullStatement(VHDLModel_NullStatement, DOMMixin):
         Initializes a statement.
 
         :param waitNode: The IIR node of the wait statement.
-        :param label:    The label of a model entity.
+        :param label:    The label of the null statement, or ``None`` if it has none.
         """
         super().__init__(label)
         DOMMixin.__init__(self, waitNode)
@@ -1091,7 +1091,7 @@ class WaitStatement(VHDLModel_WaitStatement, DOMMixin):
         :param sensitivityList: List of all signal names to wait on, or ``None`` if none was given.
         :param condition:       The condition guarding this statement.
         :param timeout:         The timeout expression, or ``None`` if none was given.
-        :param label:           The label of a model entity.
+        :param label:           The label of the wait statement, or ``None`` if it has none.
         """
         super().__init__(sensitivityList, condition, timeout, label)
         DOMMixin.__init__(self, waitNode)

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -30,6 +30,10 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+This module implements derived sequential statement classes from :mod:`pyVHDLModel.Sequential`.
+"""
+
 from typing import Iterable
 
 from pyTooling.Decorators import export
@@ -446,7 +450,12 @@ class SequentialSimpleSignalAssignment(VHDLModel_SequentialSimpleSignalAssignmen
 
 
 def GetConditionalExpressionsFromChainedNodes(nodeChain: Iir) -> Iterable["ConditionalExpression"]:
-    """Translates a chain of ``Conditional_Expression`` nodes into a sequence of :class:`ConditionalExpression`."""
+    """
+    Translates a chain of ``Conditional_Expression`` nodes into a sequence of :class:`ConditionalExpression`.
+
+    :param nodeChain: The IIR node starting the chain of conditional expressions.
+    :returns:         The translated conditional expressions, in source order.
+    """
     return [ConditionalExpression.parse(node) for node in utils.chain_iter(nodeChain)]
 
 
@@ -456,6 +465,10 @@ def GetSelectedExpressionsFromChainedNodes(nodeChain: Iir) -> Iterable:
     :class:`OthersSelectedExpression`. Same grouping algorithm as
     :func:`pyGHDL.dom.Concurrent.GetSelectedWaveformsFromChainedNodes`, but the associated content is
     a plain expression (``Get_Associated_Expr``) instead of a waveform chain.
+
+    :param nodeChain:     The IIR node starting the chain of choices.
+    :returns:             The translated selected expressions, in source order.
+    :raises DOMException: If a choice's kind is not handled.
     """
     from pyGHDL.dom._Utils import GetIirKindOfNode
     from pyGHDL.dom._Translate import GetExpressionFromNode, GetRangeFromNode

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -95,6 +95,13 @@ class IfBranch(VHDLModel_IfBranch, DOMMixin):
         condition: ExpressionUnion,
         statements: Iterable[SequentialStatement] = None,
     ) -> None:
+        """
+        Initializes an if branch.
+
+        :param branchNode: The IIR node of the branch this object represents.
+        :param condition:  The condition guarding this statement.
+        :param statements: List of all sequential statements in this construct.
+        """
         super().__init__(condition, statements)
         DOMMixin.__init__(self, branchNode)
 
@@ -120,6 +127,13 @@ class ElsifBranch(VHDLModel_ElsifBranch, DOMMixin):
         condition: ExpressionUnion,
         statements: Iterable[SequentialStatement] = None,
     ) -> None:
+        """
+        Initializes an ``elsif`` branch of an if statement.
+
+        :param branchNode: The IIR node of the branch this object represents.
+        :param condition:  The condition guarding this statement.
+        :param statements: List of all sequential statements in this construct.
+        """
         super().__init__(condition, statements)
         DOMMixin.__init__(self, branchNode)
 
@@ -144,6 +158,12 @@ class ElseBranch(VHDLModel_ElseBranch, DOMMixin):
         branchNode: Iir,
         statements: Iterable[SequentialStatement] = None,
     ) -> None:
+        """
+        Initializes an else branch.
+
+        :param branchNode: The IIR node of the branch this object represents.
+        :param statements: List of all sequential statements in this construct.
+        """
         super().__init__(statements)
         DOMMixin.__init__(self, branchNode)
 
@@ -169,6 +189,15 @@ class IfStatement(VHDLModel_IfStatement, DOMMixin):
         elseBranch: ElseBranch = None,
         label: str = None,
     ) -> None:
+        """
+        Initializes an if statement.
+
+        :param ifNode:        The IIR node of the if statement.
+        :param ifBranch:      The mandatory ``if`` branch.
+        :param elsifBranches: List of all ``elsif`` branches, in the order they were written.
+        :param elseBranch:    The optional ``else`` branch, or ``None`` if none was given.
+        :param label:         The label of a model entity.
+        """
         super().__init__(ifBranch, elsifBranches, elseBranch, label)
         DOMMixin.__init__(self, ifNode)
 
@@ -197,6 +226,12 @@ class IfStatement(VHDLModel_IfStatement, DOMMixin):
 @export
 class IndexedChoice(VHDLModel_IndexedChoice, DOMMixin):
     def __init__(self, node: Iir, expression: ExpressionUnion) -> None:
+        """
+        Initializes a case choice given by a single value.
+
+        :param node:       The IIR node this object was translated from.
+        :param expression: The expression this choice selects on.
+        """
         super().__init__(expression)
         DOMMixin.__init__(self, node)
 
@@ -204,6 +239,12 @@ class IndexedChoice(VHDLModel_IndexedChoice, DOMMixin):
 @export
 class RangedChoice(VHDLModel_RangedChoice, DOMMixin):
     def __init__(self, node: Iir, rng: Range) -> None:
+        """
+        Initializes a case choice given by a range.
+
+        :param node: The IIR node this object was translated from.
+        :param rng:  The range this choice selects on.
+        """
         super().__init__(rng)
         DOMMixin.__init__(self, node)
 
@@ -216,6 +257,13 @@ class Case(VHDLModel_Case, DOMMixin):
         choices: Iterable[SequentialChoice],
         statements: Iterable[SequentialStatement] = None,
     ) -> None:
+        """
+        Initializes a case.
+
+        :param node:       The IIR node this object was translated from.
+        :param choices:    List of all choices selecting this alternative.
+        :param statements: List of all sequential statements in this construct.
+        """
         super().__init__(choices, statements)
         DOMMixin.__init__(self, node)
 
@@ -236,6 +284,12 @@ class OthersCase(VHDLModel_OthersCase, DOMMixin):
         caseNode: Iir,
         statements: Iterable[SequentialStatement] = None,
     ) -> None:
+        """
+        Initializes a sequential case.
+
+        :param caseNode:   The IIR node of the case statement.
+        :param statements: List of all sequential statements in this construct.
+        """
         super().__init__(statements)
         DOMMixin.__init__(self, caseNode)
 
@@ -262,6 +316,14 @@ class CaseStatement(VHDLModel_CaseStatement, DOMMixin):
         expression: ExpressionUnion,
         cases: Iterable[SequentialCase],
     ) -> None:
+        """
+        Initializes a case statement.
+
+        :param caseNode:   The IIR node of the case statement.
+        :param label:      The label of a model entity.
+        :param expression: The expression being tested.
+        :param cases:      List of all alternatives, in the order they were written.
+        """
         super().__init__(expression, cases, label)
         DOMMixin.__init__(self, caseNode)
 
@@ -355,6 +417,15 @@ class ForLoopStatement(VHDLModel_ForLoopStatement, DOMMixin):
         statements: Iterable[SequentialStatement] = None,
         label: str = None,
     ) -> None:
+        """
+        Initializes a for-loop statement.
+
+        :param loopNode:   The IIR node of the loop statement.
+        :param loopIndex:  The name of the loop's index.
+        :param rng:        The range the loop iterates over.
+        :param statements: List of all sequential statements in this construct.
+        :param label:      The label of a model entity.
+        """
         super().__init__(loopIndex, rng, statements, label)
         DOMMixin.__init__(self, loopNode)
 
@@ -386,6 +457,14 @@ class WhileLoopStatement(VHDLModel_WhileLoopStatement, DOMMixin):
         statements: Iterable[SequentialStatement] = None,
         label: str = None,
     ) -> None:
+        """
+        Initializes a while-loop statement.
+
+        :param loopNode:   The IIR node of the loop statement.
+        :param condition:  The condition guarding this statement.
+        :param statements: List of all sequential statements in this construct.
+        :param label:      The label of a model entity.
+        """
         super().__init__(condition, statements, label)
         DOMMixin.__init__(self, loopNode)
 
@@ -434,6 +513,14 @@ class SequentialSimpleSignalAssignment(VHDLModel_SequentialSimpleSignalAssignmen
         waveform: Iterable[WaveformElement],
         label: str = None,
     ) -> None:
+        """
+        Initializes a simple sequential signal assignment.
+
+        :param assignmentNode: The IIR node of the assignment statement.
+        :param target:         Reference to the assignment's destination.
+        :param waveform:       List of all waveform elements, in the order they were written.
+        :param label:          The label of a model entity.
+        """
         super().__init__(target, waveform, label)
         DOMMixin.__init__(self, assignmentNode)
 
@@ -525,6 +612,13 @@ def GetSelectedExpressionsFromChainedNodes(nodeChain: Iir) -> Iterable:
 @export
 class ConditionalExpression(VHDLModel_ConditionalExpression, DOMMixin):
     def __init__(self, node: Iir, expression: ExpressionUnion, condition: ExpressionUnion = None) -> None:
+        """
+        Initializes a conditional expression.
+
+        :param node:       The IIR node this object was translated from.
+        :param expression: The value assigned when the condition holds.
+        :param condition:  The condition selecting this alternative.
+        """
         super().__init__(expression, condition)
         DOMMixin.__init__(self, node)
 
@@ -541,6 +635,13 @@ class ConditionalExpression(VHDLModel_ConditionalExpression, DOMMixin):
 @export
 class SelectedExpression(VHDLModel_SelectedExpression, DOMMixin):
     def __init__(self, node: Iir, choices: Iterable, expression: ExpressionUnion) -> None:
+        """
+        Initializes a selected expression.
+
+        :param node:       The IIR node this object was translated from.
+        :param choices:    List of all choices selecting this alternative.
+        :param expression: The value assigned for the matching choices.
+        """
         super().__init__(choices, expression)
         DOMMixin.__init__(self, node)
 
@@ -548,6 +649,12 @@ class SelectedExpression(VHDLModel_SelectedExpression, DOMMixin):
 @export
 class OthersSelectedExpression(VHDLModel_OthersSelectedExpression, DOMMixin):
     def __init__(self, node: Iir, expression: ExpressionUnion) -> None:
+        """
+        Initializes an others selected expression.
+
+        :param node:       The IIR node this object was translated from.
+        :param expression: The value assigned for every unnamed choice.
+        """
         super().__init__(expression)
         DOMMixin.__init__(self, node)
 
@@ -561,6 +668,14 @@ class SequentialVariableAssignment(VHDLModel_SequentialVariableAssignment, DOMMi
         expression: ExpressionUnion,
         label: str = None,
     ) -> None:
+        """
+        Initializes a simple sequential variable assignment.
+
+        :param assignmentNode: The IIR node of the assignment statement.
+        :param target:         Reference to the assignment's destination.
+        :param expression:     The assigned expression.
+        :param label:          The label of a model entity.
+        """
         super().__init__(target, expression, label)
         DOMMixin.__init__(self, assignmentNode)
 
@@ -584,6 +699,14 @@ class SequentialConditionalVariableAssignment(VHDLModel_SequentialConditionalVar
         conditionalExpressions: Iterable[ConditionalExpression],
         label: str = None,
     ) -> None:
+        """
+        Initializes a conditional sequential variable assignment.
+
+        :param assignmentNode:         The IIR node of the assignment statement.
+        :param target:                 Reference to the assignment's destination.
+        :param conditionalExpressions: List of all alternatives, in the order they were written.
+        :param label:                  The label of a model entity.
+        """
         super().__init__(target, conditionalExpressions, label)
         DOMMixin.__init__(self, assignmentNode)
 
@@ -609,6 +732,14 @@ class SequentialConditionalSignalAssignment(VHDLModel_SequentialConditionalSigna
         conditionalWaveforms: Iterable,
         label: str = None,
     ) -> None:
+        """
+        Initializes a conditional sequential signal assignment.
+
+        :param assignmentNode:       The IIR node of the assignment statement.
+        :param target:               Reference to the assignment's destination.
+        :param conditionalWaveforms: All alternatives, in order.
+        :param label:                The label of a model entity.
+        """
         super().__init__(target, conditionalWaveforms, label)
         DOMMixin.__init__(self, assignmentNode)
 
@@ -635,6 +766,15 @@ class SequentialSelectedVariableAssignment(VHDLModel_SequentialSelectedVariableA
         selectedExpressions: Iterable,
         label: str = None,
     ) -> None:
+        """
+        Initializes a selected sequential variable assignment.
+
+        :param assignmentNode:      The IIR node of the assignment statement.
+        :param target:              Reference to the assignment's destination.
+        :param expression:          The selector expression.
+        :param selectedExpressions: All alternatives, in order.
+        :param label:               The label of a model entity.
+        """
         super().__init__(target, expression, selectedExpressions, label)
         DOMMixin.__init__(self, assignmentNode)
 
@@ -662,6 +802,15 @@ class SequentialSelectedSignalAssignment(VHDLModel_SequentialSelectedSignalAssig
         selectedWaveforms: Iterable,
         label: str = None,
     ) -> None:
+        """
+        Initializes a selected sequential signal assignment.
+
+        :param assignmentNode:    The IIR node of the assignment statement.
+        :param target:            Reference to the assignment's destination.
+        :param expression:        The selector expression.
+        :param selectedWaveforms: All alternatives, in order.
+        :param label:             The label of a model entity.
+        """
         super().__init__(target, expression, selectedWaveforms, label)
         DOMMixin.__init__(self, assignmentNode)
 
@@ -686,6 +835,14 @@ class SignalForceAssignment(VHDLModel_SignalForceAssignment, DOMMixin):
         expression: ExpressionUnion,
         label: str = None,
     ) -> None:
+        """
+        Initializes a signal force assignment.
+
+        :param assignmentNode: The IIR node of the assignment statement.
+        :param target:         Reference to the assignment's destination.
+        :param expression:     The value forced onto the signal.
+        :param label:          The label of a model entity.
+        """
         super().__init__(target, expression, label)
         DOMMixin.__init__(self, assignmentNode)
 
@@ -703,6 +860,13 @@ class SignalForceAssignment(VHDLModel_SignalForceAssignment, DOMMixin):
 @export
 class SignalReleaseAssignment(VHDLModel_SignalReleaseAssignment, DOMMixin):
     def __init__(self, assignmentNode: Iir, target: SignalSymbol, label: str = None) -> None:
+        """
+        Initializes a signal release assignment.
+
+        :param assignmentNode: The IIR node of the assignment statement.
+        :param target:         Reference to the assignment's destination.
+        :param label:          The label of a model entity.
+        """
         super().__init__(target, label)
         DOMMixin.__init__(self, assignmentNode)
 
@@ -725,6 +889,14 @@ class SequentialProcedureCall(VHDLModel_SequentialProcedureCall, DOMMixin):
         parameterAssociationItems: Iterable[ParameterAssociationItem],
         label: str = None,
     ) -> None:
+        """
+        Initializes a procedure call as a sequential statement.
+
+        :param callNode:                  The IIR node of the subprogram call.
+        :param procedureName:             Reference to the called procedure.
+        :param parameterAssociationItems: List of all parameter associations of the call.
+        :param label:                     The label of a model entity.
+        """
         super().__init__(procedureName, parameterAssociationItems, label)
         DOMMixin.__init__(self, callNode)
 
@@ -751,6 +923,15 @@ class SequentialAssertStatement(VHDLModel_SequentialAssertStatement, DOMMixin):
         severity: ExpressionUnion = None,
         label: str = None,
     ) -> None:
+        """
+        Initializes a sequential assertion statement.
+
+        :param assertNode: The IIR node of the assertion.
+        :param condition:  The condition guarding this statement.
+        :param message:    The reported message, or ``None`` if none was given.
+        :param severity:   The reported severity level, or ``None`` if none was given.
+        :param label:      The label of a model entity.
+        """
         super().__init__(condition, message, severity, label)
         DOMMixin.__init__(self, assertNode)
 
@@ -774,6 +955,14 @@ class SequentialReportStatement(VHDLModel_SequentialReportStatement, DOMMixin):
         severity: ExpressionUnion = None,
         label: str = None,
     ) -> None:
+        """
+        Initializes a sequential report statement.
+
+        :param reportNode: The IIR node of the report statement.
+        :param message:    The reported message, or ``None`` if none was given.
+        :param severity:   The reported severity level, or ``None`` if none was given.
+        :param label:      The label of a model entity.
+        """
         super().__init__(message, severity, label)
         DOMMixin.__init__(self, reportNode)
 
@@ -795,6 +984,13 @@ class ReturnStatement(VHDLModel_ReturnStatement, DOMMixin):
         returnValue: ExpressionUnion = None,
         label: str = None,
     ) -> None:
+        """
+        Initializes a return statement.
+
+        :param returnNode:  The IIR node of the return statement.
+        :param returnValue: The returned expression, or ``None`` for a procedure.
+        :param label:       The label of a model entity.
+        """
         super().__init__(returnValue, label)
         DOMMixin.__init__(self, returnNode)
 
@@ -814,6 +1010,12 @@ class NullStatement(VHDLModel_NullStatement, DOMMixin):
         waitNode: Iir,
         label: str = None,
     ) -> None:
+        """
+        Initializes a statement.
+
+        :param waitNode: The IIR node of the wait statement.
+        :param label:    The label of a model entity.
+        """
         super().__init__(label)
         DOMMixin.__init__(self, waitNode)
 
@@ -826,6 +1028,13 @@ class NextStatement(VHDLModel_NextStatement, DOMMixin):
         condition: ExpressionUnion = None,
         label: str = None,
     ) -> None:
+        """
+        Initializes a loop control statement.
+
+        :param exitNode:  The IIR node of the exit statement.
+        :param condition: The condition guarding this statement.
+        :param label:     The label of the loop this statement applies to, or ``None`` for the enclosing loop.
+        """
         super().__init__(condition, loopLabel=label)
         DOMMixin.__init__(self, exitNode)
 
@@ -846,6 +1055,13 @@ class ExitStatement(VHDLModel_ExitStatement, DOMMixin):
         condition: ExpressionUnion = None,
         label: str = None,
     ) -> None:
+        """
+        Initializes a loop control statement.
+
+        :param exitNode:  The IIR node of the exit statement.
+        :param condition: The condition guarding this statement.
+        :param label:     The label of the loop this statement applies to, or ``None`` for the enclosing loop.
+        """
         super().__init__(condition, loopLabel=label)
         DOMMixin.__init__(self, exitNode)
 
@@ -868,6 +1084,15 @@ class WaitStatement(VHDLModel_WaitStatement, DOMMixin):
         timeout: ExpressionUnion = None,
         label: str = None,
     ) -> None:
+        """
+        Initializes a wait statement.
+
+        :param waitNode:        The IIR node of the wait statement.
+        :param sensitivityList: List of all signal names to wait on, or ``None`` if none was given.
+        :param condition:       The condition guarding this statement.
+        :param timeout:         The timeout expression, or ``None`` if none was given.
+        :param label:           The label of a model entity.
+        """
         super().__init__(sensitivityList, condition, timeout, label)
         DOMMixin.__init__(self, waitNode)
 

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -96,7 +96,7 @@ class IfBranch(VHDLModel_IfBranch, DOMMixin):
         statements: Iterable[SequentialStatement] = None,
     ) -> None:
         """
-        Initializes an if branch.
+        Initializes an :vhdlkw:`if` branch.
 
         :param branchNode: The IIR node of the branch this object represents.
         :param condition:  The condition under which this branch's statements are executed.
@@ -128,7 +128,7 @@ class ElsifBranch(VHDLModel_ElsifBranch, DOMMixin):
         statements: Iterable[SequentialStatement] = None,
     ) -> None:
         """
-        Initializes an ``elsif`` branch of an if statement.
+        Initializes an :vhdlkw:`elsif` branch of an :vhdlkw:`if` statement.
 
         :param branchNode: The IIR node of the branch this object represents.
         :param condition:  The condition under which this branch's statements are executed.
@@ -190,13 +190,13 @@ class IfStatement(VHDLModel_IfStatement, DOMMixin):
         label: str = None,
     ) -> None:
         """
-        Initializes an if statement.
+        Initializes an :vhdlkw:`if` statement.
 
-        :param ifNode:        The IIR node of the if statement.
-        :param ifBranch:      The mandatory ``if`` branch.
-        :param elsifBranches: List of all ``elsif`` branches, in the order they were written.
-        :param elseBranch:    The optional ``else`` branch, or ``None`` if none was given.
-        :param label:         The label of the if statement, or ``None`` if it has none.
+        :param ifNode:        The IIR node of the :vhdlkw:`if` statement.
+        :param ifBranch:      The mandatory :vhdlkw:`if` branch.
+        :param elsifBranches: List of all :vhdlkw:`elsif` branches, in the order they were written.
+        :param elseBranch:    The optional :vhdlkw:`else` branch, or ``None`` if none was given.
+        :param label:         The label of the :vhdlkw:`if` statement, or ``None`` if it has none.
         """
         super().__init__(ifBranch, elsifBranches, elseBranch, label)
         DOMMixin.__init__(self, ifNode)
@@ -285,9 +285,9 @@ class OthersCase(VHDLModel_OthersCase, DOMMixin):
         statements: Iterable[SequentialStatement] = None,
     ) -> None:
         """
-        Initializes an others case.
+        Initializes an :vhdlkw:`others` alternative.
 
-        :param caseNode:   The IIR node of the case statement.
+        :param caseNode:   The IIR node of the :vhdlkw:`case` statement.
         :param statements: List of all sequential statements in this construct.
         """
         super().__init__(statements)
@@ -317,10 +317,10 @@ class CaseStatement(VHDLModel_CaseStatement, DOMMixin):
         cases: Iterable[SequentialCase],
     ) -> None:
         """
-        Initializes a case statement.
+        Initializes a :vhdlkw:`case` statement.
 
-        :param caseNode:   The IIR node of the case statement.
-        :param label:      The label of the case statement, or ``None`` if it has none.
+        :param caseNode:   The IIR node of the :vhdlkw:`case` statement.
+        :param label:      The label of the :vhdlkw:`case` statement, or ``None`` if it has none.
         :param expression: The expression being tested.
         :param cases:      List of all alternatives, in the order they were written.
         """
@@ -418,13 +418,13 @@ class ForLoopStatement(VHDLModel_ForLoopStatement, DOMMixin):
         label: str = None,
     ) -> None:
         """
-        Initializes a for-loop statement.
+        Initializes a :vhdlkw:`for..loop` statement.
 
-        :param loopNode:   The IIR node of the loop statement.
+        :param loopNode:   The IIR node of the :vhdlkw:`loop` statement.
         :param loopIndex:  The name of the loop's index.
         :param rng:        The range the loop iterates over.
         :param statements: List of all sequential statements in this construct.
-        :param label:      The label of the for-loop statement, or ``None`` if it has none.
+        :param label:      The label of the :vhdlkw:`for..loop` statement, or ``None`` if it has none.
         """
         super().__init__(loopIndex, rng, statements, label)
         DOMMixin.__init__(self, loopNode)
@@ -458,12 +458,12 @@ class WhileLoopStatement(VHDLModel_WhileLoopStatement, DOMMixin):
         label: str = None,
     ) -> None:
         """
-        Initializes a while-loop statement.
+        Initializes a :vhdlkw:`while..loop` statement.
 
-        :param loopNode:   The IIR node of the loop statement.
+        :param loopNode:   The IIR node of the :vhdlkw:`loop` statement.
         :param condition:  The condition tested before each iteration; the loop ends when it is false.
         :param statements: List of all sequential statements in this construct.
-        :param label:      The label of the while-loop statement, or ``None`` if it has none.
+        :param label:      The label of the :vhdlkw:`while..loop` statement, or ``None`` if it has none.
         """
         super().__init__(condition, statements, label)
         DOMMixin.__init__(self, loopNode)
@@ -650,7 +650,7 @@ class SelectedExpression(VHDLModel_SelectedExpression, DOMMixin):
 class OthersSelectedExpression(VHDLModel_OthersSelectedExpression, DOMMixin):
     def __init__(self, node: Iir, expression: ExpressionUnion) -> None:
         """
-        Initializes an others selected expression.
+        Initializes an :vhdlkw:`others` selected expression.
 
         :param node:       The IIR node this object was translated from.
         :param expression: The value assigned for every unnamed choice.
@@ -956,12 +956,12 @@ class SequentialReportStatement(VHDLModel_SequentialReportStatement, DOMMixin):
         label: str = None,
     ) -> None:
         """
-        Initializes a sequential report statement.
+        Initializes a sequential :vhdlkw:`report` statement.
 
-        :param reportNode: The IIR node of the report statement.
+        :param reportNode: The IIR node of the :vhdlkw:`report` statement.
         :param message:    The reported message, or ``None`` if none was given.
         :param severity:   The reported severity level, or ``None`` if none was given.
-        :param label:      The label of the report statement, or ``None`` if it has none.
+        :param label:      The label of the :vhdlkw:`report` statement, or ``None`` if it has none.
         """
         super().__init__(message, severity, label)
         DOMMixin.__init__(self, reportNode)
@@ -985,11 +985,11 @@ class ReturnStatement(VHDLModel_ReturnStatement, DOMMixin):
         label: str = None,
     ) -> None:
         """
-        Initializes a return statement.
+        Initializes a :vhdlkw:`return` statement.
 
-        :param returnNode:  The IIR node of the return statement.
+        :param returnNode:  The IIR node of the :vhdlkw:`return` statement.
         :param returnValue: The returned expression, or ``None`` for a procedure.
-        :param label:       The label of the return statement, or ``None`` if it has none.
+        :param label:       The label of the :vhdlkw:`return` statement, or ``None`` if it has none.
         """
         super().__init__(returnValue, label)
         DOMMixin.__init__(self, returnNode)
@@ -1011,10 +1011,10 @@ class NullStatement(VHDLModel_NullStatement, DOMMixin):
         label: str = None,
     ) -> None:
         """
-        Initializes a null statement.
+        Initializes a :vhdlkw:`null` statement.
 
-        :param waitNode: The IIR node of the wait statement.
-        :param label:    The label of the null statement, or ``None`` if it has none.
+        :param waitNode: The IIR node of the :vhdlkw:`wait` statement.
+        :param label:    The label of the :vhdlkw:`null` statement, or ``None`` if it has none.
         """
         super().__init__(label)
         DOMMixin.__init__(self, waitNode)
@@ -1029,9 +1029,9 @@ class NextStatement(VHDLModel_NextStatement, DOMMixin):
         label: str = None,
     ) -> None:
         """
-        Initializes a next statement.
+        Initializes a :vhdlkw:`next` statement.
 
-        :param exitNode:  The IIR node of the exit statement.
+        :param exitNode:  The IIR node of the :vhdlkw:`exit` statement.
         :param condition: The condition under which the iteration is skipped, or ``None`` if unconditional.
         :param label:     The label of the loop this statement applies to, or ``None`` for the enclosing loop.
         """
@@ -1056,9 +1056,9 @@ class ExitStatement(VHDLModel_ExitStatement, DOMMixin):
         label: str = None,
     ) -> None:
         """
-        Initializes an exit statement.
+        Initializes an :vhdlkw:`exit` statement.
 
-        :param exitNode:  The IIR node of the exit statement.
+        :param exitNode:  The IIR node of the :vhdlkw:`exit` statement.
         :param condition: The condition under which the loop is left, or ``None`` if unconditional.
         :param label:     The label of the loop this statement applies to, or ``None`` for the enclosing loop.
         """
@@ -1085,13 +1085,13 @@ class WaitStatement(VHDLModel_WaitStatement, DOMMixin):
         label: str = None,
     ) -> None:
         """
-        Initializes a wait statement.
+        Initializes a :vhdlkw:`wait` statement.
 
-        :param waitNode:        The IIR node of the wait statement.
-        :param sensitivityList: List of all signal names of the ``on`` clause, or ``None`` if none was given.
-        :param condition:       The condition of the ``until`` clause, or ``None`` if none was given.
-        :param timeout:         The timeout expression of the ``for`` clause, or ``None`` if none was given.
-        :param label:           The label of the wait statement, or ``None`` if it has none.
+        :param waitNode:        The IIR node of the :vhdlkw:`wait` statement.
+        :param sensitivityList: List of all signal names of the :vhdlkw:`on` clause, or ``None`` if none was given.
+        :param condition:       The condition of the :vhdlkw:`until` clause, or ``None`` if none was given.
+        :param timeout:         The timeout expression of the :vhdlkw:`for` clause, or ``None`` if none was given.
+        :param label:           The label of the :vhdlkw:`wait` statement, or ``None`` if it has none.
         """
         super().__init__(sensitivityList, condition, timeout, label)
         DOMMixin.__init__(self, waitNode)

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -112,6 +112,13 @@ class IfBranch(VHDLModel_IfBranch, DOMMixin):
 
     @classmethod
     def parse(cls, branchNode: Iir, label: str) -> "IfBranch":
+        """
+        Translates the IIR node of the branch to an :class:`IfBranch`.
+
+        :param branchNode: The IIR node of the branch.
+        :param label:      The statement's label, or ``None`` if it has none.
+        :returns:          The translated branch.
+        """
         from pyGHDL.dom._Translate import (
             GetSequentialStatementsFromChainedNodes,
             GetExpressionFromNode,
@@ -149,6 +156,14 @@ class ElsifBranch(VHDLModel_ElsifBranch, DOMMixin):
 
     @classmethod
     def parse(cls, branchNode: Iir, condition: Iir, label: str) -> "ElsifBranch":
+        """
+        Translates the IIR node of the branch to an :class:`ElsifBranch`.
+
+        :param branchNode: The IIR node of the branch.
+        :param condition:  The condition guarding the branch.
+        :param label:      The statement's label, or ``None`` if it has none.
+        :returns:          The translated branch.
+        """
         from pyGHDL.dom._Translate import (
             GetSequentialStatementsFromChainedNodes,
             GetExpressionFromNode,
@@ -184,6 +199,13 @@ class ElseBranch(VHDLModel_ElseBranch, DOMMixin):
 
     @classmethod
     def parse(cls, branchNode: Iir, label: str) -> "ElseBranch":
+        """
+        Translates the IIR node of the branch to an :class:`ElseBranch`.
+
+        :param branchNode: The IIR node of the branch.
+        :param label:      The statement's label, or ``None`` if it has none.
+        :returns:          The translated branch.
+        """
         from pyGHDL.dom._Translate import (
             GetSequentialStatementsFromChainedNodes,
         )
@@ -223,6 +245,13 @@ class IfStatement(VHDLModel_IfStatement, DOMMixin):
 
     @classmethod
     def parse(cls, ifNode: Iir, label: str) -> "IfStatement":
+        """
+        Translates the IIR node of the :vhdlkw:`if` statement to an :class:`IfStatement`.
+
+        :param ifNode: The IIR node of the :vhdlkw:`if` statement.
+        :param label:  The statement's label, or ``None`` if it has none.
+        :returns:      The translated :vhdlkw:`if` statement.
+        """
         ifBranch = IfBranch.parse(ifNode, label)
         elsifBranches = []
         elseBranch = None
@@ -304,6 +333,14 @@ class Case(VHDLModel_Case, DOMMixin):
 
     @classmethod
     def parse(cls, caseNode: Iir, choices: Iterable[SequentialChoice], label: str) -> "Case":
+        """
+        Translates the IIR node of the alternative to a :class:`Case`.
+
+        :param caseNode: The IIR node of the alternative.
+        :param choices:  List of all choices selecting this alternative.
+        :param label:    The statement's label, or ``None`` if it has none.
+        :returns:        The translated alternative.
+        """
         from pyGHDL.dom._Translate import GetSequentialStatementsFromChainedNodes
 
         statementChain = nodes.Get_Associated_Chain(caseNode)
@@ -335,6 +372,13 @@ class OthersCase(VHDLModel_OthersCase, DOMMixin):
 
     @classmethod
     def parse(cls, caseNode: Iir, label: str = None) -> "OthersCase":
+        """
+        Translates the IIR node of the alternative to an :class:`OthersCase`.
+
+        :param caseNode: The IIR node of the alternative.
+        :param label:    The statement's label, or ``None`` if it has none.
+        :returns:        The translated alternative.
+        """
         from pyGHDL.dom._Translate import GetSequentialStatementsFromChainedNodes
 
         body = nodes.Get_Associated_Block(caseNode)
@@ -374,6 +418,13 @@ class CaseStatement(VHDLModel_CaseStatement, DOMMixin):
 
     @classmethod
     def parse(cls, caseNode: Iir, label: str) -> "CaseStatement":
+        """
+        Translates the IIR node of the alternative to a :class:`CaseStatement`.
+
+        :param caseNode: The IIR node of the alternative.
+        :param label:    The statement's label, or ``None`` if it has none.
+        :returns:        The translated alternative.
+        """
         from pyGHDL.dom._Utils import GetIirKindOfNode
         from pyGHDL.dom._Translate import (
             GetExpressionFromNode,
@@ -481,6 +532,13 @@ class ForLoopStatement(VHDLModel_ForLoopStatement, DOMMixin):
 
     @classmethod
     def parse(cls, loopNode: Iir, label: str) -> "ForLoopStatement":
+        """
+        Translates the IIR node of the loop statement to a :class:`ForLoopStatement`.
+
+        :param loopNode: The IIR node of the loop statement.
+        :param label:    The statement's label, or ``None`` if it has none.
+        :returns:        The translated loop statement.
+        """
         from pyGHDL.dom._Utils import GetNameOfNode
         from pyGHDL.dom._Translate import (
             GetSequentialStatementsFromChainedNodes,
@@ -525,6 +583,13 @@ class WhileLoopStatement(VHDLModel_WhileLoopStatement, DOMMixin):
 
     @classmethod
     def parse(cls, loopNode: Iir, label: str) -> "WhileLoopStatement":
+        """
+        Translates the IIR node of the loop statement to a :class:`WhileLoopStatement`.
+
+        :param loopNode: The IIR node of the loop statement.
+        :param label:    The statement's label, or ``None`` if it has none.
+        :returns:        The translated loop statement.
+        """
         from pyGHDL.dom._Utils import GetNameOfNode, GetIirKindOfNode
         from pyGHDL.dom._Translate import (
             GetSequentialStatementsFromChainedNodes,
@@ -586,6 +651,13 @@ class SequentialSimpleSignalAssignment(VHDLModel_SequentialSimpleSignalAssignmen
 
     @classmethod
     def parse(cls, assignmentNode: Iir, label: str = None) -> "SequentialSimpleSignalAssignment":
+        """
+        Translates the IIR node of the assignment statement to a :class:`SequentialSimpleSignalAssignment`.
+
+        :param assignmentNode: The IIR node of the assignment statement.
+        :param label:          The statement's label, or ``None`` if it has none.
+        :returns:              The translated assignment statement.
+        """
         from pyGHDL.dom._Translate import GetName
 
         targetNode = nodes.Get_Target(assignmentNode)
@@ -689,6 +761,12 @@ class ConditionalExpression(VHDLModel_ConditionalExpression, DOMMixin):
 
     @classmethod
     def parse(cls, node: Iir) -> "ConditionalExpression":
+        """
+        Translates an IIR node to a :class:`ConditionalExpression`.
+
+        :param node: The IIR node this object is translated from.
+        :returns:    The translated object.
+        """
         from pyGHDL.dom._Translate import GetExpressionFromNode, GetOptionalExpressionFromNode
 
         expression = GetExpressionFromNode(nodes.Get_Expression(node))
@@ -761,6 +839,13 @@ class SequentialVariableAssignment(VHDLModel_SequentialVariableAssignment, DOMMi
 
     @classmethod
     def parse(cls, assignmentNode: Iir, label: str = None) -> "SequentialVariableAssignment":
+        """
+        Translates the IIR node of the assignment statement to a :class:`SequentialVariableAssignment`.
+
+        :param assignmentNode: The IIR node of the assignment statement.
+        :param label:          The statement's label, or ``None`` if it has none.
+        :returns:              The translated assignment statement.
+        """
         from pyGHDL.dom._Translate import GetName, GetExpressionFromNode
 
         targetNode = nodes.Get_Target(assignmentNode)
@@ -797,6 +882,13 @@ class SequentialConditionalVariableAssignment(VHDLModel_SequentialConditionalVar
 
     @classmethod
     def parse(cls, assignmentNode: Iir, label: str = None) -> "SequentialConditionalVariableAssignment":
+        """
+        Translates the IIR node of the assignment statement to a :class:`SequentialConditionalVariableAssignment`.
+
+        :param assignmentNode: The IIR node of the assignment statement.
+        :param label:          The statement's label, or ``None`` if it has none.
+        :returns:              The translated assignment statement.
+        """
         from pyGHDL.dom._Translate import GetName
 
         targetNode = nodes.Get_Target(assignmentNode)
@@ -835,6 +927,13 @@ class SequentialConditionalSignalAssignment(VHDLModel_SequentialConditionalSigna
 
     @classmethod
     def parse(cls, assignmentNode: Iir, label: str = None) -> "SequentialConditionalSignalAssignment":
+        """
+        Translates the IIR node of the assignment statement to a :class:`SequentialConditionalSignalAssignment`.
+
+        :param assignmentNode: The IIR node of the assignment statement.
+        :param label:          The statement's label, or ``None`` if it has none.
+        :returns:              The translated assignment statement.
+        """
         from pyGHDL.dom._Translate import GetName
 
         targetNode = nodes.Get_Target(assignmentNode)
@@ -875,6 +974,13 @@ class SequentialSelectedVariableAssignment(VHDLModel_SequentialSelectedVariableA
 
     @classmethod
     def parse(cls, assignmentNode: Iir, label: str = None) -> "SequentialSelectedVariableAssignment":
+        """
+        Translates the IIR node of the assignment statement to a :class:`SequentialSelectedVariableAssignment`.
+
+        :param assignmentNode: The IIR node of the assignment statement.
+        :param label:          The statement's label, or ``None`` if it has none.
+        :returns:              The translated assignment statement.
+        """
         from pyGHDL.dom._Translate import GetName, GetExpressionFromNode
 
         targetNode = nodes.Get_Target(assignmentNode)
@@ -916,6 +1022,13 @@ class SequentialSelectedSignalAssignment(VHDLModel_SequentialSelectedSignalAssig
 
     @classmethod
     def parse(cls, assignmentNode: Iir, label: str = None) -> "SequentialSelectedSignalAssignment":
+        """
+        Translates the IIR node of the assignment statement to a :class:`SequentialSelectedSignalAssignment`.
+
+        :param assignmentNode: The IIR node of the assignment statement.
+        :param label:          The statement's label, or ``None`` if it has none.
+        :returns:              The translated assignment statement.
+        """
         from pyGHDL.dom._Translate import GetName, GetExpressionFromNode
 
         targetNode = nodes.Get_Target(assignmentNode)
@@ -953,6 +1066,13 @@ class SignalForceAssignment(VHDLModel_SignalForceAssignment, DOMMixin):
 
     @classmethod
     def parse(cls, assignmentNode: Iir, label: str = None) -> "SignalForceAssignment":
+        """
+        Translates the IIR node of the assignment statement to a :class:`SignalForceAssignment`.
+
+        :param assignmentNode: The IIR node of the assignment statement.
+        :param label:          The statement's label, or ``None`` if it has none.
+        :returns:              The translated assignment statement.
+        """
         from pyGHDL.dom._Translate import GetName, GetExpressionFromNode
 
         targetNode = nodes.Get_Target(assignmentNode)
@@ -982,6 +1102,13 @@ class SignalReleaseAssignment(VHDLModel_SignalReleaseAssignment, DOMMixin):
 
     @classmethod
     def parse(cls, assignmentNode: Iir, label: str = None) -> "SignalReleaseAssignment":
+        """
+        Translates the IIR node of the assignment statement to a :class:`SignalReleaseAssignment`.
+
+        :param assignmentNode: The IIR node of the assignment statement.
+        :param label:          The statement's label, or ``None`` if it has none.
+        :returns:              The translated assignment statement.
+        """
         from pyGHDL.dom._Translate import GetName
 
         targetNode = nodes.Get_Target(assignmentNode)
@@ -1017,6 +1144,13 @@ class SequentialProcedureCall(VHDLModel_SequentialProcedureCall, DOMMixin):
 
     @classmethod
     def parse(cls, callNode: Iir, label: str) -> "SequentialProcedureCall":
+        """
+        Translates the IIR node of the procedure call to a :class:`SequentialProcedureCall`.
+
+        :param callNode: The IIR node of the procedure call.
+        :param label:    The statement's label, or ``None`` if it has none.
+        :returns:        The translated procedure call.
+        """
         from pyGHDL.dom._Translate import GetName, GetParameterMapAspect
 
         cNode = nodes.Get_Procedure_Call(callNode)
@@ -1057,6 +1191,13 @@ class SequentialAssertStatement(VHDLModel_SequentialAssertStatement, DOMMixin):
 
     @classmethod
     def parse(cls, assertNode: Iir, label: str) -> "SequentialAssertStatement":
+        """
+        Translates the IIR node of the assertion to a :class:`SequentialAssertStatement`.
+
+        :param assertNode: The IIR node of the assertion.
+        :param label:      The statement's label, or ``None`` if it has none.
+        :returns:          The translated assertion.
+        """
         from pyGHDL.dom._Translate import GetExpressionFromNode, GetOptionalExpressionFromNode
 
         condition = GetExpressionFromNode(nodes.Get_Assertion_Condition(assertNode))
@@ -1093,6 +1234,13 @@ class SequentialReportStatement(VHDLModel_SequentialReportStatement, DOMMixin):
 
     @classmethod
     def parse(cls, reportNode: Iir, label: str) -> "SequentialReportStatement":
+        """
+        Translates the IIR node of the :vhdlkw:`report` statement to a :class:`SequentialReportStatement`.
+
+        :param reportNode: The IIR node of the :vhdlkw:`report` statement.
+        :param label:      The statement's label, or ``None`` if it has none.
+        :returns:          The translated :vhdlkw:`report` statement.
+        """
         from pyGHDL.dom._Translate import GetExpressionFromNode, GetOptionalExpressionFromNode
 
         message = GetExpressionFromNode(nodes.Get_Report_Expression(reportNode))
@@ -1126,6 +1274,13 @@ class ReturnStatement(VHDLModel_ReturnStatement, DOMMixin):
 
     @classmethod
     def parse(cls, returnNode: Iir, label: str) -> "ReturnStatement":
+        """
+        Translates the IIR node of the :vhdlkw:`return` statement to a :class:`ReturnStatement`.
+
+        :param returnNode: The IIR node of the :vhdlkw:`return` statement.
+        :param label:      The statement's label, or ``None`` if it has none.
+        :returns:          The translated :vhdlkw:`return` statement.
+        """
         from pyGHDL.dom._Translate import GetOptionalExpressionFromNode
 
         returnValue = GetOptionalExpressionFromNode(nodes.Get_Expression(returnNode))
@@ -1180,6 +1335,13 @@ class NextStatement(VHDLModel_NextStatement, DOMMixin):
 
     @classmethod
     def parse(cls, exitNode: Iir, label: str) -> "NextStatement":
+        """
+        Translates the IIR node of the exit statement to a :class:`NextStatement`.
+
+        :param exitNode: The IIR node of the exit statement.
+        :param label:    The statement's label, or ``None`` if it has none.
+        :returns:        The translated exit statement.
+        """
         from pyGHDL.dom._Translate import GetOptionalExpressionFromNode
 
         condition = GetOptionalExpressionFromNode(nodes.Get_Condition(exitNode))
@@ -1212,6 +1374,13 @@ class ExitStatement(VHDLModel_ExitStatement, DOMMixin):
 
     @classmethod
     def parse(cls, exitNode: Iir, label: str) -> "ExitStatement":
+        """
+        Translates the IIR node of the exit statement to an :class:`ExitStatement`.
+
+        :param exitNode: The IIR node of the exit statement.
+        :param label:    The statement's label, or ``None`` if it has none.
+        :returns:        The translated exit statement.
+        """
         from pyGHDL.dom._Translate import GetOptionalExpressionFromNode
 
         condition = GetOptionalExpressionFromNode(nodes.Get_Condition(exitNode))
@@ -1248,6 +1417,13 @@ class WaitStatement(VHDLModel_WaitStatement, DOMMixin):
 
     @classmethod
     def parse(cls, waitNode: Iir, label: str) -> "WaitStatement":
+        """
+        Translates the IIR node of the :vhdlkw:`wait` statement to a :class:`WaitStatement`.
+
+        :param waitNode: The IIR node of the :vhdlkw:`wait` statement.
+        :param label:    The statement's label, or ``None`` if it has none.
+        :returns:        The translated :vhdlkw:`wait` statement.
+        """
         from pyGHDL.dom._Utils import GetIirKindOfNode
         from pyGHDL.dom._Translate import GetOptionalExpressionFromNode
 

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -36,7 +36,7 @@ This module implements derived sequential statement classes from :mod:`pyVHDLMod
 
 from typing import Iterable
 
-from pyTooling.Decorators import export
+from pyTooling.Decorators import export, InheritDocString
 
 from pyVHDLModel.Base import ExpressionUnion, Range
 from pyVHDLModel.Symbol import Symbol
@@ -88,7 +88,12 @@ from pyGHDL.dom.Concurrent import GetConditionalWaveformsFromChainedNodes, GetSe
 
 
 @export
+@InheritDocString(VHDLModel_IfBranch, merge=True)
 class IfBranch(VHDLModel_IfBranch, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.IfBranch`.
+    """
+
     def __init__(
         self,
         branchNode: Iir,
@@ -120,7 +125,12 @@ class IfBranch(VHDLModel_IfBranch, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_ElsifBranch, merge=True)
 class ElsifBranch(VHDLModel_ElsifBranch, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.ElsifBranch`.
+    """
+
     def __init__(
         self,
         branchNode: Iir,
@@ -152,7 +162,12 @@ class ElsifBranch(VHDLModel_ElsifBranch, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_ElseBranch, merge=True)
 class ElseBranch(VHDLModel_ElseBranch, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.ElseBranch`.
+    """
+
     def __init__(
         self,
         branchNode: Iir,
@@ -180,7 +195,12 @@ class ElseBranch(VHDLModel_ElseBranch, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_IfStatement, merge=True)
 class IfStatement(VHDLModel_IfStatement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.IfStatement`.
+    """
+
     def __init__(
         self,
         ifNode: Iir,
@@ -224,7 +244,12 @@ class IfStatement(VHDLModel_IfStatement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_IndexedChoice, merge=True)
 class IndexedChoice(VHDLModel_IndexedChoice, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.IndexedChoice`.
+    """
+
     def __init__(self, node: Iir, expression: ExpressionUnion) -> None:
         """
         Initializes a case choice given by a single value.
@@ -237,7 +262,12 @@ class IndexedChoice(VHDLModel_IndexedChoice, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_RangedChoice, merge=True)
 class RangedChoice(VHDLModel_RangedChoice, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.RangedChoice`.
+    """
+
     def __init__(self, node: Iir, rng: Range) -> None:
         """
         Initializes a case choice given by a range.
@@ -250,7 +280,12 @@ class RangedChoice(VHDLModel_RangedChoice, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_Case, merge=True)
 class Case(VHDLModel_Case, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.Case`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -278,7 +313,12 @@ class Case(VHDLModel_Case, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_OthersCase, merge=True)
 class OthersCase(VHDLModel_OthersCase, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.OthersCase`.
+    """
+
     def __init__(
         self,
         caseNode: Iir,
@@ -308,7 +348,12 @@ class OthersCase(VHDLModel_OthersCase, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_CaseStatement, merge=True)
 class CaseStatement(VHDLModel_CaseStatement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.CaseStatement`.
+    """
+
     def __init__(
         self,
         caseNode: Iir,
@@ -408,7 +453,12 @@ class CaseStatement(VHDLModel_CaseStatement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_ForLoopStatement, merge=True)
 class ForLoopStatement(VHDLModel_ForLoopStatement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.ForLoopStatement`.
+    """
+
     def __init__(
         self,
         loopNode: Iir,
@@ -449,7 +499,12 @@ class ForLoopStatement(VHDLModel_ForLoopStatement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_WhileLoopStatement, merge=True)
 class WhileLoopStatement(VHDLModel_WhileLoopStatement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.WhileLoopStatement`.
+    """
+
     def __init__(
         self,
         loopNode: Iir,
@@ -505,7 +560,12 @@ class WhileLoopStatement(VHDLModel_WhileLoopStatement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_SequentialSimpleSignalAssignment, merge=True)
 class SequentialSimpleSignalAssignment(VHDLModel_SequentialSimpleSignalAssignment, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.SequentialSimpleSignalAssignment`.
+    """
+
     def __init__(
         self,
         assignmentNode: Iir,
@@ -610,7 +670,12 @@ def GetSelectedExpressionsFromChainedNodes(nodeChain: Iir) -> Iterable:
 
 
 @export
+@InheritDocString(VHDLModel_ConditionalExpression, merge=True)
 class ConditionalExpression(VHDLModel_ConditionalExpression, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Common.ConditionalExpression`.
+    """
+
     def __init__(self, node: Iir, expression: ExpressionUnion, condition: ExpressionUnion = None) -> None:
         """
         Initializes a conditional expression.
@@ -633,7 +698,12 @@ class ConditionalExpression(VHDLModel_ConditionalExpression, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_SelectedExpression, merge=True)
 class SelectedExpression(VHDLModel_SelectedExpression, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Common.SelectedExpression`.
+    """
+
     def __init__(self, node: Iir, choices: Iterable, expression: ExpressionUnion) -> None:
         """
         Initializes a selected expression.
@@ -647,7 +717,12 @@ class SelectedExpression(VHDLModel_SelectedExpression, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_OthersSelectedExpression, merge=True)
 class OthersSelectedExpression(VHDLModel_OthersSelectedExpression, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Common.OthersSelectedExpression`.
+    """
+
     def __init__(self, node: Iir, expression: ExpressionUnion) -> None:
         """
         Initializes an :vhdlkw:`others` selected expression.
@@ -660,7 +735,12 @@ class OthersSelectedExpression(VHDLModel_OthersSelectedExpression, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_SequentialVariableAssignment, merge=True)
 class SequentialVariableAssignment(VHDLModel_SequentialVariableAssignment, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.SequentialVariableAssignment`.
+    """
+
     def __init__(
         self,
         assignmentNode: Iir,
@@ -691,7 +771,12 @@ class SequentialVariableAssignment(VHDLModel_SequentialVariableAssignment, DOMMi
 
 
 @export
+@InheritDocString(VHDLModel_SequentialConditionalVariableAssignment, merge=True)
 class SequentialConditionalVariableAssignment(VHDLModel_SequentialConditionalVariableAssignment, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.SequentialConditionalVariableAssignment`.
+    """
+
     def __init__(
         self,
         assignmentNode: Iir,
@@ -724,7 +809,12 @@ class SequentialConditionalVariableAssignment(VHDLModel_SequentialConditionalVar
 
 
 @export
+@InheritDocString(VHDLModel_SequentialConditionalSignalAssignment, merge=True)
 class SequentialConditionalSignalAssignment(VHDLModel_SequentialConditionalSignalAssignment, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.SequentialConditionalSignalAssignment`.
+    """
+
     def __init__(
         self,
         assignmentNode: Iir,
@@ -757,7 +847,12 @@ class SequentialConditionalSignalAssignment(VHDLModel_SequentialConditionalSigna
 
 
 @export
+@InheritDocString(VHDLModel_SequentialSelectedVariableAssignment, merge=True)
 class SequentialSelectedVariableAssignment(VHDLModel_SequentialSelectedVariableAssignment, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.SequentialSelectedVariableAssignment`.
+    """
+
     def __init__(
         self,
         assignmentNode: Iir,
@@ -793,7 +888,12 @@ class SequentialSelectedVariableAssignment(VHDLModel_SequentialSelectedVariableA
 
 
 @export
+@InheritDocString(VHDLModel_SequentialSelectedSignalAssignment, merge=True)
 class SequentialSelectedSignalAssignment(VHDLModel_SequentialSelectedSignalAssignment, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.SequentialSelectedSignalAssignment`.
+    """
+
     def __init__(
         self,
         assignmentNode: Iir,
@@ -827,7 +927,12 @@ class SequentialSelectedSignalAssignment(VHDLModel_SequentialSelectedSignalAssig
 
 
 @export
+@InheritDocString(VHDLModel_SignalForceAssignment, merge=True)
 class SignalForceAssignment(VHDLModel_SignalForceAssignment, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.SignalForceAssignment`.
+    """
+
     def __init__(
         self,
         assignmentNode: Iir,
@@ -858,7 +963,12 @@ class SignalForceAssignment(VHDLModel_SignalForceAssignment, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_SignalReleaseAssignment, merge=True)
 class SignalReleaseAssignment(VHDLModel_SignalReleaseAssignment, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.SignalReleaseAssignment`.
+    """
+
     def __init__(self, assignmentNode: Iir, target: SignalSymbol, label: str = None) -> None:
         """
         Initializes a signal release assignment.
@@ -881,7 +991,12 @@ class SignalReleaseAssignment(VHDLModel_SignalReleaseAssignment, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_SequentialProcedureCall, merge=True)
 class SequentialProcedureCall(VHDLModel_SequentialProcedureCall, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.SequentialProcedureCall`.
+    """
+
     def __init__(
         self,
         callNode: Iir,
@@ -914,7 +1029,12 @@ class SequentialProcedureCall(VHDLModel_SequentialProcedureCall, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_SequentialAssertStatement, merge=True)
 class SequentialAssertStatement(VHDLModel_SequentialAssertStatement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.SequentialAssertStatement`.
+    """
+
     def __init__(
         self,
         assertNode: Iir,
@@ -947,7 +1067,12 @@ class SequentialAssertStatement(VHDLModel_SequentialAssertStatement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_SequentialReportStatement, merge=True)
 class SequentialReportStatement(VHDLModel_SequentialReportStatement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.SequentialReportStatement`.
+    """
+
     def __init__(
         self,
         reportNode: Iir,
@@ -977,7 +1102,12 @@ class SequentialReportStatement(VHDLModel_SequentialReportStatement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_ReturnStatement, merge=True)
 class ReturnStatement(VHDLModel_ReturnStatement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.ReturnStatement`.
+    """
+
     def __init__(
         self,
         returnNode: Iir,
@@ -1004,7 +1134,12 @@ class ReturnStatement(VHDLModel_ReturnStatement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_NullStatement, merge=True)
 class NullStatement(VHDLModel_NullStatement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.NullStatement`.
+    """
+
     def __init__(
         self,
         waitNode: Iir,
@@ -1021,7 +1156,12 @@ class NullStatement(VHDLModel_NullStatement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_NextStatement, merge=True)
 class NextStatement(VHDLModel_NextStatement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.NextStatement`.
+    """
+
     def __init__(
         self,
         exitNode: Iir,
@@ -1048,7 +1188,12 @@ class NextStatement(VHDLModel_NextStatement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_ExitStatement, merge=True)
 class ExitStatement(VHDLModel_ExitStatement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.ExitStatement`.
+    """
+
     def __init__(
         self,
         exitNode: Iir,
@@ -1075,7 +1220,12 @@ class ExitStatement(VHDLModel_ExitStatement, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_WaitStatement, merge=True)
 class WaitStatement(VHDLModel_WaitStatement, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Sequential.WaitStatement`.
+    """
+
     def __init__(
         self,
         waitNode: Iir,

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -99,7 +99,7 @@ class IfBranch(VHDLModel_IfBranch, DOMMixin):
         Initializes an if branch.
 
         :param branchNode: The IIR node of the branch this object represents.
-        :param condition:  The condition guarding this statement.
+        :param condition:  The condition under which this branch's statements are executed.
         :param statements: List of all sequential statements in this construct.
         """
         super().__init__(condition, statements)
@@ -131,7 +131,7 @@ class ElsifBranch(VHDLModel_ElsifBranch, DOMMixin):
         Initializes an ``elsif`` branch of an if statement.
 
         :param branchNode: The IIR node of the branch this object represents.
-        :param condition:  The condition guarding this statement.
+        :param condition:  The condition under which this branch's statements are executed.
         :param statements: List of all sequential statements in this construct.
         """
         super().__init__(condition, statements)
@@ -285,7 +285,7 @@ class OthersCase(VHDLModel_OthersCase, DOMMixin):
         statements: Iterable[SequentialStatement] = None,
     ) -> None:
         """
-        Initializes a sequential case.
+        Initializes an others case.
 
         :param caseNode:   The IIR node of the case statement.
         :param statements: List of all sequential statements in this construct.
@@ -461,7 +461,7 @@ class WhileLoopStatement(VHDLModel_WhileLoopStatement, DOMMixin):
         Initializes a while-loop statement.
 
         :param loopNode:   The IIR node of the loop statement.
-        :param condition:  The condition guarding this statement.
+        :param condition:  The condition tested before each iteration; the loop ends when it is false.
         :param statements: List of all sequential statements in this construct.
         :param label:      The label of the while-loop statement, or ``None`` if it has none.
         """
@@ -927,7 +927,7 @@ class SequentialAssertStatement(VHDLModel_SequentialAssertStatement, DOMMixin):
         Initializes a sequential assertion statement.
 
         :param assertNode: The IIR node of the assertion.
-        :param condition:  The condition guarding this statement.
+        :param condition:  The condition that must hold; the report is issued when it is false.
         :param message:    The reported message, or ``None`` if none was given.
         :param severity:   The reported severity level, or ``None`` if none was given.
         :param label:      The label of the assertion statement, or ``None`` if it has none.
@@ -1011,7 +1011,7 @@ class NullStatement(VHDLModel_NullStatement, DOMMixin):
         label: str = None,
     ) -> None:
         """
-        Initializes a statement.
+        Initializes a null statement.
 
         :param waitNode: The IIR node of the wait statement.
         :param label:    The label of the null statement, or ``None`` if it has none.
@@ -1029,10 +1029,10 @@ class NextStatement(VHDLModel_NextStatement, DOMMixin):
         label: str = None,
     ) -> None:
         """
-        Initializes a loop control statement.
+        Initializes a next statement.
 
         :param exitNode:  The IIR node of the exit statement.
-        :param condition: The condition guarding this statement.
+        :param condition: The condition under which the iteration is skipped, or ``None`` if unconditional.
         :param label:     The label of the loop this statement applies to, or ``None`` for the enclosing loop.
         """
         super().__init__(condition, loopLabel=label)
@@ -1056,10 +1056,10 @@ class ExitStatement(VHDLModel_ExitStatement, DOMMixin):
         label: str = None,
     ) -> None:
         """
-        Initializes a loop control statement.
+        Initializes an exit statement.
 
         :param exitNode:  The IIR node of the exit statement.
-        :param condition: The condition guarding this statement.
+        :param condition: The condition under which the loop is left, or ``None`` if unconditional.
         :param label:     The label of the loop this statement applies to, or ``None`` for the enclosing loop.
         """
         super().__init__(condition, loopLabel=label)
@@ -1088,9 +1088,9 @@ class WaitStatement(VHDLModel_WaitStatement, DOMMixin):
         Initializes a wait statement.
 
         :param waitNode:        The IIR node of the wait statement.
-        :param sensitivityList: List of all signal names to wait on, or ``None`` if none was given.
-        :param condition:       The condition guarding this statement.
-        :param timeout:         The timeout expression, or ``None`` if none was given.
+        :param sensitivityList: List of all signal names of the ``on`` clause, or ``None`` if none was given.
+        :param condition:       The condition of the ``until`` clause, or ``None`` if none was given.
+        :param timeout:         The timeout expression of the ``for`` clause, or ``None`` if none was given.
         :param label:           The label of the wait statement, or ``None`` if it has none.
         """
         super().__init__(sensitivityList, condition, timeout, label)

--- a/pyGHDL/dom/Subprogram.py
+++ b/pyGHDL/dom/Subprogram.py
@@ -65,6 +65,19 @@ class Function(VHDLModel_Function, DOMMixin):
         statements: List["SequentialStatement"] = None,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a function.
+
+        :param node:           The IIR node this object was translated from.
+        :param functionName:   The function's identifier.
+        :param returnType:     Reference to the subtype of the function's return value.
+        :param isPure:         ``True`` if the subprogram was declared pure.
+        :param genericItems:   List of all generics, in declaration order.
+        :param parameterItems: List of all parameters, in declaration order.
+        :param declaredItems:  List of all declared items in this sequential declaration region.
+        :param statements:     List of all sequential statements in the subprogram's body.
+        :param documentation:  The documentation comment associated with this declaration.
+        """
         super().__init__(
             functionName,
             returnType,
@@ -134,6 +147,17 @@ class Procedure(VHDLModel_Procedure, DOMMixin):
         statements: List["SequentialStatement"] = None,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a procedure.
+
+        :param node:           The IIR node this object was translated from.
+        :param procedureName:  The procedure's identifier.
+        :param genericItems:   List of all generics, in declaration order.
+        :param parameterItems: List of all parameters, in declaration order.
+        :param declaredItems:  List of all declared items in this sequential declaration region.
+        :param statements:     List of all sequential statements in the subprogram's body.
+        :param documentation:  The documentation comment associated with this declaration.
+        """
         super().__init__(
             procedureName,
             genericItems,
@@ -199,6 +223,15 @@ class FunctionInstantiation(VHDLModel_FunctionInstantiation, DOMMixin):
         genericAssociationItems: List = None,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a function instantiation.
+
+        :param node:                    The IIR node this object was translated from.
+        :param functionName:            The function's identifier.
+        :param subprogramReference:     Reference to the instantiated generic subprogram.
+        :param genericAssociationItems: List of all generic associations in the generic map aspect.
+        :param documentation:           The documentation comment associated with this declaration.
+        """
         super().__init__(
             functionName,
             subprogramReference,
@@ -245,6 +278,15 @@ class ProcedureInstantiation(VHDLModel_ProcedureInstantiation, DOMMixin):
         genericAssociationItems: List = None,
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a procedure instantiation.
+
+        :param node:                    The IIR node this object was translated from.
+        :param procedureName:           The procedure's identifier.
+        :param subprogramReference:     Reference to the instantiated generic subprogram.
+        :param genericAssociationItems: List of all generic associations in the generic map aspect.
+        :param documentation:           The documentation comment associated with this declaration.
+        """
         super().__init__(
             procedureName,
             subprogramReference,

--- a/pyGHDL/dom/Subprogram.py
+++ b/pyGHDL/dom/Subprogram.py
@@ -97,6 +97,12 @@ class Function(VHDLModel_Function, DOMMixin):
 
     @classmethod
     def parse(cls, functionNode: Iir) -> "Function":
+        """
+        Translates the IIR node of the function declaration to a :class:`Function`.
+
+        :param functionNode: The IIR node of the function declaration.
+        :returns:            The translated function declaration.
+        """
         from pyGHDL.dom._Translate import (
             GetName,
             GetGenericsFromChainedNodes,
@@ -180,6 +186,12 @@ class Procedure(VHDLModel_Procedure, DOMMixin):
 
     @classmethod
     def parse(cls, procedureNode: Iir) -> "Procedure":
+        """
+        Translates the IIR node of the procedure declaration to a :class:`Procedure`.
+
+        :param procedureNode: The IIR node of the procedure declaration.
+        :returns:             The translated procedure declaration.
+        """
         from pyGHDL.dom._Translate import (
             GetGenericsFromChainedNodes,
             GetParameterFromChainedNodes,
@@ -252,6 +264,12 @@ class FunctionInstantiation(VHDLModel_FunctionInstantiation, DOMMixin):
 
     @classmethod
     def parse(cls, functionNode: Iir) -> "FunctionInstantiation":
+        """
+        Translates the IIR node of the function declaration to a :class:`FunctionInstantiation`.
+
+        :param functionNode: The IIR node of the function declaration.
+        :returns:            The translated function declaration.
+        """
         from pyGHDL.dom._Translate import GetName, GetGenericMapAspect
         from pyGHDL.dom.Symbol import SubprogramReferenceSymbol
 
@@ -307,6 +325,12 @@ class ProcedureInstantiation(VHDLModel_ProcedureInstantiation, DOMMixin):
 
     @classmethod
     def parse(cls, procedureNode: Iir) -> "ProcedureInstantiation":
+        """
+        Translates the IIR node of the procedure declaration to a :class:`ProcedureInstantiation`.
+
+        :param procedureNode: The IIR node of the procedure declaration.
+        :returns:             The translated procedure declaration.
+        """
         from pyGHDL.dom._Translate import GetName, GetGenericMapAspect
         from pyGHDL.dom.Symbol import SubprogramReferenceSymbol
 

--- a/pyGHDL/dom/Subprogram.py
+++ b/pyGHDL/dom/Subprogram.py
@@ -36,7 +36,7 @@ This module implements derived subprogram classes from :mod:`pyVHDLModel.Subprog
 
 from typing import List
 
-from pyTooling.Decorators import export
+from pyTooling.Decorators import export, InheritDocString
 
 from pyVHDLModel.Symbol import Symbol
 from pyVHDLModel.Interface import GenericInterfaceItemMixin, ParameterInterfaceItemMixin
@@ -52,7 +52,12 @@ from pyGHDL.dom.Symbol import SimpleSubtypeSymbol
 
 
 @export
+@InheritDocString(VHDLModel_Function, merge=True)
 class Function(VHDLModel_Function, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Subprogram.Function`.
+    """
+
     def __init__(
         self,
         node: Iir,
@@ -136,7 +141,12 @@ class Function(VHDLModel_Function, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_Procedure, merge=True)
 class Procedure(VHDLModel_Procedure, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Subprogram.Procedure`.
+    """
+
     def __init__(
         self,
         node: Iir,

--- a/pyGHDL/dom/Subprogram.py
+++ b/pyGHDL/dom/Subprogram.py
@@ -30,6 +30,10 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+This module implements derived subprogram classes from :mod:`pyVHDLModel.Subprogram`.
+"""
+
 from typing import List
 
 from pyTooling.Decorators import export

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -37,7 +37,7 @@ This module implements derived symbol classes from :mod:`pyVHDLModel.Symbol`.
 from typing import List, Mapping
 
 from pyGHDL.dom.Name import SimpleName
-from pyTooling.Decorators import export
+from pyTooling.Decorators import export, InheritDocString
 
 from pyVHDLModel.Name import Name
 from pyVHDLModel.Symbol import Symbol as VHDLModel_Symbol

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -37,7 +37,7 @@ This module implements derived symbol classes from :mod:`pyVHDLModel.Symbol`.
 from typing import List, Mapping
 
 from pyGHDL.dom.Name import SimpleName
-from pyTooling.Decorators import export, InheritDocString
+from pyTooling.Decorators import export
 
 from pyVHDLModel.Name import Name
 from pyVHDLModel.Symbol import Symbol as VHDLModel_Symbol
@@ -82,8 +82,14 @@ class Symbol(VHDLModel_Symbol, DOMMixin):
     This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Symbol.Symbol`.
     """
 
-    @InheritDocString(VHDLModel_Symbol)
     def __init__(self, identifierNode: Iir, name: Name, possibleReferences: PossibleReference) -> None:
+        """
+        Initializes a symbol.
+
+        :param identifierNode:     The IIR node carrying the identifier this symbol references.
+        :param name:               The name to reference the language entity.
+        :param possibleReferences: An enumeration to filter possible references.
+        """
         super().__init__(name, possibleReferences)
         DOMMixin.__init__(self, identifierNode)
 
@@ -103,8 +109,13 @@ class LibraryReferenceSymbol(VHDLModel_LibraryReferenceSymbol, DOMMixin):
           --      ^^^^
     """
 
-    @InheritDocString(VHDLModel_LibraryReferenceSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
+        """
+        Initializes a reference (name) to a library.
+
+        :param identifierNode: The IIR node carrying the identifier this symbol references.
+        :param name:           The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
@@ -124,8 +135,13 @@ class PackageReferenceSymbol(VHDLModel_PackageReferenceSymbol, DOMMixin):
           --  ^^^^^^^^^^^^^^^^
     """
 
-    @InheritDocString(VHDLModel_PackageReferenceSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
+        """
+        Initializes a reference (name) to a package.
+
+        :param identifierNode: The IIR node carrying the identifier this symbol references.
+        :param name:           The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
@@ -145,8 +161,13 @@ class ModeViewSymbol(VHDLModel_ModeViewSymbol, DOMMixin):
           --          ^^^^^^
     """
 
-    @InheritDocString(VHDLModel_ModeViewSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
+        """
+        Initializes a reference to a mode view (VHDL-2019).
+
+        :param identifierNode: The IIR node carrying the identifier this symbol references.
+        :param name:           The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
@@ -167,8 +188,13 @@ class SubprogramReferenceSymbol(VHDLModel_SubprogramReferenceSymbol, DOMMixin):
           --                  ^
     """
 
-    @InheritDocString(VHDLModel_SubprogramReferenceSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
+        """
+        Initializes a reference to a subprogram.
+
+        :param identifierNode: The IIR node carrying the identifier this symbol references.
+        :param name:           The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
@@ -190,8 +216,13 @@ class ConfigurationSymbol(VHDLModel_ConfigurationSymbol, DOMMixin):
           --                              ^^^^^^^
     """
 
-    @InheritDocString(VHDLModel_ConfigurationSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
+        """
+        Initializes a reference to a configuration.
+
+        :param identifierNode: The IIR node carrying the identifier this symbol references.
+        :param name:           The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
@@ -211,8 +242,13 @@ class SignalSymbol(VHDLModel_SignalSymbol, DOMMixin):
           --^
     """
 
-    @InheritDocString(VHDLModel_SignalSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
+        """
+        Initializes a signal symbol.
+
+        :param identifierNode: The IIR node carrying the identifier this symbol references.
+        :param name:           The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
@@ -232,8 +268,13 @@ class VariableSymbol(VHDLModel_VariableSymbol, DOMMixin):
           --^
     """
 
-    @InheritDocString(VHDLModel_VariableSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
+        """
+        Initializes a variable symbol.
+
+        :param identifierNode: The IIR node carrying the identifier this symbol references.
+        :param name:           The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
@@ -253,8 +294,13 @@ class ContextReferenceSymbol(VHDLModel_ContextReferenceSymbol, DOMMixin):
           --      ^^^^^^^^^^^^^^^^^^^^^
     """
 
-    @InheritDocString(VHDLModel_ContextReferenceSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
+        """
+        Initializes a reference (name) to a context.
+
+        :param identifierNode: The IIR node carrying the identifier this symbol references.
+        :param name:           The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
@@ -274,8 +320,13 @@ class PackageMemberReferenceSymbol(VHDLModel_PackageMemberReferenceSymbol, DOMMi
           --  ^^^^^^^^^^^^^^^^^^^^^^^^^
     """
 
-    @InheritDocString(VHDLModel_PackageMemberReferenceSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
+        """
+        Initializes a reference (name) to a package member.
+
+        :param identifierNode: The IIR node carrying the identifier this symbol references.
+        :param name:           The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
@@ -295,8 +346,13 @@ class AllPackageMembersReferenceSymbol(VHDLModel_AllPackageMembersReferenceSymbo
           --  ^^^^^^^^^^^^^^^^^^^^
     """
 
-    @InheritDocString(VHDLModel_AllPackageMembersReferenceSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
+        """
+        Initializes a reference (name) to all package members.
+
+        :param identifierNode: The IIR node carrying the identifier this symbol references.
+        :param name:           The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
@@ -316,8 +372,13 @@ class EntityInstantiationSymbol(VHDLModel_EntityInstantiationSymbol, DOMMixin):
           --            ^^^^^^^^^^^^
     """
 
-    @InheritDocString(VHDLModel_EntityInstantiationSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
+        """
+        Initializes a reference (name) to an entity in a direct entity instantiation.
+
+        :param identifierNode: The IIR node carrying the identifier this symbol references.
+        :param name:           The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
@@ -337,8 +398,13 @@ class ComponentInstantiationSymbol(VHDLModel_ComponentInstantiationSymbol, DOMMi
           --               ^^^^^^^
     """
 
-    @InheritDocString(VHDLModel_ComponentInstantiationSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
+        """
+        Initializes a reference (name) to an entity in a component instantiation.
+
+        :param identifierNode: The IIR node carrying the identifier this symbol references.
+        :param name:           The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
@@ -358,8 +424,13 @@ class ConfigurationInstantiationSymbol(VHDLModel_ConfigurationInstantiationSymbo
           --                   ^^^^^^^
     """
 
-    @InheritDocString(VHDLModel_ConfigurationInstantiationSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
+        """
+        Initializes a reference (name) to an entity in a configuration instantiation.
+
+        :param identifierNode: The IIR node carrying the identifier this symbol references.
+        :param name:           The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
@@ -381,16 +452,26 @@ class EntitySymbol(VHDLModel_EntitySymbol, DOMMixin):
           end architecture;
     """
 
-    @InheritDocString(VHDLModel_EntitySymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
+        """
+        Initializes a reference (name) to an entity in an architecture declaration.
+
+        :param identifierNode: The IIR node carrying the identifier this symbol references.
+        :param name:           The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
 
 @export
 class ArchitectureSymbol(VHDLModel_ArchitectureSymbol, DOMMixin):
-    @InheritDocString(VHDLModel_ArchitectureSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
+        """
+        Initializes an architecture symbol.
+
+        :param identifierNode: The IIR node carrying the identifier this symbol references.
+        :param name:           The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
@@ -411,8 +492,13 @@ class PackageSymbol(VHDLModel_PackageSymbol, DOMMixin):
           end package body;
     """
 
-    @InheritDocString(VHDLModel_PackageSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
+        """
+        Initializes a reference (name) to a package in a package body declaration.
+
+        :param identifierNode: The IIR node carrying the identifier this symbol references.
+        :param name:           The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
 
@@ -423,24 +509,41 @@ class PackageSymbol(VHDLModel_PackageSymbol, DOMMixin):
 
 @export
 class SimpleSubtypeSymbol(VHDLModel_SimpleSubtypeSymbol, DOMMixin):
-    @InheritDocString(VHDLModel_SimpleSubtypeSymbol)
     def __init__(self, node: Iir, subtypeName: Name) -> None:
+        """
+        Initializes a subtype symbol.
+
+        :param node:        The IIR node this object was translated from.
+        :param subtypeName: The name of the referenced subtype.
+        """
         super().__init__(subtypeName)
         DOMMixin.__init__(self, node)
 
 
 @export
 class ConstrainedScalarSubtypeSymbol(VHDLModel_ConstrainedScalarSubtypeSymbol, DOMMixin):
-    @InheritDocString(VHDLModel_ConstrainedScalarSubtypeSymbol)
     def __init__(self, node: Iir, subtypeName: Name, rng: Range) -> None:
+        """
+        Initializes a reference to a scalar subtype narrowed by a range.
+
+        :param node:        The IIR node this object was translated from.
+        :param subtypeName: The name of the referenced subtype.
+        :param rng:         The range constraining the scalar subtype.
+        """
         super().__init__(subtypeName, rng)
         DOMMixin.__init__(self, node)
 
 
 @export
 class ConstrainedArraySubtypeSymbol(VHDLModel_ConstrainedArraySubtypeSymbol, DOMMixin):
-    @InheritDocString(VHDLModel_ConstrainedArraySubtypeSymbol)
     def __init__(self, node: Iir, subtypeName: Name, constraints: List) -> None:
+        """
+        Initializes a reference to an array subtype narrowed by index ranges.
+
+        :param node:        The IIR node this object was translated from.
+        :param subtypeName: The name of the referenced subtype.
+        :param constraints: List of all index ranges, one per dimension.
+        """
         super().__init__(subtypeName, constraints)
         DOMMixin.__init__(self, node)
 
@@ -451,8 +554,14 @@ class ConstrainedArraySubtypeSymbol(VHDLModel_ConstrainedArraySubtypeSymbol, DOM
 
 @export
 class ConstrainedRecordSubtypeSymbol(VHDLModel_ConstrainedRecordSubtypeSymbol, DOMMixin):
-    @InheritDocString(VHDLModel_ConstrainedRecordSubtypeSymbol)
     def __init__(self, node: Iir, subtypeName: Name, constraints: Mapping) -> None:
+        """
+        Initializes a reference to a record subtype with constrained elements.
+
+        :param node:        The IIR node this object was translated from.
+        :param subtypeName: The name of the referenced subtype.
+        :param constraints: Dictionary of the constraint per constrained record element.
+        """
         super().__init__(subtypeName, constraints)
         DOMMixin.__init__(self, node)
 
@@ -463,24 +572,39 @@ class ConstrainedRecordSubtypeSymbol(VHDLModel_ConstrainedRecordSubtypeSymbol, D
 
 @export
 class RecordElementSymbol(VHDLModel_RecordElementSymbol, DOMMixin):
-    @InheritDocString(VHDLModel_RecordElementSymbol)
     def __init__(self, node: Iir, name: SimpleName) -> None:
+        """
+        Initializes a reference to a record element.
+
+        :param node: The IIR node this object was translated from.
+        :param name: The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, node)
 
 
 @export
 class RangeAttributeSymbol(VHDLModel_RangeAttributeSymbol, DOMMixin):
-    @InheritDocString(VHDLModel_RangeAttributeSymbol)
     def __init__(self, node: Iir, name: Name) -> None:
+        """
+        Initialize a range attribute symbol.
+
+        :param node: The IIR node this object was translated from.
+        :param name: The attribute name referencing the range.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, node)
 
 
 @export
 class SimpleObjectOrFunctionCallSymbol(VHDLModel_SimpleObjectOrFunctionCallSymbol, DOMMixin):
-    @InheritDocString(VHDLModel_SimpleObjectOrFunctionCallSymbol)
     def __init__(self, node: Iir, name: Name) -> None:
+        """
+        Initializes a reference that is either an object or a parameterless function call.
+
+        :param node: The IIR node this object was translated from.
+        :param name: The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, node)
 
@@ -495,8 +619,13 @@ class SimpleObjectOrFunctionCallSymbol(VHDLModel_SimpleObjectOrFunctionCallSymbo
 
 @export
 class IndexedObjectOrFunctionCallSymbol(VHDLModel_IndexedObjectOrFunctionCallSymbol, DOMMixin):
-    @InheritDocString(VHDLModel_IndexedObjectOrFunctionCallSymbol)
     def __init__(self, node: Iir, name: Name) -> None:
+        """
+        Initializes a reference that is either an indexed object, a function call or a type conversion.
+
+        :param node: The IIR node this object was translated from.
+        :param name: The name to reference the language entity.
+        """
         super().__init__(name)
         DOMMixin.__init__(self, node)
 

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -592,6 +592,12 @@ class ConstrainedRecordSubtypeSymbol(VHDLModel_ConstrainedRecordSubtypeSymbol, D
 
     @classmethod
     def parse(cls, node: Iir):
+        """
+        Translates an IIR node to a :class:`ConstrainedRecordSubtypeSymbol`.
+
+        :param node: The IIR node this object is translated from.
+        :returns:    The translated object.
+        """
         pass
 
 
@@ -650,6 +656,12 @@ class SimpleObjectOrFunctionCallSymbol(VHDLModel_SimpleObjectOrFunctionCallSymbo
 
     @classmethod
     def parse(cls, node: Iir):
+        """
+        Translates an IIR node to a :class:`SimpleObjectOrFunctionCallSymbol`.
+
+        :param node: The IIR node this object is translated from.
+        :returns:    The translated object.
+        """
         from pyGHDL.dom._Translate import GetName
 
         name = GetName(node)
@@ -676,6 +688,12 @@ class IndexedObjectOrFunctionCallSymbol(VHDLModel_IndexedObjectOrFunctionCallSym
 
     @classmethod
     def parse(cls, node: Iir):
+        """
+        Translates an IIR node to an :class:`IndexedObjectOrFunctionCallSymbol`.
+
+        :param node: The IIR node this object is translated from.
+        :returns:    The translated object.
+        """
         from pyGHDL.dom._Translate import GetName
 
         name = GetName(node)

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -464,7 +464,12 @@ class EntitySymbol(VHDLModel_EntitySymbol, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_ArchitectureSymbol, merge=True)
 class ArchitectureSymbol(VHDLModel_ArchitectureSymbol, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Symbol.ArchitectureSymbol`.
+    """
+
     def __init__(self, identifierNode: Iir, name: Name) -> None:
         """
         Initializes an architecture symbol.
@@ -508,7 +513,12 @@ class PackageSymbol(VHDLModel_PackageSymbol, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_SimpleSubtypeSymbol, merge=True)
 class SimpleSubtypeSymbol(VHDLModel_SimpleSubtypeSymbol, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Symbol.SimpleSubtypeSymbol`.
+    """
+
     def __init__(self, node: Iir, subtypeName: Name) -> None:
         """
         Initializes a simple subtype symbol.
@@ -521,7 +531,12 @@ class SimpleSubtypeSymbol(VHDLModel_SimpleSubtypeSymbol, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_ConstrainedScalarSubtypeSymbol, merge=True)
 class ConstrainedScalarSubtypeSymbol(VHDLModel_ConstrainedScalarSubtypeSymbol, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Symbol.ConstrainedScalarSubtypeSymbol`.
+    """
+
     def __init__(self, node: Iir, subtypeName: Name, rng: Range) -> None:
         """
         Initializes a reference to a scalar subtype narrowed by a range.
@@ -535,7 +550,12 @@ class ConstrainedScalarSubtypeSymbol(VHDLModel_ConstrainedScalarSubtypeSymbol, D
 
 
 @export
+@InheritDocString(VHDLModel_ConstrainedArraySubtypeSymbol, merge=True)
 class ConstrainedArraySubtypeSymbol(VHDLModel_ConstrainedArraySubtypeSymbol, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Symbol.ConstrainedArraySubtypeSymbol`.
+    """
+
     def __init__(self, node: Iir, subtypeName: Name, constraints: List) -> None:
         """
         Initializes a reference to an array subtype narrowed by index ranges.
@@ -553,7 +573,12 @@ class ConstrainedArraySubtypeSymbol(VHDLModel_ConstrainedArraySubtypeSymbol, DOM
 
 
 @export
+@InheritDocString(VHDLModel_ConstrainedRecordSubtypeSymbol, merge=True)
 class ConstrainedRecordSubtypeSymbol(VHDLModel_ConstrainedRecordSubtypeSymbol, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Symbol.ConstrainedRecordSubtypeSymbol`.
+    """
+
     def __init__(self, node: Iir, subtypeName: Name, constraints: Mapping) -> None:
         """
         Initializes a reference to a record subtype with constrained elements.
@@ -571,7 +596,12 @@ class ConstrainedRecordSubtypeSymbol(VHDLModel_ConstrainedRecordSubtypeSymbol, D
 
 
 @export
+@InheritDocString(VHDLModel_RecordElementSymbol, merge=True)
 class RecordElementSymbol(VHDLModel_RecordElementSymbol, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Symbol.RecordElementSymbol`.
+    """
+
     def __init__(self, node: Iir, name: SimpleName) -> None:
         """
         Initializes a reference to a record element.
@@ -584,7 +614,12 @@ class RecordElementSymbol(VHDLModel_RecordElementSymbol, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_RangeAttributeSymbol, merge=True)
 class RangeAttributeSymbol(VHDLModel_RangeAttributeSymbol, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Symbol.RangeAttributeSymbol`.
+    """
+
     def __init__(self, node: Iir, name: Name) -> None:
         """
         Initialize a range attribute symbol.
@@ -597,7 +632,12 @@ class RangeAttributeSymbol(VHDLModel_RangeAttributeSymbol, DOMMixin):
 
 
 @export
+@InheritDocString(VHDLModel_SimpleObjectOrFunctionCallSymbol, merge=True)
 class SimpleObjectOrFunctionCallSymbol(VHDLModel_SimpleObjectOrFunctionCallSymbol, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Symbol.SimpleObjectOrFunctionCallSymbol`.
+    """
+
     def __init__(self, node: Iir, name: Name) -> None:
         """
         Initializes a reference that is either an object or a parameterless function call.
@@ -618,7 +658,12 @@ class SimpleObjectOrFunctionCallSymbol(VHDLModel_SimpleObjectOrFunctionCallSymbo
 
 
 @export
+@InheritDocString(VHDLModel_IndexedObjectOrFunctionCallSymbol, merge=True)
 class IndexedObjectOrFunctionCallSymbol(VHDLModel_IndexedObjectOrFunctionCallSymbol, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Symbol.IndexedObjectOrFunctionCallSymbol`.
+    """
+
     def __init__(self, node: Iir, name: Name) -> None:
         """
         Initializes a reference that is either an indexed object, a function call or a type conversion.

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -86,8 +86,8 @@ class Symbol(VHDLModel_Symbol, DOMMixin):
         """
         Initializes a symbol.
 
-        :param identifierNode:     The IIR node carrying the identifier this symbol references.
-        :param name:               The name to reference the language entity.
+        :param identifierNode:     The IIR node of the name this symbol was translated from.
+        :param name:               The name referencing the language entity this symbol stands for.
         :param possibleReferences: An enumeration to filter possible references.
         """
         super().__init__(name, possibleReferences)
@@ -113,8 +113,8 @@ class LibraryReferenceSymbol(VHDLModel_LibraryReferenceSymbol, DOMMixin):
         """
         Initializes a reference (name) to a library.
 
-        :param identifierNode: The IIR node carrying the identifier this symbol references.
-        :param name:           The name to reference the language entity.
+        :param identifierNode: The IIR node of the name this symbol was translated from.
+        :param name:           The name referencing the library.
         """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
@@ -139,8 +139,8 @@ class PackageReferenceSymbol(VHDLModel_PackageReferenceSymbol, DOMMixin):
         """
         Initializes a reference (name) to a package.
 
-        :param identifierNode: The IIR node carrying the identifier this symbol references.
-        :param name:           The name to reference the language entity.
+        :param identifierNode: The IIR node of the name this symbol was translated from.
+        :param name:           The name referencing the package.
         """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
@@ -165,8 +165,8 @@ class ModeViewSymbol(VHDLModel_ModeViewSymbol, DOMMixin):
         """
         Initializes a reference to a mode view (VHDL-2019).
 
-        :param identifierNode: The IIR node carrying the identifier this symbol references.
-        :param name:           The name to reference the language entity.
+        :param identifierNode: The IIR node of the name this symbol was translated from.
+        :param name:           The name referencing the mode view.
         """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
@@ -192,8 +192,8 @@ class SubprogramReferenceSymbol(VHDLModel_SubprogramReferenceSymbol, DOMMixin):
         """
         Initializes a reference to a subprogram.
 
-        :param identifierNode: The IIR node carrying the identifier this symbol references.
-        :param name:           The name to reference the language entity.
+        :param identifierNode: The IIR node of the name this symbol was translated from.
+        :param name:           The name referencing the subprogram.
         """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
@@ -220,8 +220,8 @@ class ConfigurationSymbol(VHDLModel_ConfigurationSymbol, DOMMixin):
         """
         Initializes a reference to a configuration.
 
-        :param identifierNode: The IIR node carrying the identifier this symbol references.
-        :param name:           The name to reference the language entity.
+        :param identifierNode: The IIR node of the name this symbol was translated from.
+        :param name:           The name referencing the configuration.
         """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
@@ -246,8 +246,8 @@ class SignalSymbol(VHDLModel_SignalSymbol, DOMMixin):
         """
         Initializes a signal symbol.
 
-        :param identifierNode: The IIR node carrying the identifier this symbol references.
-        :param name:           The name to reference the language entity.
+        :param identifierNode: The IIR node of the name this symbol was translated from.
+        :param name:           The name referencing the signal.
         """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
@@ -272,8 +272,8 @@ class VariableSymbol(VHDLModel_VariableSymbol, DOMMixin):
         """
         Initializes a variable symbol.
 
-        :param identifierNode: The IIR node carrying the identifier this symbol references.
-        :param name:           The name to reference the language entity.
+        :param identifierNode: The IIR node of the name this symbol was translated from.
+        :param name:           The name referencing the variable.
         """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
@@ -298,8 +298,8 @@ class ContextReferenceSymbol(VHDLModel_ContextReferenceSymbol, DOMMixin):
         """
         Initializes a reference (name) to a context.
 
-        :param identifierNode: The IIR node carrying the identifier this symbol references.
-        :param name:           The name to reference the language entity.
+        :param identifierNode: The IIR node of the name this symbol was translated from.
+        :param name:           The name referencing the context.
         """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
@@ -324,8 +324,8 @@ class PackageMemberReferenceSymbol(VHDLModel_PackageMemberReferenceSymbol, DOMMi
         """
         Initializes a reference (name) to a package member.
 
-        :param identifierNode: The IIR node carrying the identifier this symbol references.
-        :param name:           The name to reference the language entity.
+        :param identifierNode: The IIR node of the name this symbol was translated from.
+        :param name:           The name referencing the package member.
         """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
@@ -350,8 +350,8 @@ class AllPackageMembersReferenceSymbol(VHDLModel_AllPackageMembersReferenceSymbo
         """
         Initializes a reference (name) to all package members.
 
-        :param identifierNode: The IIR node carrying the identifier this symbol references.
-        :param name:           The name to reference the language entity.
+        :param identifierNode: The IIR node of the name this symbol was translated from.
+        :param name:           The name referencing the package whose members are all referenced.
         """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
@@ -376,8 +376,8 @@ class EntityInstantiationSymbol(VHDLModel_EntityInstantiationSymbol, DOMMixin):
         """
         Initializes a reference (name) to an entity in a direct entity instantiation.
 
-        :param identifierNode: The IIR node carrying the identifier this symbol references.
-        :param name:           The name to reference the language entity.
+        :param identifierNode: The IIR node of the name this symbol was translated from.
+        :param name:           The name referencing the instantiated entity.
         """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
@@ -402,8 +402,8 @@ class ComponentInstantiationSymbol(VHDLModel_ComponentInstantiationSymbol, DOMMi
         """
         Initializes a reference (name) to an entity in a component instantiation.
 
-        :param identifierNode: The IIR node carrying the identifier this symbol references.
-        :param name:           The name to reference the language entity.
+        :param identifierNode: The IIR node of the name this symbol was translated from.
+        :param name:           The name referencing the instantiated component.
         """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
@@ -428,8 +428,8 @@ class ConfigurationInstantiationSymbol(VHDLModel_ConfigurationInstantiationSymbo
         """
         Initializes a reference (name) to an entity in a configuration instantiation.
 
-        :param identifierNode: The IIR node carrying the identifier this symbol references.
-        :param name:           The name to reference the language entity.
+        :param identifierNode: The IIR node of the name this symbol was translated from.
+        :param name:           The name referencing the instantiated configuration.
         """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
@@ -456,8 +456,8 @@ class EntitySymbol(VHDLModel_EntitySymbol, DOMMixin):
         """
         Initializes a reference (name) to an entity in an architecture declaration.
 
-        :param identifierNode: The IIR node carrying the identifier this symbol references.
-        :param name:           The name to reference the language entity.
+        :param identifierNode: The IIR node of the name this symbol was translated from.
+        :param name:           The name referencing the entity the architecture belongs to.
         """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
@@ -469,8 +469,8 @@ class ArchitectureSymbol(VHDLModel_ArchitectureSymbol, DOMMixin):
         """
         Initializes an architecture symbol.
 
-        :param identifierNode: The IIR node carrying the identifier this symbol references.
-        :param name:           The name to reference the language entity.
+        :param identifierNode: The IIR node of the name this symbol was translated from.
+        :param name:           The name referencing the architecture.
         """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
@@ -496,8 +496,8 @@ class PackageSymbol(VHDLModel_PackageSymbol, DOMMixin):
         """
         Initializes a reference (name) to a package in a package body declaration.
 
-        :param identifierNode: The IIR node carrying the identifier this symbol references.
-        :param name:           The name to reference the language entity.
+        :param identifierNode: The IIR node of the name this symbol was translated from.
+        :param name:           The name referencing the package the package body belongs to.
         """
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)
@@ -511,7 +511,7 @@ class PackageSymbol(VHDLModel_PackageSymbol, DOMMixin):
 class SimpleSubtypeSymbol(VHDLModel_SimpleSubtypeSymbol, DOMMixin):
     def __init__(self, node: Iir, subtypeName: Name) -> None:
         """
-        Initializes a subtype symbol.
+        Initializes a simple subtype symbol.
 
         :param node:        The IIR node this object was translated from.
         :param subtypeName: The name of the referenced subtype.
@@ -577,7 +577,7 @@ class RecordElementSymbol(VHDLModel_RecordElementSymbol, DOMMixin):
         Initializes a reference to a record element.
 
         :param node: The IIR node this object was translated from.
-        :param name: The name to reference the language entity.
+        :param name: The name referencing the record element.
         """
         super().__init__(name)
         DOMMixin.__init__(self, node)
@@ -603,7 +603,7 @@ class SimpleObjectOrFunctionCallSymbol(VHDLModel_SimpleObjectOrFunctionCallSymbo
         Initializes a reference that is either an object or a parameterless function call.
 
         :param node: The IIR node this object was translated from.
-        :param name: The name to reference the language entity.
+        :param name: The name referencing the object or parameterless function.
         """
         super().__init__(name)
         DOMMixin.__init__(self, node)
@@ -624,7 +624,7 @@ class IndexedObjectOrFunctionCallSymbol(VHDLModel_IndexedObjectOrFunctionCallSym
         Initializes a reference that is either an indexed object, a function call or a type conversion.
 
         :param node: The IIR node this object was translated from.
-        :param name: The name to reference the language entity.
+        :param name: The name referencing the object, function or type being converted.
         """
         super().__init__(name)
         DOMMixin.__init__(self, node)

--- a/pyGHDL/dom/Type.py
+++ b/pyGHDL/dom/Type.py
@@ -84,6 +84,13 @@ class IncompleteType(VHDLModel_AnonymousType, DOMMixin):
 
     @classmethod
     def parse(cls, node: Iir, documentation: str = None) -> "IncompleteType":
+        """
+        Translates an IIR node to an :class:`IncompleteType`.
+
+        :param node:          The IIR node this object is translated from.
+        :param documentation: The documentation comment associated with this declaration.
+        :returns:             The translated object.
+        """
         from pyGHDL.dom._Utils import GetNameOfNode
 
         name = GetNameOfNode(node)

--- a/pyGHDL/dom/Type.py
+++ b/pyGHDL/dom/Type.py
@@ -37,7 +37,7 @@ This module implements derived type classes from :mod:`pyVHDLModel.Type`.
 from typing import List, Union, Iterator, Tuple, Iterable
 
 from pyGHDL.dom.Name import SimpleName
-from pyTooling.Decorators import export
+from pyTooling.Decorators import export, InheritDocString
 
 from pyVHDLModel.Name import Name
 from pyVHDLModel.Symbol import Symbol
@@ -65,7 +65,12 @@ from pyGHDL.dom.Subprogram import Function, Procedure
 
 
 @export
+@InheritDocString(VHDLModel_AnonymousType, merge=True)
 class IncompleteType(VHDLModel_AnonymousType, DOMMixin):
+    """
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Type.AnonymousType`.
+    """
+
     def __init__(self, node: Iir, identifier: str, documentation: str = None) -> None:
         """
         Initializes an incomplete type declaration.

--- a/pyGHDL/dom/Type.py
+++ b/pyGHDL/dom/Type.py
@@ -107,7 +107,7 @@ class EnumeratedType(VHDLModel_EnumeratedType, DOMMixin):
         Initializes an enumerated type definition.
 
         :param node:          The IIR node this object was translated from.
-        :param identifier:    The identifier of a model entity.
+        :param identifier:    The enumeration type's identifier.
         :param literals:      List of all enumeration literals, in declaration order.
         :param documentation: The documentation comment associated with this declaration.
         """
@@ -263,7 +263,7 @@ class ArrayType(VHDLModel_ArrayType, DOMMixin):
         Initializes an array type definition.
 
         :param node:           The IIR node this object was translated from.
-        :param identifier:     The identifier of a model entity.
+        :param identifier:     The array type's identifier.
         :param indices:        List of all index ranges, one per dimension.
         :param elementSubtype: Reference to the subtype of the array's elements.
         :param documentation:  The documentation comment associated with this declaration.
@@ -380,7 +380,7 @@ class RecordType(VHDLModel_RecordType, DOMMixin):
         Initializes a record type definition.
 
         :param node:          The IIR node this object was translated from.
-        :param identifier:    The identifier of a model entity.
+        :param identifier:    The record type's identifier.
         :param elements:      List of all element declarations, in declaration order.
         :param documentation: The documentation comment associated with this declaration.
         """
@@ -456,7 +456,7 @@ class ProtectedType(VHDLModel_ProtectedType, DOMMixin):
         Initializes a protected type declaration.
 
         :param node:          The IIR node this object was translated from.
-        :param identifier:    The identifier of a model entity.
+        :param identifier:    The protected type's identifier.
         :param methods:       List of the protected type's methods, in declaration order.
         :param documentation: The documentation comment associated with this declaration.
         """
@@ -510,7 +510,7 @@ class ProtectedTypeBody(VHDLModel_ProtectedTypeBody, DOMMixin):
         Initializes a protected type body.
 
         :param node:          The IIR node this object was translated from.
-        :param identifier:    The identifier of a model entity.
+        :param identifier:    The protected type body's identifier.
         :param declaredItems: Iterable of all items declared in this body.
         :param documentation: The documentation comment associated with this declaration.
         """
@@ -558,7 +558,7 @@ class AccessType(VHDLModel_AccessType, DOMMixin):
         Initializes an access type definition.
 
         :param node:              The IIR node this object was translated from.
-        :param identifier:        The identifier of a model entity.
+        :param identifier:        The access type's identifier.
         :param designatedSubtype: Reference to the subtype the access values designate.
         :param documentation:     The documentation comment associated with this declaration.
         """
@@ -602,7 +602,7 @@ class FileType(VHDLModel_FileType, DOMMixin):
         Initializes a file type definition.
 
         :param node:              The IIR node this object was translated from.
-        :param identifier:        The identifier of a model entity.
+        :param identifier:        The file type's identifier.
         :param designatedSubtype: Reference to the subtype of the values stored in the file.
         :param documentation:     The documentation comment associated with this declaration.
         """

--- a/pyGHDL/dom/Type.py
+++ b/pyGHDL/dom/Type.py
@@ -68,7 +68,7 @@ from pyGHDL.dom.Subprogram import Function, Procedure
 class IncompleteType(VHDLModel_AnonymousType, DOMMixin):
     def __init__(self, node: Iir, identifier: str, documentation: str = None) -> None:
         """
-        Initializes underlying ``BaseType``.
+        Initializes an incomplete type declaration.
 
         :param node:          The IIR node this object was translated from.
         :param identifier:    Name of the type.

--- a/pyGHDL/dom/Type.py
+++ b/pyGHDL/dom/Type.py
@@ -107,7 +107,7 @@ class EnumeratedType(VHDLModel_EnumeratedType, DOMMixin):
         :param typeName:           The identifier of the type.
         :param typeDefinitionNode: The IIR node to parse.
         :param documentation:      The documentation comment on the type declaration.
-        :return:                   The enumerated type instance.
+        :returns:                  The enumerated type instance.
         """
         literals = []
         enumerationLiterals = nodes.Get_Enumeration_Literal_List(typeDefinitionNode)
@@ -175,7 +175,7 @@ class PhysicalType(VHDLModel_PhysicalType, DOMMixin):
         :param typeName:           The identifier of the type.
         :param typeDefinitionNode: The IIR node to parse.
         :param documentation:      The documentation comment on the type declaration.
-        :return:                   The physical type instance.
+        :returns:                  The physical type instance.
         """
         from pyGHDL.dom._Utils import GetIirKindOfNode, GetNameOfNode
         from pyGHDL.dom._Translate import GetRangeFromNode, GetName
@@ -237,7 +237,7 @@ class ArrayType(VHDLModel_ArrayType, DOMMixin):
         :param typeName:           The identifier of the type.
         :param typeDefinitionNode: The IIR node to parse.
         :param documentation:      The documentation comment on the type declaration.
-        :return:                   The array type instance.
+        :returns:                  The array type instance.
         """
         from pyGHDL.dom._Utils import GetIirKindOfNode
         from pyGHDL.dom._Translate import (
@@ -291,7 +291,7 @@ class RecordTypeElement(VHDLModel_RecordTypeElement, DOMMixin):
 
         :param elementDeclarationNode: The IIR node to parse.
         :param furtherIdentifiers:     The list of record element identifiers.
-        :return:                       The record element instance.
+        :returns:                      The record element instance.
         """
         from pyGHDL.dom._Utils import GetNameOfNode, GetDocumentationOfNode
         from pyGHDL.dom._Translate import GetSubtypeIndicationFromNode
@@ -337,7 +337,7 @@ class RecordType(VHDLModel_RecordType, DOMMixin):
         :param typeName:           The identifier of the type.
         :param typeDefinitionNode: The IIR node to parse.
         :param documentation:      The documentation comment on the type declaration.
-        :return:                   The record type instance.
+        :returns:                  The record type instance.
         """
         from pyGHDL.dom._Utils import GetNameOfNode
 
@@ -405,7 +405,7 @@ class ProtectedType(VHDLModel_ProtectedType, DOMMixin):
         :param typeName:           The identifier of the type.
         :param typeDefinitionNode: The IIR node to parse.
         :param documentation:      The documentation comment on the type declaration.
-        :return:                   The protected type instance.
+        :returns:                  The protected type instance.
         """
         from pyGHDL.dom._Utils import GetIirKindOfNode
 
@@ -449,7 +449,7 @@ class ProtectedTypeBody(VHDLModel_ProtectedTypeBody, DOMMixin):
         Parses a *protected type body* IIR and returns an :class:`~pyVHDLModel.Type.ProtectedTypeBody` instance.
 
         :param protectedBodyNode: The IIR node to parse.
-        :return:                  The protected type body instance.
+        :returns:                 The protected type body instance.
         """
         from pyGHDL.dom._Utils import GetNameOfNode, GetDocumentationOfNode
         from pyGHDL.dom._Translate import GetDeclaredItemsFromChainedNodes
@@ -491,7 +491,7 @@ class AccessType(VHDLModel_AccessType, DOMMixin):
         :param typeName:           The identifier of the type.
         :param typeDefinitionNode: The IIR node to parse.
         :param documentation:      The documentation comment on the type declaration.
-        :return:                   The access type instance.
+        :returns:                  The access type instance.
         """
         from pyGHDL.dom._Translate import GetSubtypeIndicationFromIndicationNode
 
@@ -527,7 +527,7 @@ class FileType(VHDLModel_FileType, DOMMixin):
         :param typeName:           The identifier of the type.
         :param typeDefinitionNode: The IIR node to parse.
         :param documentation:      The documentation comment on the type declaration.
-        :return:                   The file type instance.
+        :returns:                  The file type instance.
         """
         from pyGHDL.dom._Utils import GetNameOfNode
 

--- a/pyGHDL/dom/Type.py
+++ b/pyGHDL/dom/Type.py
@@ -67,6 +67,13 @@ from pyGHDL.dom.Subprogram import Function, Procedure
 @export
 class IncompleteType(VHDLModel_AnonymousType, DOMMixin):
     def __init__(self, node: Iir, identifier: str, documentation: str = None) -> None:
+        """
+        Initializes underlying ``BaseType``.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifier:    Name of the type.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, documentation)
         DOMMixin.__init__(self, node)
 
@@ -96,6 +103,14 @@ class EnumeratedType(VHDLModel_EnumeratedType, DOMMixin):
     def __init__(
         self, node: Iir, identifier: str, literals: List[EnumerationLiteral], documentation: str = None
     ) -> None:
+        """
+        Initializes an enumerated type definition.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifier:    The identifier of a model entity.
+        :param literals:      List of all enumeration literals, in declaration order.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, literals, documentation)
         DOMMixin.__init__(self, node)
 
@@ -133,6 +148,14 @@ class IntegerType(VHDLModel_IntegerType, DOMMixin):
     """
 
     def __init__(self, node: Iir, typeName: str, rng: Union[Range, "Name"], documentation: str = None) -> None:
+        """
+        Initializes an integer type definition.
+
+        :param node:          The IIR node this object was translated from.
+        :param typeName:      The type's identifier.
+        :param rng:           The range constraining this scalar type.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(typeName, rng, documentation)
         DOMMixin.__init__(self, node)
 
@@ -164,6 +187,16 @@ class PhysicalType(VHDLModel_PhysicalType, DOMMixin):
         units: List[Tuple[str, PhysicalIntegerLiteral]],
         documentation: str = None,
     ) -> None:
+        """
+        Initializes a physical type definition.
+
+        :param node:          The IIR node this object was translated from.
+        :param typeName:      The type's identifier.
+        :param rng:           The range constraining this scalar type.
+        :param primaryUnit:   The name of the type's primary unit.
+        :param units:         Iterable of the secondary units as (name, value) pairs.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(typeName, rng, primaryUnit, units, documentation)
         DOMMixin.__init__(self, node)
 
@@ -226,6 +259,15 @@ class ArrayType(VHDLModel_ArrayType, DOMMixin):
     def __init__(
         self, node: Iir, identifier: str, indices: List, elementSubtype: Symbol, documentation: str = None
     ) -> None:
+        """
+        Initializes an array type definition.
+
+        :param node:           The IIR node this object was translated from.
+        :param identifier:     The identifier of a model entity.
+        :param indices:        List of all index ranges, one per dimension.
+        :param elementSubtype: Reference to the subtype of the array's elements.
+        :param documentation:  The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, indices, elementSubtype, documentation)
         DOMMixin.__init__(self, node)
 
@@ -281,6 +323,14 @@ class RecordTypeElement(VHDLModel_RecordTypeElement, DOMMixin):
     """
 
     def __init__(self, node: Iir, identifiers: List[str], subtype: Symbol, documentation: str = None) -> None:
+        """
+        Initializes a record type element.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifiers:   A list of identifiers.
+        :param subtype:       Reference to the subtype shared by all identifiers of this element declaration.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifiers, subtype, documentation)
         DOMMixin.__init__(self, node)
 
@@ -326,6 +376,14 @@ class RecordType(VHDLModel_RecordType, DOMMixin):
     def __init__(
         self, node: Iir, identifier: str, elements: List[RecordTypeElement] = None, documentation: str = None
     ) -> None:
+        """
+        Initializes a record type definition.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifier:    The identifier of a model entity.
+        :param elements:      List of all element declarations, in declaration order.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, elements, documentation)
         DOMMixin.__init__(self, node)
 
@@ -394,6 +452,14 @@ class ProtectedType(VHDLModel_ProtectedType, DOMMixin):
     def __init__(
         self, node: Iir, identifier: str, methods: Union[List, Iterator] = None, documentation: str = None
     ) -> None:
+        """
+        Initializes a protected type declaration.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifier:    The identifier of a model entity.
+        :param methods:       List of the protected type's methods, in declaration order.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, methods, documentation)
         DOMMixin.__init__(self, node)
 
@@ -440,6 +506,14 @@ class ProtectedTypeBody(VHDLModel_ProtectedTypeBody, DOMMixin):
     def __init__(
         self, node: Iir, identifier: str, declaredItems: Union[List, Iterator] = None, documentation: str = None
     ) -> None:
+        """
+        Initializes a protected type body.
+
+        :param node:          The IIR node this object was translated from.
+        :param identifier:    The identifier of a model entity.
+        :param declaredItems: Iterable of all items declared in this body.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, declaredItems, documentation)
         DOMMixin.__init__(self, node)
 
@@ -480,6 +554,14 @@ class AccessType(VHDLModel_AccessType, DOMMixin):
     """
 
     def __init__(self, node: Iir, identifier: str, designatedSubtype: Symbol, documentation: str = None) -> None:
+        """
+        Initializes an access type definition.
+
+        :param node:              The IIR node this object was translated from.
+        :param identifier:        The identifier of a model entity.
+        :param designatedSubtype: Reference to the subtype the access values designate.
+        :param documentation:     The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, designatedSubtype, documentation)
         DOMMixin.__init__(self, node)
 
@@ -516,6 +598,14 @@ class FileType(VHDLModel_FileType, DOMMixin):
     """
 
     def __init__(self, node: Iir, identifier: str, designatedSubtype: Symbol, documentation: str = None) -> None:
+        """
+        Initializes a file type definition.
+
+        :param node:              The IIR node this object was translated from.
+        :param identifier:        The identifier of a model entity.
+        :param designatedSubtype: Reference to the subtype of the values stored in the file.
+        :param documentation:     The documentation comment associated with this declaration.
+        """
         super().__init__(identifier, designatedSubtype, documentation)
         DOMMixin.__init__(self, node)
 
@@ -549,5 +639,13 @@ class Subtype(VHDLModel_Subtype, DOMMixin):
     """
 
     def __init__(self, node: Iir, subtypeName: str, symbol: Symbol, documentation: str = None) -> None:
+        """
+        Initializes a subtype declaration.
+
+        :param node:          The IIR node this object was translated from.
+        :param subtypeName:   The subtype's identifier.
+        :param symbol:        Reference to the type or subtype this subtype is derived from.
+        :param documentation: The documentation comment associated with this declaration.
+        """
         super().__init__(subtypeName, symbol, documentation)
         DOMMixin.__init__(self, node)

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -425,9 +425,9 @@ def GetSubtypeIndicationFromIndicationNode(subtypeIndicationNode: Iir, entity: s
     :param subtypeIndicationNode: The subtype indication IIR node.
     :param entity:                The entity kind the subtype indication is extracted from (e.g. :vhdlkw:`constant`).
                                   Used in exception messages.
-    :param name:                  The entity's name the subtype indication is extracted from (e.g. ``BITS``).
+    :param name: The entity's name the subtype indication is extracted from (e.g. ``BITS``).
                                   Used in exception messages.
-    :returns:                     A symbol referencing a type or subtype, with array or record constraints.
+    :returns: A symbol referencing a type or subtype, with array or record constraints.
     """
     if subtypeIndicationNode is nodes.Null_Iir:
         raise ValueError("Parameter 'subtypeIndicationNode' is 'Null_Iir'.")

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -425,9 +425,9 @@ def GetSubtypeIndicationFromIndicationNode(subtypeIndicationNode: Iir, entity: s
     :param subtypeIndicationNode: The subtype indication IIR node.
     :param entity:                The entity kind the subtype indication is extracted from (e.g. :vhdlkw:`constant`).
                                   Used in exception messages.
-    :param name: The entity's name the subtype indication is extracted from (e.g. ``BITS``).
+    :param name:                  The entity's name the subtype indication is extracted from (e.g. ``BITS``).
                                   Used in exception messages.
-    :returns: A symbol referencing a type or subtype, with array or record constraints.
+    :returns:                     A symbol referencing a type or subtype, with array or record constraints.
     """
     if subtypeIndicationNode is nodes.Null_Iir:
         raise ValueError("Parameter 'subtypeIndicationNode' is 'Null_Iir'.")

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -191,7 +191,7 @@ def GetName(node: Iir) -> Name:
     :attr:`~pyVHDLModel.Name.Name.Prefix` property.
 
     :param node: The name IIR node to translate.
-    :return:     A name object.
+    :returns:    A name object.
     """
     kind = GetIirKindOfNode(node)
     if kind == nodes.Iir_Kind.Simple_Name:
@@ -217,6 +217,17 @@ def GetName(node: Iir) -> Name:
 
 
 def GetAssociations(node: Iir) -> List:
+    """
+    Translates the association chain of an indexed name, a slice or a function call to a list of expressions.
+
+    Only the actual part of each association is translated; a formal part, if present, is discarded. The
+    three constructs this is used for cannot be told apart before the name is resolved, so they share one
+    translation.
+
+    :param node:          The IIR node carrying the association chain.
+    :returns:             List of the translated actual expressions, in source order.
+    :raises DOMException: If an association element is neither by expression nor by name.
+    """
     associations = []
     for item in utils.chain_iter(nodes.Get_Association_Chain(node)):
         kind = GetIirKindOfNode(item)
@@ -238,6 +249,16 @@ def GetAssociations(node: Iir) -> List:
 def GetArrayConstraintsFromSubtypeIndication(
     subtypeIndication: Iir,
 ) -> List:
+    """
+    Translates the index constraints of an array subtype indication to a list of ranges.
+
+    A constraint is either a range expression (``0 to 7``) or a name denoting a range
+    (``v'range``, ``my_range``).
+
+    :param subtypeIndication: The IIR node of the array subtype indication.
+    :returns:                 List of the translated index constraints, one per dimension.
+    :raises DOMException:     If a constraint is neither a range expression nor a name.
+    """
     constraints = []
     for constraint in utils.flist_iter(nodes.Get_Index_Constraint_List(subtypeIndication)):
         constraintKind = GetIirKindOfNode(constraint)
@@ -263,6 +284,16 @@ def GetArrayConstraintsFromSubtypeIndication(
 def GetRecordConstraintsFromSubtypeIndication(
     subtypeIndication: Iir,
 ) -> Dict:
+    """
+    Translates the element constraints of a record subtype indication to a dictionary.
+
+    The dictionary is keyed by a :class:`~pyGHDL.dom.Symbol.RecordElementSymbol` naming the constrained
+    element; the values are not translated yet.
+
+    :param subtypeIndication: The IIR node of the record subtype indication.
+    :returns:                 Mapping from record element symbol to its constraint.
+    :raises DOMException:     If an element of the chain is not a record element constraint.
+    """
     constraints = {}
     recordElementConstraint = nodes.Get_Owned_Elements_Chain(subtypeIndication)
     while recordElementConstraint != nodes.Null_Iir:
@@ -285,6 +316,17 @@ def GetRecordConstraintsFromSubtypeIndication(
 
 @export
 def GetTypeFromNode(node: Iir) -> BaseType:
+    """
+    Translates a type declaration to the matching :mod:`pyGHDL.dom.Type` class.
+
+    The doc-comment attaches to the type *declaration*, not to the type definition inside it, so it is
+    read here and handed to whichever class parses the definition. A declaration without a definition is
+    an incomplete type.
+
+    :param node:          The IIR node of the type declaration.
+    :returns:             The translated type.
+    :raises DOMException: If the type definition's kind is not handled.
+    """
     typeName = GetNameOfNode(node)
     # A doc comment attaches to the type *declaration*, not the type definition inside it, so it is read
     # here and handed to whichever class parses the definition.
@@ -315,6 +357,16 @@ def GetTypeFromNode(node: Iir) -> BaseType:
 
 @export
 def GetAnonymousTypeFromNode(node: Iir) -> BaseType:
+    """
+    Translates an anonymous type declaration to the matching :mod:`pyGHDL.dom.Type` class.
+
+    GHDL creates an anonymous type declaration for the type definitions that have no name of their own -
+    an integer or physical type behind a subtype, for instance.
+
+    :param node:          The IIR node of the anonymous type declaration.
+    :returns:             The translated type.
+    :raises DOMException: If the type definition's kind is not handled.
+    """
     typeName = GetNameOfNode(node)
     documentation = GetDocumentationOfNode(node)
     typeDefinition = nodes.Get_Type_Definition(node)
@@ -371,9 +423,11 @@ def GetSubtypeIndicationFromIndicationNode(subtypeIndicationNode: Iir, entity: s
     Translate a subtype indication to a :class:`~pyVHDLModel.Symbol.Symbol`.
 
     :param subtypeIndicationNode: The subtype indication IIR node.
-    :param entity: The entity kind the subtype indication is extracted from (e.g. ``constant``). Used in exception messages.
-    :param name:   The entity's name the subtype indication is extracted from (e.g. ``BITS``). Used in exception messages.
-    :returns:      A symbol representing a reference to a type/subtype and possible array or record constraints.
+    :param entity:                The entity kind the subtype indication is extracted from (e.g. ``constant``).
+                                  Used in exception messages.
+    :param name:                  The entity's name the subtype indication is extracted from (e.g. ``BITS``).
+                                  Used in exception messages.
+    :returns:                     A symbol referencing a type or subtype, with array or record constraints.
     """
     if subtypeIndicationNode is nodes.Null_Iir:
         raise ValueError("Parameter 'subtypeIndicationNode' is 'Null_Iir'.")
@@ -397,6 +451,12 @@ def GetSubtypeIndicationFromIndicationNode(subtypeIndicationNode: Iir, entity: s
 
 @export
 def GetSimpleTypeFromNode(subtypeIndicationNode: Iir) -> SimpleSubtypeSymbol:
+    """
+    Translates a subtype indication that is just a type mark to a simple subtype symbol.
+
+    :param subtypeIndicationNode: The IIR node of the subtype indication.
+    :returns:                     A subtype symbol referencing the type mark.
+    """
     subtypeName = GetName(subtypeIndicationNode)
     return SimpleSubtypeSymbol(subtypeIndicationNode, subtypeName)
 
@@ -450,6 +510,12 @@ def GetScalarConstrainedSubtypeFromNode(
 def GetArrayConstrainedSubtypeFromNode(
     subtypeIndicationNode: Iir,
 ) -> ConstrainedArraySubtypeSymbol:
+    """
+    Translates an array subtype indication with an index constraint to a constrained array subtype symbol.
+
+    :param subtypeIndicationNode: The IIR node of the array subtype indication.
+    :returns:                     A subtype symbol carrying the type mark and one range per dimension.
+    """
     typeMark = nodes.Get_Subtype_Type_Mark(subtypeIndicationNode)
     typeMarkName = GetNameOfNode(typeMark)
     simpleTypeMark = SimpleName(typeMark, typeMarkName)
@@ -462,6 +528,12 @@ def GetArrayConstrainedSubtypeFromNode(
 def GetRecordConstrainedSubtypeFromNode(
     subtypeIndicationNode: Iir,
 ) -> ConstrainedRecordSubtypeSymbol:
+    """
+    Translates a record subtype indication with an element constraint to a constrained record subtype symbol.
+
+    :param subtypeIndicationNode: The IIR node of the record subtype indication.
+    :returns:                     A subtype symbol carrying the type mark and the constrained elements.
+    """
     typeMark = nodes.Get_Subtype_Type_Mark(subtypeIndicationNode)
     typeMarkName = GetNameOfNode(typeMark)
     simpleTypeMark = SimpleName(typeMark, typeMarkName)
@@ -472,6 +544,12 @@ def GetRecordConstrainedSubtypeFromNode(
 
 @export
 def GetSubtypeFromNode(subtypeNode: Iir) -> Symbol:
+    """
+    Translates a subtype declaration to a :class:`~pyGHDL.dom.Type.Subtype`.
+
+    :param subtypeNode: The IIR node of the subtype declaration.
+    :returns:           The translated subtype, carrying the symbol of its subtype indication.
+    """
     subtypeName = GetNameOfNode(subtypeNode)
     symbol = GetSubtypeIndicationFromNode(subtypeNode, "subtype", subtypeName)
 
@@ -484,7 +562,7 @@ def GetRangeFromNode(node: Iir) -> SimpleRange:
     Translate a range IIR node to a :class:`~pyVHDLModel.Base.SimpleRange`.
 
     :param node: The IIR node representing a range.
-    :return:     The translated range object.
+    :returns:    The translated range object.
     """
     direction = nodes.Get_Direction(node)
     leftBound = nodes.Get_Left_Limit_Expr(node)
@@ -612,7 +690,7 @@ def GetExpressionFromNode(node: Iir) -> ExpressionUnion:
     Translates an expression IIR node to an :class:`~pyVHDLModel.Expression.BaseExpression`.
 
     :param node: The IIR node representing an expression.
-    :return:     The translated expression.
+    :returns:    The translated expression.
     """
     kind = GetIirKindOfNode(node)
 
@@ -633,7 +711,7 @@ def GetOptionalExpressionFromNode(node: Iir) -> Nullable[ExpressionUnion]:
     ``Null_Iir``, rather than requiring every call site to repeat that check.
 
     :param node: The IIR node representing an expression, or ``Null_Iir`` if absent.
-    :return:     The translated expression, or ``None``.
+    :returns:    The translated expression, or ``None``.
     """
     return None if node == nodes.Null_Iir else GetExpressionFromNode(node)
 
@@ -645,7 +723,7 @@ def GetModeViewElementsFromChainedNodes(nodeChain: Iir) -> Generator["ModeViewEl
     :class:`pyVHDLModel.Interface.ModeViewElement`.
 
     :param nodeChain: The IIR node representing the first mode view element in the chain.
-    :return:          A generator returning mode view elements.
+    :returns:         A generator returning mode view elements.
 
     .. note::
 
@@ -694,7 +772,7 @@ def GetGenericsFromChainedNodes(nodeChain: Iir) -> Generator[GenericInterfaceIte
     Translates a chain of generics (IIR nodes) to a sequence of :class:`pyVHDLModel.Interface.GenericInterfaceItem`.
 
     :param nodeChain: The IIR node representing the first generic in the chain.
-    :return:          A generator returning generic interface items.
+    :returns:         A generator returning generic interface items.
     """
     from pyGHDL.dom.InterfaceItem import (
         GenericTypeInterfaceItem,
@@ -757,7 +835,7 @@ def GetPortsFromChainedNodes(nodeChain: Iir) -> Generator[PortInterfaceItemMixin
     Translates a chain of ports (IIR nodes) to a sequence of :class:`pyVHDLModel.Interface.PortInterfaceItem`.
 
     :param nodeChain: The IIR node representing the first port in the chain.
-    :return:          A generator returning port interface items.
+    :returns:         A generator returning port interface items.
     """
     furtherIdentifiers = []
     port = nodeChain
@@ -807,7 +885,7 @@ def GetParameterFromChainedNodes(nodeChain: Iir) -> Generator[ParameterInterface
     Translates a chain of parameters (IIR nodes) to a sequence of :class:`pyVHDLModel.Interface.ParameterInterfaceItem`.
 
     :param nodeChain: The IIR node representing the first parameter in the chain.
-    :return:          A generator returning parameter interface items.
+    :returns:         A generator returning parameter interface items.
     """
     identifiers = []
     parameter = nodeChain
@@ -866,6 +944,18 @@ def GetParameterFromChainedNodes(nodeChain: Iir) -> Generator[ParameterInterface
 
 
 def GetMapAspect(mapAspect: Iir, cls: Type, entity: str) -> Generator[AssociationItem, None, None]:
+    """
+    Translates a generic, port or parameter map aspect to association items.
+
+    An association without a formal part is positional, so its formal is ``None``. An association to
+    ``open`` yields an :class:`~pyGHDL.dom.Name.OpenName` as the actual.
+
+    :param mapAspect:     The IIR node starting the association chain of the map aspect.
+    :param cls:           The association item class to instantiate, e.g. :class:`~pyGHDL.dom.Concurrent.PortAssociationItem`.
+    :param entity:        The kind of map aspect (``generic``, ``port``, ``parameter``). Used in exception messages.
+    :returns:             Generator yielding the translated association items, in source order.
+    :raises DOMException: If an association element is neither by expression nor open.
+    """
     for item in utils.chain_iter(mapAspect):
         kind = GetIirKindOfNode(item)
         if kind is nodes.Iir_Kind.Association_Element_By_Expression:
@@ -892,18 +982,48 @@ def GetMapAspect(mapAspect: Iir, cls: Type, entity: str) -> Generator[Associatio
 
 
 def GetGenericMapAspect(genericMapAspect: Iir) -> Generator[GenericAssociationItem, None, None]:
+    """
+    Translates a generic map aspect to generic association items.
+
+    :param genericMapAspect: The IIR node starting the generic map aspect's association chain.
+    :returns:                Generator yielding the translated generic associations, in source order.
+    """
     return GetMapAspect(genericMapAspect, GenericAssociationItem, "generic")
 
 
 def GetPortMapAspect(portMapAspect: Iir) -> Generator[PortAssociationItem, None, None]:
+    """
+    Translates a port map aspect to port association items.
+
+    :param portMapAspect: The IIR node starting the port map aspect's association chain.
+    :returns:             Generator yielding the translated port associations, in source order.
+    """
     return GetMapAspect(portMapAspect, PortAssociationItem, "port")
 
 
 def GetParameterMapAspect(parameterMapAspect: Iir) -> Generator[ParameterAssociationItem, None, None]:
+    """
+    Translates a subprogram call's parameter map to parameter association items.
+
+    :param parameterMapAspect: The IIR node starting the parameter map's association chain.
+    :returns:                  Generator yielding the translated parameter associations, in source order.
+    """
     return GetMapAspect(parameterMapAspect, ParameterAssociationItem, "parameter")
 
 
 def GetDeclaredItemsFromChainedNodes(nodeChain: Iir, entity: str, name: str) -> Generator[ModelEntity, None, None]:
+    """
+    Translates a chain of declarations to the matching :mod:`pyGHDL.dom` objects.
+
+    GHDL splits a declaration naming several identifiers (``signal a, b : bit;``) into one node per
+    identifier. They are collected here and yielded as a single object carrying all identifiers.
+
+    :param nodeChain:     The IIR node starting the chain of declarations.
+    :param entity:        The kind of declarative region the chain belongs to. Used in exception messages.
+    :param name:          The name of that declarative region. Used in exception messages.
+    :returns:             Generator yielding the translated declared items, in source order.
+    :raises DOMException: If a declaration's kind is not handled.
+    """
     furtherIdentifiers = []
     item = nodeChain
     lastKind = None
@@ -1071,6 +1191,15 @@ def GetDeclaredItemsFromChainedNodes(nodeChain: Iir, entity: str, name: str) -> 
 def GetConcurrentStatementsFromChainedNodes(
     nodeChain: Iir, entity: str, name: str
 ) -> Generator[ConcurrentStatement, None, None]:
+    """
+    Translates a chain of concurrent statements to the matching :mod:`pyGHDL.dom.Concurrent` objects.
+
+    :param nodeChain:     The IIR node starting the chain of concurrent statements.
+    :param entity:        The kind of statement region the chain belongs to. Used in exception messages.
+    :param name:          The name of that statement region. Used in exception messages.
+    :returns:             Generator yielding the translated statements, in source order.
+    :raises DOMException: If a statement's kind is not handled.
+    """
     for statement in utils.chain_iter(nodeChain):
         label = GetLabelOfNode(statement)
 
@@ -1135,6 +1264,15 @@ def GetConcurrentStatementsFromChainedNodes(
 def GetSequentialStatementsFromChainedNodes(
     nodeChain: Iir, entity: str, name: str
 ) -> Generator[SequentialStatement, None, None]:
+    """
+    Translates a chain of sequential statements to the matching :mod:`pyGHDL.dom.Sequential` objects.
+
+    :param nodeChain:     The IIR node starting the chain of sequential statements.
+    :param entity:        The kind of statement region the chain belongs to. Used in exception messages.
+    :param name:          The name of that statement region. Used in exception messages.
+    :returns:             Generator yielding the translated statements, in source order.
+    :raises DOMException: If a statement's kind is not handled.
+    """
     for statement in utils.chain_iter(nodeChain):
         label = GetLabelOfNode(statement)
 

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -409,7 +409,7 @@ def GetSubtypeIndicationFromNode(node: Iir, entity: str, name: str) -> Symbol:
        subtype indication is return by another getter.
 
     :param node:   The IIR node to get the subtype indication from.
-    :param entity: The entity kind the subtype indication is extracted from (e.g. ``constant``). Used in exception messages.
+    :param entity: The entity kind the subtype indication is extracted from (e.g. :vhdlkw:`constant`). Used in exception messages.
     :param name:   The entity's name the subtype indication is extracted from (e.g. ``BITS``). Used in exception messages.
     :returns:      A symbol representing a reference to a type/subtype and possible array or record constraints.
     """
@@ -423,7 +423,7 @@ def GetSubtypeIndicationFromIndicationNode(subtypeIndicationNode: Iir, entity: s
     Translate a subtype indication to a :class:`~pyVHDLModel.Symbol.Symbol`.
 
     :param subtypeIndicationNode: The subtype indication IIR node.
-    :param entity:                The entity kind the subtype indication is extracted from (e.g. ``constant``).
+    :param entity:                The entity kind the subtype indication is extracted from (e.g. :vhdlkw:`constant`).
                                   Used in exception messages.
     :param name:                  The entity's name the subtype indication is extracted from (e.g. ``BITS``).
                                   Used in exception messages.
@@ -586,11 +586,11 @@ def GetDiscreteRangeFromNode(discreteRangeNode: Iir, entity: str) -> Range:
     Everything but the explicit-bounds form becomes a
     :class:`~pyVHDLModel.Base.RangeFromName` wrapping the referenced symbol.
 
-    Shared by ``for ... loop`` statements, ``for ... generate`` statements and aggregate choices, which
+    Shared by :vhdlkw:`for..loop` statements, :vhdlkw:`for..generate` statements and aggregate choices, which
     all use the same VHDL ``discrete_range`` grammar rule.
 
     :param discreteRangeNode: The IIR node representing a discrete range.
-    :param entity:            The construct the discrete range appears in (e.g. ``for...loop``). Used in exception messages.
+    :param entity:            The construct the discrete range appears in (e.g. :vhdlkw:`for..loop`). Used in exception messages.
     :returns:                 The translated range.
     :raises DOMException:     If the IIR node's kind isn't a known discrete range.
     """
@@ -707,7 +707,7 @@ def GetOptionalExpressionFromNode(node: Iir) -> Nullable[ExpressionUnion]:
     """
     Like :func:`GetExpressionFromNode`, but for fields that may legitimately be absent (e.g. an
     optional condition on the final branch of a conditional assignment, or on an unconditional
-    ``exit``/``next`` statement) - returns ``None`` instead of translating when ``node`` is
+    :vhdlkw:`exit`/:vhdlkw:`next` statement) - returns ``None`` instead of translating when ``node`` is
     ``Null_Iir``, rather than requiring every call site to repeat that check.
 
     :param node: The IIR node representing an expression, or ``Null_Iir`` if absent.
@@ -948,11 +948,11 @@ def GetMapAspect(mapAspect: Iir, cls: Type, entity: str) -> Generator[Associatio
     Translates a generic, port or parameter map aspect to association items.
 
     An association without a formal part is positional, so its formal is ``None``. An association to
-    ``open`` yields an :class:`~pyGHDL.dom.Name.OpenName` as the actual.
+    :vhdlkw:`open` yields an :class:`~pyGHDL.dom.Name.OpenName` as the actual.
 
     :param mapAspect:     The IIR node starting the association chain of the map aspect.
     :param cls:           The association item class to instantiate, e.g. :class:`~pyGHDL.dom.Concurrent.PortAssociationItem`.
-    :param entity:        The kind of map aspect (``generic``, ``port``, ``parameter``). Used in exception messages.
+    :param entity:        The kind of map aspect (:vhdlkw:`generic`, :vhdlkw:`port`, :vhdlkw:`parameter`). Used in exception messages.
     :returns:             Generator yielding the translated association items, in source order.
     :raises DOMException: If an association element is neither by expression nor open.
     """

--- a/pyGHDL/dom/_Utils.py
+++ b/pyGHDL/dom/_Utils.py
@@ -128,8 +128,8 @@ def GetLabelOfNode(node: Iir) -> Nullable[str]:
     if-generate or case-generate statement - carries it in ``Alternative_Label``. No node kind has
     both, so the field is chosen from the node's kind.
 
-    :param node:        The IIR node to read the label of.
-    :returns:           The label, or ``None`` if the node has no label field or no label was given
+    :param node: The IIR node to read the label of.
+    :returns:    The label, or ``None`` if the node has no label field or no label was given
                         in the source.
     :raises ValueError: If parameter ``node`` is :data:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`.
     """

--- a/pyGHDL/dom/_Utils.py
+++ b/pyGHDL/dom/_Utils.py
@@ -30,6 +30,10 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+This module offers helper functions to read an IIR node's kind, name, label, mode and documentation.
+"""
+
 from typing import Optional as Nullable
 
 from pyTooling.Decorators import export
@@ -85,8 +89,10 @@ def CheckForErrors() -> None:
 
 @export
 def GetIirKindOfNode(node: Iir) -> nodes.Iir_Kind:
-    """Return the kind of a node in the IIR tree.
+    """
+    Return the kind of a node in the IIR tree.
 
+    :param node:        The IIR node to read the kind of.
     :returns:           The IIR kind of a node.
     :raises ValueError: If parameter ``node`` is :data:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`.
     """
@@ -99,8 +105,11 @@ def GetIirKindOfNode(node: Iir) -> nodes.Iir_Kind:
 
 @export
 def GetNameOfNode(node: Iir) -> str:
-    """Return the Python string from node ``node`` identifier.
+    """
+    Return the Python string from node ``node`` identifier.
 
+    :param node:        The IIR node to read the identifier of.
+    :returns:           The node's identifier as written in the source file.
     :raises ValueError: If parameter ``node`` is :data:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`.
     """
     if node == Null_Iir:
@@ -112,12 +121,14 @@ def GetNameOfNode(node: Iir) -> str:
 
 @export
 def GetLabelOfNode(node: Iir) -> Nullable[str]:
-    """Return the Python string from node ``node``'s optional label.
+    """
+    Return the Python string from node ``node``'s optional label.
 
     A statement carries its label in ``Label``, while a generate-statement body - the branch of an
     if-generate or case-generate statement - carries it in ``Alternative_Label``. No node kind has
     both, so the field is chosen from the node's kind.
 
+    :param node:        The IIR node to read the label of.
     :returns:           The label, or ``None`` if the node has no label field or no label was given
                         in the source.
     :raises ValueError: If parameter ``node`` is :data:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`.
@@ -138,6 +149,15 @@ def GetLabelOfNode(node: Iir) -> Nullable[str]:
 
 @export
 def GetDocumentationOfNode(node: Iir) -> str:
+    """
+    Collects the doc-comment lines attached to an IIR node.
+
+    *libghdl* only gathers comments if :data:`~pyGHDL.libghdl.flags.Flag_Gather_Comments` was enabled
+    before parsing, which :class:`~pyGHDL.dom.NonStandard.Design` does.
+
+    :param node: The IIR node to read the comments of.
+    :returns:    The comment lines joined by newlines, or an empty string if the node has no comment.
+    """
     file = files_map.Location_To_File(nodes.Get_Location(node))
     idx = file_comments.Find_First_Comment(file, node)
     documentation = []
@@ -150,8 +170,11 @@ def GetDocumentationOfNode(node: Iir) -> str:
 
 @export
 def GetModeOfNode(node: Iir) -> Mode:
-    """Return the mode of a ``node``.
+    """
+    Return the mode of a ``node``.
 
+    :param node:          The IIR node to read the mode of.
+    :returns:             The node's mode as a pyVHDLModel enumeration value.
     :raises ValueError:   If parameter ``node`` is :data:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`.
     :raises DOMException: If mode returned by libghdl is not known by :data:`__MODE_TRANSLATION`.
     """

--- a/pyGHDL/dom/__init__.py
+++ b/pyGHDL/dom/__init__.py
@@ -116,6 +116,13 @@ class Position(metaclass=ExtendedType):
 
 @export
 class DOMMixin(metaclass=ExtendedType, mixin=True):
+    """
+    Mixin adding the originating IIR node and its source code position to a :mod:`pyGHDL.dom` object.
+
+    Every class in :mod:`pyGHDL.dom` that mirrors a pyVHDLModel class inherits this mixin, so a model
+    object can always be traced back to the node in *libghdl*'s tree it was translated from.
+    """
+
     _iirNode: Iir  #: The IIR node in *libghdl*'s tree this DOM object was translated from.
     _position: Position  #: The IIR node's position in the source file, resolved on first access and then cached.
 

--- a/pyGHDL/dom/__init__.py
+++ b/pyGHDL/dom/__init__.py
@@ -52,6 +52,13 @@ class Position(metaclass=ExtendedType):
     _column: int
 
     def __init__(self, filename: Path, line: int, column: int) -> None:
+        """
+        Initializes a source code position.
+
+        :param filename: The source file this position refers to.
+        :param line:     The line number in the source file, starting at 1.
+        :param column:   The character offset within the line, starting at 0.
+        """
         self._filename = filename
         self._line = line
         self._column = column
@@ -108,6 +115,13 @@ class DOMMixin(metaclass=ExtendedType, mixin=True):
     _position: Position
 
     def __init__(self, node: Iir) -> None:
+        """
+        Initializes the mixin with the IIR node a DOM object was translated from.
+
+        The source code position is not resolved here, but on first access of :attr:`Position`.
+
+        :param node: The IIR node in *libghdl*'s tree this DOM object was translated from.
+        """
         self._iirNode = node
         self._position = None
 

--- a/pyGHDL/dom/__init__.py
+++ b/pyGHDL/dom/__init__.py
@@ -47,11 +47,9 @@ from pyGHDL.libghdl.vhdl import nodes
 class Position(metaclass=ExtendedType):
     """Represents the source code position of a IIR node in a source file."""
 
-    # fmt: off
     _filename: Path  #: The source file this position refers to.
-    _line:     int   #: The line number in the source file, starting at 1.
-    _column:   int   #: The character offset within the line, starting at 0.
-    # fmt: on
+    _line: int  #: The line number in the source file, starting at 1.
+    _column: int  #: The character offset within the line, starting at 0.
 
     def __init__(self, filename: Path, line: int, column: int) -> None:
         self._filename = filename
@@ -106,10 +104,8 @@ class Position(metaclass=ExtendedType):
 
 @export
 class DOMMixin(metaclass=ExtendedType, mixin=True):
-    # fmt: off
-    _iirNode:  Iir       #: The IIR node in *libghdl*'s tree this DOM object was translated from.
+    _iirNode: Iir  #: The IIR node in *libghdl*'s tree this DOM object was translated from.
     _position: Position  #: The IIR node's position in the source file, resolved on first access and then cached.
-    # fmt: on
 
     def __init__(self, node: Iir) -> None:
         self._iirNode = node

--- a/pyGHDL/dom/__init__.py
+++ b/pyGHDL/dom/__init__.py
@@ -65,7 +65,13 @@ class Position(metaclass=ExtendedType):
 
     @classmethod
     def parse(cls, node: Iir) -> "Position":
-        """Return the source code position of a IIR node."""
+        """
+        Return the source code position of a IIR node.
+
+        :param node:        The IIR node to read the position of.
+        :returns:           The node's position in its source file.
+        :raises ValueError: If parameter ``node`` is :data:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`.
+        """
         if node == nodes.Null_Iir:
             raise ValueError("Position.parse(): Parameter 'node' must not be 'Null_iir'.")
 

--- a/pyGHDL/dom/__init__.py
+++ b/pyGHDL/dom/__init__.py
@@ -47,9 +47,11 @@ from pyGHDL.libghdl.vhdl import nodes
 class Position(metaclass=ExtendedType):
     """Represents the source code position of a IIR node in a source file."""
 
+    # fmt: off
     _filename: Path  #: The source file this position refers to.
-    _line: int  #: The line number in the source file, starting at 1.
-    _column: int  #: The character offset within the line, starting at 0.
+    _line:     int   #: The line number in the source file, starting at 1.
+    _column:   int   #: The character offset within the line, starting at 0.
+    # fmt: on
 
     def __init__(self, filename: Path, line: int, column: int) -> None:
         self._filename = filename
@@ -104,8 +106,10 @@ class Position(metaclass=ExtendedType):
 
 @export
 class DOMMixin(metaclass=ExtendedType, mixin=True):
-    _iirNode: Iir  #: The IIR node in *libghdl*'s tree this DOM object was translated from.
+    # fmt: off
+    _iirNode:  Iir       #: The IIR node in *libghdl*'s tree this DOM object was translated from.
     _position: Position  #: The IIR node's position in the source file, resolved on first access and then cached.
+    # fmt: on
 
     def __init__(self, node: Iir) -> None:
         self._iirNode = node

--- a/pyGHDL/dom/__init__.py
+++ b/pyGHDL/dom/__init__.py
@@ -47,9 +47,9 @@ from pyGHDL.libghdl.vhdl import nodes
 class Position(metaclass=ExtendedType):
     """Represents the source code position of a IIR node in a source file."""
 
-    _filename: Path
-    _line: int
-    _column: int
+    _filename: Path  #: The source file this position refers to.
+    _line: int  #: The line number in the source file, starting at 1.
+    _column: int  #: The character offset within the line, starting at 0.
 
     def __init__(self, filename: Path, line: int, column: int) -> None:
         self._filename = filename
@@ -104,8 +104,8 @@ class Position(metaclass=ExtendedType):
 
 @export
 class DOMMixin(metaclass=ExtendedType, mixin=True):
-    _iirNode: Iir
-    _position: Position
+    _iirNode: Iir  #: The IIR node in *libghdl*'s tree this DOM object was translated from.
+    _position: Position  #: The IIR node's position in the source file, resolved on first access and then cached.
 
     def __init__(self, node: Iir) -> None:
         self._iirNode = node

--- a/pyGHDL/dom/__init__.py
+++ b/pyGHDL/dom/__init__.py
@@ -74,7 +74,7 @@ class Position(metaclass=ExtendedType):
     @readonly
     def Filename(self) -> Path:
         """
-        Read-only property to access the filename this source code position referres to (:attr:`_filename`).
+        Read-only property to access the filename this source code position refers to (:attr:`_filename`).
 
         :returns: The source code position's filename.
         """
@@ -83,7 +83,7 @@ class Position(metaclass=ExtendedType):
     @readonly
     def Line(self) -> int:
         """
-        Read-only property to access the line number this source code position referres to (:attr:`_line`).
+        Read-only property to access the line number this source code position refers to (:attr:`_line`).
 
         :returns: The source code position's line.
         """
@@ -92,7 +92,7 @@ class Position(metaclass=ExtendedType):
     @readonly
     def Column(self) -> int:
         """
-        Read-only property to access the column this source code position referres to (:attr:`_column`).
+        Read-only property to access the column this source code position refers to (:attr:`_column`).
 
         :returns: The source code position's column.
         """

--- a/pyGHDL/dom/__init__.py
+++ b/pyGHDL/dom/__init__.py
@@ -98,7 +98,12 @@ class Position(metaclass=ExtendedType):
         """
         return self._column
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """
+        Formats the source code position as ``<filename>:<line>:<column>``.
+
+        :returns: A string representation of this source code position.
+        """
         return f"{self._filename}:{self._line}:{self._column}"
 
 

--- a/pyGHDL/dom/formatting/GraphML.py
+++ b/pyGHDL/dom/formatting/GraphML.py
@@ -87,6 +87,50 @@ class DependencyGraphFormatter(Formatter):
         """
         Writes the dependency graph as a GraphML file, grouping the vertices by library.
 
+        The document declares six `GraphML <http://graphml.graphdrawing.org>`__ keys, four for nodes and two for edges:
+
+        .. list-table::
+           :header-rows: 1
+           :widths: 8 8 12 72
+
+           * - Key
+             - Applies to
+             - Attribute
+             - Value
+           * - ``nd1``
+             - node
+             - ``id``
+             - The vertex' ID, repeated as data so a reader ignoring the XML ``id`` still sees it.
+           * - ``nd2``
+             - node
+             - ``value``
+             - The label to display. An architecture is written as ``entity(architecture)``, a document as its ID,
+               anything else as its identifier.
+           * - ``nd3``
+             - node
+             - ``kind``
+             - The name of the vertex' :class:`~pyVHDLModel.DependencyGraphVertexKind`.
+           * - ``nd4``
+             - node
+             - ``color``
+             - The fill color from :attr:`NODE_COLORS`, selected by vertex kind.
+           * - ``ed3``
+             - edge
+             - ``kind``
+             - The name of the edge's :class:`~pyVHDLModel.DependencyGraphEdgeKind`.
+           * - ``ed4``
+             - edge
+             - ``color``
+             - The line color from :attr:`EDGE_COLORS`, selected by edge kind.
+
+        A node's XML ``id`` is the vertex' ID from the model. An edge has none, so edges are numbered in the order they
+        are written and get ``e1``, ``e2``, ...; their ``source`` and ``target`` are vertex IDs.
+
+        The graph is **grouped into one subgraph per library**: an enclosing node ``grp_<library>`` holds a nested
+        ``<graph id="<library>">`` with that library's vertices. A vertex is assigned to a library by asking the model -
+        a library vertex for itself, a document vertex through its first design unit, anything else through its own
+        ``Library``. Edges are written afterwards at the top level, so an edge may cross from one subgraph into another.
+
         :param path: The path of the file to write.
         """
         with path.open("w") as file:
@@ -198,6 +242,46 @@ class HierarchyGraphFormatter(Formatter):
         """
         Writes the hierarchy graph as a GraphML file.
 
+        The document declares six `GraphML <http://graphml.graphdrawing.org>`__ keys, four for nodes and two for edges:
+
+        .. list-table::
+           :header-rows: 1
+           :widths: 8 8 12 72
+
+           * - Key
+             - Applies to
+             - Attribute
+             - Value
+           * - ``nd1``
+             - node
+             - ``id``
+             - The vertex' ID, repeated as data so a reader ignoring the XML ``id`` still sees it.
+           * - ``nd2``
+             - node
+             - ``value``
+             - The label to display. The vertex' identifier.
+           * - ``nd3``
+             - node
+             - ``kind``
+             - The name of the vertex' :class:`~pyVHDLModel.DependencyGraphVertexKind`.
+           * - ``nd4``
+             - node
+             - ``color``
+             - The fill color from :attr:`NODE_COLORS`, selected by vertex kind.
+           * - ``ed3``
+             - edge
+             - ``kind``
+             - The name of the edge's :class:`~pyVHDLModel.DependencyGraphEdgeKind`.
+           * - ``ed4``
+             - edge
+             - ``color``
+             - The line color from :attr:`EDGE_COLORS`, selected by edge kind.
+
+        A node's XML ``id`` is the vertex' ID from the model. An edge has none, so edges are numbered in the order they
+        are written and get ``e1``, ``e2``, ...; their ``source`` and ``target`` are vertex IDs.
+
+        The vertices are written flat, without subgraphs.
+
         :param path: The path of the file to write.
         """
         with path.open("w") as file:
@@ -287,6 +371,46 @@ class CompileOrderGraphFormatter(Formatter):
     def WriteGraphML(self, path: Path):
         """
         Writes the compile order graph as a GraphML file.
+
+        The document declares six `GraphML <http://graphml.graphdrawing.org>`__ keys, four for nodes and two for edges:
+
+        .. list-table::
+           :header-rows: 1
+           :widths: 8 8 12 72
+
+           * - Key
+             - Applies to
+             - Attribute
+             - Value
+           * - ``nd1``
+             - node
+             - ``id``
+             - The vertex' ID, repeated as data so a reader ignoring the XML ``id`` still sees it.
+           * - ``nd2``
+             - node
+             - ``value``
+             - The label to display. The vertex' identifier.
+           * - ``nd3``
+             - node
+             - ``kind``
+             - The name of the vertex' :class:`~pyVHDLModel.DependencyGraphVertexKind`.
+           * - ``nd4``
+             - node
+             - ``color``
+             - The fill color from :attr:`NODE_COLORS`, selected by vertex kind.
+           * - ``ed3``
+             - edge
+             - ``kind``
+             - The name of the edge's :class:`~pyVHDLModel.DependencyGraphEdgeKind`.
+           * - ``ed4``
+             - edge
+             - ``color``
+             - The line color from :attr:`EDGE_COLORS`, selected by edge kind.
+
+        A node's XML ``id`` is the vertex' ID from the model. An edge has none, so edges are numbered in the order they
+        are written and get ``e1``, ``e2``, ...; their ``source`` and ``target`` are vertex IDs.
+
+        The vertices are written flat, without subgraphs.
 
         :param path: The path of the file to write.
         """

--- a/pyGHDL/dom/formatting/GraphML.py
+++ b/pyGHDL/dom/formatting/GraphML.py
@@ -19,8 +19,10 @@ from pyVHDLModel import (
 class Formatter:  # (metaclass=ExtendedType):
     _graph: Graph  #: The graph to be written as GraphML.
 
-    NODE_COLORS: ClassVar[Dict[Flag, str]]  #: Vertex kind to fill color; set by each derived formatter.
-    EDGE_COLORS: ClassVar[Dict[Flag, str]]  #: Edge kind to line color; set by each derived formatter.
+    # fmt: off
+    NODE_COLORS: ClassVar[Dict[Flag, str]]  #: Translation dictionary of *vertex kind* to *fill color*; set by each derived formatter.
+    EDGE_COLORS: ClassVar[Dict[Flag, str]]  #: Translation dictionary of *edge kind* to *line color*; set by each derived formatter.
+    # fmt: on
 
     def __init__(self, graph: Graph) -> None:
         self._graph = graph

--- a/pyGHDL/dom/formatting/GraphML.py
+++ b/pyGHDL/dom/formatting/GraphML.py
@@ -19,10 +19,10 @@ from pyVHDLModel import (
 class Formatter:  # (metaclass=ExtendedType):
     _graph: Graph  #: The graph to be written as GraphML.
 
-    # fmt: off
-    NODE_COLORS: ClassVar[Dict[Flag, str]]  #: Translation dictionary of *vertex kind* to *fill color*; set by each derived formatter.
-    EDGE_COLORS: ClassVar[Dict[Flag, str]]  #: Translation dictionary of *edge kind* to *line color*; set by each derived formatter.
-    # fmt: on
+    #: Translation dictionary of *vertex kind* to *fill color*; set by each derived formatter.
+    NODE_COLORS: ClassVar[Dict[Flag, str]]
+    #: Translation dictionary of *edge kind* to *line color*; set by each derived formatter.
+    EDGE_COLORS: ClassVar[Dict[Flag, str]]
 
     def __init__(self, graph: Graph) -> None:
         self._graph = graph

--- a/pyGHDL/dom/formatting/GraphML.py
+++ b/pyGHDL/dom/formatting/GraphML.py
@@ -27,6 +27,11 @@ class Formatter:  # (metaclass=ExtendedType):
     EDGE_COLORS: ClassVar[Dict[Flag, str]]
 
     def __init__(self, graph: Graph) -> None:
+        """
+        Initializes a GraphML formatter for the given graph.
+
+        :param graph: The graph to be written as GraphML by :meth:`WriteGraphML`.
+        """
         self._graph = graph
 
     @abstractmethod

--- a/pyGHDL/dom/formatting/GraphML.py
+++ b/pyGHDL/dom/formatting/GraphML.py
@@ -45,6 +45,11 @@ class Formatter:  # (metaclass=ExtendedType):
 
     @abstractmethod
     def WriteGraphML(self, path: Path):
+        """
+        Writes the graph as a GraphML file.
+
+        :param path: The path of the file to write.
+        """
         pass
 
 
@@ -79,6 +84,11 @@ class DependencyGraphFormatter(Formatter):
     }
 
     def WriteGraphML(self, path: Path):
+        """
+        Writes the dependency graph as a GraphML file, grouping the vertices by library.
+
+        :param path: The path of the file to write.
+        """
         with path.open("w") as file:
             file.write(dedent(f"""\
             <graphml xmlns="http://graphml.graphdrawing.org/xmlns"
@@ -185,6 +195,11 @@ class HierarchyGraphFormatter(Formatter):
     }
 
     def WriteGraphML(self, path: Path):
+        """
+        Writes the hierarchy graph as a GraphML file.
+
+        :param path: The path of the file to write.
+        """
         with path.open("w") as file:
             file.write(dedent(f"""\
             <graphml xmlns="http://graphml.graphdrawing.org/xmlns"
@@ -270,6 +285,11 @@ class CompileOrderGraphFormatter(Formatter):
     }
 
     def WriteGraphML(self, path: Path):
+        """
+        Writes the compile order graph as a GraphML file.
+
+        :param path: The path of the file to write.
+        """
         with path.open("w") as file:
             file.write(dedent(f"""\
             <graphml xmlns="http://graphml.graphdrawing.org/xmlns"

--- a/pyGHDL/dom/formatting/GraphML.py
+++ b/pyGHDL/dom/formatting/GraphML.py
@@ -17,10 +17,10 @@ from pyVHDLModel import (
 
 @export
 class Formatter:  # (metaclass=ExtendedType):
-    _graph: Graph
+    _graph: Graph  #: The graph to be written as GraphML.
 
-    NODE_COLORS: ClassVar[Dict[Flag, str]]
-    EDGE_COLORS: ClassVar[Dict[Flag, str]]
+    NODE_COLORS: ClassVar[Dict[Flag, str]]  #: Vertex kind to fill color; set by each derived formatter.
+    EDGE_COLORS: ClassVar[Dict[Flag, str]]  #: Edge kind to line color; set by each derived formatter.
 
     def __init__(self, graph: Graph) -> None:
         self._graph = graph

--- a/pyGHDL/dom/formatting/GraphML.py
+++ b/pyGHDL/dom/formatting/GraphML.py
@@ -21,6 +21,13 @@ from pyVHDLModel import (
 
 @export
 class Formatter:  # (metaclass=ExtendedType):
+    """
+    Abstract base-class for writing a pyVHDLModel graph as a `GraphML <http://graphml.graphdrawing.org>`__ file.
+
+    A derived formatter provides the two color translation dictionaries and implements
+    :meth:`WriteGraphML` for the graph it can render.
+    """
+
     _graph: Graph  #: The graph to be written as GraphML.
 
     #: Translation dictionary of *vertex kind* to *fill color*; set by each derived formatter.
@@ -43,6 +50,10 @@ class Formatter:  # (metaclass=ExtendedType):
 
 @export
 class DependencyGraphFormatter(Formatter):
+    """
+    Writes a design's *dependency graph* as GraphML, grouping the vertices by library.
+    """
+
     NODE_COLORS = {
         DependencyGraphVertexKind.Document: "#999999",
         DependencyGraphVertexKind.Library: "#99ccff",
@@ -146,6 +157,10 @@ class DependencyGraphFormatter(Formatter):
 
 @export
 class HierarchyGraphFormatter(Formatter):
+    """
+    Writes a design's *hierarchy graph* as GraphML.
+    """
+
     NODE_COLORS = {
         DependencyGraphVertexKind.Document: "#999999",
         DependencyGraphVertexKind.Library: "#99ccff",
@@ -227,6 +242,10 @@ class HierarchyGraphFormatter(Formatter):
 
 @export
 class CompileOrderGraphFormatter(Formatter):
+    """
+    Writes a design's *compile order graph* as GraphML.
+    """
+
     NODE_COLORS = {
         DependencyGraphVertexKind.Document: "#999999",
         DependencyGraphVertexKind.Library: "#99ccff",

--- a/pyGHDL/dom/formatting/GraphML.py
+++ b/pyGHDL/dom/formatting/GraphML.py
@@ -1,3 +1,7 @@
+"""
+This module offers formatters to write a design's graphs as `GraphML <http://graphml.graphdrawing.org>`__ files.
+"""
+
 from enum import Flag
 from pathlib import Path
 from textwrap import dedent

--- a/pyGHDL/dom/formatting/__init__.py
+++ b/pyGHDL/dom/formatting/__init__.py
@@ -30,3 +30,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+This package offers formatters to render a :mod:`pyGHDL.dom` design in other representations.
+"""

--- a/pyGHDL/dom/formatting/prettyprint.py
+++ b/pyGHDL/dom/formatting/prettyprint.py
@@ -121,7 +121,7 @@ class PrettyPrint:
     Renders a :mod:`pyGHDL.dom` design, document or design unit as an indented plain-text tree.
 
     Each ``Format*`` method returns a list of lines and is given an indentation ``level``, so the
-    methods compose from a whole design down to a single interface item.
+    methods compose from a whole design down to the smallest model item.
     """
 
     # _buffer: StringBuffer

--- a/pyGHDL/dom/formatting/prettyprint.py
+++ b/pyGHDL/dom/formatting/prettyprint.py
@@ -30,6 +30,10 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+This module offers a formatter to render a design, document or design unit as an indented plain-text tree.
+"""
+
 from typing import List, Union
 
 from pyTooling.Common import getFullyQualifiedName
@@ -97,6 +101,9 @@ from pyGHDL.dom.Misc import Alias
 from pyGHDL.dom.PSL import DefaultClock
 
 StringBuffer = List[str]
+"""
+A list of already formatted lines, which the ``Format*`` methods append to and return.
+"""
 
 
 @export

--- a/pyGHDL/dom/formatting/prettyprint.py
+++ b/pyGHDL/dom/formatting/prettyprint.py
@@ -117,6 +117,13 @@ class PrettyPrintException(GHDLBaseException):
 
 @export
 class PrettyPrint:
+    """
+    Renders a :mod:`pyGHDL.dom` design, document or design unit as an indented plain-text tree.
+
+    Each ``Format*`` method returns a list of lines and is given an indentation ``level``, so the
+    methods compose from a whole design down to a single interface item.
+    """
+
     # _buffer: StringBuffer
     #
     # def __init__(self) -> None:

--- a/pyGHDL/dom/formatting/prettyprint.py
+++ b/pyGHDL/dom/formatting/prettyprint.py
@@ -130,6 +130,13 @@ class PrettyPrint:
     #     self._buffer = []
 
     def CleanupDocumentationBlocks(self, documentationContent: str, level: int = 0):
+        """
+        Renders a documentation comment as its first line, indented to the given level.
+
+        :param documentationContent: The documentation comment, or ``None`` if the item has none.
+        :param level:                The indentation level, two spaces each.
+        :returns:                    The indented first line of the comment, or just the indentation.
+        """
         prefix = "  " * level
         if documentationContent is None:
             return prefix
@@ -138,6 +145,13 @@ class PrettyPrint:
         return f"{prefix}{documentationLines[0][2:].lstrip()}"
 
     def formatDesign(self, design: Design, level: int = 0) -> StringBuffer:
+        """
+        Renders a design's libraries and documents.
+
+        :param design: The design to render.
+        :param level:  The indentation level, two spaces each.
+        :returns:      The rendered lines.
+        """
         buffer = []
         prefix = "  " * level
         buffer.append(f"{prefix}Libraries ({len(design.Libraries)}):")
@@ -154,6 +168,13 @@ class PrettyPrint:
         return buffer
 
     def formatLibrary(self, library: Library, level: int = 0) -> StringBuffer:
+        """
+        Renders a library's design units.
+
+        :param library: The library to render.
+        :param level:   The indentation level, two spaces each.
+        :returns:       The rendered lines.
+        """
         buffer = []
         prefix = "  " * level
         buffer.append(f"{prefix}Contexts ({len(library.Contexts)}):")
@@ -177,6 +198,13 @@ class PrettyPrint:
         return buffer
 
     def formatDocument(self, document: Document, level: int = 0) -> StringBuffer:
+        """
+        Renders a document's design units.
+
+        :param document: The document to render.
+        :param level:    The indentation level, two spaces each.
+        :returns:        The rendered lines.
+        """
         buffer = []
         prefix = "  " * level
         buffer.append(f"{prefix}Contexts ({len(document.Contexts)}):")
@@ -213,6 +241,13 @@ class PrettyPrint:
         return buffer
 
     def formatEntity(self, entity: Entity, level: int = 0) -> StringBuffer:
+        """
+        Renders an entity's generics, ports, declarations and statements.
+
+        :param entity: The entity to render.
+        :param level:  The indentation level, two spaces each.
+        :returns:      The rendered lines.
+        """
         buffer = []
         prefix = "  " * level
         documentationFirstLine = self.CleanupDocumentationBlocks(entity.Documentation)
@@ -244,6 +279,13 @@ class PrettyPrint:
         return buffer
 
     def formatArchitecture(self, architecture: Architecture, level: int = 0) -> StringBuffer:
+        """
+        Renders an architecture's declarations and statements.
+
+        :param architecture: The architecture to render.
+        :param level:        The indentation level, two spaces each.
+        :returns:            The rendered lines.
+        """
         buffer = []
         prefix = "  " * level
         documentationFirstLine = self.CleanupDocumentationBlocks(architecture.Documentation)
@@ -271,6 +313,13 @@ class PrettyPrint:
         return buffer
 
     def formatComponent(self, component: Component, level: int = 0) -> StringBuffer:
+        """
+        Renders a component's generics and ports.
+
+        :param component: The component to render.
+        :param level:     The indentation level, two spaces each.
+        :returns:         The rendered lines.
+        """
         buffer = []
         prefix = "  " * level
         documentationFirstLine = self.CleanupDocumentationBlocks(component.Documentation)
@@ -287,6 +336,13 @@ class PrettyPrint:
         return buffer
 
     def formatPackage(self, package: Package, level: int = 0) -> StringBuffer:
+        """
+        Renders a package's generics and declarations.
+
+        :param package: The package to render.
+        :param level:   The indentation level, two spaces each.
+        :returns:       The rendered lines.
+        """
         buffer = []
         prefix = "  " * level
         documentationFirstLine = self.CleanupDocumentationBlocks(package.Documentation)
@@ -304,6 +360,13 @@ class PrettyPrint:
         return buffer
 
     def formatPackageInstance(self, package: PackageInstantiation, level: int = 0) -> StringBuffer:
+        """
+        Renders a package instantiation's generic map.
+
+        :param package: The package instantiation to render.
+        :param level:   The indentation level, two spaces each.
+        :returns:       The rendered lines.
+        """
         buffer = []
         prefix = "  " * level
         documentationFirstLine = self.CleanupDocumentationBlocks(package.Documentation)
@@ -317,6 +380,13 @@ class PrettyPrint:
         return buffer
 
     def formatPackageBody(self, packageBody: PackageBody, level: int = 0) -> StringBuffer:
+        """
+        Renders a package body's declarations.
+
+        :param packageBody: The package body to render.
+        :param level:       The indentation level, two spaces each.
+        :returns:           The rendered lines.
+        """
         buffer = []
         prefix = "  " * level
         documentationFirstLine = self.CleanupDocumentationBlocks(packageBody.Documentation)
@@ -329,6 +399,13 @@ class PrettyPrint:
         return buffer
 
     def formatConfiguration(self, configuration: Configuration, level: int = 0) -> StringBuffer:
+        """
+        Renders a configuration.
+
+        :param configuration: The configuration to render.
+        :param level:         The indentation level, two spaces each.
+        :returns:             The rendered lines.
+        """
         buffer = []
         prefix = "  " * level
         buffer.append(f"{prefix}- Name: {configuration.Identifier}")
@@ -336,6 +413,13 @@ class PrettyPrint:
         return buffer
 
     def formatContext(self, context: Context, level: int = 0) -> StringBuffer:
+        """
+        Renders a context's clauses.
+
+        :param context: The context to render.
+        :param level:   The indentation level, two spaces each.
+        :returns:       The rendered lines.
+        """
         buffer = []
         prefix = "  " * level
         buffer.append(f"{prefix}- Name: {context.Identifier}")
@@ -345,6 +429,13 @@ class PrettyPrint:
     def formatGeneric(
         self, generic: Union[NamedEntityMixin, GenericInterfaceItemMixin], level: int = 0
     ) -> StringBuffer:
+        """
+        Renders a generic, dispatching on its kind.
+
+        :param generic: The generic interface item to render.
+        :param level:   The indentation level, two spaces each.
+        :returns:       The rendered lines.
+        """
         if isinstance(generic, GenericConstantInterfaceItem):
             return self.formatGenericConstant(generic, level)
         elif isinstance(generic, GenericTypeInterfaceItem):
@@ -355,6 +446,13 @@ class PrettyPrint:
             )
 
     def formatPort(self, port: Union[NamedEntityMixin, PortInterfaceItemMixin], level: int = 0) -> StringBuffer:
+        """
+        Renders a port, dispatching on its kind.
+
+        :param port:  The port interface item to render.
+        :param level: The indentation level, two spaces each.
+        :returns:     The rendered lines.
+        """
         if isinstance(port, PortSimpleSignalInterfaceItem):
             return self.formatPortSignal(port, level)
         elif isinstance(port, PortViewSignalInterfaceItem):
@@ -365,6 +463,13 @@ class PrettyPrint:
             )
 
     def formatGenericConstant(self, generic: GenericConstantInterfaceItem, level: int = 0) -> StringBuffer:
+        """
+        Renders a generic constant.
+
+        :param generic: The generic constant to render.
+        :param level:   The indentation level, two spaces each.
+        :returns:       The rendered lines.
+        """
         buffer = []
         prefix = "  " * level
 
@@ -376,6 +481,13 @@ class PrettyPrint:
         return buffer
 
     def formatGenericType(self, generic: GenericConstantInterfaceItem, level: int = 0) -> StringBuffer:
+        """
+        Renders a generic type.
+
+        :param generic: The generic type to render.
+        :param level:   The indentation level, two spaces each.
+        :returns:       The rendered lines.
+        """
         buffer = []
         prefix = "  " * level
 
@@ -384,6 +496,13 @@ class PrettyPrint:
         return buffer
 
     def formatPortSignal(self, port: PortSimpleSignalInterfaceItem, level: int = 0) -> StringBuffer:
+        """
+        Renders a port signal.
+
+        :param port:  The port signal to render.
+        :param level: The indentation level, two spaces each.
+        :returns:     The rendered lines.
+        """
         buffer = []
         prefix = "  " * level
 
@@ -395,6 +514,13 @@ class PrettyPrint:
         return buffer
 
     def formatPortView(self, port: PortViewSignalInterfaceItem, level: int = 0) -> StringBuffer:
+        """
+        Renders a port declared with a mode view.
+
+        :param port:  The port mode view to render.
+        :param level: The indentation level, two spaces each.
+        :returns:     The rendered lines.
+        """
         buffer = []
         prefix = "  " * level
 
@@ -404,6 +530,13 @@ class PrettyPrint:
         return buffer
 
     def formatDeclaredItems(self, item, level: int = 0) -> StringBuffer:
+        """
+        Renders the declared items of a declarative region.
+
+        :param item:  The declarative region to render.
+        :param level: The indentation level, two spaces each.
+        :returns:     The rendered lines.
+        """
         buffer = []
         prefix = "  " * level
 
@@ -456,6 +589,12 @@ class PrettyPrint:
         return buffer
 
     def formatModeViewElement(self, element: ModeViewElement) -> str:
+        """
+        Renders a mode view element.
+
+        :param element: The mode view element to render.
+        :returns:       The rendered line.
+        """
         identifiers = ", ".join(element.Identifiers)
 
         if isinstance(element, SimpleModeViewElement):
@@ -466,6 +605,12 @@ class PrettyPrint:
         raise PrettyPrintException(f"Unhandled mode view element kind '{getFullyQualifiedName(element)}'.")
 
     def formatType(self, item: BaseType) -> str:
+        """
+        Renders an object's subtype indication.
+
+        :param item: The object to render.
+        :returns:    The rendered line.
+        """
         result = f"type {item.Identifier} is "
         if isinstance(item, IncompleteType):
             result += ""
@@ -493,6 +638,15 @@ class PrettyPrint:
         return result
 
     def formatSubtypeIndication(self, subtypeIndication, entity: str, name: str) -> str:
+        """
+        Renders a subtype indication.
+
+        :param subtypeIndication:     The subtype indication to render.
+        :param entity:                The kind of item the subtype indication belongs to. Used in exception messages.
+        :param name:                  The name of that item. Used in exception messages.
+        :returns:                     The rendered subtype indication.
+        :raises PrettyPrintException: If the subtype indication's kind is not handled.
+        """
         if isinstance(subtypeIndication, SimpleSubtypeSymbol):
             return f"{subtypeIndication.Name.Identifier}"
         elif isinstance(subtypeIndication, ConstrainedArraySubtypeSymbol):
@@ -508,9 +662,22 @@ class PrettyPrint:
             )
 
     def formatInitialValue(self, item: WithDefaultExpressionMixin) -> str:
+        """
+        Renders an object's default value, if it has one.
+
+        :param item: The object to render.
+        :returns:    The rendered line.
+        """
         return f" := {item.DefaultExpression}" if item.DefaultExpression is not None else ""
 
     def formatHierarchy(self, statement: ConcurrentStatement, level: int = 0) -> StringBuffer:
+        """
+        Renders a statement and the statements nested in it.
+
+        :param statement: The statement to render.
+        :param level:     The indentation level, two spaces each.
+        :returns:         The rendered lines.
+        """
         buffer = []
         prefix = "  " * level
 

--- a/pyGHDL/lib/__init__.py
+++ b/pyGHDL/lib/__init__.py
@@ -39,23 +39,23 @@ next to itself instead of somewhere on the system.
 
 **Contents of an installed package:**
 
-+-------------------------------+--------------------------------------------------------------------+
-| File or directory             | Purpose                                                            |
-+===============================+====================================================================+
-| :file:`libghdl-*.so`,         | GHDL's analyzer and simulator as a shared library, loaded by        |
-| :file:`libghdl-*.dll`,        | :mod:`pyGHDL.libghdl` through :mod:`ctypes <python:ctypes>`. The    |
-| :file:`libghdl-*.dylib`       | filename carries GHDL's version, e.g.                              |
-|                               | :file:`libghdl-7_0_0_dev.so`.                                      |
-+-------------------------------+--------------------------------------------------------------------+
-| :file:`libgnat-*.so`          | The GNAT runtime ``libghdl`` was linked against, shipped when it is |
-|                               | not expected to be present on the target system.                   |
-+-------------------------------+--------------------------------------------------------------------+
-| :file:`libghdlvpi.*`          | The VPI support library, used by simulations loading VPI modules.  |
-+-------------------------------+--------------------------------------------------------------------+
-| :file:`ghdl/`                 | The pre-analyzed VHDL libraries - ``std`` and ``ieee`` for each     |
-|                               | supported language revision (:file:`v87`, :file:`v93`, :file:`v08`, |
-|                               | :file:`v19`) - plus their sources in :file:`ghdl/src`.             |
-+-------------------------------+--------------------------------------------------------------------+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - File or directory
+     - Purpose
+   * - :file:`libghdl-*.so`, :file:`libghdl-*.dll`, :file:`libghdl-*.dylib`
+     - GHDL's analyzer and simulator as a shared library, loaded by :mod:`pyGHDL.libghdl` through
+       :mod:`ctypes <python:ctypes>`. The filename carries GHDL's version, e.g. :file:`libghdl-7_0_0_dev.so`.
+   * - :file:`libgnat-*.so`
+     - The GNAT runtime ``libghdl`` was linked against, shipped when it is not expected to be present on the
+       target system.
+   * - :file:`libghdlvpi.*`
+     - The VPI support library, used by simulations loading VPI modules.
+   * - :file:`ghdl/`
+     - The pre-analyzed VHDL libraries - ``std`` and ``ieee`` for each supported language revision
+       (:file:`v87`, :file:`v93`, :file:`v08`, :file:`v19`) - plus their sources in :file:`ghdl/src`.
 
 .. note::
 

--- a/pyGHDL/libghdl/__init__.py
+++ b/pyGHDL/libghdl/__init__.py
@@ -268,7 +268,7 @@ def initialize() -> None:
 # @BindToLibGHDL("libghdl__set_option")
 def set_option(opt: str) -> bool:
     """\
-    Set option :obj:`opt`.
+    Set option ``opt``.
 
     :param opt: Option to set.
     :returns:   Return ``True``, if the option is known and handled.
@@ -304,7 +304,7 @@ def analyze_init_status() -> int:
 # @BindToLibGHDL("libghdl__analyze_file")
 def analyze_file(fname: str) -> Iir:
     """\
-    Analyze a given filename :obj:`fname`.
+    Analyze a given filename ``fname``.
 
     :param fname: File name
     :returns:     Internal Intermediate Representation (IIR)

--- a/pyGHDL/libghdl/__init__.py
+++ b/pyGHDL/libghdl/__init__.py
@@ -71,11 +71,22 @@ class LibGHDLException(GHDLBaseException):
     _internalErrors: Nullable[List[str]]
 
     def __init__(self, message: str, errors: List[str] = None):
+        """
+        Initializes an exception raised by the ``libghdl`` binding.
+
+        :param message: The message describing what failed on the Python side.
+        :param errors:  Messages collected from *libghdl*'s error buffer, or ``None`` if there are none.
+        """
         super().__init__(message)
         self._internalErrors = errors
 
     @readonly
     def InternalErrors(self) -> Nullable[List[str]]:
+        """
+        Read-only property to access the errors reported by *libghdl* (:attr:`_internalErrors`).
+
+        :returns: The messages from *libghdl*'s error buffer, or ``None`` if none were collected.
+        """
         return self._internalErrors
 
 
@@ -104,12 +115,21 @@ def _get_libghdl_path() -> Path:
     4. Try within ``pyGHDL/lib`` Python package installation path.
     5. Try searching the ``ghdl`` binary via ``which``.
     6. Try ``../../lib`` when running from the build directory.
+
+    :returns: The path of the ``libghdl`` shared library.
     """
 
     libGHDLSharedLibraryFile = _get_libghdl_name()
     searchedAt = []
 
     def _check_libghdl_libdir(libDirectory: Path) -> Path:
+        """
+        Check whether the shared library is below ``<libdir>`` and return its path.
+
+        :param libDirectory:      The library directory to look in.
+        :returns:                 The path of the shared library.
+        :raises FileNotFoundError: If the shared library is not in that directory.
+        """
         libFile = libDirectory / libGHDLSharedLibraryFile
         if not libFile.exists():
             raise FileNotFoundError(f"{libFile}")
@@ -117,6 +137,13 @@ def _get_libghdl_path() -> Path:
         return libFile
 
     def _check_libghdl_bindir(binDirectory: Path) -> Path:
+        """
+        Check whether the shared library is below ``<bindir>/../lib`` and return its path.
+
+        :param binDirectory:      The binary directory to look next to.
+        :returns:                 The path of the shared library.
+        :raises FileNotFoundError: If the shared library is not below that directory.
+        """
         libDirectory = (binDirectory / "../lib").resolve()
         return _check_libghdl_libdir(libDirectory)
 
@@ -195,6 +222,13 @@ def _get_libghdl_path() -> Path:
 @export
 def _initialize():
     # Load the shared library
+    """
+    Locate and load the ``libghdl`` shared library.
+
+    :returns:                            The loaded shared library.
+    :raises LibGHDLException: If the shared library cannot be found.
+
+    """
     _libghdl_path = _get_libghdl_path()
 
     # Load libghdl shared object

--- a/pyGHDL/libghdl/__init__.py
+++ b/pyGHDL/libghdl/__init__.py
@@ -126,8 +126,8 @@ def _get_libghdl_path() -> Path:
         """
         Check whether the shared library is below ``<libdir>`` and return its path.
 
-        :param libDirectory:      The library directory to look in.
-        :returns:                 The path of the shared library.
+        :param libDirectory:       The library directory to look in.
+        :returns:                  The path of the shared library.
         :raises FileNotFoundError: If the shared library is not in that directory.
         """
         libFile = libDirectory / libGHDLSharedLibraryFile
@@ -140,8 +140,8 @@ def _get_libghdl_path() -> Path:
         """
         Check whether the shared library is below ``<bindir>/../lib`` and return its path.
 
-        :param binDirectory:      The binary directory to look next to.
-        :returns:                 The path of the shared library.
+        :param binDirectory:       The binary directory to look next to.
+        :returns:                  The path of the shared library.
         :raises FileNotFoundError: If the shared library is not below that directory.
         """
         libDirectory = (binDirectory / "../lib").resolve()
@@ -225,9 +225,8 @@ def _initialize():
     """
     Locate and load the ``libghdl`` shared library.
 
-    :returns:                            The loaded shared library.
+    :returns:                 The loaded shared library.
     :raises LibGHDLException: If the shared library cannot be found.
-
     """
     _libghdl_path = _get_libghdl_path()
 
@@ -272,7 +271,7 @@ def set_option(opt: str) -> bool:
     Set option :obj:`opt`.
 
     :param opt: Option to set.
-    :return:    Return ``True``, if the option is known and handled.
+    :returns:   Return ``True``, if the option is known and handled.
     """
     opt = opt.encode(ENCODING)
     return libghdl.libghdl__set_option(c_char_p(opt), len(opt)) == 0
@@ -296,7 +295,7 @@ def analyze_init_status() -> int:
     """\
     Initialize the analyzer.
 
-    :return: Returns 0 in case of success.
+    :returns: Returns 0 in case of success.
     """
     return libghdl.libghdl__analyze_init_status()
 
@@ -308,7 +307,7 @@ def analyze_file(fname: str) -> Iir:
     Analyze a given filename :obj:`fname`.
 
     :param fname: File name
-    :return:      Internal Intermediate Representation (IIR)
+    :returns:     Internal Intermediate Representation (IIR)
     """
     fname = fname.encode(ENCODING)
     return libghdl.libghdl__analyze_file(c_char_p(fname), len(fname))

--- a/pyGHDL/libghdl/_decorator.py
+++ b/pyGHDL/libghdl/_decorator.py
@@ -66,7 +66,7 @@ def EnumLookupTable(cls) -> Callable:
     Decorator to precalculate an enum lookup table (LUT) for enum position to
     enum literal name.
 
-    :returns:   Decorator function replacing the placeholder with a table lookup.
+    :returns: Decorator function replacing the placeholder with a table lookup.
     """
 
     def decorator(func) -> Callable:
@@ -82,7 +82,6 @@ def EnumLookupTable(cls) -> Callable:
             Build the lookup table from an enum position to the literal's name.
 
             :returns: The list of literal names, indexed by enum position.
-
             """
             d = [e for e in dir(cls) if e[0].isupper() and e[0] != "_"]
             res = [None] * len(d)
@@ -119,10 +118,9 @@ def BindToLibGHDL(subprogramName):
         """
         Translate a Python type hint to the matching :mod:`ctypes` type.
 
-        :param typ:                   The type hint to translate.
-        :returns:                       The matching ctypes type, or ``None`` for a procedure's return type.
-        :raises TypeError:     If the type hint has no ctypes equivalent.
-
+        :param typ:        The type hint to translate.
+        :returns:          The matching ctypes type, or ``None`` for a procedure's return type.
+        :raises TypeError: If the type hint has no ctypes equivalent.
         """
         if typ is None:
             return None
@@ -165,8 +163,8 @@ def BindToLibGHDL(subprogramName):
         The :mod:`ctypes` signature is derived from the function's type hints, so the placeholder needs
         a full annotation and no body.
 
-        :param func:       The placeholder function being decorated.
-        :returns:          A function calling ``subprogramName`` in *libghdl*.
+        :param func:        The placeholder function being decorated.
+        :returns:           A function calling ``subprogramName`` in *libghdl*.
         :raises ValueError: If the function is not annotated, or the annotations do not match its parameters.
         """
         typeHints: Dict[str, Any] = func.__annotations__

--- a/pyGHDL/libghdl/_decorator.py
+++ b/pyGHDL/libghdl/_decorator.py
@@ -118,6 +118,31 @@ def BindToLibGHDL(subprogramName):
         """
         Translate a Python type hint to the matching :mod:`ctypes` type.
 
+        .. list-table::
+           :header-rows: 1
+           :widths: 40 60
+
+           * - Type hint
+             - ctypes type
+           * - ``None``
+             - ``None`` - a procedure's return type
+           * - :class:`int`
+             - ``c_int32``
+           * - :class:`float`
+             - ``c_double``
+           * - :class:`bool`
+             - ``c_bool``
+           * - :class:`bytes`
+             - ``c_char_p`` - passed through, *not* encoded
+           * - ``c_char``, ``c_char_p``, ``c_uint32``, ``c_void_p``
+             - itself
+           * - a :class:`~typing.TypeVar` from :mod:`~pyGHDL.libghdl._types`
+             - its ``__bound__``, or ``c_int32`` / ``c_double`` when bound to :class:`int` / :class:`float`
+           * - an :class:`~enum.IntEnum`
+             - ``c_int32``
+           * - a :class:`~ctypes.Structure`
+             - itself
+
         :param typ:        The type hint to translate.
         :returns:          The matching ctypes type, or ``None`` for a procedure's return type.
         :raises TypeError: If the type hint has no ctypes equivalent.

--- a/pyGHDL/libghdl/_decorator.py
+++ b/pyGHDL/libghdl/_decorator.py
@@ -31,6 +31,14 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
+"""
+Decorators binding a Python function to a subprogram in the shared library ``libghdl``.
+
+:func:`BindToLibGHDL` reads a function's type hints, derives the matching :mod:`ctypes` signature and replaces the
+function body with a call into the shared library. :func:`EnumLookupTable` precalculates an enum position to name
+table.
+"""
+
 from ctypes import (
     c_int32,
     c_uint32,
@@ -58,11 +66,24 @@ def EnumLookupTable(cls) -> Callable:
     Decorator to precalculate an enum lookup table (LUT) for enum position to
     enum literal name.
 
-    :param cls: Enumerator class for which a LUT shall be pre-calculated.
+    :returns:   Decorator function replacing the placeholder with a table lookup.
     """
 
     def decorator(func) -> Callable:
+        """
+        Replace the decorated placeholder with a lookup in the precalculated table.
+
+        :param func: The placeholder function being decorated.
+        :returns:    A function mapping an enum position to the literal's name.
+        """
+
         def gen() -> List[str]:
+            """
+            Build the lookup table from an enum position to the literal's name.
+
+            :returns: The list of literal names, indexed by enum position.
+
+            """
             d = [e for e in dir(cls) if e[0].isupper() and e[0] != "_"]
             res = [None] * len(d)
             for e in d:
@@ -73,7 +94,12 @@ def EnumLookupTable(cls) -> Callable:
 
         @wraps(func)
         def wrapper(id: int) -> str:
-            # function that replaces the placeholder function
+            """
+            Return the name of the enum literal at the given position.
+
+            :param id: The position of the enum literal.
+            :returns:  The literal's name.
+            """
             return __lut[id]
 
         return wrapper
@@ -90,6 +116,14 @@ def BindToLibGHDL(subprogramName):
     """
 
     def PythonTypeToCtype(typ):
+        """
+        Translate a Python type hint to the matching :mod:`ctypes` type.
+
+        :param typ:                   The type hint to translate.
+        :returns:                       The matching ctypes type, or ``None`` for a procedure's return type.
+        :raises TypeError:     If the type hint has no ctypes equivalent.
+
+        """
         if typ is None:
             return None
         elif typ is int:
@@ -125,6 +159,16 @@ def BindToLibGHDL(subprogramName):
         raise TypeError
 
     def wrapper(func: Callable):
+        """
+        Replace the decorated placeholder with a call into the shared library.
+
+        The :mod:`ctypes` signature is derived from the function's type hints, so the placeholder needs
+        a full annotation and no body.
+
+        :param func:       The placeholder function being decorated.
+        :returns:          A function calling ``subprogramName`` in *libghdl*.
+        :raises ValueError: If the function is not annotated, or the annotations do not match its parameters.
+        """
         typeHints: Dict[str, Any] = func.__annotations__
         typeHintCount = len(typeHints)
 
@@ -166,6 +210,13 @@ def BindToLibGHDL(subprogramName):
 
             @wraps(func)
             def inner(*args):
+                """
+                Call ``subprogramName`` in *libghdl* and translate a failure into an exception.
+
+                :param args:              The arguments to pass to the subprogram.
+                :returns:                 The subprogram's result.
+                :raises LibGHDLException: If the call into the shared library fails.
+                """
                 try:
                     returnValue = functionPointer(*args)
                 except OSError as ex:
@@ -182,6 +233,13 @@ def BindToLibGHDL(subprogramName):
 
             @wraps(func)
             def inner(*args):
+                """
+                Call ``subprogramName`` in *libghdl* and translate a failure into an exception.
+
+                :param args:              The arguments to pass to the subprogram.
+                :returns:                 The subprogram's result.
+                :raises LibGHDLException: If the call into the shared library fails.
+                """
                 try:
                     return functionPointer(*args)
                 except OSError as ex:

--- a/pyGHDL/libghdl/_types.py
+++ b/pyGHDL/libghdl/_types.py
@@ -30,6 +30,13 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Type aliases for the scalar handles the ``libghdl`` API passes around.
+
+A node, a name or a source file is an index into a table on the Ada side, not a pointer, so every one of these is a
+32-bit integer at run-time. The distinct names say which table an index belongs to.
+"""
+
 from enum import IntEnum, unique
 from ctypes import c_int32, c_uint32, c_int64, c_double, c_bool
 from typing import TypeVar
@@ -49,6 +56,8 @@ __all__ = [
 @export
 @unique
 class TriStateType(IntEnum):
+    """An Ada tri-state: unknown, false or true."""
+
     Unknown = 0
     TFalse = 1
     TTrue = 2
@@ -57,6 +66,8 @@ class TriStateType(IntEnum):
 @export
 @unique
 class DirectionType(IntEnum):
+    """The direction of a range: ``to`` or ``downto``."""
+
     To = 0
     Downto = 1
 

--- a/pyGHDL/libghdl/errorout_console.py
+++ b/pyGHDL/libghdl/errorout_console.py
@@ -31,6 +31,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Errorout.Console`` in *libghdl*.
+
+Reports analysis messages on the console.
+"""
 
 from pyTooling.Decorators import export
 

--- a/pyGHDL/libghdl/errorout_memory.py
+++ b/pyGHDL/libghdl/errorout_memory.py
@@ -31,6 +31,12 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Errorout.Memory`` in *libghdl*.
+
+Collects analysis messages in memory instead of printing them, so a caller can read them back with
+:func:`Get_Nbr_Messages` and :func:`Get_Error_Record`. :class:`~pyGHDL.dom.NonStandard.Design` installs this handler.
+"""
 
 from ctypes import c_int8, c_int32, c_char_p, Structure
 
@@ -112,6 +118,15 @@ def Get_Error_Record(Idx: ErrorIndex) -> Error_Message:
 # @export
 @BindToLibGHDL("errorout__memory__get_error_message_addr")
 def _Get_Error_Message(Idx: ErrorIndex) -> c_char_p:
+    """
+    Raw binding returning the message text as a C string.
+
+    Use :func:`Get_Error_Message` instead, which decodes it.
+
+    :param Idx: The index of the message to read.
+    :returns:     The message as a C string.
+
+    """
     return ""  # pragma: no cover
 
 

--- a/pyGHDL/libghdl/errorout_memory.py
+++ b/pyGHDL/libghdl/errorout_memory.py
@@ -111,7 +111,7 @@ def Get_Error_Record(Idx: ErrorIndex) -> Error_Message:
     Get error messages by index :obj:`Idy` as structure :class:`Error_Message`.
 
     :param Idx: Index from 1 to ``Nbr_Messages`` See :func:`Get_Nbr_Messages`.
-    :returns:
+    :returns:   The message record at that index.
     """
 
 

--- a/pyGHDL/libghdl/errorout_memory.py
+++ b/pyGHDL/libghdl/errorout_memory.py
@@ -108,7 +108,7 @@ def Get_Nbr_Messages() -> ErrorIndex:
 @BindToLibGHDL("errorout__memory__get_error_record")
 def Get_Error_Record(Idx: ErrorIndex) -> Error_Message:
     """
-    Get error messages by index ``Idy`` as structure :class:`Error_Message`.
+    Get error messages by index ``Idx`` as structure :class:`Error_Message`.
 
     :param Idx: Index from 1 to ``Nbr_Messages`` See :func:`Get_Nbr_Messages`.
     :returns:   The message record at that index.

--- a/pyGHDL/libghdl/errorout_memory.py
+++ b/pyGHDL/libghdl/errorout_memory.py
@@ -108,7 +108,7 @@ def Get_Nbr_Messages() -> ErrorIndex:
 @BindToLibGHDL("errorout__memory__get_error_record")
 def Get_Error_Record(Idx: ErrorIndex) -> Error_Message:
     """
-    Get error messages by index :obj:`Idy` as structure :class:`Error_Message`.
+    Get error messages by index ``Idy`` as structure :class:`Error_Message`.
 
     :param Idx: Index from 1 to ``Nbr_Messages`` See :func:`Get_Nbr_Messages`.
     :returns:   The message record at that index.
@@ -132,7 +132,7 @@ def _Get_Error_Message(Idx: ErrorIndex) -> c_char_p:
 @export
 def Get_Error_Message(Idx: ErrorIndex) -> str:
     """
-    Get error messages by index :obj:`Idx` as string.
+    Get error messages by index ``Idx`` as string.
 
     :param Idx: Index from 1 to ``Nbr_Messages`` See :func:`Get_Nbr_Messages`.
     :returns:   Error message.

--- a/pyGHDL/libghdl/errorout_memory.py
+++ b/pyGHDL/libghdl/errorout_memory.py
@@ -99,7 +99,7 @@ def Get_Nbr_Messages() -> ErrorIndex:
     """
     Get number of error messages available.
 
-    :return: Number of messages available.
+    :returns: Number of messages available.
     """
     return 0  # pragma: no cover
 
@@ -111,7 +111,7 @@ def Get_Error_Record(Idx: ErrorIndex) -> Error_Message:
     Get error messages by index :obj:`Idy` as structure :class:`Error_Message`.
 
     :param Idx: Index from 1 to ``Nbr_Messages`` See :func:`Get_Nbr_Messages`.
-    :return:    Type: ``Error_Message``
+    :returns:
     """
 
 
@@ -124,8 +124,7 @@ def _Get_Error_Message(Idx: ErrorIndex) -> c_char_p:
     Use :func:`Get_Error_Message` instead, which decodes it.
 
     :param Idx: The index of the message to read.
-    :returns:     The message as a C string.
-
+    :returns:   The message as a C string.
     """
     return ""  # pragma: no cover
 
@@ -136,7 +135,7 @@ def Get_Error_Message(Idx: ErrorIndex) -> str:
     Get error messages by index :obj:`Idx` as string.
 
     :param Idx: Index from 1 to ``Nbr_Messages`` See :func:`Get_Nbr_Messages`.
-    :return:    Error message.
+    :returns:   Error message.
     """
     return _Get_Error_Message(Idx).decode(ENCODING)
 

--- a/pyGHDL/libghdl/file_comments.py
+++ b/pyGHDL/libghdl/file_comments.py
@@ -32,6 +32,12 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
+"""
+Python binding for the Ada package ``File_Comments`` in *libghdl*.
+
+Gives access to the comments *libghdl* gathered while parsing, which is how doc-comments reach the DOM. Comments are
+only recorded if :data:`~pyGHDL.libghdl.flags.Flag_Gather_Comments` was set before parsing.
+"""
 
 from ctypes import c_uint32
 from typing import TypeVar

--- a/pyGHDL/libghdl/file_comments.py
+++ b/pyGHDL/libghdl/file_comments.py
@@ -108,5 +108,5 @@ def Get_Next_Comment(File: SourceFileEntry, Idx: Comment_Index) -> Comment_Index
     """
     Get the next comment
 
-    :returns: The index of the next comment, or ``No_Comment_Index``.
+    :returns: The index of the next comment, or :attr:`~pyGHDL.libghdl.file_comments.No_Comment_Index`.
     """

--- a/pyGHDL/libghdl/file_comments.py
+++ b/pyGHDL/libghdl/file_comments.py
@@ -65,7 +65,7 @@ def Find_First_Comment(File: SourceFileEntry, N: c_uint32) -> Comment_Index:
     Get the first comment associated to a node.
     :param File: Source file for node
     :param N:    The node to find the first comment of.
-    :returns:    The first comment index, or No_Comment_Index if none.
+    :returns:    The first comment index, or ``No_Comment_Index`` if none.
     """
     return 0  # pragma: no cover
 

--- a/pyGHDL/libghdl/file_comments.py
+++ b/pyGHDL/libghdl/file_comments.py
@@ -63,9 +63,9 @@ No_Comment_Index = 0
 def Find_First_Comment(File: SourceFileEntry, N: c_uint32) -> Comment_Index:
     """
     Get the first comment associated to a node.
-    :param N:    Node
     :param File: Source file for node
-    :return:     The first comment index, or No_Comment_Index if none.
+    :param N:    Node
+    :returns:    The first comment index, or No_Comment_Index if none.
     """
     return 0  # pragma: no cover
 
@@ -75,6 +75,8 @@ def Find_First_Comment(File: SourceFileEntry, N: c_uint32) -> Comment_Index:
 def Get_Comment_Start(File: SourceFileEntry, Idx: Comment_Index) -> SourcePtr:
     """
     Get the start of comment
+
+    :returns: The position of the comment's first character.
     """
 
 
@@ -83,12 +85,16 @@ def Get_Comment_Start(File: SourceFileEntry, Idx: Comment_Index) -> SourcePtr:
 def Get_Comment_Last(File: SourceFileEntry, Idx: Comment_Index) -> SourcePtr:
     """
     Get the end of comment
+
+    :returns: The position of the comment's last character.
     """
 
 
 def Get_Comment(File: SourceFileEntry, Idx: Comment_Index) -> str:
     """
     Get a comment
+
+    :returns: The comment's text.
     """
     buf = files_map.Get_File_Buffer(File)
     s = Get_Comment_Start(File, Idx)
@@ -101,4 +107,6 @@ def Get_Comment(File: SourceFileEntry, Idx: Comment_Index) -> str:
 def Get_Next_Comment(File: SourceFileEntry, Idx: Comment_Index) -> Comment_Index:
     """
     Get the next comment
+
+    :returns: The index of the next comment, or ``No_Comment_Index``.
     """

--- a/pyGHDL/libghdl/file_comments.py
+++ b/pyGHDL/libghdl/file_comments.py
@@ -64,7 +64,7 @@ def Find_First_Comment(File: SourceFileEntry, N: c_uint32) -> Comment_Index:
     """
     Get the first comment associated to a node.
     :param File: Source file for node
-    :param N:    Node
+    :param N:    The node to find the first comment of.
     :returns:    The first comment index, or No_Comment_Index if none.
     """
     return 0  # pragma: no cover

--- a/pyGHDL/libghdl/files_map.py
+++ b/pyGHDL/libghdl/files_map.py
@@ -31,6 +31,12 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Files_Map`` in *libghdl*.
+
+Maps between a *location* - the compact position *libghdl* stores in a node - and a source file with a line and a
+column, and holds the source buffers themselves.
+"""
 
 from ctypes import POINTER, c_char, c_void_p, cast
 
@@ -183,6 +189,14 @@ def Get_Directory_Name(File: SourceFileEntry) -> NameId:
 @export
 @BindToLibGHDL("files_map__get_file_buffer")
 def Get_File_Buffer_voidp(File: SourceFileEntry) -> c_void_p:
+    """
+    Raw binding returning the source buffer as an untyped pointer.
+
+    Use :func:`Get_File_Buffer` instead, which types it as a character pointer.
+
+    :param File: The source file entry to read the buffer of.
+    :returns:        The address of the source buffer.
+    """
     return 0  # pragma: no cover
 
 

--- a/pyGHDL/libghdl/files_map.py
+++ b/pyGHDL/libghdl/files_map.py
@@ -64,9 +64,9 @@ def Location_To_File(Location: LocationType) -> SourceFileEntry:
     """
     Convert ``Location`` to a source file.
 
-    :param Location: Location
+    :param Location: The location to resolve.
     :returns:        The source file, or :attr:`~pyGHDL.libghdl.files_map.No_Source_File_Entry` if the location is
-                 incorrect.
+                     incorrect.
     """
     return 0  # pragma: no cover
 
@@ -77,7 +77,7 @@ def Location_File_To_Pos(Location: LocationType, File: SourceFileEntry) -> int:
     """
     Convert ``Location`` and ``File`` to a position (offset) into the source file.
 
-    :param Location: Location
+    :param Location: The location to resolve.
     :param File:     Source file
     :returns:        Offset
     """
@@ -90,7 +90,7 @@ def Location_File_To_Line(Location: LocationType, File: SourceFileEntry) -> int:
     """
     Convert ``Location`` and ``File`` to a line number.
 
-    :param Location: Location
+    :param Location: The location to resolve.
     :param File:     Source file
     :returns:        Line number
     """
@@ -103,7 +103,7 @@ def Location_File_Line_To_Offset(Location: LocationType, File: SourceFileEntry, 
     """
     Get the offset in ``Line`` of ``Location``.
 
-    :param Location: Location
+    :param Location: The location to resolve.
     :param File:     Source file
     :param Line:     Line number
     :returns:        Offset
@@ -118,7 +118,7 @@ def Location_File_Line_To_Col(Location: LocationType, File: SourceFileEntry, Lin
     Get logical column (with HT expanded) from ``Location``, ``File`` and
     ``Line``.
 
-    :param Location: Location
+    :param Location: The location to resolve.
     :param File:     Source file
     :param Line:     Line number
     :returns:        logical column (horizontal tabs are expanded)

--- a/pyGHDL/libghdl/files_map.py
+++ b/pyGHDL/libghdl/files_map.py
@@ -65,7 +65,8 @@ def Location_To_File(Location: LocationType) -> SourceFileEntry:
     Convert :obj:`Location` to a source file.
 
     :param Location: Location
-    :returns:        Source file. Return ``No_Source_File_Entry`` if location is incorrect.
+    :returns:        The source file, or :attr:`~pyGHDL.libghdl.files_map.No_Source_File_Entry` if the location is
+                 incorrect.
     """
     return 0  # pragma: no cover
 
@@ -130,7 +131,7 @@ def Location_File_Line_To_Col(Location: LocationType, File: SourceFileEntry, Lin
 def File_To_Location(File: SourceFileEntry) -> LocationType:
     """Convert a :obj:`File` into a location.
 
-    :param File: Source file
+    :param File: The source file to query.
     :returns:    Location.
     """
     return 0  # pragma: no cover
@@ -142,7 +143,7 @@ def File_Pos_To_Location(File: SourceFileEntry, Pos: int) -> LocationType:
     """
     Convert a :obj:`File` and an offset :obj:`Pos` in the file into a location.
 
-    :param File: Source file
+    :param File: The source file to query.
     :param Pos:  Offset in the file
     :returns:    Location.
     """
@@ -155,7 +156,7 @@ def File_Line_To_Position(File: SourceFileEntry, Line: int) -> int:
     """
     Convert a :obj:`File` and :obj:`Line` into a position.
 
-    :param File: Source file
+    :param File: The source file to query.
     :param Line: Line number
     :returns:    Return ``Source_Ptr_Bad`` in case of error (:obj:`Line` out of bounds).
     """
@@ -205,7 +206,7 @@ def Get_File_Buffer(File: SourceFileEntry) -> POINTER(c_char):
     Return a buffer (access to the contents of the file) for a file entry.
 
     :param File: Source file to get the buffer from.
-    :returns:
+    :returns:    A pointer to the file's contents.
     """
     return cast(Get_File_Buffer_voidp(File), POINTER(c_char))
 
@@ -216,8 +217,8 @@ def Get_File_Length(File: SourceFileEntry) -> int:
     """
     Get the position of the first EOT character.
 
-    :param File: Source file
-    :returns:
+    :param File: The source file to query.
+    :returns:    The position of the first EOT character, i.e. the length of the source text.
     """
     return 0  # pragma: no cover
 
@@ -242,8 +243,8 @@ def Get_Buffer_Length(File: SourceFileEntry) -> int:
     """
     Get the length of the buffer, including the gap and the two EOT.
 
-    :param File: Source file
-    :returns:
+    :param File: The source file to query.
+    :returns:    The length of the buffer.
     """
 
 
@@ -253,8 +254,8 @@ def Get_Buffer_Length(File: SourceFileEntry) -> int:
     """
     Get the length of the buffer, including the gap and the two EOT.
 
-    :param File: Source file
-    :returns:
+    :param File: The source file to query.
+    :returns:    The length of the buffer.
     """
 
 
@@ -264,9 +265,9 @@ def Find_Source_File(Directory: NameId, Name: NameId) -> SourceFileEntry:
     """
     Return an existing entry for a filename.
 
-    :param Directory: ``Null_Identifier`` for :obj:`DirectoryId` means current directory.
+    :param Directory: :attr:`~pyGHDL.libghdl.name_table.Null_Identifier` for :obj:`DirectoryId` means current directory.
     :param Name:      File name
-    :returns:         Return ``No_Source_File_Entry``, if the file is not already open.
+    :returns:         Return :attr:`~pyGHDL.libghdl.files_map.No_Source_File_Entry`, if the file is not already open.
     """
     return 0
 
@@ -279,9 +280,9 @@ def Read_Source_File(Directory: NameId, Name: NameId) -> SourceFileEntry:
 
     Load the filename if necessary.
 
-    :param Directory: ``Null_Identifier`` for :obj:`DirectoryId` means current directory.
+    :param Directory: :attr:`~pyGHDL.libghdl.name_table.Null_Identifier` for :obj:`DirectoryId` means current directory.
     :param Name:      File name
-    :returns:         Return ``No_Source_File_Entry``, if the file does not exist.
+    :returns:         Return :attr:`~pyGHDL.libghdl.files_map.No_Source_File_Entry`, if the file does not exist.
     """
     return 0  # pragma: no cover
 

--- a/pyGHDL/libghdl/files_map.py
+++ b/pyGHDL/libghdl/files_map.py
@@ -62,7 +62,7 @@ No_Location = 0
 @BindToLibGHDL("files_map__location_to_file")
 def Location_To_File(Location: LocationType) -> SourceFileEntry:
     """
-    Convert :obj:`Location` to a source file.
+    Convert ``Location`` to a source file.
 
     :param Location: Location
     :returns:        The source file, or :attr:`~pyGHDL.libghdl.files_map.No_Source_File_Entry` if the location is
@@ -75,7 +75,7 @@ def Location_To_File(Location: LocationType) -> SourceFileEntry:
 @BindToLibGHDL("files_map__location_file_to_pos")
 def Location_File_To_Pos(Location: LocationType, File: SourceFileEntry) -> int:
     """
-    Convert :obj:`Location` and :obj:`File` to a position (offset) into the source file.
+    Convert ``Location`` and ``File`` to a position (offset) into the source file.
 
     :param Location: Location
     :param File:     Source file
@@ -88,7 +88,7 @@ def Location_File_To_Pos(Location: LocationType, File: SourceFileEntry) -> int:
 @BindToLibGHDL("files_map__location_file_to_line")
 def Location_File_To_Line(Location: LocationType, File: SourceFileEntry) -> int:
     """
-    Convert :obj:`Location` and :obj:`File` to a line number.
+    Convert ``Location`` and ``File`` to a line number.
 
     :param Location: Location
     :param File:     Source file
@@ -101,7 +101,7 @@ def Location_File_To_Line(Location: LocationType, File: SourceFileEntry) -> int:
 @BindToLibGHDL("files_map__location_file_line_to_offset")
 def Location_File_Line_To_Offset(Location: LocationType, File: SourceFileEntry, Line: int) -> int:
     """
-    Get the offset in :obj:`Line` of :obj:`Location`.
+    Get the offset in ``Line`` of ``Location``.
 
     :param Location: Location
     :param File:     Source file
@@ -115,8 +115,8 @@ def Location_File_Line_To_Offset(Location: LocationType, File: SourceFileEntry, 
 @BindToLibGHDL("files_map__location_file_line_to_col")
 def Location_File_Line_To_Col(Location: LocationType, File: SourceFileEntry, Line: int) -> int:
     """
-    Get logical column (with HT expanded) from :obj:`Location`, :obj:`File` and
-    :obj:`Line`.
+    Get logical column (with HT expanded) from ``Location``, ``File`` and
+    ``Line``.
 
     :param Location: Location
     :param File:     Source file
@@ -129,7 +129,7 @@ def Location_File_Line_To_Col(Location: LocationType, File: SourceFileEntry, Lin
 @export
 @BindToLibGHDL("files_map__file_to_location")
 def File_To_Location(File: SourceFileEntry) -> LocationType:
-    """Convert a :obj:`File` into a location.
+    """Convert a ``File`` into a location.
 
     :param File: The source file to query.
     :returns:    Location.
@@ -141,7 +141,7 @@ def File_To_Location(File: SourceFileEntry) -> LocationType:
 @BindToLibGHDL("files_map__file_pos_to_location")
 def File_Pos_To_Location(File: SourceFileEntry, Pos: int) -> LocationType:
     """
-    Convert a :obj:`File` and an offset :obj:`Pos` in the file into a location.
+    Convert a ``File`` and an offset ``Pos`` in the file into a location.
 
     :param File: The source file to query.
     :param Pos:  Offset in the file
@@ -154,11 +154,11 @@ def File_Pos_To_Location(File: SourceFileEntry, Pos: int) -> LocationType:
 @BindToLibGHDL("files_map__file_line_to_position")
 def File_Line_To_Position(File: SourceFileEntry, Line: int) -> int:
     """
-    Convert a :obj:`File` and :obj:`Line` into a position.
+    Convert a ``File`` and ``Line`` into a position.
 
     :param File: The source file to query.
     :param Line: Line number
-    :returns:    Return ``Source_Ptr_Bad`` in case of error (:obj:`Line` out of bounds).
+    :returns:    Return ``Source_Ptr_Bad`` in case of error (``Line`` out of bounds).
     """
     return 0  # pragma: no cover
 
@@ -265,7 +265,7 @@ def Find_Source_File(Directory: NameId, Name: NameId) -> SourceFileEntry:
     """
     Return an existing entry for a filename.
 
-    :param Directory: :attr:`~pyGHDL.libghdl.name_table.Null_Identifier` for :obj:`DirectoryId` means current directory.
+    :param Directory: :attr:`~pyGHDL.libghdl.name_table.Null_Identifier` for ``DirectoryId`` means current directory.
     :param Name:      File name
     :returns:         Return :attr:`~pyGHDL.libghdl.files_map.No_Source_File_Entry`, if the file is not already open.
     """
@@ -280,7 +280,7 @@ def Read_Source_File(Directory: NameId, Name: NameId) -> SourceFileEntry:
 
     Load the filename if necessary.
 
-    :param Directory: :attr:`~pyGHDL.libghdl.name_table.Null_Identifier` for :obj:`DirectoryId` means current directory.
+    :param Directory: :attr:`~pyGHDL.libghdl.name_table.Null_Identifier` for ``DirectoryId`` means current directory.
     :param Name:      File name
     :returns:         Return :attr:`~pyGHDL.libghdl.files_map.No_Source_File_Entry`, if the file does not exist.
     """
@@ -307,7 +307,7 @@ def Reserve_Source_File(Directory: NameId, Name: NameId, Length: int) -> SourceF
 @BindToLibGHDL("files_map__discard_source_file")
 def Discard_Source_File(File: SourceFileEntry) -> None:
     """
-    Mark :obj:`File` as unavailable: clear the name and directory.
+    Mark ``File`` as unavailable: clear the name and directory.
 
     .. hint:: This is needed before creating a new source file with the same name.
 
@@ -319,7 +319,7 @@ def Discard_Source_File(File: SourceFileEntry) -> None:
 @BindToLibGHDL("files_map__free_source_file")
 def Free_Source_File(File: SourceFileEntry) -> None:
     """
-    Free resources used by :obj:`File`, but keep the entry.
+    Free resources used by ``File``, but keep the entry.
 
     .. note:: It could be recycled for files that could fit - not implemented.
 

--- a/pyGHDL/libghdl/files_map.py
+++ b/pyGHDL/libghdl/files_map.py
@@ -65,7 +65,7 @@ def Location_To_File(Location: LocationType) -> SourceFileEntry:
     Convert :obj:`Location` to a source file.
 
     :param Location: Location
-    :return:         Source file. Return ``No_Source_File_Entry`` if location is incorrect.
+    :returns:        Source file. Return ``No_Source_File_Entry`` if location is incorrect.
     """
     return 0  # pragma: no cover
 
@@ -78,7 +78,7 @@ def Location_File_To_Pos(Location: LocationType, File: SourceFileEntry) -> int:
 
     :param Location: Location
     :param File:     Source file
-    :return:         Offset
+    :returns:        Offset
     """
     return 0  # pragma: no cover
 
@@ -91,7 +91,7 @@ def Location_File_To_Line(Location: LocationType, File: SourceFileEntry) -> int:
 
     :param Location: Location
     :param File:     Source file
-    :return:         Line number
+    :returns:        Line number
     """
     return 0  # pragma: no cover
 
@@ -105,7 +105,7 @@ def Location_File_Line_To_Offset(Location: LocationType, File: SourceFileEntry, 
     :param Location: Location
     :param File:     Source file
     :param Line:     Line number
-    :return:         Offset
+    :returns:        Offset
     """
     return 0  # pragma: no cover
 
@@ -120,7 +120,7 @@ def Location_File_Line_To_Col(Location: LocationType, File: SourceFileEntry, Lin
     :param Location: Location
     :param File:     Source file
     :param Line:     Line number
-    :return:         logical column (horizontal tabs are expanded)
+    :returns:        logical column (horizontal tabs are expanded)
     """
     return 0  # pragma: no cover
 
@@ -131,7 +131,7 @@ def File_To_Location(File: SourceFileEntry) -> LocationType:
     """Convert a :obj:`File` into a location.
 
     :param File: Source file
-    :return:     Location.
+    :returns:    Location.
     """
     return 0  # pragma: no cover
 
@@ -144,7 +144,7 @@ def File_Pos_To_Location(File: SourceFileEntry, Pos: int) -> LocationType:
 
     :param File: Source file
     :param Pos:  Offset in the file
-    :return:     Location.
+    :returns:    Location.
     """
     return 0  # pragma: no cover
 
@@ -157,7 +157,7 @@ def File_Line_To_Position(File: SourceFileEntry, Line: int) -> int:
 
     :param File: Source file
     :param Line: Line number
-    :return:     Return ``Source_Ptr_Bad`` in case of error (:obj:`Line` out of bounds).
+    :returns:    Return ``Source_Ptr_Bad`` in case of error (:obj:`Line` out of bounds).
     """
     return 0  # pragma: no cover
 
@@ -169,7 +169,7 @@ def Get_File_Name(File: SourceFileEntry) -> NameId:
     Return the name of the file.
 
     :param File: Source file to get the filename from.
-    :return:     NameId for the filename.
+    :returns:    NameId for the filename.
     """
     return 0  # pragma: no cover
 
@@ -181,7 +181,7 @@ def Get_Directory_Name(File: SourceFileEntry) -> NameId:
     Return the directory of the file.
 
     :param File: Source file to get the directory name from.
-    :return:     NameId for the directory.
+    :returns:    NameId for the directory.
     """
     return 0  # pragma: no cover
 
@@ -195,7 +195,7 @@ def Get_File_Buffer_voidp(File: SourceFileEntry) -> c_void_p:
     Use :func:`Get_File_Buffer` instead, which types it as a character pointer.
 
     :param File: The source file entry to read the buffer of.
-    :returns:        The address of the source buffer.
+    :returns:    The address of the source buffer.
     """
     return 0  # pragma: no cover
 
@@ -205,7 +205,7 @@ def Get_File_Buffer(File: SourceFileEntry) -> POINTER(c_char):
     Return a buffer (access to the contents of the file) for a file entry.
 
     :param File: Source file to get the buffer from.
-    :return:     Type: ``File_Buffer_Ptr``
+    :returns:
     """
     return cast(Get_File_Buffer_voidp(File), POINTER(c_char))
 
@@ -217,7 +217,7 @@ def Get_File_Length(File: SourceFileEntry) -> int:
     Get the position of the first EOT character.
 
     :param File: Source file
-    :return:     Type: ``Source_Ptr``
+    :returns:
     """
     return 0  # pragma: no cover
 
@@ -231,7 +231,7 @@ def Set_File_Length(File: SourceFileEntry, Length: int) -> None:
     Set also append two EOT at the end of the file.
 
     :param File:   Source file
-    :param Length: Length for the file. Type: ``Source_Ptr``
+    :param Length: Length for the file
     """
     return 0  # pragma: no cover
 
@@ -243,7 +243,7 @@ def Get_Buffer_Length(File: SourceFileEntry) -> int:
     Get the length of the buffer, including the gap and the two EOT.
 
     :param File: Source file
-    :return:     Type: ``Source_Ptr``
+    :returns:
     """
 
 
@@ -254,7 +254,7 @@ def Get_Buffer_Length(File: SourceFileEntry) -> int:
     Get the length of the buffer, including the gap and the two EOT.
 
     :param File: Source file
-    :return:     Type: ``Source_Ptr``
+    :returns:
     """
 
 
@@ -266,7 +266,7 @@ def Find_Source_File(Directory: NameId, Name: NameId) -> SourceFileEntry:
 
     :param Directory: ``Null_Identifier`` for :obj:`DirectoryId` means current directory.
     :param Name:      File name
-    :return:          Return ``No_Source_File_Entry``, if the file is not already open.
+    :returns:         Return ``No_Source_File_Entry``, if the file is not already open.
     """
     return 0
 
@@ -281,7 +281,7 @@ def Read_Source_File(Directory: NameId, Name: NameId) -> SourceFileEntry:
 
     :param Directory: ``Null_Identifier`` for :obj:`DirectoryId` means current directory.
     :param Name:      File name
-    :return:          Return ``No_Source_File_Entry``, if the file does not exist.
+    :returns:         Return ``No_Source_File_Entry``, if the file does not exist.
     """
     return 0  # pragma: no cover
 
@@ -296,8 +296,8 @@ def Reserve_Source_File(Directory: NameId, Name: NameId, Length: int) -> SourceF
 
     :param Directory: Directory name
     :param Name:      File name
-    :param Length:    Length to reserve. Type: ``Source_Ptr``
-    :return:          SourceFile
+    :param Length:    Length to reserve
+    :returns:         SourceFile
     """
     return 0  # pragma: no cover
 
@@ -334,6 +334,6 @@ def Get_Last_Source_File_Entry() -> SourceFileEntry:
 
     .. hint:: This allows creating a table of ``SourceFileEntry``.
 
-    :return: Last SourceFileEntry. Type: ``SourceFileEntry``
+    :returns: Last SourceFileEntry
     """
     return 0  # pragma: no cover

--- a/pyGHDL/libghdl/files_map_editor.py
+++ b/pyGHDL/libghdl/files_map_editor.py
@@ -60,14 +60,14 @@ def _Replace_Text(
 ) -> bool:
     """Replace [START; END) by TEXT.
 
-    :param File: File where to replace a text section.
-    :param Start_Line:
-    :param Start_Offset:
-    :param End_Line:
-    :param End_Offset:
-    :param Text_Pointer:
-    :param Text_Length:
-    :returns: Return True in case of success, False in case of failure (the gap is too small).
+    :param File:         File where to replace a text section.
+    :param Start_Line:   The line the replaced range starts on.
+    :param Start_Offset: The character offset the replaced range starts at.
+    :param End_Line:     The line the replaced range ends on.
+    :param End_Offset:   The character offset the replaced range ends at.
+    :param Text_Pointer: A pointer to the replacement text.
+    :param Text_Length:  The number of characters in the replacement text.
+    :returns:            Return True in case of success, False in case of failure (the gap is too small).
     """
     return False  # pragma: no cover
 
@@ -110,9 +110,9 @@ def Fill_Text(File: SourceFileEntry, Text_Pointer, Text_Length: int) -> None:
 
     .. todo:: Replace ``Text_Pointer`` and ``Text_Length`` with Python string
 
-    :param File: File where to replace the content.
-    :param Text_Pointer:
-    :param Text_Length:
+    :param File:         File where to replace the content.
+    :param Text_Pointer: A pointer to the new content.
+    :param Text_Length:  The number of characters in the new content.
     """
     libghdl.files_map__editor__fill_text_ptr(File, Text_Pointer, Text_Length)
 
@@ -125,9 +125,9 @@ def Check_Buffer_Content(File: SourceFileEntry, String_Pointer: c_char_p, String
 
     .. todo:: Replace ``String_Pointer`` and ``String_Length`` with Python string
 
-    :param File: File to check the content.
-    :param String_Pointer:
-    :param String_Length:
+    :param File:           File to check the content.
+    :param String_Pointer: A pointer to the expected content.
+    :param String_Length:  The number of characters in the expected content.
     """
     libghdl.files_map__editor__check_buffer_content(File, String_Pointer, String_Length)
 

--- a/pyGHDL/libghdl/files_map_editor.py
+++ b/pyGHDL/libghdl/files_map_editor.py
@@ -31,6 +31,12 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Files_Map.Editor`` in *libghdl*.
+
+Modifies the content of a source buffer in place, which is what the language server uses to apply an edit without
+reloading the file.
+"""
 
 from ctypes import c_int32, c_char_p, c_bool, c_uint32
 

--- a/pyGHDL/libghdl/files_map_editor.py
+++ b/pyGHDL/libghdl/files_map_editor.py
@@ -60,14 +60,14 @@ def _Replace_Text(
 ) -> bool:
     """Replace [START; END) by TEXT.
 
-    :param File:         File where to replace a text section.
+    :param File: File where to replace a text section.
     :param Start_Line:
     :param Start_Offset:
     :param End_Line:
     :param End_Offset:
-    :param Text_Pointer: Type: ``File_Buffer_Ptr``
-    :param Text_Length:  Type: ``Source_Ptr``
-    :return:             Return True in case of success, False in case of failure (the gap is too small).
+    :param Text_Pointer:
+    :param Text_Length:
+    :returns: Return True in case of success, False in case of failure (the gap is too small).
     """
     return False  # pragma: no cover
 
@@ -84,12 +84,12 @@ def Replace_Text(
     """Replace [START; END) by TEXT.
 
     :param File:         File where to replace a text section.
-    :param Start_Line:   undocumented
-    :param Start_Offset: undocumented
-    :param End_Line:     undocumented
-    :param End_Offset:   undocumented
-    :param Text:         undocumented
-    :return:             Return True in case of success, False in case of failure (the gap is too small).
+    :param Start_Line:   The line the replaced range starts on.
+    :param Start_Offset: The character offset the replaced range starts at.
+    :param End_Line:     The line the replaced range ends on.
+    :param End_Offset:   The character offset the replaced range ends at.
+    :param Text:         The replacement text.
+    :returns:            Return True in case of success, False in case of failure (the gap is too small).
     """
     buffer = Text.encode(ENCODING)
     return _Replace_Text(
@@ -110,9 +110,9 @@ def Fill_Text(File: SourceFileEntry, Text_Pointer, Text_Length: int) -> None:
 
     .. todo:: Replace ``Text_Pointer`` and ``Text_Length`` with Python string
 
-    :param File:         File where to replace the content.
-    :param Text_Pointer: Type: ``File_Buffer_Ptr``
-    :param Text_Length:  Type: ``Source_Ptr``
+    :param File: File where to replace the content.
+    :param Text_Pointer:
+    :param Text_Length:
     """
     libghdl.files_map__editor__fill_text_ptr(File, Text_Pointer, Text_Length)
 
@@ -125,9 +125,9 @@ def Check_Buffer_Content(File: SourceFileEntry, String_Pointer: c_char_p, String
 
     .. todo:: Replace ``String_Pointer`` and ``String_Length`` with Python string
 
-    :param File:           File to check the content.
-    :param String_Pointer: Type: ``File_Buffer_Ptr``
-    :param String_Length:  Type: ``Source_Ptr``
+    :param File: File to check the content.
+    :param String_Pointer:
+    :param String_Length:
     """
     libghdl.files_map__editor__check_buffer_content(File, String_Pointer, String_Length)
 

--- a/pyGHDL/libghdl/files_map_editor.py
+++ b/pyGHDL/libghdl/files_map_editor.py
@@ -106,7 +106,7 @@ def Replace_Text(
 @export
 # @BindToLibGHDL("files_map__editor__fill_text_ptr")
 def Fill_Text(File: SourceFileEntry, Text_Pointer, Text_Length: int) -> None:
-    """Replace the content of :obj:`File` with TEXT.
+    """Replace the content of ``File`` with TEXT.
 
     .. todo:: Replace ``Text_Pointer`` and ``Text_Length`` with Python string
 
@@ -121,7 +121,7 @@ def Fill_Text(File: SourceFileEntry, Text_Pointer, Text_Length: int) -> None:
 # @BindToLibGHDL("files_map__editor__check_buffer_content")
 def Check_Buffer_Content(File: SourceFileEntry, String_Pointer: c_char_p, String_Length: c_uint32) -> None:
     """
-    Check that content of :obj:`File` is STR[1 .. STR_LEN].
+    Check that content of ``File`` is STR[1 .. STR_LEN].
 
     .. todo:: Replace ``String_Pointer`` and ``String_Length`` with Python string
 
@@ -136,9 +136,9 @@ def Check_Buffer_Content(File: SourceFileEntry, String_Pointer: c_char_p, String
 @BindToLibGHDL("files_map__editor__copy_source_file")
 def Copy_Source_File(Dest: SourceFileEntry, Src: SourceFileEntry) -> None:
     """
-    Copy content of :obj:`Src` to :obj:`Dest`.
+    Copy content of ``Src`` to ``Dest``.
 
-    .. warning:: The size of :obj:`Dest` must be large enough.
+    .. warning:: The size of ``Dest`` must be large enough.
 
-    Clear lines table of :obj:`Dest`.
+    Clear lines table of ``Dest``.
     """

--- a/pyGHDL/libghdl/flags.py
+++ b/pyGHDL/libghdl/flags.py
@@ -31,6 +31,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Flags`` in *libghdl*.
+
+The analysis options, set before a file is parsed.
+"""
 
 from ctypes import c_bool, sizeof
 from enum import unique, IntEnum

--- a/pyGHDL/libghdl/libraries.py
+++ b/pyGHDL/libghdl/libraries.py
@@ -100,7 +100,7 @@ def Add_Design_Unit_Into_Library(Unit: Iir_Design_Unit, Keep_Obsolete: bool) -> 
     Units are always appended to the design_file. Therefore, the order is kept.
 
     :param Unit:          The design unit to add.
-    :param Keep_Obsolete: If :obj:`Keep_Obsolete` is True, obsoleted units are
+    :param Keep_Obsolete: If ``Keep_Obsolete`` is ``True``, obsoleted units are
                           kept in the library.
 
                           This is used when a whole design file has to be added
@@ -128,7 +128,7 @@ def Find_Entity_For_Component(Name: NameId) -> Iir_Design_Unit:
     If there are several entities, return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`;
 
     :param Name: Entity name to search for.
-    :returns:    The entity's design unit, or ``Null_Iir`` if there is not exactly one.
+    :returns:    The entity's design unit, or :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` if there is not exactly one.
     """
     return 0  # pragma: no cover
 
@@ -167,7 +167,7 @@ def Find_Primary_Unit(Library: Iir_Library_Declaration, Name: NameId) -> Iir_Des
 
     :param Library: Library to look in.
     :param Name:    Primary unit to search for.
-    :returns:       The primary unit's design unit, or ``Null_Iir`` if it was not found.
+    :returns:       The primary unit's design unit, or :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` if it was not found.
     """
     return 0  # pragma: no cover
 

--- a/pyGHDL/libghdl/libraries.py
+++ b/pyGHDL/libghdl/libraries.py
@@ -31,6 +31,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Libraries`` in *libghdl*.
+
+Manages the design libraries: which one is the work library, loading it, and adding a design unit to it.
+"""
 
 from ctypes import c_int32
 
@@ -147,8 +152,9 @@ def Get_Library(Ident: NameId, Loc: LocationType, Force: bool) -> Iir_Library_De
     Get the library named :obj:`Ident`.
 
     :param Ident: Library to look for.
-    :param Loc: Location in case of errors.
-    :return:      Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` if it doesn't exist.
+    :param Loc:   Location in case of errors.
+    :param Force: ``True`` to load the library if it is not loaded yet.
+    :return:           Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` if it doesn't exist.
     """
     return 0  # pragma: no cover
 

--- a/pyGHDL/libghdl/libraries.py
+++ b/pyGHDL/libghdl/libraries.py
@@ -83,7 +83,7 @@ def Get_Libraries_Chain() -> Iir_Library_Declaration:
     """
     Get the chain of libraries. Can be used only to read (it mustn't be modified).
 
-    :return: undocumented
+    :returns: The first library declaration of the chain.
     """
     return 0  # pragma: no cover
 
@@ -99,7 +99,7 @@ def Add_Design_Unit_Into_Library(Unit: Iir_Design_Unit, Keep_Obsolete: bool) -> 
 
     Units are always appended to the design_file. Therefore, the order is kept.
 
-    :param Unit:          undocumented
+    :param Unit:          The design unit to add.
     :param Keep_Obsolete: If :obj:`Keep_Obsolete` is True, obsoleted units are
                           kept in the library.
 
@@ -115,7 +115,7 @@ def Purge_Design_File(Design_File: Iir_Design_File) -> None:
     """
     Remove the same file as :obj:`Design_File` from work library and all of its units.
 
-    :param Design_File: undocumented
+    :param Design_File: The design file to add.
     """
 
 
@@ -128,7 +128,7 @@ def Find_Entity_For_Component(Name: NameId) -> Iir_Design_Unit:
     If there are several entities, return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`;
 
     :param Name: Entity name to search for.
-    :return:     undocumented
+    :returns:    The entity's design unit, or ``Null_Iir`` if there is not exactly one.
     """
     return 0  # pragma: no cover
 
@@ -140,7 +140,7 @@ def Get_Library_No_Create(Ident: NameId) -> Iir_Library_Declaration:
     Get the library named :obj:`Ident`.
 
     :param Ident: Library to look for.
-    :return:      Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` if it doesn't exist.
+    :returns:     Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` if it doesn't exist.
     """
     return 0  # pragma: no cover
 
@@ -154,7 +154,7 @@ def Get_Library(Ident: NameId, Loc: LocationType, Force: bool) -> Iir_Library_De
     :param Ident: Library to look for.
     :param Loc:   Location in case of errors.
     :param Force: ``True`` to load the library if it is not loaded yet.
-    :return:           Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` if it doesn't exist.
+    :returns:     Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` if it doesn't exist.
     """
     return 0  # pragma: no cover
 
@@ -167,7 +167,7 @@ def Find_Primary_Unit(Library: Iir_Library_Declaration, Name: NameId) -> Iir_Des
 
     :param Library: Library to look in.
     :param Name:    Primary unit to search for.
-    :return:        undocumented
+    :returns:       The primary unit's design unit, or ``Null_Iir`` if it was not found.
     """
     return 0  # pragma: no cover
 

--- a/pyGHDL/libghdl/libraries.py
+++ b/pyGHDL/libghdl/libraries.py
@@ -113,7 +113,7 @@ def Add_Design_Unit_Into_Library(Unit: Iir_Design_Unit, Keep_Obsolete: bool) -> 
 @BindToLibGHDL("libraries__purge_design_file")
 def Purge_Design_File(Design_File: Iir_Design_File) -> None:
     """
-    Remove the same file as :obj:`Design_File` from work library and all of its units.
+    Remove the same file as ``Design_File`` from work library and all of its units.
 
     :param Design_File: The design file to add.
     """
@@ -123,7 +123,7 @@ def Purge_Design_File(Design_File: Iir_Design_File) -> None:
 @BindToLibGHDL("libraries__find_entity_for_component")
 def Find_Entity_For_Component(Name: NameId) -> Iir_Design_Unit:
     """
-    Find an entity whose name is :obj:`Name` in any library. |br|
+    Find an entity whose name is ``Name`` in any library. |br|
     If there is no such entity, return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`. |br|
     If there are several entities, return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`;
 
@@ -137,7 +137,7 @@ def Find_Entity_For_Component(Name: NameId) -> Iir_Design_Unit:
 @BindToLibGHDL("libraries__get_library_no_create")
 def Get_Library_No_Create(Ident: NameId) -> Iir_Library_Declaration:
     """
-    Get the library named :obj:`Ident`.
+    Get the library named ``Ident``.
 
     :param Ident: Library to look for.
     :returns:     Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` if it doesn't exist.
@@ -149,7 +149,7 @@ def Get_Library_No_Create(Ident: NameId) -> Iir_Library_Declaration:
 @BindToLibGHDL("libraries__get_library")
 def Get_Library(Ident: NameId, Loc: LocationType, Force: bool) -> Iir_Library_Declaration:
     """
-    Get the library named :obj:`Ident`.
+    Get the library named ``Ident``.
 
     :param Ident: Library to look for.
     :param Loc:   Location in case of errors.
@@ -163,7 +163,7 @@ def Get_Library(Ident: NameId, Loc: LocationType, Force: bool) -> Iir_Library_De
 @BindToLibGHDL("libraries__find_primary_unit")
 def Find_Primary_Unit(Library: Iir_Library_Declaration, Name: NameId) -> Iir_Design_Unit:
     """
-    Just return the design_unit for :obj:`Name`, or ``NULL`` if not found.
+    Just return the design_unit for ``Name``, or ``NULL`` if not found.
 
     :param Library: Library to look in.
     :param Name:    Primary unit to search for.

--- a/pyGHDL/libghdl/name_table.py
+++ b/pyGHDL/libghdl/name_table.py
@@ -59,7 +59,7 @@ def Get_Name_Length(Id: NameId) -> int:
     Get the length of an identifier denoted by a ``NameId``.
 
     :param Id: NameId for the identifier to query.
-    :return:   Length of the identifier.
+    :returns:  Length of the identifier.
     """
     return 0  # pragma: no cover
 
@@ -73,8 +73,7 @@ def _Get_Name_Ptr(Id: NameId) -> c_char_p:
     Use :func:`Get_Name_Ptr` instead, which decodes it to a Python string.
 
     :param Id: The identifier to read.
-    :returns:   The identifier as a C string.
-
+    :returns:  The identifier as a C string.
     """
     """"""
     return ""  # pragma: no cover
@@ -88,7 +87,7 @@ def Get_Name_Ptr(Id: NameId) -> str:
     The string is NUL-terminated (this is done by get_identifier).
 
     :param Id: NameId for the identifier to query.
-    :return:   Identifier as string.
+    :returns:  Identifier as string.
     """
     return _Get_Name_Ptr(Id).decode(ENCODING)
 
@@ -102,8 +101,7 @@ def _Get_Character(Id: NameId) -> c_char:
     Use :func:`Get_Character` instead, which decodes it.
 
     :param Id: The identifier of the character literal.
-    :returns:   The character as a C string.
-
+    :returns:  The character as a C string.
     """
     """"""
     return 0  # pragma: no cover
@@ -119,7 +117,7 @@ def Get_Character(Id: NameId) -> str:
        This is used for character literals and enumeration literals.
 
     :param Id: NameId for the identifier to query.
-    :return:   Get the character of the identifier.
+    :returns:  Get the character of the identifier.
     """
     return _Get_Character(Id).decode(ENCODING)
 
@@ -134,7 +132,7 @@ def _Get_Identifier(string: c_char_p, length: int) -> NameId:
 
     :param string: The string to intern, encoded.
     :param length: The number of characters in ``string``.
-    :returns:                The identifier of the interned string.
+    :returns:      The identifier of the interned string.
     """
     """"""
     return 0  # pragma: no cover
@@ -152,7 +150,7 @@ def Get_Identifier(string: str) -> NameId:
          backslashes are simplified.
 
     :param string: String to create or lookup.
-    :return:       Id in name table.
+    :returns:      Id in name table.
     """
     string = string.encode(ENCODING)
     return _Get_Identifier(c_char_p(string), len(string))

--- a/pyGHDL/libghdl/name_table.py
+++ b/pyGHDL/libghdl/name_table.py
@@ -32,6 +32,13 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
+"""
+Python binding for the Ada package ``Name_Table`` in *libghdl*.
+
+*libghdl* interns every identifier in a table and refers to it by a :data:`~pyGHDL.libghdl._types.NameId`. These
+functions convert between an identifier and its Python string.
+"""
+
 from ctypes import c_char, c_char_p
 
 from pyTooling.Decorators import export
@@ -60,6 +67,15 @@ def Get_Name_Length(Id: NameId) -> int:
 # @export
 @BindToLibGHDL("name_table__get_name_ptr")
 def _Get_Name_Ptr(Id: NameId) -> c_char_p:
+    """
+    Raw binding returning the identifier as a C string.
+
+    Use :func:`Get_Name_Ptr` instead, which decodes it to a Python string.
+
+    :param Id: The identifier to read.
+    :returns:   The identifier as a C string.
+
+    """
     """"""
     return ""  # pragma: no cover
 
@@ -80,6 +96,15 @@ def Get_Name_Ptr(Id: NameId) -> str:
 # @export
 @BindToLibGHDL("name_table__get_character")
 def _Get_Character(Id: NameId) -> c_char:
+    """
+    Raw binding returning a character literal's value as a C string.
+
+    Use :func:`Get_Character` instead, which decodes it.
+
+    :param Id: The identifier of the character literal.
+    :returns:   The character as a C string.
+
+    """
     """"""
     return 0  # pragma: no cover
 
@@ -102,6 +127,15 @@ def Get_Character(Id: NameId) -> str:
 # @export
 @BindToLibGHDL("name_table__get_identifier_with_len")
 def _Get_Identifier(string: c_char_p, length: int) -> NameId:
+    """
+    Raw binding interning a C string and returning its identifier.
+
+    Use :func:`Get_Identifier` instead, which encodes a Python string first.
+
+    :param string: The string to intern, encoded.
+    :param length: The number of characters in ``string``.
+    :returns:                The identifier of the interned string.
+    """
     """"""
     return 0  # pragma: no cover
 

--- a/pyGHDL/libghdl/str_table.py
+++ b/pyGHDL/libghdl/str_table.py
@@ -56,7 +56,6 @@ def _String8_Address(Id: String8Id) -> c_char_p:
     Use :func:`Get_String` instead, which reads a string out of it.
 
     :returns: The address of the string table.
-
     """
     """"""
     return ""  # pragma: no cover
@@ -71,6 +70,6 @@ def Get_String8_Ptr(Id: String8Id, Length: int) -> str:
 
     :param Id:     String8Id for the string to query.
     :param Length: The number of characters to read.
-    :return:         String8 as string.
+    :returns:      String8 as string.
     """
     return _String8_Address(Id)[:Length].decode(ENCODING)

--- a/pyGHDL/libghdl/str_table.py
+++ b/pyGHDL/libghdl/str_table.py
@@ -32,6 +32,12 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
 #
+"""
+Python binding for the Ada package ``Str_Table`` in *libghdl*.
+
+Holds the string literals found in the source code, addressed by a ``String8_Id``.
+"""
+
 from ctypes import c_char_p
 
 from pyTooling.Decorators import export
@@ -44,6 +50,14 @@ from pyGHDL.libghdl._decorator import BindToLibGHDL
 @export
 @BindToLibGHDL("str_table__string8_address")
 def _String8_Address(Id: String8Id) -> c_char_p:
+    """
+    Raw binding returning the address of the string table.
+
+    Use :func:`Get_String` instead, which reads a string out of it.
+
+    :returns: The address of the string table.
+
+    """
     """"""
     return ""  # pragma: no cover
 
@@ -55,7 +69,8 @@ def Get_String8_Ptr(Id: String8Id, Length: int) -> str:
     (using Append_String8) or a string8 is resized (using Resize_String8), an
     address previously returned is not valid anymore.
 
-    :param Id: String8Id for the string to query.
-    :return:   String8 as string.
+    :param Id:     String8Id for the string to query.
+    :param Length: The number of characters to read.
+    :return:         String8 as string.
     """
     return _String8_Address(Id)[:Length].decode(ENCODING)

--- a/pyGHDL/libghdl/utils.py
+++ b/pyGHDL/libghdl/utils.py
@@ -54,32 +54,52 @@ import pyGHDL.libghdl.vhdl.flists as flists
 
 @export
 def name_image(Id: NameId) -> str:
-    """Lookup a :obj:`Id` and return its string."""
+    """
+    Lookup a :obj:`Id` and return its string.
+
+    :returns: The identifier's text.
+    """
     return name_table.Get_Name_Ptr(Id)
 
 
 @export
 @EnumLookupTable(nodes_meta.fields)
 def fields_image(idx: int) -> str:
-    """String representation of Nodes_Meta.fields :obj:`idx`."""
+    """
+    String representation of Nodes_Meta.fields :obj:`idx`.
+
+    :returns: The field's name.
+    """
 
 
 @export
 @EnumLookupTable(nodes.Iir_Kind)
 def kind_image(k: int) -> str:
-    """String representation of Nodes.Iir_Kind :obj:`k`."""
+    """
+    String representation of Nodes.Iir_Kind :obj:`k`.
+
+    :returns: The node kind's name.
+    """
 
 
 @export
 @EnumLookupTable(nodes_meta.types)
 def types_image(t: int) -> str:
-    """String representation of Nodes_Meta.Types :obj:`t`."""
+    """
+    String representation of Nodes_Meta.Types :obj:`t`.
+
+    :returns: The field type's name.
+    """
 
 
 @export
 @EnumLookupTable(nodes_meta.Attr)
 def attr_image(a: int) -> str:
-    """String representation of Nodes_Meta.Attr :obj:`a`."""
+    """
+    String representation of Nodes_Meta.Attr :obj:`a`.
+
+    :returns: The attribute's name.
+    """
 
 
 @export
@@ -105,7 +125,11 @@ def leftest_location(n):
 
 @export
 def fields_iter(n) -> Generator[Any, None, None]:
-    """Iterate on fields of node :obj:`n`."""
+    """
+    Iterate on fields of node :obj:`n`.
+
+    :returns: Generator yielding the node's fields.
+    """
     if n == nodes.Null_Iir:
         return
     k = nodes.Get_Kind(n)
@@ -117,7 +141,11 @@ def fields_iter(n) -> Generator[Any, None, None]:
 
 @export
 def chain_iter(n) -> Generator[Any, None, None]:
-    """Iterate of a chain headed by node :obj:`n`."""
+    """
+    Iterate of a chain headed by node :obj:`n`.
+
+    :returns: Generator yielding the elements of the chain, in order.
+    """
     while n != nodes.Null_Iir:
         yield n
         n = nodes.Get_Chain(n)
@@ -125,7 +153,11 @@ def chain_iter(n) -> Generator[Any, None, None]:
 
 @export
 def chain_to_list(n) -> List[Any]:
-    """Convert a chain headed by node :obj:`n` to a Python list."""
+    """
+    Convert a chain headed by node :obj:`n` to a Python list.
+
+    :returns: The elements of the chain, in order.
+    """
     return [e for e in chain_iter(n)]
 
 
@@ -134,6 +166,8 @@ def nodes_iter(n) -> Generator[Any, None, None]:
     """
     Iterate all nodes of :obj:`n`, including :obj:`n`.
     Nodes are returned only once.
+
+    :returns: Generator yielding the node and all its sub-nodes.
     """
     if n == nodes.Null_Iir:
         return
@@ -174,7 +208,11 @@ def nodes_iter(n) -> Generator[Any, None, None]:
 
 @export
 def list_iter(lst) -> Generator[Any, None, None]:
-    """Iterate all element of Iir_List :obj:`lst`."""
+    """
+    Iterate all element of Iir_List :obj:`lst`.
+
+    :returns: Generator yielding the elements of the list, in order.
+    """
     if lst <= nodes.Iir_List_All:
         return
     iter = lists.Iterate(lst)
@@ -185,7 +223,11 @@ def list_iter(lst) -> Generator[Any, None, None]:
 
 @export
 def flist_iter(lst) -> Generator[Any, None, None]:
-    """Iterate all element of Iir_List :obj:`lst`."""
+    """
+    Iterate all element of Iir_List :obj:`lst`.
+
+    :returns: Generator yielding the elements of the flist, in order.
+    """
     if lst <= nodes.Iir_Flist_All:
         return
     for i in range(flists.Flast(lst) + 1):
@@ -194,7 +236,11 @@ def flist_iter(lst) -> Generator[Any, None, None]:
 
 @export
 def declarations_iter(n) -> Generator[Any, None, None]:
-    """Iterate all declarations in node :obj:`n`."""
+    """
+    Iterate all declarations in node :obj:`n`.
+
+    :returns: Generator yielding the declarations of the node.
+    """
     k = nodes.Get_Kind(n)
     if nodes_meta.Has_Generic_Chain(k):
         for n1 in chain_iter(nodes.Get_Generic_Chain(n)):
@@ -311,7 +357,11 @@ def declarations_iter(n) -> Generator[Any, None, None]:
 
 @export
 def concurrent_stmts_iter(n) -> Generator[Any, None, None]:
-    """Iterate concurrent statements in node :obj:`n`."""
+    """
+    Iterate concurrent statements in node :obj:`n`.
+
+    :returns: Generator yielding the concurrent statements of the node.
+    """
     k = nodes.Get_Kind(n)
     if k == nodes.Iir_Kind.Design_File:
         for n1 in chain_iter(nodes.Get_First_Design_Unit(n)):
@@ -351,6 +401,8 @@ def constructs_iter(n) -> Generator[Any, None, None]:
     """
     Iterate library units, concurrent statements and declarations
     that appear directly within a declarative part.
+
+    :returns: Generator yielding the declarations and concurrent statements of the node.
     """
     if n == nodes.Null_Iir:
         return
@@ -421,6 +473,8 @@ def sequential_iter(n) -> Generator[Any, None, None]:
     """
     Iterate sequential statements. The first node must be either
     a process or a subprogram body.
+
+    :returns: Generator yielding the sequential statements of the node.
     """
     if n == nodes.Null_Iir:
         return

--- a/pyGHDL/libghdl/utils.py
+++ b/pyGHDL/libghdl/utils.py
@@ -55,7 +55,7 @@ import pyGHDL.libghdl.vhdl.flists as flists
 @export
 def name_image(Id: NameId) -> str:
     """
-    Lookup a :obj:`Id` and return its string.
+    Lookup a ``Id`` and return its string.
 
     :returns: The identifier's text.
     """
@@ -66,7 +66,7 @@ def name_image(Id: NameId) -> str:
 @EnumLookupTable(nodes_meta.fields)
 def fields_image(idx: int) -> str:
     """
-    String representation of :class:`~pyGHDL.libghdl.vhdl.nodes_meta.fields` :obj:`idx`.
+    String representation of :class:`~pyGHDL.libghdl.vhdl.nodes_meta.fields` ``idx``.
 
     :returns: The field's name.
     """
@@ -76,7 +76,7 @@ def fields_image(idx: int) -> str:
 @EnumLookupTable(nodes.Iir_Kind)
 def kind_image(k: int) -> str:
     """
-    String representation of :class:`~pyGHDL.libghdl.vhdl.nodes.Iir_Kind` :obj:`k`.
+    String representation of :class:`~pyGHDL.libghdl.vhdl.nodes.Iir_Kind` ``k``.
 
     :returns: The node kind's name.
     """
@@ -86,7 +86,7 @@ def kind_image(k: int) -> str:
 @EnumLookupTable(nodes_meta.types)
 def types_image(t: int) -> str:
     """
-    String representation of :class:`~pyGHDL.libghdl.vhdl.nodes_meta.types` :obj:`t`.
+    String representation of :class:`~pyGHDL.libghdl.vhdl.nodes_meta.types` ``t``.
 
     :returns: The field type's name.
     """
@@ -96,7 +96,7 @@ def types_image(t: int) -> str:
 @EnumLookupTable(nodes_meta.Attr)
 def attr_image(a: int) -> str:
     """
-    String representation of Nodes_Meta.Attr :obj:`a`.
+    String representation of :class:`~pyGHDL.libghdl.vhdl.nodes_meta.Attr` ``a``.
 
     :returns: The attribute's name.
     """
@@ -127,7 +127,7 @@ def leftest_location(n):
 @export
 def fields_iter(n) -> Generator[Any, None, None]:
     """
-    Iterate on fields of node :obj:`n`.
+    Iterate on fields of node ``n``.
 
     :returns: Generator yielding the node's fields.
     """
@@ -143,7 +143,7 @@ def fields_iter(n) -> Generator[Any, None, None]:
 @export
 def chain_iter(n) -> Generator[Any, None, None]:
     """
-    Iterate of a chain headed by node :obj:`n`.
+    Iterate of a chain headed by node ``n``.
 
     :returns: Generator yielding the elements of the chain, in order.
     """
@@ -155,7 +155,7 @@ def chain_iter(n) -> Generator[Any, None, None]:
 @export
 def chain_to_list(n) -> List[Any]:
     """
-    Convert a chain headed by node :obj:`n` to a Python list.
+    Convert a chain headed by node ``n`` to a Python list.
 
     :returns: The elements of the chain, in order.
     """
@@ -165,7 +165,7 @@ def chain_to_list(n) -> List[Any]:
 @export
 def nodes_iter(n) -> Generator[Any, None, None]:
     """
-    Iterate all nodes of :obj:`n`, including :obj:`n`.
+    Iterate all nodes of ``n``, including ``n``.
     Nodes are returned only once.
 
     :returns: Generator yielding the node and all its sub-nodes.
@@ -210,7 +210,7 @@ def nodes_iter(n) -> Generator[Any, None, None]:
 @export
 def list_iter(lst) -> Generator[Any, None, None]:
     """
-    Iterate all element of Iir_List :obj:`lst`.
+    Iterate all element of Iir_List ``lst``.
 
     :returns: Generator yielding the elements of the list, in order.
     """
@@ -225,7 +225,7 @@ def list_iter(lst) -> Generator[Any, None, None]:
 @export
 def flist_iter(lst) -> Generator[Any, None, None]:
     """
-    Iterate all element of Iir_List :obj:`lst`.
+    Iterate all element of Iir_List ``lst``.
 
     :returns: Generator yielding the elements of the flist, in order.
     """
@@ -238,7 +238,7 @@ def flist_iter(lst) -> Generator[Any, None, None]:
 @export
 def declarations_iter(n) -> Generator[Any, None, None]:
     """
-    Iterate all declarations in node :obj:`n`.
+    Iterate all declarations in node ``n``.
 
     :returns: Generator yielding the declarations of the node.
     """
@@ -359,7 +359,7 @@ def declarations_iter(n) -> Generator[Any, None, None]:
 @export
 def concurrent_stmts_iter(n) -> Generator[Any, None, None]:
     """
-    Iterate concurrent statements in node :obj:`n`.
+    Iterate concurrent statements in node ``n``.
 
     :returns: Generator yielding the concurrent statements of the node.
     """

--- a/pyGHDL/libghdl/utils.py
+++ b/pyGHDL/libghdl/utils.py
@@ -30,6 +30,12 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Generators and helpers on top of the raw ``libghdl`` bindings.
+
+Iterating a chain, a list or an flist, and resolving the leftmost source location of a node, are needed everywhere and
+are ugly against the raw API, so they live here.
+"""
 
 from ctypes import byref
 from typing import List, Any, Generator
@@ -78,6 +84,15 @@ def attr_image(a: int) -> str:
 
 @export
 def leftest_location(n):
+    """
+    Return the location of the leftmost token of a node.
+
+    A node's own location is the token the parser considered characteristic, which for a subtype indication or a name is
+    not the first one written. This walks left until there is nothing further.
+
+    :param n: The IIR node to locate.
+    :returns: The location of the leftmost token, or ``No_Location`` for ``Null_Iir``.
+    """
     while True:
         if n == nodes.Null_Iir:
             return files_map.No_Location

--- a/pyGHDL/libghdl/utils.py
+++ b/pyGHDL/libghdl/utils.py
@@ -66,7 +66,7 @@ def name_image(Id: NameId) -> str:
 @EnumLookupTable(nodes_meta.fields)
 def fields_image(idx: int) -> str:
     """
-    String representation of Nodes_Meta.fields :obj:`idx`.
+    String representation of :class:`~pyGHDL.libghdl.vhdl.nodes_meta.fields` :obj:`idx`.
 
     :returns: The field's name.
     """
@@ -76,7 +76,7 @@ def fields_image(idx: int) -> str:
 @EnumLookupTable(nodes.Iir_Kind)
 def kind_image(k: int) -> str:
     """
-    String representation of Nodes.Iir_Kind :obj:`k`.
+    String representation of :class:`~pyGHDL.libghdl.vhdl.nodes.Iir_Kind` :obj:`k`.
 
     :returns: The node kind's name.
     """
@@ -86,7 +86,7 @@ def kind_image(k: int) -> str:
 @EnumLookupTable(nodes_meta.types)
 def types_image(t: int) -> str:
     """
-    String representation of Nodes_Meta.Types :obj:`t`.
+    String representation of :class:`~pyGHDL.libghdl.vhdl.nodes_meta.types` :obj:`t`.
 
     :returns: The field type's name.
     """
@@ -111,7 +111,8 @@ def leftest_location(n):
     not the first one written. This walks left until there is nothing further.
 
     :param n: The IIR node to locate.
-    :returns: The location of the leftmost token, or ``No_Location`` for ``Null_Iir``.
+    :returns: The location of the leftmost token, or :attr:`~pyGHDL.libghdl.files_map.No_Location` if ``n`` is
+              :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`.
     """
     while True:
         if n == nodes.Null_Iir:

--- a/pyGHDL/libghdl/utils.py
+++ b/pyGHDL/libghdl/utils.py
@@ -210,7 +210,7 @@ def nodes_iter(n) -> Generator[Any, None, None]:
 @export
 def list_iter(lst) -> Generator[Any, None, None]:
     """
-    Iterate all element of Iir_List ``lst``.
+    Iterate all elements of the Iir_List ``lst``.
 
     :returns: Generator yielding the elements of the list, in order.
     """
@@ -225,7 +225,7 @@ def list_iter(lst) -> Generator[Any, None, None]:
 @export
 def flist_iter(lst) -> Generator[Any, None, None]:
     """
-    Iterate all element of Iir_List ``lst``.
+    Iterate all elements of the Iir_Flist ``lst``.
 
     :returns: Generator yielding the elements of the flist, in order.
     """

--- a/pyGHDL/libghdl/vhdl/__init__.py
+++ b/pyGHDL/libghdl/vhdl/__init__.py
@@ -30,3 +30,9 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python bindings for the VHDL front-end of *libghdl*.
+
+The modules in this package mirror the Ada packages below ``Vhdl``: the AST in :mod:`~pyGHDL.libghdl.vhdl.nodes`, its
+meta-model in :mod:`~pyGHDL.libghdl.vhdl.nodes_meta`, and the passes that build and check it.
+"""

--- a/pyGHDL/libghdl/vhdl/canon.py
+++ b/pyGHDL/libghdl/vhdl/canon.py
@@ -31,6 +31,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Vhdl.Canon`` in *libghdl*.
+
+Canonicalization: the pass that rewrites the AST into a simpler, equivalent form after semantic analysis.
+"""
 
 from ctypes import c_bool
 

--- a/pyGHDL/libghdl/vhdl/disp_tree.py
+++ b/pyGHDL/libghdl/vhdl/disp_tree.py
@@ -52,7 +52,8 @@ def Disp_Tree(Tree: Iir, Flat: bool = False) -> None:
     """
     Disp a tree for debugging.
 
-    :param Tree:      The node to display.
+    :param Tree: The node to display.
+    :param Flat: ``True`` to print only the node itself, without its sub-nodes.
     """
 
 
@@ -63,6 +64,8 @@ def Disp_Iir(N: Iir, Indent: int, Depth: int) -> None:
     Disp a node for debugging.
 
     :param N:      The node to display.
+    :param Indent: The indentation level to print at.
+    :param Depth:  How many levels of sub-nodes to print.
     """
 
 

--- a/pyGHDL/libghdl/vhdl/disp_tree.py
+++ b/pyGHDL/libghdl/vhdl/disp_tree.py
@@ -31,6 +31,12 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Vhdl.Disp_Tree`` in *libghdl*.
+
+Dumps a node and its sub-nodes for debugging. It is written against the meta-model, so it needs no change when a node
+kind is added.
+"""
 
 from ctypes import c_int32, c_char_p, c_void_p
 
@@ -61,4 +67,9 @@ def Disp_Iir(N: Iir, Indent: int, Depth: int) -> None:
 
 
 def debug_iir(N: Iir) -> None:
+    """
+    Dump a node and one level of its sub-nodes, for use from a debugger.
+
+    :param N: The IIR node to dump.
+    """
     Disp_Iir(N, 0, 1)

--- a/pyGHDL/libghdl/vhdl/flists.py
+++ b/pyGHDL/libghdl/vhdl/flists.py
@@ -55,7 +55,7 @@ Ffirst = 0
 @BindToLibGHDL("vhdl__flists__flast")
 def Flast(FList: int) -> int:
     """
-    Last index of :obj:`FList`.
+    Last index of ``FList``.
 
     .. hint:: Could be used to iterate.
 
@@ -69,7 +69,7 @@ def Flast(FList: int) -> int:
 @BindToLibGHDL("vhdl__flists__length")
 def Length(FList: int) -> int:
     """
-    Get the length of :obj:`FList`.
+    Get the length of ``FList``.
 
     :param FList: List to query.
     :returns:     Number of elements in the list.
@@ -81,7 +81,7 @@ def Length(FList: int) -> int:
 @BindToLibGHDL("vhdl__flists__get_nth_element")
 def Get_Nth_Element(FList: int, N: int) -> int:
     """
-    Get the N-th element of :obj:`FList`.
+    Get the N-th element of ``FList``.
 
     First element has index 0.
 

--- a/pyGHDL/libghdl/vhdl/flists.py
+++ b/pyGHDL/libghdl/vhdl/flists.py
@@ -87,6 +87,6 @@ def Get_Nth_Element(FList: int, N: int) -> int:
 
     :param FList: List to query.
     :param N:     The zero-based index of the element to read.
-    :returns:
+    :returns:     The element at index ``N``.
     """
     return 0  # pragma: no cover

--- a/pyGHDL/libghdl/vhdl/flists.py
+++ b/pyGHDL/libghdl/vhdl/flists.py
@@ -31,6 +31,13 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Vhdl.Flists`` in *libghdl*.
+
+Fixed-length lists of nodes, whose length is set when the list is created - the index constraints of an array subtype,
+for instance. See :func:`~pyGHDL.libghdl.utils.flist_iter` for iterating one.
+"""
+
 from ctypes import c_int32
 
 from pyTooling.Decorators import export
@@ -79,6 +86,7 @@ def Get_Nth_Element(FList: int, N: int) -> int:
     First element has index 0.
 
     :param FList: List to query.
-    :return:      Type: ``El_Type``
+    :param N:     The zero-based index of the element to read.
+    :return:           Type: ``El_Type``
     """
     return 0  # pragma: no cover

--- a/pyGHDL/libghdl/vhdl/flists.py
+++ b/pyGHDL/libghdl/vhdl/flists.py
@@ -60,7 +60,7 @@ def Flast(FList: int) -> int:
     .. hint:: Could be used to iterate.
 
     :param FList: List to query.
-    :return:      Index of the last element in the list.
+    :returns:     Index of the last element in the list.
     """
     return 0  # pragma: no cover
 
@@ -72,7 +72,7 @@ def Length(FList: int) -> int:
     Get the length of :obj:`FList`.
 
     :param FList: List to query.
-    :return:      Number of elements in the list.
+    :returns:     Number of elements in the list.
     """
     return 0  # pragma: no cover
 
@@ -87,6 +87,6 @@ def Get_Nth_Element(FList: int, N: int) -> int:
 
     :param FList: List to query.
     :param N:     The zero-based index of the element to read.
-    :return:           Type: ``El_Type``
+    :returns:
     """
     return 0  # pragma: no cover

--- a/pyGHDL/libghdl/vhdl/formatters.py
+++ b/pyGHDL/libghdl/vhdl/formatters.py
@@ -48,7 +48,7 @@ from pyGHDL.libghdl._decorator import BindToLibGHDL
 @BindToLibGHDL("vhdl__formatters__indent_string")
 def Indent_String(File: int, Handle: c_void_p, FirstLine: int, LastLine: int) -> None:
     """
-    Reindent all lines of F between [First_Line; Last_Line] to :obj:`Handle`.
+    Reindent all lines of F between [First_Line; Last_Line] to ``Handle``.
 
     :param File:      File to indent lines within
     :param Handle:    The handle of the string buffer to append to.

--- a/pyGHDL/libghdl/vhdl/formatters.py
+++ b/pyGHDL/libghdl/vhdl/formatters.py
@@ -50,8 +50,8 @@ def Indent_String(File: int, Handle: c_void_p, FirstLine: int, LastLine: int) ->
     """
     Reindent all lines of F between [First_Line; Last_Line] to :obj:`Handle`.
 
-    :param File:      File to indent lines within. Type: ``Iir_Design_File``
-    :param Handle:    undocumented. Type: ``Vstring_Acc``
-    :param FirstLine: undocumented.
-    :param LastLine:  undocumented.
+    :param File:      File to indent lines within
+    :param Handle:    The handle of the string buffer to append to.
+    :param FirstLine: The first line to reindent.
+    :param LastLine:  The last line to reindent.
     """

--- a/pyGHDL/libghdl/vhdl/formatters.py
+++ b/pyGHDL/libghdl/vhdl/formatters.py
@@ -31,6 +31,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Vhdl.Formatters`` in *libghdl*.
+
+Reformats VHDL source code, used by the language server.
+"""
 
 from ctypes import c_void_p
 

--- a/pyGHDL/libghdl/vhdl/ieee.py
+++ b/pyGHDL/libghdl/vhdl/ieee.py
@@ -30,6 +30,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Vhdl.Ieee`` in *libghdl*.
+
+Recognizes the declarations of the ``ieee`` library, so the analyzer can treat the standard packages specially.
+"""
 
 from ctypes import c_int
 

--- a/pyGHDL/libghdl/vhdl/lists.py
+++ b/pyGHDL/libghdl/vhdl/lists.py
@@ -70,7 +70,7 @@ def Iterate(List: int) -> Iterator:
          Next(It)
 
     :param List: List to create an iterator from.
-    :return:     Iterator structure.
+    :returns:    Iterator structure.
     """
 
 
@@ -81,7 +81,7 @@ def Is_Valid(it: Iterator) -> bool:
     Check if iterator reached the end.
 
     :param it: Iterator to check.
-    :return:   ``False``, if iterator has reached the end.
+    :returns:  ``False``, if iterator has reached the end.
     """
     func = libghdl.vhdl__lists__is_valid
     func.argstype = [POINTER(Iterator)]
@@ -97,7 +97,7 @@ def Next(it: Iterator) -> bool:
     Move iterator to the next element.
 
     :param it: Iterator to increment.
-    :return:   ``False``, if iterator has reached the end.
+    :returns:  ``False``, if iterator has reached the end.
     """
     func = libghdl.vhdl__lists__next
     func.argstype = [POINTER(Iterator)]
@@ -113,7 +113,7 @@ def Get_Element(it: Iterator) -> int:
     Get the current element from iterator.
 
     :param it: Iterator the get the element from.
-    :return:   The current element the iterator points to. Type: ``El_Type``
+    :returns:  The current element the iterator points to
     """
     func = libghdl.vhdl__lists__get_element
     func.argstype = [POINTER(Iterator)]
@@ -131,7 +131,7 @@ def Get_Nbr_Elements(List: int) -> int:
     .. hint:: This is also 1 + the position of the last element.
 
     :param List: The list to use.
-    :return:     Number of list elements.
+    :returns:    Number of list elements.
     """
     return 0  # pragma: no cover
 
@@ -142,7 +142,7 @@ def Create_Iir_List() -> int:
     """
     Create a list.
 
-    :return: undocumented; Type: ``List_Type``
+    :returns: The newly created list.
     """
     return 0  # pragma: no cover
 

--- a/pyGHDL/libghdl/vhdl/lists.py
+++ b/pyGHDL/libghdl/vhdl/lists.py
@@ -31,6 +31,12 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Vhdl.Lists`` in *libghdl*.
+
+Growable lists of node references, used where a node appears in a collection it does not own - a sensitivity list, for
+instance. See :func:`~pyGHDL.libghdl.utils.list_iter` for iterating one.
+"""
 
 from ctypes import c_int32, c_bool, POINTER, Structure
 
@@ -42,6 +48,8 @@ from pyGHDL.libghdl._decorator import BindToLibGHDL
 
 @export
 class Iterator(Structure):
+    """The cursor a list iteration walks with, mirroring the Ada record."""
+
     _fields_ = [("chunk", c_int32), ("chunk_idx", c_int32), ("remain", c_int32)]
 
 

--- a/pyGHDL/libghdl/vhdl/nodes_utils.py
+++ b/pyGHDL/libghdl/vhdl/nodes_utils.py
@@ -61,7 +61,7 @@ def Strip_Denoting_Name(Name: Iir) -> Iir:
 def Get_Entity(Decl: Iir) -> Iir:
     """
     This is a wrapper around ``Get_Entity_Name`` to return the entity declaration
-    of the entity name of :obj:`Decl`, or ``Null_Iir`` in case of error.
+    of the entity name of :obj:`Decl`, or :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` in case of error.
 
     :param Decl: Declaration
     :returns:    Entity
@@ -90,7 +90,7 @@ def Get_Entity_From_Entity_Aspect(Aspect: Iir) -> Iir:
     Extract the entity from :obj:`Aspect`.
 
     If :obj:`Aspect` is a component declaration, return :obj:`Aspect`. If it's
-    open, return ``Null_Iir``
+    open, return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`
 
     :param Aspect: Aspect
     :returns:      Entity

--- a/pyGHDL/libghdl/vhdl/nodes_utils.py
+++ b/pyGHDL/libghdl/vhdl/nodes_utils.py
@@ -47,8 +47,8 @@ from pyGHDL.libghdl._decorator import BindToLibGHDL
 @BindToLibGHDL("vhdl__utils__strip_denoting_name")
 def Strip_Denoting_Name(Name: Iir) -> Iir:
     """
-    If :obj:`Name` is a simple or an expanded name, return the denoted declaration.
-    Otherwise, return :obj:`Name`.
+    If ``Name`` is a simple or an expanded name, return the denoted declaration.
+    Otherwise, return ``Name``.
 
     :param Name: Simple or an expanded name.
     :returns:    Denoted declaration.
@@ -61,7 +61,7 @@ def Strip_Denoting_Name(Name: Iir) -> Iir:
 def Get_Entity(Decl: Iir) -> Iir:
     """
     This is a wrapper around ``Get_Entity_Name`` to return the entity declaration
-    of the entity name of :obj:`Decl`, or :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` in case of error.
+    of the entity name of ``Decl``, or :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` in case of error.
 
     :param Decl: Declaration
     :returns:    Entity
@@ -73,8 +73,8 @@ def Get_Entity(Decl: Iir) -> Iir:
 @BindToLibGHDL("vhdl__utils__is_second_subprogram_specification")
 def Is_Second_Subprogram_Specification(Spec: Iir) -> bool:
     """
-    Check if :obj:`Spec` is the subprogram specification of a subprogram body
-    which was previously declared. In that case, the only use of :obj:`Spec`
+    Check if ``Spec`` is the subprogram specification of a subprogram body
+    which was previously declared. In that case, the only use of ``Spec``
     is to match the body with its declaration.
 
     :param Spec: Specification
@@ -87,9 +87,9 @@ def Is_Second_Subprogram_Specification(Spec: Iir) -> bool:
 @BindToLibGHDL("vhdl__utils__get_entity_from_entity_aspect")
 def Get_Entity_From_Entity_Aspect(Aspect: Iir) -> Iir:
     """
-    Extract the entity from :obj:`Aspect`.
+    Extract the entity from ``Aspect``.
 
-    If :obj:`Aspect` is a component declaration, return :obj:`Aspect`. If it's
+    If ``Aspect`` is a component declaration, return ``Aspect``. If it's
     open, return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`
 
     :param Aspect: Aspect
@@ -102,7 +102,7 @@ def Get_Entity_From_Entity_Aspect(Aspect: Iir) -> Iir:
 @BindToLibGHDL("vhdl__utils__get_interface_of_formal")
 def Get_Interface_Of_Formal(Formal: Iir) -> Iir:
     """
-    Get the interface corresponding to the formal name :obj:`Formal`. This is
+    Get the interface corresponding to the formal name ``Formal``. This is
     always an interface, even if the formal is a name.
 
     :param Formal: The formal.

--- a/pyGHDL/libghdl/vhdl/nodes_utils.py
+++ b/pyGHDL/libghdl/vhdl/nodes_utils.py
@@ -63,7 +63,7 @@ def Get_Entity(Decl: Iir) -> Iir:
     This is a wrapper around ``Get_Entity_Name`` to return the entity declaration
     of the entity name of ``Decl``, or :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` in case of error.
 
-    :param Decl: Declaration
+    :param Decl: The declaration to get the entity of.
     :returns:    Entity
     """
     return 0
@@ -77,7 +77,7 @@ def Is_Second_Subprogram_Specification(Spec: Iir) -> bool:
     which was previously declared. In that case, the only use of ``Spec``
     is to match the body with its declaration.
 
-    :param Spec: Specification
+    :param Spec: The subprogram specification to check.
     :returns:    ``True`` if subprogram specification and previously declared subprogram body match
     """
     return False
@@ -92,7 +92,7 @@ def Get_Entity_From_Entity_Aspect(Aspect: Iir) -> Iir:
     If ``Aspect`` is a component declaration, return ``Aspect``. If it's
     open, return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir`
 
-    :param Aspect: Aspect
+    :param Aspect: The entity aspect to extract the entity from.
     :returns:      Entity
     """
     return 0

--- a/pyGHDL/libghdl/vhdl/nodes_utils.py
+++ b/pyGHDL/libghdl/vhdl/nodes_utils.py
@@ -51,7 +51,7 @@ def Strip_Denoting_Name(Name: Iir) -> Iir:
     Otherwise, return :obj:`Name`.
 
     :param Name: Simple or an expanded name.
-    :return:     Denoted declaration.
+    :returns:    Denoted declaration.
     """
     return 0
 
@@ -64,7 +64,7 @@ def Get_Entity(Decl: Iir) -> Iir:
     of the entity name of :obj:`Decl`, or ``Null_Iir`` in case of error.
 
     :param Decl: Declaration
-    :return:     Entity
+    :returns:    Entity
     """
     return 0
 
@@ -78,7 +78,7 @@ def Is_Second_Subprogram_Specification(Spec: Iir) -> bool:
     is to match the body with its declaration.
 
     :param Spec: Specification
-    :return:     ``True`` if subprogram specification and previously declared subprogram body match
+    :returns:    ``True`` if subprogram specification and previously declared subprogram body match
     """
     return False
 
@@ -93,7 +93,7 @@ def Get_Entity_From_Entity_Aspect(Aspect: Iir) -> Iir:
     open, return ``Null_Iir``
 
     :param Aspect: Aspect
-    :return:       Entity
+    :returns:      Entity
     """
     return 0
 
@@ -106,6 +106,6 @@ def Get_Interface_Of_Formal(Formal: Iir) -> Iir:
     always an interface, even if the formal is a name.
 
     :param Formal: The formal.
-    :return:       The corresponding interface.
+    :returns:      The corresponding interface.
     """
     return 0

--- a/pyGHDL/libghdl/vhdl/nodes_utils.py
+++ b/pyGHDL/libghdl/vhdl/nodes_utils.py
@@ -31,6 +31,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Vhdl.Nodes_Utils`` in *libghdl*.
+
+Helpers that answer questions about a node which are more than a field access, such as stripping a denoting name.
+"""
 
 from pyTooling.Decorators import export
 

--- a/pyGHDL/libghdl/vhdl/parse.py
+++ b/pyGHDL/libghdl/vhdl/parse.py
@@ -31,6 +31,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Vhdl.Parse`` in *libghdl*.
+
+The parser: builds the AST of a design file from its source code.
+"""
 
 from ctypes import c_bool
 

--- a/pyGHDL/libghdl/vhdl/parse.py
+++ b/pyGHDL/libghdl/vhdl/parse.py
@@ -59,6 +59,6 @@ def Parse_Design_File() -> Iir:
 
     ..note:: The scanner must have been initialized as for parse_design_unit.
 
-    :return: Return :obj:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` in case of error. Type: ``Iir_Design_File``
+    :returns: Return :obj:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` in case of error
     """
     return 0

--- a/pyGHDL/libghdl/vhdl/parse.py
+++ b/pyGHDL/libghdl/vhdl/parse.py
@@ -59,6 +59,6 @@ def Parse_Design_File() -> Iir:
 
     ..note:: The scanner must have been initialized as for parse_design_unit.
 
-    :returns: Return :obj:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` in case of error
+    :returns: Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` in case of error
     """
     return 0

--- a/pyGHDL/libghdl/vhdl/prints.py
+++ b/pyGHDL/libghdl/vhdl/prints.py
@@ -84,7 +84,7 @@ def Get_C_String(Handle: c_void_p) -> c_char_p:
     .. todo:: Undocumented in Ada code.
 
     :param Handle: The handle of the string buffer to append to.
-    :returns:
+    :returns:      The string buffer's contents as a C string.
     """
 
 

--- a/pyGHDL/libghdl/vhdl/prints.py
+++ b/pyGHDL/libghdl/vhdl/prints.py
@@ -31,6 +31,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Vhdl.Prints`` in *libghdl*.
+
+Unparses a node back to VHDL source code.
+"""
 
 from ctypes import c_int32, c_char_p, c_void_p
 
@@ -46,10 +51,8 @@ def Print_String(File: int, Handle: c_void_p) -> None:
     """
     Reindent all lines of F between [First_Line; Last_Line] to :obj:`Handle`.
 
-    :param File:      File to indent lines within. Type: ``Iir_Design_File``
+    :param File:        File to indent lines within. Type: ``Iir_Design_File``
     :param Handle:    undocumented. Type: ``Vstring_Acc``
-    :param FirstLine: undocumented.
-    :param LastLine:  undocumented.
     """
 
 

--- a/pyGHDL/libghdl/vhdl/prints.py
+++ b/pyGHDL/libghdl/vhdl/prints.py
@@ -51,8 +51,8 @@ def Print_String(File: int, Handle: c_void_p) -> None:
     """
     Reindent all lines of F between [First_Line; Last_Line] to :obj:`Handle`.
 
-    :param File:        File to indent lines within. Type: ``Iir_Design_File``
-    :param Handle:    undocumented. Type: ``Vstring_Acc``
+    :param File:   File to indent lines within
+    :param Handle: The handle of the string buffer to append to.
     """
 
 
@@ -62,7 +62,7 @@ def Allocate_Handle() -> c_void_p:
     """
     .. todo:: Undocumented in Ada code.
 
-    :return: undocumented. Type: ``Vstring_Acc``
+    :returns: The handle of a freshly allocated string buffer.
     """
 
 
@@ -72,8 +72,8 @@ def Get_Length(Handle: c_void_p) -> int:
     """
     .. todo:: Undocumented in Ada code.
 
-    :param Handle: undocumented. Type: ``Vstring_Acc``
-    :return:       undocumented.
+    :param Handle: The handle of the string buffer to append to.
+    :returns:      The number of characters in the string buffer.
     """
 
 
@@ -83,8 +83,8 @@ def Get_C_String(Handle: c_void_p) -> c_char_p:
     """
     .. todo:: Undocumented in Ada code.
 
-    :param Handle: undocumented. Type: ``Vstring_Acc``
-    :return:       Type: ``Grt.Types.Ghdl_C_String``
+    :param Handle: The handle of the string buffer to append to.
+    :returns:
     """
 
 
@@ -94,5 +94,5 @@ def Free_Handle(Handle: c_void_p) -> None:
     """
     .. todo:: Undocumented in Ada code.
 
-    :param Handle: undocumented. Type: ``Vstring_Acc``
+    :param Handle: The handle of the string buffer to append to.
     """

--- a/pyGHDL/libghdl/vhdl/prints.py
+++ b/pyGHDL/libghdl/vhdl/prints.py
@@ -49,7 +49,7 @@ from pyGHDL.libghdl._decorator import BindToLibGHDL
 @BindToLibGHDL("vhdl__prints__print_string")
 def Print_String(File: int, Handle: c_void_p) -> None:
     """
-    Reindent all lines of F between [First_Line; Last_Line] to :obj:`Handle`.
+    Reindent all lines of F between [First_Line; Last_Line] to ``Handle``.
 
     :param File:   File to indent lines within
     :param Handle: The handle of the string buffer to append to.

--- a/pyGHDL/libghdl/vhdl/scanner.py
+++ b/pyGHDL/libghdl/vhdl/scanner.py
@@ -83,7 +83,7 @@ def Get_Current_Line() -> int:
     Since a token cannot spread over lines, file and line of the current token are
     the same as those of the current position. The offset is the offset in the current line.
 
-    :return: Current token's line.
+    :returns: Current token's line.
     """
     return 0
 
@@ -94,7 +94,7 @@ def Get_Token_Offset() -> int:
     """
     Get the current token's offset in the current line.
 
-    :return: Current token's offset.
+    :returns: Current token's offset.
     """
     return 0
 
@@ -105,7 +105,7 @@ def Get_Token_Position() -> int:
     """
     Get the current token's position.
 
-    :return: Current token's position. Type: ``Source_Ptr``
+    :returns: Current token's position
     """
     return 0
 
@@ -116,7 +116,7 @@ def Get_Position() -> int:
     """
     Get the current position.
 
-    :return: Current position. Type: ``Source_Ptr``
+    :returns: Current position
     """
     return 0
 
@@ -129,6 +129,6 @@ def Current_Identifier() -> NameId:
     ``tok_identifier``, ``tok_char`` or ``tok_string``, its name_id can be
     retrieved via this function.
 
-    :return: NameId of the current token.
+    :returns: NameId of the current token.
     """
     return 0

--- a/pyGHDL/libghdl/vhdl/scanner.py
+++ b/pyGHDL/libghdl/vhdl/scanner.py
@@ -56,7 +56,7 @@ Flag_Comment = c_bool.in_dll(libghdl, "vhdl__scanner__flag_comment")
 @BindToLibGHDL("vhdl__scanner__set_file")
 def Set_File(SourceFile: SourceFileEntry) -> None:
     """
-    Initialize the scanner with file :obj:`SourceFile`.
+    Initialize the scanner with file ``SourceFile``.
 
     :param SourceFile: File to scan.
     """

--- a/pyGHDL/libghdl/vhdl/scanner.py
+++ b/pyGHDL/libghdl/vhdl/scanner.py
@@ -31,6 +31,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Vhdl.Scanner`` in *libghdl*.
+
+The lexer: turns a source buffer into the token stream the parser reads.
+"""
 
 from ctypes import c_int, c_bool
 

--- a/pyGHDL/libghdl/vhdl/sem.py
+++ b/pyGHDL/libghdl/vhdl/sem.py
@@ -31,6 +31,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Vhdl.Sem`` in *libghdl*.
+
+Semantic analysis: resolves names, computes types and decorates the AST with the results.
+"""
 
 from pyTooling.Decorators import export
 

--- a/pyGHDL/libghdl/vhdl/sem.py
+++ b/pyGHDL/libghdl/vhdl/sem.py
@@ -47,7 +47,7 @@ from pyGHDL.libghdl._decorator import BindToLibGHDL
 @BindToLibGHDL("vhdl__sem__semantic")
 def Semantic(DesignUnit: Iir_Design_Unit) -> None:
     """
-    Do the semantic analysis of design unit :obj:`DesignUnit`.
+    Do the semantic analysis of design unit ``DesignUnit``.
 
     Also add a few nodes or change some nodes, when for example an identifier is
     changed into an access to the type.

--- a/pyGHDL/libghdl/vhdl/sem.py
+++ b/pyGHDL/libghdl/vhdl/sem.py
@@ -52,5 +52,5 @@ def Semantic(DesignUnit: Iir_Design_Unit) -> None:
     Also add a few nodes or change some nodes, when for example an identifier is
     changed into an access to the type.
 
-    :param DesignUnit: Design unit to semantically analyze. Type: ``Iir_Design_Unit``
+    :param DesignUnit: Design unit to semantically analyze
     """

--- a/pyGHDL/libghdl/vhdl/sem_lib.py
+++ b/pyGHDL/libghdl/vhdl/sem_lib.py
@@ -31,6 +31,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Vhdl.Sem_Lib`` in *libghdl*.
+
+Loads and analyzes a design file, which is the entry point :class:`~pyGHDL.dom.NonStandard.Document` uses.
+"""
 
 from pyTooling.Decorators import export
 

--- a/pyGHDL/libghdl/vhdl/sem_lib.py
+++ b/pyGHDL/libghdl/vhdl/sem_lib.py
@@ -50,7 +50,7 @@ def Load_File(File: SourceFileEntry) -> Iir_Design_File:
     Start to analyse a file (i.e. load and parse it).
 
     :param File: File to analyse.
-    :return:     Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` in case of parse error. Type: ``Iir_Design_File``
+    :returns:    Return :attr:`~pyGHDL.libghdl.vhdl.nodes.Null_Iir` in case of parse error
     """
     return 0
 

--- a/pyGHDL/libghdl/vhdl/sem_lib.py
+++ b/pyGHDL/libghdl/vhdl/sem_lib.py
@@ -59,7 +59,7 @@ def Load_File(File: SourceFileEntry) -> Iir_Design_File:
 @BindToLibGHDL("vhdl__sem_lib__finish_compilation")
 def Finish_Compilation(Unit: Iir_Design_Unit, Main: bool = False) -> None:
     """
-    Analyze :obj:`Unit`.
+    Analyze ``Unit``.
 
     :param Unit: Design unit to analyze.
     :param Main: Is main unit.
@@ -70,7 +70,7 @@ def Finish_Compilation(Unit: Iir_Design_Unit, Main: bool = False) -> None:
 @BindToLibGHDL("vhdl__sem_lib__free_dependence_list")
 def Free_Dependence_List(Design: Iir_Design_Unit) -> None:
     """
-    Free the dependence list of :obj:`Design`.
+    Free the dependence list of ``Design``.
 
     :param Design: Design unit to free dependencies for.
     """

--- a/pyGHDL/libghdl/vhdl/std_package.py
+++ b/pyGHDL/libghdl/vhdl/std_package.py
@@ -31,6 +31,12 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Python binding for the Ada package ``Vhdl.Std_Package`` in *libghdl*.
+
+The nodes of the implicitly declared ``std.standard`` package, so the analyzer can refer to ``bit``, ``boolean`` and
+the other predefined types.
+"""
 
 from ctypes import c_int32
 

--- a/pyGHDL/libghdl/vhdl/utils.py
+++ b/pyGHDL/libghdl/vhdl/utils.py
@@ -31,6 +31,9 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Helpers on top of the raw :mod:`pyGHDL.libghdl.vhdl` bindings.
+"""
 
 from pyTooling.Decorators import export
 
@@ -48,12 +51,24 @@ def Get_Source_Identifier(Decl: Iir) -> NameId:
     Not useful for analysis as VHDL is case insensitive, but could be useful for error messages or tooling.
 
     :param Decl: Iir Node. Type: ``Iir``
+    :returns:    The identifier as written in the source file.
     """
     return 0
 
 
 @export
 def Get_Source_Identifier_Str(n: Iir) -> str:
+    """
+    Return a declaration's identifier as it was written in the source file.
+
+    :func:`~pyGHDL.libghdl.name_table.Get_Name_Ptr` returns the *normalized* identifier, which is lower:
+    case; this reads the characters back out of the source buffer instead, so the original casing is
+    preserved.
+
+    :param n: The IIR node of the declaration.
+    :returns: The identifier as written.
+
+    """
     loc = nodes.Get_Location(n)
     l = name_table.Get_Name_Length(nodes.Get_Identifier(n))
     sfe = files_map.Location_To_File(loc)

--- a/pyGHDL/libghdl/vhdl/utils.py
+++ b/pyGHDL/libghdl/vhdl/utils.py
@@ -50,7 +50,7 @@ def Get_Source_Identifier(Decl: Iir) -> NameId:
     Like ``Get_Identifier`` but return a ``NameId`` for the same casing as it appears in the source file.
     Not useful for analysis as VHDL is case insensitive, but could be useful for error messages or tooling.
 
-    :param Decl: Iir Node. Type: ``Iir``
+    :param Decl: Iir Node
     :returns:    The identifier as written in the source file.
     """
     return 0
@@ -67,7 +67,6 @@ def Get_Source_Identifier_Str(n: Iir) -> str:
 
     :param n: The IIR node of the declaration.
     :returns: The identifier as written.
-
     """
     loc = nodes.Get_Location(n)
     l = name_table.Get_Name_Length(nodes.Get_Identifier(n))

--- a/pyGHDL/lsp/document.py
+++ b/pyGHDL/lsp/document.py
@@ -102,7 +102,12 @@ class Document(object):
             self.__extend_source_buffer(l)
         files_map_editor.Fill_Text(self._fe, ctypes.c_char_p(src_bytes), l)
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """
+        Returns the document's URI, which is how the language server protocol identifies a document.
+
+        :returns: A string representation of this document.
+        """
         return str(self.uri)
 
     def apply_change(self, change):


### PR DESCRIPTION
> [!NOTE]
> This branch is split off `paebbels/dom-updates` (ghdl/ghdl#3313) and only the changes **on top of
> it** are described here. The diff against `master` also carries #3313's content; please review that
> one there.

Documentation for the `pyGHDL` Python package. No behaviour changes: doc-strings, three type
annotations, and one deleted file.

Doc-string coverage measured with `interrogate` (`fail-under = 59` in `pyproject.toml`):

| | before | after |
|---|---|---|
| `pyGHDL.dom` | 14.7 % | **100.0 %** |
| `pyGHDL.libghdl` | 8.3 % | 11.8 % |
| **`pyGHDL`** | 11.1 % | **39.2 %** |

# `pyGHDL.dom` — complete

Every module, class, field, `__init__`, dunder method, property, function and method now has a
doc-string whose `:param:` list matches its signature, verified by an AST pass.

* **238 classes.** 227 mirror a pyVHDLModel class and every undocumented one had a base carrying
  real text, so they reuse it with `@InheritDocString(VHDLModel_X, merge=True)` and add the
  pyGHDL-specific sentence. `BaseFirst` order is deliberate: the autoapi module template lists
  classes by their first line, so the pyGHDL note must come second or every entry in the module
  index reads alike.
* **228 `__init__` methods.** The 28 that already carried `@InheritDocString` are *fixed*, not
  extended: a `pyGHDL.dom` mirror takes the IIR node first and no `parent`, so the inherited
  parameter list described a different signature — all 28 disagreed. `Design` published
  `:param allowBlackbox:`, which it does not accept, and omitted `vhdlVersion`, which it does.
* **146 methods**, of which 113 are the `parse` classmethods. The IIR node parameter has 45 distinct
  names across them, so each names the construct it holds rather than sharing one sentence.
* **19 class fields**, **7 properties**, the module level, and the last dunder methods.

Wording conventions applied throughout: a keyword is marked with a new `:vhdlkw:` role (see below),
a construct is named rather than called "a model entity", and whether a statement's label is optional
was **checked against GHDL** rather than assumed — it is mandatory for the three instantiations, the
block statement and the three generate statements, optional everywhere else.

# `pyGHDL.libghdl` — the hand-written half

The six generated files (`nodes.py`, `nodes_meta.py`, `tokens.py`, `elocations.py`, `errorout.py`,
`std_names.py`) are **untouched**: they are written by `scripts/pnodespy.py` and a doc-string added
here would be lost on the next regeneration. Filling those is ghdl/ghdl#3328.

The 28 hand-written modules are complete — 27 module doc-strings naming the Ada package each binds,
3 classes and 17 functions and closures. The private raw bindings (`_Get_Name_Ptr`,
`_String8_Address`, …) now say which public function to use instead.

Three legacy patterns were cleared while sweeping: **61** `:return:` became `:returns:`, **31**
`Type: ``X``` suffixes were dropped (they name the *Ada* type, which the Python signature already
gives), and **22** `undocumented` placeholders were filled.

# Infrastructure

* **A `:vhdlkw:` role** in `doc/prolog.inc`, beside the existing `:pycode:` and colour roles, marking
  a VHDL keyword in prose so it is not mistaken for ordinary English — `others`, `for`, `report` and
  `process` all read as both. Rendered as emphasis with a CSS class, so the styling can change
  without touching a doc-string. It is deliberately **not** called `keyword`: Sphinx's standard
  domain owns that name, and registering another role under it is silently ignored.
* **`setup.py`** declares `pythonVersions`, and `pyGHDL/lsp/version.py` is deleted — nothing imported
  it and its `0.1dev` contradicted `pyGHDL.__version__`.
* **A malformed grid table** in `pyGHDL/lib/__init__.py` emitted `ERROR: Malformed table.` on every
  documentation build; it is a `list-table` now.

# Defects found and recorded

Several of these are behaviour, not documentation, so they are described in the doc-strings and left
for a separate change:

* **`Document.LibGHDLProcessingTime` raises `AttributeError`** rather than returning `None` when the
  document was constructed with `dontParse=True` — the backing field is only assigned when parsing
  ran, and `ExtendedType` uses slots. `Design`'s sibling fields are `Nullable[float] = None`, so the
  two classes disagree, and `pyGHDL/cli/dom.py:309` multiplies one of them unguarded.
* **`FunctionCall.__init__` discards its `operand`** — `super().__init__()` takes no arguments
  because `pyVHDLModel.Expression.FunctionCall` is a `pass` stub. Recorded as a `.. todo::`; the class
  is never constructed, so nothing is broken today.
* **208 parameters default to `None` while annotated with the bare type**, including all 70 `label`
  parameters.

# Verification

* `pytest testsuite/pyunit` — **190 passed, 17 xfailed**, unchanged throughout.
* `black --check pyGHDL` — 71 files unchanged.
* AST checks: 0 classes, methods or functions without a doc-string in `pyGHDL.dom`; 0 `:param:` lists
  disagreeing with a signature.
* A local HTML build: the only `pyGHDL.dom` messages are 188 pre-existing
  `sphinx_autodoc_typehints` forward-reference warnings about type annotations.
