### PR TITLE
Documentation for pyGHDL.cli and pyGHDL.lsp

### DIFF
--- a/pyGHDL/cli/__init__.py
+++ b/pyGHDL/cli/__init__.py
@@ -34,6 +34,6 @@
 """
 Command line applications shipped with pyGHDL.
 
-:mod:`~pyGHDL.cli.dom` exercises :mod:`pyGHDL.dom` from a terminal, and :mod:`~pyGHDL.cli.lsp` starts the language
+:mod:`pyGHDL.cli.dom` exercises :mod:`pyGHDL.dom` from a terminal, and :mod:`pyGHDL.cli.lsp` starts the language
 server. Both are registered as console scripts by :file:`setup.py`.
 """

--- a/pyGHDL/cli/__init__.py
+++ b/pyGHDL/cli/__init__.py
@@ -31,3 +31,9 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Command line applications shipped with pyGHDL.
+
+:mod:`~pyGHDL.cli.dom` exercises :mod:`pyGHDL.dom` from a terminal, and :mod:`~pyGHDL.cli.lsp` starts the language
+server. Both are registered as console scripts by :file:`setup.py`.
+"""

--- a/pyGHDL/cli/dom.py
+++ b/pyGHDL/cli/dom.py
@@ -36,7 +36,8 @@
 A terminal application to exercise :mod:`pyGHDL.dom`.
 
 It analyzes VHDL source files with *libghdl*, translates the result to the document object model and pretty-prints it,
-which makes it the quickest way to see what the model makes of a given file. Installed as ``pyghdl-dom``.
+which makes it the quickest way to see what the model makes of a given file. Installed as ``pyghdl-dom`` by
+:file:`setup.py`.
 """
 
 from argparse import RawDescriptionHelpFormatter
@@ -148,7 +149,7 @@ class Application(TerminalApplication, ArgParseHelperMixin):
 
     def __init__(self):
         """
-        Initializes the application with an empty design and the argument parser.
+        Initializes the application.
         """
         super().__init__()
 

--- a/pyGHDL/cli/dom.py
+++ b/pyGHDL/cli/dom.py
@@ -32,6 +32,13 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+A terminal application to exercise :mod:`pyGHDL.dom`.
+
+It analyzes VHDL source files with *libghdl*, translates the result to the document object model and pretty-prints it,
+which makes it the quickest way to see what the model makes of a given file. Installed as ``pyghdl-dom``.
+"""
+
 from argparse import RawDescriptionHelpFormatter
 from pathlib import Path
 from platform import system as platform_system
@@ -56,6 +63,10 @@ __license__ = ""
 
 
 class SourceAttribute(Attribute):
+    """
+    Attribute attaching the source selection command line arguments to a handler method.
+    """
+
     def __call__(self, func):
         """
         Attaches the source selection command line arguments to the decorated handler method.
@@ -121,6 +132,13 @@ class SourceAttribute(Attribute):
 
 @export
 class Application(TerminalApplication, ArgParseHelperMixin):
+    """
+    The ``pyghdl-dom`` application.
+
+    It owns a :class:`~pyGHDL.dom.NonStandard.Design`, adds the requested source files to it, and dispatches the
+    sub-command the user asked for.
+    """
+
     HeadLine = "pyGHDL.dom - Test Application"
 
     # load platform information (Windows, Linux, Darwin, ...)
@@ -129,6 +147,9 @@ class Application(TerminalApplication, ArgParseHelperMixin):
     _design: Design
 
     def __init__(self):
+        """
+        Initializes the application with an empty design and the argument parser.
+        """
         super().__init__()
 
         # Initialize DOM with an empty design
@@ -152,7 +173,17 @@ class Application(TerminalApplication, ArgParseHelperMixin):
         )
 
         class HelpFormatter(RawDescriptionHelpFormatter):
+            """
+            Help formatter widening argparse's output to the terminal.
+            """
+
             def __init__(self, *args, **kwargs):
+                """
+                Initializes the formatter with a wider help column and line width.
+
+                :param args:   Positional arguments passed on to :class:`~argparse.RawDescriptionHelpFormatter`.
+                :param kwargs: Keyword arguments passed on, with the width settings overridden.
+                """
                 kwargs["max_help_position"] = 30
                 kwargs["width"] = textWidth
                 super().__init__(*args, **kwargs)
@@ -176,9 +207,17 @@ class Application(TerminalApplication, ArgParseHelperMixin):
     # ============================================================================
     @readonly
     def Platform(self):
+        """
+        Read-only property to access the platform the application runs on (:attr:`__PLATFORM`).
+
+        :returns: The platform's name, as :func:`platform.system` reports it.
+        """
         return self.__PLATFORM
 
     def PrintHeadline(self):
+        """
+        Print the application's headline banner.
+        """
         self.WriteNormal(dedent("""\
                 {HEADLINE}{line}
                 {headline: ^80s}
@@ -193,10 +232,18 @@ class Application(TerminalApplication, ArgParseHelperMixin):
     @FlagArgument("-v", "--verbose", dest="verbose", help="Print out detailed messages.")
     @FlagArgument("-q", "--quiet", dest="quiet", help="Reduce messages to a minimum.")
     def Run(self):
+        """
+        Parse the command line and run the requested sub-command.
+        """
         ArgParseHelperMixin.Run(self)
 
     @DefaultHandler()
     def HandleDefault(self, _):
+        """
+        Handle an invocation with no sub-command by printing the help page.
+
+        :param _: The parsed arguments, unused.
+        """
         self.PrintHeadline()
         self.MainParser.print_help()
 
@@ -209,6 +256,11 @@ class Application(TerminalApplication, ArgParseHelperMixin):
     @CommandHandler("help", help="Display help page(s) for the given command name.")
     @StringArgument(metaName="Command", dest="Command", optional=True, help="Print help page(s) for a command.")
     def HandleHelp(self, args):
+        """
+        Handle the ``help`` sub-command: print the help page of a command, or the overview.
+
+        :param args: The parsed arguments, carrying the optional command name.
+        """
         self.PrintHeadline()
 
         if args.Command is None:
@@ -229,6 +281,11 @@ class Application(TerminalApplication, ArgParseHelperMixin):
     # ----------------------------------------------------------------------------
     @CommandHandler("version", help="Display tool and version information.")
     def HandleInfo(self, args):
+        """
+        Handle the ``version`` sub-command: print copyright, license and authors.
+
+        :param args: The parsed arguments, unused.
+        """
         self.PrintHeadline()
 
         copyrights = __copyright__.split("\n", 1)
@@ -253,6 +310,14 @@ class Application(TerminalApplication, ArgParseHelperMixin):
     )
     @SourceAttribute()
     def HandlePretty(self, args):
+        """
+        Handle the ``pretty`` sub-command: analyze the selected sources and pretty-print the resulting model.
+
+        A file is analyzed on its own; a directory is scanned, and each subdirectory is treated as a library of that
+        name. The time *libghdl* spent parsing and the time the translation took are reported per file.
+
+        :param args: The parsed arguments, carrying the selected files, directory and default library.
+        """
         self.PrintHeadline()
 
         if args.Files is not None:
@@ -336,6 +401,13 @@ class Application(TerminalApplication, ArgParseHelperMixin):
         self.Exit()
 
     def addFile(self, filename: Path, library: str) -> Document:
+        """
+        Analyze a source file and add the resulting document to the design.
+
+        :param filename: The source file to analyze.
+        :param library:  The name of the library to add the document to.
+        :returns:        The analyzed document.
+        """
         lib = self._design.GetLibrary(library)
 
         document = Document(filename)

--- a/pyGHDL/cli/lsp.py
+++ b/pyGHDL/cli/lsp.py
@@ -31,6 +31,13 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+The command line entry point of GHDL's language server.
+
+It parses the command line, sets up logging - including a rotating trace of the protocol traffic, which is what makes a
+misbehaving editor debuggable - and hands over to :class:`pyGHDL.lsp.vhdl_ls.VhdlLanguageServer`. Installed as
+``ghdl-ls``.
+"""
 
 from argparse import ArgumentParser
 from logging import getLogger, DEBUG, INFO, ERROR, basicConfig
@@ -58,7 +65,15 @@ __loggerName = "ghdl-ls"
 
 
 def __rotate_log_files(basename: str, num: int):
-    """Rotate existing log files."""
+    """
+    Rotate existing log files.
+
+    The oldest file is removed - on Windows renaming onto an existing file is an error - then each remaining file is
+    shifted up one number and the current log becomes ``.0``.
+
+    :param basename: The path of the current log file, without a rotation suffix.
+    :param num:      How many rotated files to keep.
+    """
     # Remove the oldest file.  This one will be lost.
     # Required on Windows as it is an error to rename a file to an existing
     # one.
@@ -79,7 +94,11 @@ def __rotate_log_files(basename: str, num: int):
 
 
 def _generateCLIParser() -> ArgumentParser:
-    """Creates an CLI argument parser based on ``argparse``."""
+    """
+    Creates an CLI argument parser based on ``argparse``.
+
+    :returns: The parser for the language server's arguments.
+    """
     parser = ArgumentParser(
         description="VHDL Language Protocol Server. Find info about clients in `ghdl/ghdl-language-server <https://github.com/ghdl/ghdl-language-server>`__."
     )

--- a/pyGHDL/lsp/__init__.py
+++ b/pyGHDL/lsp/__init__.py
@@ -33,9 +33,13 @@
 """
 Implementation of GHDL's language server.
 
-The package is layered: :mod:`~pyGHDL.lsp.lsp` speaks the Language Server Protocol over stdin and stdout,
-:mod:`~pyGHDL.lsp.vhdl_ls` implements the VHDL-specific requests on top of it, and
-:mod:`~pyGHDL.lsp.workspace` and :mod:`~pyGHDL.lsp.document` hold the analyzed sources the requests are answered from.
+The package is layered, from the wire upwards:
+
+1. :mod:`pyGHDL.lsp.lsp` speaks the Language Server Protocol over stdin and stdout.
+2. :mod:`pyGHDL.lsp.vhdl_ls` implements the VHDL-specific requests on top of it.
+3. :mod:`pyGHDL.lsp.workspace` and :mod:`pyGHDL.lsp.document` hold the analyzed sources the requests are answered
+   from.
+
 The entry point is :mod:`pyGHDL.cli.lsp`.
 """
 

--- a/pyGHDL/lsp/__init__.py
+++ b/pyGHDL/lsp/__init__.py
@@ -30,6 +30,15 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Implementation of GHDL's language server.
+
+The package is layered: :mod:`~pyGHDL.lsp.lsp` speaks the Language Server Protocol over stdin and stdout,
+:mod:`~pyGHDL.lsp.vhdl_ls` implements the VHDL-specific requests on top of it, and
+:mod:`~pyGHDL.lsp.workspace` and :mod:`~pyGHDL.lsp.document` hold the analyzed sources the requests are answered from.
+The entry point is :mod:`pyGHDL.cli.lsp`.
+"""
+
 from pyTooling.Decorators import export
 
 from pyGHDL import GHDLBaseException

--- a/pyGHDL/lsp/__init__.py
+++ b/pyGHDL/lsp/__init__.py
@@ -49,22 +49,44 @@ class LSPConnTrace(object):
     """Wrapper class to save in and out packets"""
 
     def __init__(self, basename, conn):
+        """
+        Initializes the trace by opening the two log files beside the connection.
+
+        :param basename: The path the traces are written to, with ``.in`` and ``.out`` appended.
+        :param conn:     The connection to wrap.
+        """
         self.conn = conn
         self.trace_in = open(basename + ".in", "w")
         self.trace_out = open(basename + ".out", "w")
 
     def readline(self):
+        """
+        Read a line from the wrapped connection and record it.
+
+        :returns: The line that was read.
+        """
         res = self.conn.readline()
         self.trace_in.write(res)
         return res
 
     def read(self, size):
+        """
+        Read from the wrapped connection and record what was read.
+
+        :param size: The number of characters to read.
+        :returns:    The characters that were read.
+        """
         res = self.conn.read(size)
         self.trace_in.write(res)
         self.trace_in.flush()
         return res
 
     def write(self, out):
+        """
+        Write to the wrapped connection and record what was written.
+
+        :param out: The text to write.
+        """
         self.conn.write(out)
         self.trace_out.write(out)
         self.trace_out.flush()

--- a/pyGHDL/lsp/document.py
+++ b/pyGHDL/lsp/document.py
@@ -57,6 +57,13 @@ log = logging.getLogger(__name__)
 
 
 class Document(object):
+    """
+    A source file known to the language server.
+
+    The document owns the source buffer *libghdl* analyzes and the IIR tree of the last successful analysis. An
+    editor's edits are applied to the buffer in place, so the file on disk is never re-read.
+    """
+
     # The encoding used for the files.
     # Unfortunately this is not fully reliable.  The client can read the
     # file using its own view of the encoding.  It then pass the document
@@ -64,18 +71,19 @@ class Document(object):
     # back to bytes using this encoding.  And we hope the result would be
     # the same as the file.  Because VHDL uses the iso 8859-1 character
     # set, we use the same encoding.  The client should also use 8859-1.
-    """
-    A source file known to the language server.
-
-    The document owns the source buffer *libghdl* analyzes and the IIR tree of the last successful analysis. An
-    editor's edits are applied to the buffer in place, so the file on disk is never re-read.
-
-    """
     encoding = "iso-8859-1"
 
     initial_gap_size = 4096
 
     def __init__(self, uri, sfe=None, lib=None, version=None):
+        """
+        Initialize a document from the source file *libghdl* has reserved for it.
+
+        :param uri:     The URI the client identifies this document by.
+        :param sfe:     The source file entry holding the text, as returned by :meth:`load`.
+        :param lib:     The name of the library the units are analyzed into, or ``None`` for ``work``.
+        :param version: The version the client attached to the document, used to detect stale edits.
+        """
         self.uri = uri
         self.version = version
         self._fe = sfe
@@ -85,6 +93,17 @@ class Document(object):
 
     @staticmethod
     def load(src_bytes, dirname, filename):
+        """
+        Reserve a source file in *libghdl* and fill it with the given text.
+
+        The buffer is over-allocated by :attr:`initial_gap_size`, so the first edits an editor sends fit without
+        reallocating it.
+
+        :param src_bytes: The source text, already encoded with :attr:`encoding`.
+        :param dirname:   The directory the file lives in. It is ignored when ``filename`` is absolute.
+        :param filename:  The name of the file.
+        :returns:         The source file entry the text was written to.
+        """
         # Write text to file buffer.
         src_len = len(src_bytes)
         buf_len = src_len + Document.initial_gap_size
@@ -98,6 +117,14 @@ class Document(object):
         return sfe
 
     def __extend_source_buffer(self, new_size):
+        """
+        Move the source to a larger buffer, because an edit no longer fits in the current one.
+
+        The gap is doubled on every extension, so a document that keeps growing is not reallocated on every
+        keystroke. The old source file is copied and freed, which invalidates the previous source file entry.
+
+        :param new_size: The number of bytes the edit needs on top of the current file length.
+        """
         self.gap_size *= 2
         fileid = files_map.Get_File_Name(self._fe)
         dirid = files_map.Get_Directory_Name(self._fe)
@@ -109,7 +136,12 @@ class Document(object):
         self._fe = new_sfe
 
     def reload(self, source):
-        """Reload the source of a document."""
+        """
+        Replace the whole source of the document.
+
+        :param source: The new source text. It is encoded with :attr:`encoding`, replacing characters that cannot
+                       be represented.
+        """
         src_bytes = source.encode(Document.encoding, "replace")
         l = len(src_bytes)
         if l >= files_map.Get_Buffer_Length(self._fe):
@@ -125,7 +157,16 @@ class Document(object):
         return str(self.uri)
 
     def apply_change(self, change):
-        """Apply a change to the document."""
+        """
+        Apply one incremental edit to the source buffer.
+
+        The replacement is retried once against a larger buffer, because a text longer than the gap fails the first
+        time. Line numbers are converted from the protocol's 0-based counting to *libghdl*'s 1-based counting.
+
+        :param change:          A ``TextDocumentContentChangeEvent`` with a ``range`` and the replacing ``text``.
+        :raises AssertionError: If the change has no ``range``, which is how a client asking to replace the whole
+                                document is rejected.
+        """
         text = change["text"]
         change_range = change.get("range")
 
@@ -173,6 +214,13 @@ class Document(object):
         assert status
 
     def check_document(self, text):
+        """
+        Compare the server's buffer against the client's text, to catch edits that were applied differently.
+
+        A mismatch is reported by *libghdl* as an internal error; the buffer is left as it is.
+
+        :param text: The document contents as the client sees them.
+        """
         log.debug("Checking document: %s", self.uri)
 
         text_bytes = text.encode(Document.encoding, "replace")
@@ -181,6 +229,17 @@ class Document(object):
 
     @staticmethod
     def add_to_library(tree, library):
+        """
+        Move the design units of a parsed file into a library.
+
+        The units are detached from the design file and added one by one, because the library owns them afterwards
+        and may replace an older unit of the same name. A unit without a library unit or without an identifier is
+        dropped rather than added.
+
+        :param tree:    The design file the parser produced.
+        :param library: The name of the target library, or ``None`` for ``work``.
+        :returns:       The design file the library holds the units in, or ``Null_Iir`` if none were added.
+        """
         # Set the target library
         if library is None:
             library = "work"
@@ -205,7 +264,15 @@ class Document(object):
         return tree
 
     def parse_document(self):
-        """Parse a document and put the units in the library."""
+        """
+        Parse the source buffer and put the units it declares into the library.
+
+        The tree is left as ``Null_Iir`` when the file declares no unit, which is not an error - an empty file or a
+        file holding only comments reaches this point.
+
+        :raises AssertionError: If the document already has a tree, because a document must be flushed before it is
+                                parsed again.
+        """
         assert self._tree == nodes.Null_Iir
         tree = sem_lib.Load_File(self._fe)
         if tree == nodes.Null_Iir:
@@ -217,6 +284,12 @@ class Document(object):
         nodes.Set_Design_File_Source(self._tree, self._fe)
 
     def compute_diags(self):
+        """
+        Parse the document and analyze every unit in it, so the errors reported are semantic ones too.
+
+        The diagnostics themselves are not returned; they are collected by the error handler the workspace
+        installed while this runs.
+        """
         log.debug("parse doc %d %s", self._fe, self.uri)
         self.parse_document()
         if self._tree == nodes.Null_Iir:
@@ -230,6 +303,16 @@ class Document(object):
             unit = nodes.Get_Chain(unit)
 
     def flatten_symbols(self, syms, parent):
+        """
+        Turn the tree of ``DocumentSymbol`` into the flat list of ``SymbolInformation``.
+
+        The two shapes differ in more than nesting: a location replaces the range, ``detail`` has no counterpart,
+        and the nesting is expressed by naming the container. A client that asked for the flat form gets it here.
+
+        :param syms:   The symbols to flatten. They are modified in place.
+        :param parent: The symbol the given ones are nested in, or ``None`` at the top level.
+        :returns:      The symbols and all their children, in one list.
+        """
         res = []
         for s in syms:
             s["location"] = {"uri": self.uri, "range": s["range"]}
@@ -244,6 +327,12 @@ class Document(object):
         return res
 
     def document_symbols(self):
+        """
+        Answer ``textDocument/documentSymbol`` for this document.
+
+        :returns: The symbols declared in the file, flattened. An empty list if the document has no tree, which is
+                  how a file that failed to parse is answered.
+        """
         log.debug("document_symbols")
         if self._tree == nodes.Null_Iir:
             return []
@@ -251,14 +340,38 @@ class Document(object):
         return self.flatten_symbols(syms, None)
 
     def position_to_location(self, position):
+        """
+        Convert a position in the protocol's coordinates to a *libghdl* location.
+
+        The character offset is added to the location of the line, which assumes one byte per character - the same
+        assumption :attr:`encoding` makes.
+
+        :param position: A ``Position``, with its 0-based ``line`` and ``character``.
+        :returns:        The location in the source file.
+        """
         pos = files_map.File_Line_To_Position(self._fe, position["line"] + 1)
         return files_map.File_Pos_To_Location(self._fe, pos) + position["character"]
 
     def find_definition(self, position):
+        """
+        Find the declaration the name under a position refers to.
+
+        :param position: The position the client asked about.
+        :returns:        The declaration node, or ``None`` if the position is not on a name.
+        """
         loc = self.position_to_location(position)
         return references.find_definition_by_loc(self._tree, loc)
 
     def hover(self, position):
+        """
+        Answer ``textDocument/hover`` by reprinting the declaration under a position.
+
+        The comments written above the declaration are shown before it, separated by a rule, so the documentation
+        the author wrote is what the reader sees first.
+
+        :param position: The position the client asked about.
+        :returns:        A ``Hover`` holding markdown, or ``None`` if there is no declaration at that position.
+        """
         loc = self.position_to_location(position)
         t = references.find_definition_by_loc(self._tree, loc)
         if t is None:
@@ -295,6 +408,16 @@ class Document(object):
         return res
 
     def format_range(self, rng):
+        """
+        Re-indent a range of lines.
+
+        Only whole lines are formatted. A range ending at character 0 does not extend into the line it ends on,
+        which is how a client selecting whole lines is handled.
+
+        :param rng: The ``Range`` to format.
+        :returns:   A list holding the single ``TextEdit`` that replaces those lines, or ``None`` if the range is
+                    empty or the document has no tree.
+        """
         first_line = rng["start"]["line"] + 1
         last_line = rng["end"]["line"] + (1 if rng["end"]["character"] != 0 else 0)
         if last_line < first_line:

--- a/pyGHDL/lsp/document.py
+++ b/pyGHDL/lsp/document.py
@@ -30,6 +30,13 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+A source file known to the language server.
+
+A :class:`Document` owns the source buffer *libghdl* analyzes and the IIR tree that came out of it, and applies the
+edits an editor sends without reloading the file from disk.
+"""
+
 import ctypes
 import logging
 import os
@@ -57,6 +64,13 @@ class Document(object):
     # back to bytes using this encoding.  And we hope the result would be
     # the same as the file.  Because VHDL uses the iso 8859-1 character
     # set, we use the same encoding.  The client should also use 8859-1.
+    """
+    A source file known to the language server.
+
+    The document owns the source buffer *libghdl* analyzes and the IIR tree of the last successful analysis. An
+    editor's edits are applied to the buffer in place, so the file on disk is never re-read.
+
+    """
     encoding = "iso-8859-1"
 
     initial_gap_size = 4096

--- a/pyGHDL/lsp/lsp.py
+++ b/pyGHDL/lsp/lsp.py
@@ -61,7 +61,6 @@ class LSPConn:
 
     Messages are framed with a ``Content-Length`` header, which is what distinguishes this from a plain JSON
     stream: the reader has to consume the header to know how many bytes the body has.
-
     """
 
     def __init__(self, reader, writer):
@@ -170,7 +169,6 @@ class LanguageProtocolServer(object):
 
     It decodes a message from the connection, dispatches it to the handler named by its ``method`` on the server
     object it was given, and writes back a response or an error. Requests are answered in the order they arrive.
-
     """
 
     def __init__(self, handler, conn):

--- a/pyGHDL/lsp/lsp.py
+++ b/pyGHDL/lsp/lsp.py
@@ -175,7 +175,8 @@ class LanguageProtocolServer(object):
         """
         Initializes the server with the object that handles the requests.
 
-        :param handler: The object whose ``lsp_*`` methods implement the protocol requests.
+        :param handler: The object answering the requests. Its ``dispatcher`` maps a protocol method to the method
+                        implementing it.
         :param conn:    The connection to serve on, or ``None`` to build one from stdin and stdout.
         """
         self.conn = conn
@@ -241,6 +242,7 @@ class LanguageProtocolServer(object):
         reported as ``MethodNotFound`` rather than raising.
 
         :param msg:            The decoded message.
+        :returns:              The response to write back, or ``None`` for a notification, which is not answered.
         :raises ProtocolError: If the message is not JSON-RPC 2.0.
         """
         if msg.get("jsonrpc", None) != "2.0":

--- a/pyGHDL/lsp/lsp.py
+++ b/pyGHDL/lsp/lsp.py
@@ -49,18 +49,40 @@ class ProtocolError(LSPException):
 
 class LSPConn:
     def __init__(self, reader, writer):
+        """
+        Initializes the connection from a reader and a writer.
+
+        :param reader: The binary stream messages are read from.
+        :param writer: The binary stream messages are written to.
+        """
         self.reader = reader
         self.writer = writer
 
     def readline(self):
+        """
+        Read one line, which is how a header line is consumed.
+
+        :returns: The line, decoded as UTF-8.
+        """
         data = self.reader.readline()
         return data.decode("utf-8")
 
     def read(self, size):
+        """
+        Read a message body of a known length.
+
+        :param size: The number of bytes to read, from the ``Content-Length`` header.
+        :returns:    The body, decoded as UTF-8.
+        """
         data = self.reader.read(size)
         return data.decode("utf-8")
 
     def write(self, out):
+        """
+        Write a message and flush, so the client sees it immediately.
+
+        :param out: The text to write.
+        """
         self.writer.write(out.encode())
         self.writer.flush()
 
@@ -69,6 +91,15 @@ def path_from_uri(uri):
     # Convert file uri to path (strip html like head part)
     # This is needed to get the root path and to load a document when the
     # textual source is not present.
+    """
+    Convert a ``file:`` URI to a path.
+
+    A URI that does not name a local file is returned unchanged, which is how a client sending something else is
+    tolerated rather than crashing the server.
+
+    :param uri: The URI to convert.
+    :returns:   The path the URI names, or the URI itself if it is not a ``file:`` URI.
+    """
     if not uri.startswith("file://"):
         # No scheme
         return uri
@@ -85,6 +116,12 @@ def path_from_uri(uri):
 
 
 def path_to_uri(path):
+    """
+    Convert a path to a ``file:`` URI, resolving it first.
+
+    :param path: The path to convert.
+    :returns:    The absolute ``file:`` URI of that path.
+    """
     return Path(path).resolve().as_uri()
 
 
@@ -93,6 +130,15 @@ def normalize_rpc_file_uris(rpc):
     # Fixes a crash on windows where the underlying ada crashes
     # if paths to the same file are given with inconsistent
     # capitalization.
+    """
+    Normalize the capitalization of every ``file:`` URI in a message.
+
+    Clients differ in how they capitalize a drive letter on Windows, so the same document can arrive under two
+    spellings and be looked up as two different files.
+
+    :param rpc: The decoded message to normalize, modified in place.
+    :returns:   The same message.
+    """
     for key, val in rpc.items():
         # recurse into all leaf elements.
         if isinstance(val, dict):
@@ -104,6 +150,12 @@ def normalize_rpc_file_uris(rpc):
 
 class LanguageProtocolServer(object):
     def __init__(self, handler, conn):
+        """
+        Initializes the server with the object that handles the requests.
+
+        :param handler: The object whose ``lsp_*`` methods implement the protocol requests.
+        :param conn:    The connection to serve on, or ``None`` to build one from stdin and stdout.
+        """
         self.conn = conn
         self.handler = handler
         if handler is not None:
@@ -112,6 +164,12 @@ class LanguageProtocolServer(object):
         self._next_id = 0
 
     def read_request(self):
+        """
+        Read one message: the headers, then the body of the length they announce.
+
+        :returns:              The message body, or ``None`` at end of input.
+        :raises ProtocolError: If a header line is malformed or ``Content-Length`` is missing.
+        """
         headers = {}
         while True:
             # Read a line
@@ -136,6 +194,9 @@ class LanguageProtocolServer(object):
                 headers[key] = value
 
     def run(self):
+        """
+        Serve requests until the client disconnects or asks the server to exit.
+        """
         while self.running:
             body = self.read_request()
             if body is None:
@@ -151,6 +212,15 @@ class LanguageProtocolServer(object):
                 self.write_output(reply)
 
     def handle(self, msg):
+        """
+        Dispatch one decoded message to the handler named by its ``method``.
+
+        A request is answered with a response, a notification is not answered at all, and an unknown method is
+        reported as ``MethodNotFound`` rather than raising.
+
+        :param msg:            The decoded message.
+        :raises ProtocolError: If the message is not JSON-RPC 2.0.
+        """
         if msg.get("jsonrpc", None) != "2.0":
             raise ProtocolError("invalid jsonrpc version")
         tid = msg.get("id", None)
@@ -203,13 +273,23 @@ class LanguageProtocolServer(object):
         return rbody
 
     def write_output(self, body):
+        """
+        Encode a message and write it with its ``Content-Length`` header.
+
+        :param body: The message to send.
+        """
         output = json.dumps(body, separators=(",", ":"))
         self.conn.write(f"Content-Length: {len(output)}\r\n")
         self.conn.write("\r\n")
         self.conn.write(output)
 
     def notify(self, method, params):
-        """Send a notification."""
+        """
+        Send a notification, which the client does not answer.
+
+        :param method: The protocol method to notify.
+        :param params: The parameters of the notification.
+        """
         body = {
             "jsonrpc": "2.0",
             "method": method,
@@ -218,7 +298,13 @@ class LanguageProtocolServer(object):
         self.write_output(body)
 
     def send_request(self, method, params):
-        """Send a request."""
+        """
+        Send a request to the client and wait for its answer.
+
+        :param method: The protocol method to call.
+        :param params: The parameters of the request.
+        :returns:      The client's result.
+        """
         self._next_id += 1
         body = {
             "jsonrpc": "2.0",
@@ -233,9 +319,21 @@ class LanguageProtocolServer(object):
         self.running = False
 
     def show_message(self, typ, message):
+        """
+        Ask the client to show a message to the user.
+
+        :param typ:     The severity, from :class:`MessageType`.
+        :param message: The text to show.
+        """
         self.notify("window/showMessage", {"type": typ, "message": message})
 
     def configuration(self, items):
+        """
+        Ask the client for configuration values.
+
+        :param items: The configuration items to request.
+        :returns:     The client's answer.
+        """
         return self.send_request("workspace/configuration", {"items": items})
 
 

--- a/pyGHDL/lsp/lsp.py
+++ b/pyGHDL/lsp/lsp.py
@@ -30,6 +30,14 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+The transport and dispatch layer of the Language Server Protocol.
+
+:class:`LSPConn` reads and writes the ``Content-Length`` framed JSON-RPC messages on a pair of streams, and
+:class:`LanguageProtocolServer` runs the request loop: it decodes a message, calls the matching handler on the server
+object and writes the response. It knows nothing about VHDL - :mod:`pyGHDL.lsp.vhdl_ls` supplies the handlers.
+"""
+
 import os
 from pathlib import Path
 import logging
@@ -48,6 +56,14 @@ class ProtocolError(LSPException):
 
 
 class LSPConn:
+    """
+    The stream pair a language server talks over.
+
+    Messages are framed with a ``Content-Length`` header, which is what distinguishes this from a plain JSON
+    stream: the reader has to consume the header to know how many bytes the body has.
+
+    """
+
     def __init__(self, reader, writer):
         self.reader = reader
         self.writer = writer
@@ -103,6 +119,14 @@ def normalize_rpc_file_uris(rpc):
 
 
 class LanguageProtocolServer(object):
+    """
+    The request loop of the Language Server Protocol.
+
+    It decodes a message from the connection, dispatches it to the handler named by its ``method`` on the server
+    object it was given, and writes back a response or an error. Requests are answered in the order they arrive.
+
+    """
+
     def __init__(self, handler, conn):
         self.conn = conn
         self.handler = handler
@@ -246,6 +270,9 @@ class LanguageProtocolServer(object):
 
 class JSONErrorCodes(object):
     # Defined by JSON RPC
+    """
+    The JSON-RPC and Language Server Protocol error codes.
+    """
     ParseError = -32700
     InvalidRequest = -32600
     MethodNotFound = -32601
@@ -262,6 +289,10 @@ class JSONErrorCodes(object):
 
 
 class CompletionKind(object):
+    """
+    The kinds of completion item an editor can display, as the protocol numbers them.
+    """
+
     Text = 1
     Method = 2
     Function = 3
@@ -283,6 +314,10 @@ class CompletionKind(object):
 
 
 class DiagnosticSeverity(object):
+    """
+    The severity levels a diagnostic can carry.
+    """
+
     Error = 1
     Warning = 2
     Information = 3
@@ -290,12 +325,20 @@ class DiagnosticSeverity(object):
 
 
 class TextDocumentSyncKind(object):
+    """
+    How a client sends document changes: not at all, in full, or incrementally.
+    """
+
     NONE = (0,)
     FULL = 1
     INCREMENTAL = 2
 
 
 class MessageType(object):
+    """
+    The severity levels of a message shown to the user.
+    """
+
     Error = 1
     Warning = 2
     Info = 3
@@ -303,6 +346,10 @@ class MessageType(object):
 
 
 class SymbolKind(object):
+    """
+    The kinds of symbol an editor can display in its outline, as the protocol numbers them.
+    """
+
     File = 1
     Module = 2
     Namespace = 3

--- a/pyGHDL/lsp/lsptools.py
+++ b/pyGHDL/lsp/lsptools.py
@@ -30,6 +30,13 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+A small command line helper to convert a captured protocol trace between its LSP and JSON forms.
+
+A trace recorded by :class:`~pyGHDL.lsp.LSPConnTrace` is a stream of ``Content-Length`` framed messages; ``lsp2json``
+turns it into plain JSON and ``json2lsp`` back again, which is what makes a recorded session replayable.
+"""
+
 import sys
 import argparse
 import json

--- a/pyGHDL/lsp/lsptools.py
+++ b/pyGHDL/lsp/lsptools.py
@@ -66,6 +66,11 @@ def json2lsp():
 
 
 def main():
+    """
+    Run the tool named by the first argument.
+
+    :raises AttributeError: If no sub-command was given, as there is no default one.
+    """
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(help="sub-command help")
     parser_l2j = subparsers.add_parser("lsp2json", help="convert lsp dump to JSON")

--- a/pyGHDL/lsp/references.py
+++ b/pyGHDL/lsp/references.py
@@ -44,6 +44,13 @@ log = logging.getLogger(__name__)
 
 
 def find_def_chain(first, loc):
+    """
+    Search a chain of nodes for the one a location falls in.
+
+    :param first: The first node of the chain.
+    :param loc:   The location to look for.
+    :returns:     The node covering that location, or ``None`` if no node of the chain does.
+    """
     n1 = first
     while n1 != nodes.Null_Iir:
         res = find_def(n1, loc)
@@ -54,7 +61,21 @@ def find_def_chain(first, loc):
 
 
 def find_def(n, loc):
-    """Return the node at location :param loc:, or None if not under :param n:."""
+    """
+    Search a subtree for the name a location falls in.
+
+    A name is matched by its own location and the length of its identifier, as a node records where it starts but
+    not where it ends. An operator has no identifier to measure, so the kinds are grouped by the width of the
+    symbol that wrote them - ``+`` is one character, ``**`` two, ``and`` three, ``nand`` four.
+
+    The descent reads the fields from the node metadata rather than walking the node's children, which is much
+    faster. A field holding a reference is not followed: the node it names is reached through the field that owns
+    it, and following both would visit a node twice and could not terminate on a cycle.
+
+    :param n:   The node to search. ``Null_Iir`` searches nothing.
+    :param loc: The location to look for.
+    :returns:   The name covering that location, or ``None`` if no name in this subtree does.
+    """
     if n == nodes.Null_Iir:
         return None
     k = nodes.Get_Kind(n)
@@ -177,14 +198,31 @@ def find_def(n, loc):
 
 
 def find_node_by_loc(n, loc):
-    """Return the denoting node for :param loc: or None."""
+    """
+    Find the name written at a location.
+
+    :param n:   The tree to search, usually a design file.
+    :param loc: The location to look for.
+    :returns:   The name at that location, or ``None`` if there is no name there.
+    """
     ref = find_def(n, loc)
     log.debug("for loc %u found node %s", loc, ref)
     return ref
 
 
 def find_definition_by_loc(n, loc):
-    """Return the declaration (as a node) under :param loc: or None."""
+    """
+    Find the declaration the name at a location refers to.
+
+    This is the step from the name to what it denotes, which is what *go to definition* needs. A name resolves
+    through the entity it was bound to during analysis; anything else - an operator, for one - resolves through the
+    subprogram chosen to implement it.
+
+    :param n:   The tree to search, usually a design file.
+    :param loc: The location to look for.
+    :returns:   The declaration, or ``None`` if there is no name at that location or it was never resolved, which
+                is what an unanalyzed or erroneous unit leaves behind.
+    """
     ref = find_node_by_loc(n, loc)
     if ref is None:
         return None

--- a/pyGHDL/lsp/references.py
+++ b/pyGHDL/lsp/references.py
@@ -30,6 +30,10 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Resolution of a source location to the declaration it refers to, for *go to definition*.
+"""
+
 import logging
 import pyGHDL.libghdl.vhdl.nodes as nodes
 import pyGHDL.libghdl.vhdl.nodes_meta as nodes_meta

--- a/pyGHDL/lsp/symbols.py
+++ b/pyGHDL/lsp/symbols.py
@@ -110,6 +110,14 @@ SYMBOLS_MAP = {
 
 
 def location_to_position(fe, loc):
+    """
+    Convert a *libghdl* location to a position in the protocol's coordinates.
+
+    :param fe:              The source file the location is in.
+    :param loc:             The location to convert.
+    :returns:               A ``Position``, with its 0-based ``line`` and ``character``.
+    :raises AssertionError: If the location is ``No_Location``, which does not name a place in a file.
+    """
     assert loc != files_map.No_Location
     line = files_map.Location_File_To_Line(loc, fe)
     off = files_map.Location_File_Line_To_Offset(loc, fe, line)
@@ -117,11 +125,38 @@ def location_to_position(fe, loc):
 
 
 def get_symbols_chain(fe, n):
+    """
+    Collect the symbols of a chain of nodes.
+
+    A node that is not a symbol - a use clause, or a declaration that is not worth showing - contributes nothing
+    rather than an empty entry.
+
+    :param fe: The source file the nodes are in.
+    :param n:  The first node of the chain.
+    :returns:  One ``DocumentSymbol`` per node that has one.
+    """
     res = [get_symbols(fe, el) for el in pyutils.chain_iter(n)]
     return [e for e in res if e is not None]
 
 
 def get_symbols(fe, n):
+    """
+    Build the symbol of one node, with the symbols declared inside it as its children.
+
+    The range covers the whole construct where the parser recorded its extent, so folding an architecture in an
+    editor folds all of it; elsewhere it covers the declared name alone. A construct whose end was never reached
+    is given an empty range rather than an invalid one, which is what a file with a syntax error leaves behind.
+
+    Two kinds of node are dropped: an implicit subprogram, which the user never wrote, and a subprogram
+    declaration whose body is in the same file, which would otherwise be listed twice. An anonymous construct is
+    kept only if it has children worth showing.
+
+    :param fe:              The source file the node is in.
+    :param n:               The node to describe.
+    :returns:               A ``DocumentSymbol``, or ``None`` if this node is not shown.
+    :raises AssertionError: If the kind of the node is not in :data:`SYMBOLS_MAP`, which means a construct was
+                            added to the parser without deciding how it should appear in an outline.
+    """
     if n == nodes.Null_Iir:
         return None
     k = nodes.Get_Kind(n)

--- a/pyGHDL/lsp/symbols.py
+++ b/pyGHDL/lsp/symbols.py
@@ -30,6 +30,10 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+Translation of IIR declarations into the document symbols an editor displays in its outline.
+"""
+
 import pyGHDL.libghdl.name_table as name_table
 import pyGHDL.libghdl.files_map as files_map
 import pyGHDL.libghdl.vhdl.nodes as nodes

--- a/pyGHDL/lsp/vhdl_ls.py
+++ b/pyGHDL/lsp/vhdl_ls.py
@@ -33,9 +33,10 @@
 """
 The VHDL side of GHDL's language server.
 
-Each request of the Language Server Protocol is a ``lsp_*`` method on :class:`VhdlLanguageServer`, which
-:class:`~pyGHDL.lsp.lsp.LanguageProtocolServer` dispatches to by name. The answers are read from the
-:class:`~pyGHDL.lsp.workspace.Workspace`; nothing here parses VHDL itself.
+Each request of the Language Server Protocol is a method of :class:`VhdlLanguageServer`, named in the
+:attr:`~VhdlLanguageServer.dispatcher` that :class:`~pyGHDL.lsp.lsp.LanguageProtocolServer` looks the incoming
+method up in. The answers are read from the :class:`~pyGHDL.lsp.workspace.Workspace`; nothing here parses VHDL
+itself.
 """
 
 import logging
@@ -50,12 +51,19 @@ class VhdlLanguageServer(object):
     """
     The VHDL side of the language server.
 
-    Each ``lsp_*`` method implements one Language Server Protocol request, and
-    :class:`~pyGHDL.lsp.lsp.LanguageProtocolServer` dispatches to it by name. The answers come from the
+    One method implements one request of the protocol. Which method that is comes from :attr:`dispatcher`, not from
+    the method's name: the name only follows the request by convention, and a request that is not a key of that
+    mapping is answered as unknown however the method is called. The answers come from the
     :class:`~pyGHDL.lsp.workspace.Workspace`, which holds the analyzed sources.
     """
 
     def __init__(self):
+        """
+        Build the dispatcher, mapping each supported request to the method answering it.
+
+        The workspace is not created here. It needs the root the client sends, so it is built by
+        :meth:`initialize`.
+        """
         self.workspace = None
         self.lsp = None
         self._shutdown = False
@@ -83,21 +91,56 @@ class VhdlLanguageServer(object):
         }
 
     def set_lsp(self, server):
+        """
+        Attach the protocol server the answers are sent through.
+
+        :param server: The :class:`~pyGHDL.lsp.lsp.LanguageProtocolServer` serving this handler.
+        """
         self.lsp = server
 
     def shutdown(self):
+        """
+        Answer ``shutdown`` by asking the protocol server to stop reading requests.
+        """
         self.lsp.shutdown()
 
     def setTraceNotification(self, value):
+        """
+        Accept ``$/setTraceNotification`` and do nothing, because the server has no trace levels to set.
+
+        :param value: The trace level the client asked for.
+        """
         pass
 
     def setTrace(self, value):
+        """
+        Accept ``$/setTrace`` and do nothing, because the server has no trace levels to set.
+
+        :param value: The trace level the client asked for.
+        """
         pass
 
     def cancelRequest(self, id):
+        """
+        Accept ``$/cancelRequest`` and do nothing.
+
+        Requests are answered in the order they arrive, so by the time a cancellation is read the request it names
+        has already been answered.
+
+        :param id: The identifier of the request the client wants cancelled.
+        """
         pass
 
     def capabilities(self):
+        """
+        Report what this server can do, as the reply to ``initialize`` requires.
+
+        The document synchronization is incremental: the client sends the edits rather than the whole file, which
+        is what :meth:`~pyGHDL.lsp.workspace.Workspace.apply_changes` expects. A capability that is ``False`` is
+        listed rather than omitted, so what is not implemented can be read off this one place.
+
+        :returns: The ``ServerCapabilities`` of this server.
+        """
         server_capabilities = {
             "textDocumentSync": {
                 "openClose": True,
@@ -122,6 +165,22 @@ class VhdlLanguageServer(object):
         return server_capabilities
 
     def initialize(self, processId, rootPath, capabilities, rootUri=None, initializationOptions=None, **_):
+        """
+        Answer ``initialize`` by creating the workspace for the root the client opened.
+
+        The root may arrive as a path or as a URI, depending on how old the client is; the path is converted when
+        only it was given. A client sending neither gets an empty root, and the workspace then works on the open
+        documents alone.
+
+        :param processId:             The identifier of the process that started the server.
+        :param rootPath:              The root as a path, superseded by ``rootUri`` in newer clients.
+        :param capabilities:          What the client can do. This server does not vary its answers by it.
+        :param rootUri:               The root as a URI.
+        :param initializationOptions: Options from the client. They are logged, not read.
+        :param _:                     Further members of the request, ignored.
+        :returns:                     The capabilities of this server.
+        :raises InitError:            If *libghdl* could not be initialized.
+        """
         log.debug(
             "Language server initialize: pid=%s uri=%s path=%s options=%s",
             processId,
@@ -137,26 +196,70 @@ class VhdlLanguageServer(object):
         return {"capabilities": self.capabilities()}
 
     def initialized(self):
+        """
+        Accept the ``initialized`` notification, which says the client has finished starting up.
+
+        :returns: ``None``, as a notification is not answered.
+        """
         # Event when the client is fully initialized.
         return None
 
     def textDocument_didOpen(self, textDocument=None):
+        """
+        Take a document the client opened and check it.
+
+        :param textDocument: A ``TextDocumentItem`` with the URI, the text and the version.
+        """
         doc_uri = textDocument["uri"]
         self.workspace.put_document(doc_uri, textDocument["text"], version=textDocument.get("version"))
         self.lint(doc_uri)
 
     def textDocument_didChange(self, textDocument=None, contentChanges=None, **_kwargs):
+        """
+        Apply the edits the client made.
+
+        The diagnostics are published by :meth:`~pyGHDL.lsp.workspace.Workspace.apply_changes` itself, which is why
+        this does not lint afterwards.
+
+        :param textDocument:   A ``VersionedTextDocumentIdentifier`` naming the document.
+        :param contentChanges: The edits, in the order they are to be applied.
+        :param _kwargs:        Further members of the notification, ignored.
+        """
         doc_uri = textDocument["uri"]
         new_version = textDocument.get("version")
         self.workspace.apply_changes(doc_uri, contentChanges, new_version)
 
     def lint(self, doc_uri):
+        """
+        Re-analyze a document and publish its diagnostics.
+
+        :param doc_uri: The URI of the document to check.
+        """
         self.workspace.lint(doc_uri)
 
     def textDocument_didClose(self, textDocument=None, **_kwargs):
+        """
+        Drop the diagnostics of a document the client closed.
+
+        The document itself stays in the workspace, as other documents may have been analyzed against it.
+
+        :param textDocument: A ``TextDocumentIdentifier`` naming the document.
+        :param _kwargs:      Further members of the notification, ignored.
+        """
         self.workspace.rm_document(textDocument["uri"])
 
     def textDocument_didSave(self, textDocument=None, text=None, **_kwargs):
+        """
+        Re-check a document the client saved.
+
+        When the client sends the text along, it is first compared against the buffer the server has been editing.
+        A difference there means the edits were applied differently on the two sides, which would make every
+        position reported from now on wrong.
+
+        :param textDocument: A ``TextDocumentIdentifier`` naming the document.
+        :param text:         The saved text, if the client was asked to include it.
+        :param _kwargs:      Further members of the notification, ignored.
+        """
         if text is not None:
             # Sanity check: check we have the same content for the document.
             self.workspace.check_document(textDocument["uri"], text)
@@ -165,16 +268,51 @@ class VhdlLanguageServer(object):
         self.lint(textDocument["uri"])
 
     def textDocument_definition(self, textDocument=None, position=None):
+        """
+        Answer ``textDocument/definition``.
+
+        :param textDocument: A ``TextDocumentIdentifier`` naming the document.
+        :param position:     The position of the name to resolve.
+        :returns:            A list holding the location of the declaration, or ``None``.
+        """
         return self.workspace.goto_definition(textDocument["uri"], position)
 
     def textDocument_implementation(self, textDocument=None, position=None):
+        """
+        Answer ``textDocument/implementation``.
+
+        :param textDocument: A ``TextDocumentIdentifier`` naming the document.
+        :param position:     The position of the name to resolve.
+        :returns:            A list holding the location of the body, or ``None``.
+        """
         return self.workspace.goto_implementation(textDocument["uri"], position)
 
     def textDocument_documentSymbol(self, textDocument=None):
+        """
+        Answer ``textDocument/documentSymbol``.
+
+        The document is loaded if the client never opened it, because an editor may ask for the symbols of a file
+        it is only showing in an outline.
+
+        :param textDocument: A ``TextDocumentIdentifier`` naming the document.
+        :returns:            The symbols declared in the document.
+        """
         doc = self.workspace.get_or_create_document(textDocument["uri"])
         return doc.document_symbols()
 
     def textDocument_rangeFormatting(self, textDocument=None, range=None, options=None):
+        """
+        Answer ``textDocument/rangeFormatting`` by re-indenting a range of lines.
+
+        The document is re-checked after a successful format, because the edit changes the positions everything
+        else was reported at.
+
+        :param textDocument:    A ``TextDocumentIdentifier`` naming the document.
+        :param range:           The range to format.
+        :param options:         The formatting options of the client. The indentation follows the source, not these.
+        :returns:               The edits to apply, or ``None`` if there is nothing to format.
+        :raises AssertionError: If the document is not loaded.
+        """
         doc_uri = textDocument["uri"]
         doc = self.workspace.get_document(doc_uri)
         assert doc is not None, "Try to format a non-loaded document"
@@ -184,9 +322,24 @@ class VhdlLanguageServer(object):
         return res
 
     def textDocument_hover(self, textDocument=None, position=None):
+        """
+        Answer ``textDocument/hover``.
+
+        :param textDocument: A ``TextDocumentIdentifier`` naming the document.
+        :param position:     The position the client is hovering over.
+        :returns:            A ``Hover``, or ``None`` if there is no declaration there.
+        """
         return self.workspace.hover(textDocument["uri"], position)
 
     def textDocument_codeAction(self, textDocument=None, range=None, context=None):
+        """
+        Answer ``textDocument/codeAction`` with nothing, as no action is implemented.
+
+        :param textDocument: A ``TextDocumentIdentifier`` naming the document.
+        :param range:        The range the actions would apply to.
+        :param context:      The diagnostics the client wants addressed.
+        :returns:            ``None``.
+        """
         # Not yet implemented.
         # * reorder associations (but keep comments !)
         # * add missing associations (all or only IN)
@@ -194,19 +347,46 @@ class VhdlLanguageServer(object):
         return None
 
     def m_workspace__did_change_configuration(self, _settings=None):
+        """
+        Re-check every document, as a setting may change what is reported.
+
+        :param _settings: The new settings. They are not read; the server asks the client for what it needs.
+        """
         for doc_uri in self.workspace.documents:
             self.lint(doc_uri)
 
     def m_workspace__did_change_watched_files(self, **_kwargs):
+        """
+        Re-check every document, as a file changed outside the editor may change what is reported.
+
+        :param _kwargs: The events the client sent, ignored. Every document is re-checked either way.
+        """
         # Externally changed files may result in changed diagnostics
         for doc_uri in self.workspace.documents:
             self.lint(doc_uri)
 
     def workspace_xShowAllFiles(self):
+        """
+        Answer the ``workspace/xShowAllFiles`` extension.
+
+        :returns: One entry per source file *libghdl* holds.
+        """
         return self.workspace.x_show_all_files()
 
     def workspace_xGetAllEntities(self):
+        """
+        Answer the ``workspace/xGetAllEntities`` extension.
+
+        :returns: One entry per entity, with its name and library.
+        """
         return self.workspace.x_get_all_entities()
 
     def workspace_xGetEntityInterface(self, library, name):
+        """
+        Answer the ``workspace/xGetEntityInterface`` extension.
+
+        :param library: The name of the library the entity lives in.
+        :param name:    The name of the entity.
+        :returns:       The entity with its generics and ports, or ``None`` if it is unknown.
+        """
         return self.workspace.x_get_entity_interface(library, name)

--- a/pyGHDL/lsp/vhdl_ls.py
+++ b/pyGHDL/lsp/vhdl_ls.py
@@ -30,6 +30,14 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+The VHDL side of GHDL's language server.
+
+Each request of the Language Server Protocol is a ``lsp_*`` method on :class:`VhdlLanguageServer`, which
+:class:`~pyGHDL.lsp.lsp.LanguageProtocolServer` dispatches to by name. The answers are read from the
+:class:`~pyGHDL.lsp.workspace.Workspace`; nothing here parses VHDL itself.
+"""
+
 import logging
 
 from . import lsp
@@ -39,6 +47,15 @@ log = logging.getLogger(__name__)
 
 
 class VhdlLanguageServer(object):
+    """
+    The VHDL side of the language server.
+
+    Each ``lsp_*`` method implements one Language Server Protocol request, and
+    :class:`~pyGHDL.lsp.lsp.LanguageProtocolServer` dispatches to it by name. The answers come from the:
+    :class:`~pyGHDL.lsp.workspace.Workspace`, which holds the analyzed sources.:
+
+    """
+
     def __init__(self):
         self.workspace = None
         self.lsp = None

--- a/pyGHDL/lsp/vhdl_ls.py
+++ b/pyGHDL/lsp/vhdl_ls.py
@@ -51,9 +51,8 @@ class VhdlLanguageServer(object):
     The VHDL side of the language server.
 
     Each ``lsp_*`` method implements one Language Server Protocol request, and
-    :class:`~pyGHDL.lsp.lsp.LanguageProtocolServer` dispatches to it by name. The answers come from the:
-    :class:`~pyGHDL.lsp.workspace.Workspace`, which holds the analyzed sources.:
-
+    :class:`~pyGHDL.lsp.lsp.LanguageProtocolServer` dispatches to it by name. The answers come from the
+    :class:`~pyGHDL.lsp.workspace.Workspace`, which holds the analyzed sources.
     """
 
     def __init__(self):

--- a/pyGHDL/lsp/workspace.py
+++ b/pyGHDL/lsp/workspace.py
@@ -30,6 +30,13 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
+"""
+The set of source files the language server knows about.
+
+A :class:`Workspace` maps between the URIs an editor uses and the documents behind them, keeps the project
+configuration read from :file:`hdl-prj.json`, and re-analyzes what an edit invalidated.
+"""
+
 import logging
 import os
 import json
@@ -65,6 +72,15 @@ class InitError(LSPException):
 
 
 class Workspace(object):
+    """
+    The set of source files the language server knows about.
+
+    The workspace maps between the URIs an editor uses and the :class:`~pyGHDL.lsp.document.Document` objects behind
+    them, holds the project configuration read from :file:`hdl-prj.json`, and re-analyzes the documents an edit
+    invalidated.
+
+    """
+
     def __init__(self, root_uri, server):
         self._root_uri = root_uri
         self._server = server

--- a/pyGHDL/lsp/workspace.py
+++ b/pyGHDL/lsp/workspace.py
@@ -78,10 +78,22 @@ class Workspace(object):
     The workspace maps between the URIs an editor uses and the :class:`~pyGHDL.lsp.document.Document` objects behind
     them, holds the project configuration read from :file:`hdl-prj.json`, and re-analyzes the documents an edit
     invalidated.
-
     """
 
     def __init__(self, root_uri, server):
+        """
+        Set up *libghdl* for interactive use and load the project.
+
+        The analysis flags differ from a batch run of GHDL: locations and comments are kept because the server
+        answers questions about them, and analysis continues past an error because a file being edited is
+        incomplete most of the time. The unused, missing-association and sensitivity warnings are enabled, as they
+        are the ones worth showing while typing.
+
+        :param root_uri:   The URI of the directory the client opened.
+        :param server:     The server the notifications are sent through.
+        :raises InitError: If *libghdl* could not be initialized, which leaves the server unable to analyze
+                           anything.
+        """
         self._root_uri = root_uri
         self._server = server
         self._root_path = lsp.path_from_uri(self._root_uri)
@@ -115,24 +127,55 @@ class Workspace(object):
 
     @property
     def documents(self):
+        """
+        Read-only: The documents of this workspace, indexed by their URI.
+        """
         return self._docs
 
     @property
     def root_path(self):
+        """
+        Read-only: The path of the directory the client opened.
+        """
         return self._root_path
 
     @property
     def root_uri(self):
+        """
+        Read-only: The URI of the directory the client opened.
+        """
         return self._root_uri
 
     def _create_document(self, doc_uri, sfe, lib, version=None):
-        """Create a document and put it in this workspace."""
+        """
+        Create a document and register it under both the URI and the source file it uses.
+
+        Both indices are needed: the client names a document by its URI, while *libghdl* reports an error against a
+        source file.
+
+        :param doc_uri: The URI the client identifies the document by.
+        :param sfe:     The source file entry holding the text.
+        :param lib:     The name of the library the units are analyzed into, or ``None`` for ``work``.
+        :param version: The version the client attached to the document.
+        :returns:       The new document.
+        """
         doc = document.Document(doc_uri, sfe, lib, version)
         self._docs[doc_uri] = doc
         self._fe_map[sfe] = doc
         return doc
 
     def create_document_from_sfe(self, sfe, abspath, lib):
+        """
+        Create a document for a source file *libghdl* already holds.
+
+        This is how a file that the client never opened becomes reportable: an error in it names a source file, and
+        a diagnostic can only be published against a URI.
+
+        :param sfe:     The source file entry the text is already in.
+        :param abspath: The absolute path of that file.
+        :param lib:     The name of the library the units are analyzed into, or ``None`` for ``work``.
+        :returns:       The new document.
+        """
         # A filename has been given without a corresponding document.
         # Create the document.
         # Common case: an error message was reported in a non-open document.
@@ -141,6 +184,15 @@ class Workspace(object):
         return self._create_document(doc_uri, sfe, lib)
 
     def create_document_from_uri(self, doc_uri, source=None, version=None):
+        """
+        Create a document for a URI the workspace does not know yet.
+
+        :param doc_uri:            The URI to load. It is assumed to name a readable local file.
+        :param source:             The text the client sent, or ``None`` to read the file from disk.
+        :param version:            The version the client attached to the document.
+        :returns:                  The new document. It is not parsed yet.
+        :raises FileNotFoundError: If no source was given and the file cannot be opened.
+        """
         # A document is referenced by an uri but not known.  Load it.
         # We assume the path is correct.
         path = lsp.path_from_uri(doc_uri)
@@ -152,6 +204,12 @@ class Workspace(object):
         return self._create_document(doc_uri, sfe, None)
 
     def get_or_create_document(self, doc_uri):
+        """
+        Get a document, loading and parsing it if the workspace does not know it yet.
+
+        :param doc_uri: The URI of the document.
+        :returns:       The document, parsed either now or earlier.
+        """
         res = self.get_document(doc_uri)
         if res is not None:
             return res
@@ -161,13 +219,25 @@ class Workspace(object):
 
     def get_document(self, doc_uri):
         """
-        Get a document from :param doc_uri:
+        Look up a document by its URI.
 
-        Note that the document may not exist, and this function may return None.
+        :param doc_uri: The URI of the document.
+        :returns:       The document, or ``None`` if the workspace does not know it.
         """
         return self._docs.get(doc_uri)
 
     def put_document(self, doc_uri, source, version=None):
+        """
+        Take the client's version of a document, creating it if needed.
+
+        A document loaded from the project is overwritten rather than kept, because the client has been editing it
+        and its buffer is the newer one.
+
+        :param doc_uri: The URI of the document.
+        :param source:  The text the client sent.
+        :param version: The version the client attached to the document.
+        :returns:       The document holding that text.
+        """
         doc = self.get_document(doc_uri)
         if doc is None:
             doc = self.create_document_from_uri(doc_uri, source=source, version=version)
@@ -180,9 +250,11 @@ class Workspace(object):
 
     def sfe_to_document(self, sfe):
         """
-        Get the document correspond to :param sfe: source file.
+        Find the document a source file belongs to, creating one if the file came from outside the workspace.
 
-        Can create the document if needed.
+        :param sfe:             The source file entry, as it appears in an error record.
+        :returns:               The document holding that source file.
+        :raises AssertionError: If the source file entry is 0, which is not a file.
         """
         assert sfe != 0
         doc = self._fe_map.get(sfe, None)
@@ -196,6 +268,15 @@ class Workspace(object):
         return doc
 
     def add_vhdl_file(self, name, lib):
+        """
+        Load and parse one VHDL file listed in the project.
+
+        A file that cannot be read is reported to the client and skipped, so one bad entry in the project does not
+        stop the rest of it from loading.
+
+        :param name: The file name, relative to the root path or absolute.
+        :param lib:  The name of the library the units are analyzed into, or ``None`` for ``work``.
+        """
         log.info("loading %s in library %s", name, lib)
         if os.path.isabs(name):
             absname = name
@@ -213,6 +294,12 @@ class Workspace(object):
         doc.parse_document()
 
     def read_project(self):
+        """
+        Read :file:`hdl-prj.json` from the root path, if there is one.
+
+        A missing project file is normal - the server then works on the open documents alone. A file that exists
+        but cannot be read or parsed is reported to the client, and the workspace keeps its empty configuration.
+        """
         prj_file = os.path.join(self.root_path, "hdl-prj.json")
         if not os.path.exists(prj_file):
             log.info("project file %s does not exist", prj_file)
@@ -237,6 +324,12 @@ class Workspace(object):
         f.close()
 
     def set_options_from_project(self):
+        """
+        Pass the ``options.ghdl_analysis`` entries of the project to *libghdl* as analysis options.
+
+        A malformed project or a rejected option is reported to the client rather than raised, because the server
+        stays useful with the options it did accept.
+        """
         try:
             if self._prj is None:
                 return
@@ -258,6 +351,12 @@ class Workspace(object):
             self._server.show_message(lsp.MessageType.Error, f"error in project file: {e}")
 
     def read_files_from_project(self):
+        """
+        Load every VHDL file the project lists.
+
+        Files of another language are skipped rather than rejected. A malformed ``files`` entry stops the loading
+        and is reported to the client.
+        """
         try:
             files = self._prj.get("files", [])
             if not isinstance(files, list):
@@ -276,9 +375,24 @@ class Workspace(object):
             self._server.show_message(lsp.MessageType.Error, f"error in project file: {e}")
 
     def get_configuration(self):
+        """
+        Ask the client for the ``vhdl.maxNumberOfProblems`` setting.
+
+        The reply arrives as a separate message, so nothing is returned here.
+        """
         self._server.configuration([{"scopeUri": "", "section": "vhdl.maxNumberOfProblems"}])
 
     def gather_diagnostics(self, doc):
+        """
+        Turn the messages *libghdl* collected into diagnostics and publish them, one notification per file.
+
+        A message belonging to a group beyond the main one is not a diagnostic of its own; it is attached to the
+        preceding one as related information, which is how the two halves of "declaration is here, use is there"
+        stay together. The messages are cleared once they have been read.
+
+        :param doc: The document that was analyzed, so an empty list can be published for it when its errors are
+                    gone. ``None`` when the whole project was analyzed.
+        """
         # Gather messages (per file)
         nbr_msgs = errorout_memory.Get_Nbr_Messages()
         diags = {}
@@ -333,7 +447,19 @@ class Workspace(object):
             self.publish_diagnostics(doc.uri, [])
 
     def obsolete_dependent_units(self, unit, antideps):
-        """Obsolete units that depends of :param unit:."""
+        """
+        Mark every unit that depends on the given one as no longer analyzed, transitively.
+
+        A unit is put back into the state it had before analysis, and its dependence list is freed. Its position in
+        the source is written into the node first, because that is what is left to find it by once its tree is
+        gone.
+
+        The recursion is broken by clearing the entry as it is taken, so a cycle between two units does not loop
+        forever.
+
+        :param unit:     The unit whose dependents are to be obsoleted.
+        :param antideps: The anti-dependencies, as returned by :meth:`compute_anti_dependences`. It is modified.
+        """
         udeps = antideps.get(unit, None)
         if udeps is None:
             # There are no units.
@@ -360,6 +486,15 @@ class Workspace(object):
             nodes.Set_Design_Unit_Source_Col(un, col)
 
     def obsolete_doc(self, doc):
+        """
+        Throw away the analysis of a document, and of everything that was analyzed against it.
+
+        Dropping the units of one file is not enough: another file that used a package from it holds references
+        into the tree being freed, so those units are obsoleted too. The design file is then purged from its
+        library, which leaves the document ready to be parsed again.
+
+        :param doc: The document to obsolete. A document without a tree is left alone.
+        """
         if doc._tree == nodes.Null_Iir:
             return
         # Free old tree
@@ -378,12 +513,29 @@ class Workspace(object):
         doc._tree = nodes.Null_Iir
 
     def lint(self, doc_uri):
+        """
+        Re-analyze a document from its current buffer and publish what that found.
+
+        :param doc_uri: The URI of the document to check.
+        """
         doc = self.get_document(doc_uri)
         self.obsolete_doc(doc)
         doc.compute_diags()
         self.gather_diagnostics(doc)
 
     def apply_changes(self, doc_uri, contentChanges, new_version):
+        """
+        Apply the edits of a ``textDocument/didChange`` and re-analyze the document.
+
+        An edit that does not fit moves the text to a new source file, so the map from source files to documents is
+        corrected afterwards.
+
+        :param doc_uri:         The URI of the document that changed.
+        :param contentChanges:  The edits, applied in the order the client sent them.
+        :param new_version:     The version the client attached to the document.
+        :raises AssertionError: If the document is not loaded, because an edit can only be applied to a buffer that
+                                exists.
+        """
         doc = self.get_document(doc_uri)
         assert doc is not None, "try to modify a non-loaded document"
         self.obsolete_doc(doc)
@@ -398,27 +550,69 @@ class Workspace(object):
         self.gather_diagnostics(doc)
 
     def check_document(self, doc_uri, source):
+        """
+        Compare the buffer of a document against the client's text.
+
+        :param doc_uri:   The URI of the document to check.
+        :param source:    The document contents as the client sees them.
+        :raises KeyError: If the workspace does not know that URI.
+        """
         self._docs[doc_uri].check_document(source)
 
     def rm_document(self, doc_uri):
+        """
+        Drop the diagnostics of a document the client closed.
+
+        The client does not discard them on its own, so an empty list has to be published.
+
+        :param doc_uri: The URI of the closed document.
+        """
         # Clear diagnostics as it's not done automatically.
         self.publish_diagnostics(doc_uri, [])
 
     def apply_edit(self, edit):
+        """
+        Ask the client to apply an edit to the workspace.
+
+        :param edit: The ``WorkspaceEdit`` to apply.
+        :returns:    The identifier of the request, which the reply will carry.
+        """
         return self._server.request("workspace/applyEdit", {"edit": edit})
 
     def publish_diagnostics(self, doc_uri, diagnostics):
+        """
+        Send the diagnostics of one document to the client.
+
+        :param doc_uri:     The URI the diagnostics belong to.
+        :param diagnostics: The diagnostics, replacing the ones sent before. An empty list clears them.
+        """
         self._server.notify(
             "textDocument/publishDiagnostics",
             params={"uri": doc_uri, "diagnostics": diagnostics},
         )
 
     def show_message(self, message, msg_type=lsp.MessageType.Info):
+        """
+        Show a message in the client's user interface.
+
+        :param message:  The text to show.
+        :param msg_type: How the client should present it.
+        """
         self._server.notify("window/showMessage", params={"type": msg_type, "message": message})
 
     def declaration_to_location(self, decl, decl_name):
-        """Convert declaration :param decl: to an LSP Location.
-        :param decl_name: holds the identifier (used by subprogram bodies)"""
+        """
+        Convert a declaration to a location the client can jump to.
+
+        The range covers the declared name, whose length comes from the identifier. The two nodes are separate
+        because a jump may target one node while naming another - going to the implementation of a subprogram
+        lands on the body but measures the name of the declaration.
+
+        :param decl:      The node whose location is used.
+        :param decl_name: The node holding the identifier.
+        :returns:         A ``Location``, or ``None`` for a declaration that has no place in a file - the ``std``
+                          library and the library declarations themselves are virtual.
+        """
         decl_loc = nodes.Get_Location(decl)
         if decl_loc == std_package.Std_Location.value:
             # There is no real file for the std.standard package.
@@ -437,6 +631,14 @@ class Workspace(object):
         return res
 
     def goto_definition(self, doc_uri, position):
+        """
+        Answer ``textDocument/definition``.
+
+        :param doc_uri:  The URI of the document the client asked from.
+        :param position: The position of the name to resolve.
+        :returns:        A list holding the single location of the declaration, or ``None`` if there is no name at
+                         that position or its declaration is virtual.
+        """
         decl = self._docs[doc_uri].find_definition(position)
         if decl is None:
             return None
@@ -446,6 +648,17 @@ class Workspace(object):
         return [decl_loc]
 
     def goto_implementation(self, doc_uri, position):
+        """
+        Answer ``textDocument/implementation``, which asks for the body behind a declaration.
+
+        A subprogram leads to its body, and a component to an entity of the same name. The component case is a
+        guess - a configuration may bind the component to something else - but it is the answer a reader expects.
+        Where no body is known yet, the declaration itself is returned rather than nothing.
+
+        :param doc_uri:  The URI of the document the client asked from.
+        :param position: The position of the name to resolve.
+        :returns:        A list holding the single location of the implementation, or ``None`` if there is none.
+        """
         decl = self._docs[doc_uri].find_definition(position)
         if decl is None:
             return None
@@ -472,9 +685,24 @@ class Workspace(object):
         return [decl_loc]
 
     def hover(self, doc_uri, position):
+        """
+        Answer ``textDocument/hover``.
+
+        :param doc_uri:  The URI of the document the client asked from.
+        :param position: The position the client is hovering over.
+        :returns:        A ``Hover``, or ``None`` if there is no declaration at that position.
+        """
         return self._docs[doc_uri].hover(position)
 
     def x_show_all_files(self):
+        """
+        List every source file *libghdl* holds, for the ``workspace/xShowAllFiles`` extension.
+
+        This is a debugging aid: it shows the files the server loaded, including the ones no client ever opened,
+        which is why the URI may be ``None``.
+
+        :returns: One entry per source file, with its entry number, URI, name and directory.
+        """
         res = []
         for fe in range(1, files_map.Get_Last_Source_File_Entry() + 1):
             doc = self._fe_map.get(fe, None)
@@ -489,6 +717,13 @@ class Workspace(object):
         return res
 
     def x_get_all_entities(self):
+        """
+        List every entity of every library, for the ``workspace/xGetAllEntities`` extension.
+
+        A client uses this to offer the entities that can be instantiated.
+
+        :returns: One entry per entity, with its name and the library it lives in.
+        """
         res = []
         lib = libraries.Get_Libraries_Chain()
         while lib != nodes.Null_Iir:
@@ -509,7 +744,24 @@ class Workspace(object):
         return res
 
     def x_get_entity_interface(self, library, name):
+        """
+        Report the generics and ports of one entity, for the ``workspace/xGetEntityInterface`` extension.
+
+        A client uses this to write the instantiation of an entity the user picked.
+
+        :param library: The name of the library the entity lives in.
+        :param name:    The name of the entity.
+        :returns:       The entity with its generics and ports, or ``None`` if either the library or the entity is
+                        unknown.
+        """
+
         def create_interfaces(inters):
+            """
+            Collect the names of an interface chain.
+
+            :param inters: The first interface of the chain.
+            :returns:      One entry per interface, holding its name.
+            """
             res = []
             while inters != nodes.Null_Iir:
                 res.append({"name": name_table.Get_Name_Ptr(nodes.Get_Identifier(inters))})
@@ -535,7 +787,18 @@ class Workspace(object):
         }
 
     def compute_anti_dependences(self):
-        """Return a dictionnary of anti dependencies for design unit."""
+        """
+        Build the reverse of the dependency graph: which units were analyzed against each unit.
+
+        A unit records what it depends on, and re-analysis needs the opposite question answered - editing a package
+        has to invalidate its users. Only analyzed units are walked, because that is when the dependence list is
+        filled in.
+
+        :returns:               A mapping from a design unit to the units depending on it. A unit nothing depends
+                                on is absent rather than mapped to an empty list.
+        :raises AssertionError: If a dependence is neither a design unit nor an entity aspect, which would mean the
+                                dependence list holds something this does not know how to follow.
+        """
         res = {}
         lib = libraries.Get_Libraries_Chain()
         while lib != nodes.Null_Iir:


### PR DESCRIPTION
Doc-strings for `pyGHDL.cli` and `pyGHDL.lsp`, the two packages of `pyGHDL` that had none worth speaking of.

This branch was split off `master`, so it is independent of #3327 and #3328 and touches none of the same files. It changes doc-strings and comments only — no signature, no behaviour, no dependency.

| Package | Before | After |
|---------|-------:|------:|
| `pyGHDL.cli` | 23.8 % | **100 %** |
| `pyGHDL.lsp` | 17.6 % | **100 %** |
| `pyGHDL` overall | 39.2 % | 44.6 % |

(`interrogate`; the overall figure moves only this far because `pyGHDL.dom` and `pyGHDL.libghdl` are documented in #3327 and #3328.)

## What is documented

**`pyGHDL.cli`** — the two console scripts registered by `setup.py`. `dom.py` is the one worth reading: its handlers say what each output is for, and the difference between analyzing a single file and a directory is stated where it matters.

**`pyGHDL.lsp`** — the language server, in the order a message travels through it:

- **`lsp.py`**, the transport. Messages are framed with a `Content-Length` header, which is what separates this from a plain JSON stream — the reader has to consume the header to know how many bytes the body has. Dispatch, the error replies and the URI normalization are described here; the last exists because clients disagree about capitalizing a Windows drive letter, and the same document arriving under two spellings would be looked up as two files.
- **`vhdl_ls.py`**, one method per request. Mostly one-line delegations, so the doc-strings carry what the delegation does not: `didChange` does not lint because `apply_changes` has already published, `didSave` compares the client's text against the server's buffer because a divergence there makes every position reported from then on wrong, and `rangeFormatting` re-lints because its own edit moves everything that was reported.
- **`document.py`**, the source buffer. Not a string: *libghdl* analyzes bytes it owns, so the buffer is over-allocated by a gap and edits are written into it in place. Extending it doubles the gap and moves the text, which invalidates the source file entry — and that is why `apply_changes` repairs the `sfe -> document` map afterwards. The conversion between the protocol's 0-based positions and *libghdl*'s 1-based lines is noted at each crossing.
- **`workspace.py`**, the project and the re-analysis. Documented below.
- **`references.py`** and **`symbols.py`**, resolution and the outline.

## The part worth reading twice

Editing one file cannot simply drop that file's units. Another file that used a package from it was analyzed against the tree being freed and holds references into it. Three methods handle this and now say so:

- `compute_anti_dependences` reverses the dependency graph. A unit records what it depends on; invalidation needs the opposite question answered.
- `obsolete_dependent_units` walks that reverse graph transitively and puts each unit back to `Disk` state. It writes the unit's position in the source into the node **before** freeing anything, because the tree is exactly what is about to disappear. The recursion is broken by clearing each entry as it is taken, so a cycle cannot loop forever.
- `obsolete_doc` ties the two together and purges the design file from its library.

`Workspace.__init__` describes the analysis flags rather than restating them: locations and comments are kept because the server answers questions about them, and analysis is forced past errors because a file being edited is incomplete most of the time.

In `references.py`, `find_def` matches a name by its own location plus the length of its identifier, because a node records where it *starts* but not where it ends. That is what the otherwise-puzzling operator groupings are — the width of the symbol that wrote them, one character for `+`, two for `**`, three for `and`, four for `nand`. Its descent reads the node metadata instead of walking children (much faster) and skips fields holding a reference, so a node is reached only through the field that owns it; that is also what keeps a cycle from looping forever.

## Incidental corrections

- Three doc-strings described an `lsp_*` naming convention for the request handlers. There is no such prefix, and the name is not what dispatch uses — `LanguageProtocolServer.handle` looks the incoming method up in `VhdlLanguageServer.dispatcher`, an explicit table. Corrected.
- Several doc-strings used `:param x:` inside prose (`Get a document from :param doc_uri:`), which is not what that role means. They have real field lists now.
- The class doc-string of `Document` sat between the encoding comment and the `encoding` attribute the comment describes. The comment is back on its attribute.
- Four class doc-strings ended in a blank line, which renders as a stray paragraph break.

## Verification

`pytest testsuite/pyunit` passes unchanged (190 passed, 17 xfailed, 12 subtests). `black --check` is clean over `pyGHDL`. The CI's `Python`, `DocCoverage` and `StaticTypeCheck` jobs are green.

Comparing the AST of every touched file against `master` with doc-strings stripped gives an identical dump for all of them, so no executable code changed. (`pyGHDL/cli/__init__.py` is the one apparent exception, and only because it had no module body at all before this branch gave it a doc-string.)

## Not in this PR

Four bugs turned up while reading the code. None is fixed here, since this PR is documentation:

- `Document.flatten_symbols` puts the parent *symbol* in `containerName`, which the protocol specifies as a `string`. The golden replies record the violation — `"containerName": {"kind": 2, "name": "rtl", ...}` where `"rtl"` belongs. Fixing it also updates four `replies.json` files.
- `Workspace.gather_diagnostics` reuses its `doc` parameter as a loop variable, so the "clear the diagnostics of a document that no longer has any" test at the end checks the wrong document. Fix the last error in one file while any other file still has one and the editor keeps showing the stale diagnostics.
- `Workspace._last_linted_doc` is set to `None` in `__init__` and never assigned again, so its branch in `obsolete_doc` is dead and `compute_anti_dependences` — which walks every unit of every library — runs on every keystroke.
- `m_workspace__did_change_configuration` and `m_workspace__did_change_watched_files` use the `m_<area>__<request>` naming of *python-language-server*, and neither request is a key of `dispatcher`. Both are unreachable, so changing a setting or touching a file outside the editor does not re-lint.

The last three are pre-existing on `master`; `_last_linted_doc` goes back to `bf74a0983` ("rework 'python', rename to 'pyGHDL'"), so the assignment was most likely lost in that move. The last two interact — wiring up the handlers makes two notifications live that each re-lint every document — so they are best done together. Happy to open them as issues or as a follow-up PR, whichever you prefer.
