### PR TITLE
Bug fixes for pyGHDL.lsp

### DIFF
--- a/pyGHDL/lsp/document.py
+++ b/pyGHDL/lsp/document.py
@@ -309,6 +309,8 @@ class Document(object):
         The two shapes differ in more than nesting: a location replaces the range, ``detail`` has no counterpart,
         and the nesting is expressed by naming the container. A client that asked for the flat form gets it here.
 
+        ``containerName`` is the *name* of the enclosing symbol, as ``SymbolInformation`` declares it a string.
+
         :param syms:   The symbols to flatten. They are modified in place.
         :param parent: The symbol the given ones are nested in, or ``None`` at the top level.
         :returns:      The symbols and all their children, in one list.
@@ -319,7 +321,7 @@ class Document(object):
             del s["range"]
             s.pop("detail", None)
             if parent is not None:
-                s["containerName"] = parent
+                s["containerName"] = parent["name"]
             res.append(s)
             children = s.pop("children", None)
             if children is not None:

--- a/pyGHDL/lsp/vhdl_ls.py
+++ b/pyGHDL/lsp/vhdl_ls.py
@@ -41,6 +41,8 @@ itself.
 
 import logging
 
+from pyGHDL import __version__ as pyGHDLVersion
+
 from . import lsp
 from .workspace import Workspace
 
@@ -178,7 +180,7 @@ class VhdlLanguageServer(object):
         :param rootUri:               The root as a URI.
         :param initializationOptions: Options from the client. They are logged, not read.
         :param _:                     Further members of the request, ignored.
-        :returns:                     The capabilities of this server.
+        :returns:                     The capabilities of this server, and the name and version it runs under.
         :raises InitError:            If *libghdl* could not be initialized.
         """
         log.debug(
@@ -193,7 +195,10 @@ class VhdlLanguageServer(object):
         self.workspace = Workspace(rootUri, self.lsp)
 
         # Get our capabilities
-        return {"capabilities": self.capabilities()}
+        return {
+            "capabilities": self.capabilities(),
+            "serverInfo": {"name": "ghdl-ls", "version": pyGHDLVersion},
+        }
 
     def initialized(self):
         """

--- a/pyGHDL/lsp/workspace.py
+++ b/pyGHDL/lsp/workspace.py
@@ -502,6 +502,11 @@ class Workspace(object):
         into the tree being freed, so those units are obsoleted too. The design file is then purged from its
         library, which leaves the document ready to be parsed again.
 
+        Obsoleting the dependent units is skipped when this document was also the one analyzed last, as it is while
+        a file is being edited: they were obsoleted by that previous round and only an analysis of their own could
+        have brought them back, which would have made that document the last analyzed one instead. Semantic analysis
+        happens in :meth:`lint` and :meth:`apply_changes` alone, so this holds for every path into the workspace.
+
         :param doc: The document to obsolete. A document without a tree is left alone.
         """
         if doc._tree == nodes.Null_Iir:
@@ -530,6 +535,7 @@ class Workspace(object):
         doc = self.get_document(doc_uri)
         self.obsolete_doc(doc)
         doc.compute_diags()
+        self._last_linted_doc = doc
         self.gather_diagnostics(doc)
 
     def apply_changes(self, doc_uri, contentChanges, new_version):
@@ -556,6 +562,7 @@ class Workspace(object):
             self._fe_map[doc._fe] = doc
         # Like lint
         doc.compute_diags()
+        self._last_linted_doc = doc
         self.gather_diagnostics(doc)
 
     def check_document(self, doc_uri, source):

--- a/pyGHDL/lsp/workspace.py
+++ b/pyGHDL/lsp/workspace.py
@@ -121,7 +121,7 @@ class Workspace(object):
         if libghdl.analyze_init_status() != 0:
             log.error("cannot initialize libghdl")
             raise InitError
-        self._diags_set = set()  # Documents with at least one diagnostic.
+        self._diags_set = set()  # URIs of the documents diagnostics were last published for.
         self.read_files_from_project()
         self.gather_diagnostics(None)
 
@@ -390,6 +390,10 @@ class Workspace(object):
         preceding one as related information, which is how the two halves of "declaration is here, use is there"
         stay together. The messages are cleared once they have been read.
 
+        A client keeps the diagnostics of a file until it is sent new ones, so every document that had diagnostics
+        published for it and has none now is sent an empty list. The documents that carry diagnostics are tracked in
+        :attr:`_diags_set` for that, because analyzing one document can equally clear a diagnostic in another.
+
         :param doc: The document that was analyzed, so an empty list can be published for it when its errors are
                     gone. ``None`` when the whole project was analyzed.
         """
@@ -429,22 +433,27 @@ class Workspace(object):
                     fdiag.append(diag)
             else:
                 assert diag
-                if True:
-                    doc = self.sfe_to_document(hdr.file)
-                    diag["relatedInformation"].append(
-                        {
-                            "location": {"uri": doc.uri, "range": err_range},
-                            "message": msg,
-                        }
-                    )
+                relatedDocument = self.sfe_to_document(hdr.file)
+                diag["relatedInformation"].append(
+                    {
+                        "location": {"uri": relatedDocument.uri, "range": err_range},
+                        "message": msg,
+                    }
+                )
         errorout_memory.Clear_Errors()
         # Publish diagnostics
+        publishedURIs = set()
         for sfe, diag in diags.items():
-            doc = self.sfe_to_document(sfe)
-            self.publish_diagnostics(doc.uri, diag)
-        if doc is not None and doc._fe not in diags:
-            # Clear previous diagnostics for the doc.
-            self.publish_diagnostics(doc.uri, [])
+            diagnosedDocument = self.sfe_to_document(sfe)
+            self.publish_diagnostics(diagnosedDocument.uri, diag)
+            publishedURIs.add(diagnosedDocument.uri)
+        # Clear previous diagnostics of the analyzed document and of every document that has none left.
+        staleURIs = set(self._diags_set)
+        if doc is not None:
+            staleURIs.add(doc.uri)
+        for uri in staleURIs - publishedURIs:
+            self.publish_diagnostics(uri, [])
+        self._diags_set = publishedURIs
 
     def obsolete_dependent_units(self, unit, antideps):
         """
@@ -569,6 +578,7 @@ class Workspace(object):
         """
         # Clear diagnostics as it's not done automatically.
         self.publish_diagnostics(doc_uri, [])
+        self._diags_set.discard(doc_uri)
 
     def apply_edit(self, edit):
         """

--- a/testsuite/pyunit/lsp/001simple/replies.json
+++ b/testsuite/pyunit/lsp/001simple/replies.json
@@ -21,6 +21,10 @@
         "documentFormattingProvider": false,
         "documentRangeFormattingProvider": true,
         "renameProvider": false
+      },
+      "serverInfo": {
+        "name": "ghdl-ls",
+        "version": "7.0.0-dev"
       }
     }
   },

--- a/testsuite/pyunit/lsp/002coverage/replies.json
+++ b/testsuite/pyunit/lsp/002coverage/replies.json
@@ -21,6 +21,10 @@
         "documentFormattingProvider": false,
         "documentRangeFormattingProvider": true,
         "renameProvider": false
+      },
+      "serverInfo": {
+        "name": "ghdl-ls",
+        "version": "7.0.0-dev"
       }
     }
   },
@@ -134,23 +138,7 @@
             }
           }
         },
-        "containerName": {
-          "kind": 2,
-          "name": "behav",
-          "location": {
-            "uri": "file://@ROOT@/files/adder_tb.vhdl",
-            "range": {
-              "start": {
-                "line": 5,
-                "character": 0
-              },
-              "end": {
-                "line": 57,
-                "character": 0
-              }
-            }
-          }
-        }
+        "containerName": "behav"
       }
     ]
   },

--- a/testsuite/pyunit/lsp/003errors/replies.json
+++ b/testsuite/pyunit/lsp/003errors/replies.json
@@ -21,6 +21,10 @@
         "documentFormattingProvider": false,
         "documentRangeFormattingProvider": true,
         "renameProvider": false
+      },
+      "serverInfo": {
+        "name": "ghdl-ls",
+        "version": "7.0.0-dev"
       }
     }
   },

--- a/testsuite/pyunit/lsp/004errprj/replies.json
+++ b/testsuite/pyunit/lsp/004errprj/replies.json
@@ -29,6 +29,10 @@
         "documentFormattingProvider": false,
         "documentRangeFormattingProvider": true,
         "renameProvider": false
+      },
+      "serverInfo": {
+        "name": "ghdl-ls",
+        "version": "7.0.0-dev"
       }
     }
   },

--- a/testsuite/pyunit/lsp/005create/replies.json
+++ b/testsuite/pyunit/lsp/005create/replies.json
@@ -21,6 +21,10 @@
         "documentFormattingProvider": false,
         "documentRangeFormattingProvider": true,
         "renameProvider": false
+      },
+      "serverInfo": {
+        "name": "ghdl-ls",
+        "version": "7.0.0-dev"
       }
     }
   },

--- a/testsuite/pyunit/lsp/006opterr/replies.json
+++ b/testsuite/pyunit/lsp/006opterr/replies.json
@@ -29,6 +29,10 @@
         "documentFormattingProvider": false,
         "documentRangeFormattingProvider": true,
         "renameProvider": false
+      },
+      "serverInfo": {
+        "name": "ghdl-ls",
+        "version": "7.0.0-dev"
       }
     }
   },
@@ -94,23 +98,7 @@
             }
           }
         },
-        "containerName": {
-          "kind": 2,
-          "name": "behaviour",
-          "location": {
-            "uri": "file://@ROOT@/files/heartbeat.vhdl",
-            "range": {
-              "start": {
-                "line": 8,
-                "character": 0
-              },
-              "end": {
-                "line": 20,
-                "character": 0
-              }
-            }
-          }
-        }
+        "containerName": "behaviour"
       }
     ]
   }

--- a/testsuite/pyunit/lsp/007errprj/replies.json
+++ b/testsuite/pyunit/lsp/007errprj/replies.json
@@ -29,6 +29,10 @@
         "documentFormattingProvider": false,
         "documentRangeFormattingProvider": true,
         "renameProvider": false
+      },
+      "serverInfo": {
+        "name": "ghdl-ls",
+        "version": "7.0.0-dev"
       }
     }
   }

--- a/testsuite/pyunit/lsp/008errnofile/replies.json
+++ b/testsuite/pyunit/lsp/008errnofile/replies.json
@@ -29,6 +29,10 @@
         "documentFormattingProvider": false,
         "documentRangeFormattingProvider": true,
         "renameProvider": false
+      },
+      "serverInfo": {
+        "name": "ghdl-ls",
+        "version": "7.0.0-dev"
       }
     }
   },

--- a/testsuite/pyunit/lsp/009ls122/replies.json
+++ b/testsuite/pyunit/lsp/009ls122/replies.json
@@ -21,6 +21,10 @@
         "documentFormattingProvider": false,
         "documentRangeFormattingProvider": true,
         "renameProvider": false
+      },
+      "serverInfo": {
+        "name": "ghdl-ls",
+        "version": "7.0.0-dev"
       }
     }
   },

--- a/testsuite/pyunit/lsp/010ls28/replies.json
+++ b/testsuite/pyunit/lsp/010ls28/replies.json
@@ -21,6 +21,10 @@
         "documentFormattingProvider": false,
         "documentRangeFormattingProvider": true,
         "renameProvider": false
+      },
+      "serverInfo": {
+        "name": "ghdl-ls",
+        "version": "7.0.0-dev"
       }
     }
   },
@@ -86,23 +90,7 @@
             }
           }
         },
-        "containerName": {
-          "kind": 2,
-          "name": "rtl",
-          "location": {
-            "uri": "file://@ROOT@/top.vhdl",
-            "range": {
-              "start": {
-                "line": 10,
-                "character": 0
-              },
-              "end": {
-                "line": 21,
-                "character": 0
-              }
-            }
-          }
-        }
+        "containerName": "rtl"
       }
     ]
   },
@@ -168,23 +156,7 @@
             }
           }
         },
-        "containerName": {
-          "kind": 2,
-          "name": "rtl",
-          "location": {
-            "uri": "file://@ROOT@/top.vhdl",
-            "range": {
-              "start": {
-                "line": 10,
-                "character": 0
-              },
-              "end": {
-                "line": 21,
-                "character": 0
-              }
-            }
-          }
-        }
+        "containerName": "rtl"
       }
     ]
   }

--- a/testsuite/pyunit/lsp/011closediag/replies.json
+++ b/testsuite/pyunit/lsp/011closediag/replies.json
@@ -21,6 +21,10 @@
         "documentFormattingProvider": false,
         "documentRangeFormattingProvider": true,
         "renameProvider": false
+      },
+      "serverInfo": {
+        "name": "ghdl-ls",
+        "version": "7.0.0-dev"
       }
     }
   },

--- a/testsuite/pyunit/lsp/012library/replies.json
+++ b/testsuite/pyunit/lsp/012library/replies.json
@@ -21,6 +21,10 @@
         "documentFormattingProvider": false,
         "documentRangeFormattingProvider": true,
         "renameProvider": false
+      },
+      "serverInfo": {
+        "name": "ghdl-ls",
+        "version": "7.0.0-dev"
       }
     }
   },

--- a/testsuite/pyunit/lsp/013record/replies.json
+++ b/testsuite/pyunit/lsp/013record/replies.json
@@ -45,6 +45,10 @@
         "documentFormattingProvider": false,
         "documentRangeFormattingProvider": true,
         "renameProvider": false
+      },
+      "serverInfo": {
+        "name": "ghdl-ls",
+        "version": "7.0.0-dev"
       }
     }
   },

--- a/testsuite/pyunit/lsp/Diagnostics.py
+++ b/testsuite/pyunit/lsp/Diagnostics.py
@@ -1,0 +1,140 @@
+from typing import Any, Dict, List, Optional, Tuple
+from unittest import TestCase
+
+from pyGHDL.libghdl import errorout_memory
+from pyGHDL.lsp.workspace import Workspace
+
+
+class FakeDocument:
+    """A stand-in for :class:`~pyGHDL.lsp.document.Document`, which needs a parsed file to exist."""
+
+    def __init__(self, uri: str, sfe: int):
+        self.uri = uri
+        self._fe = sfe
+
+
+class FakeErrorRecord:
+    """The fields of ``errorout_memory.Error_Message`` that :meth:`Workspace.gather_diagnostics` reads."""
+
+    def __init__(self, sfe: int, group: int = errorout_memory.Msg_Single, msgid: int = 3):
+        self.id = msgid
+        self.group = group
+        self.file = sfe
+        self.line = 1
+        self.offset = 0
+        self.length = 1
+
+
+class DiagnosticsWorkspace(Workspace):
+    """A workspace whose documents and published notifications are scripted, so no libghdl state is needed."""
+
+    def __init__(self, documents: Dict[int, FakeDocument]):
+        # Deliberately not calling super().__init__: it initializes libghdl and reads a project.
+        self._fe_map = documents
+        self._diags_set = set()
+        self.published: List[Tuple[str, int]] = []
+
+    def sfe_to_document(self, sfe: int) -> FakeDocument:
+        return self._fe_map[sfe]
+
+    def publish_diagnostics(self, doc_uri: str, diagnostics: List[Any]) -> None:
+        self.published.append((doc_uri, len(diagnostics)))
+
+
+class Diagnostics(TestCase):
+    """Test how :meth:`~pyGHDL.lsp.workspace.Workspace.gather_diagnostics` publishes and withdraws diagnostics."""
+
+    _URI_A = "file:///a.vhdl"
+    _URI_B = "file:///b.vhdl"
+
+    def _createWorkspace(self) -> DiagnosticsWorkspace:
+        return DiagnosticsWorkspace({1: FakeDocument(self._URI_A, 1), 2: FakeDocument(self._URI_B, 2)})
+
+    def _scriptMessages(self, workspace: DiagnosticsWorkspace, records: List[FakeErrorRecord]) -> None:
+        """Let the error memory report the given records for the next gathering."""
+        workspace.published.clear()
+        errorout_memory.Get_Nbr_Messages = lambda: len(records)
+        errorout_memory.Get_Error_Record = lambda index: records[index - 1]
+        errorout_memory.Get_Error_Message = lambda index: f"message {index}"
+        errorout_memory.Clear_Errors = lambda: None
+
+    def setUp(self) -> None:
+        self._originals = {
+            name: getattr(errorout_memory, name)
+            for name in ("Get_Nbr_Messages", "Get_Error_Record", "Get_Error_Message", "Clear_Errors")
+        }
+
+    def tearDown(self) -> None:
+        for name, function in self._originals.items():
+            setattr(errorout_memory, name, function)
+
+    def test_DiagnosticsArePublishedPerFile(self) -> None:
+        workspace = self._createWorkspace()
+        self._scriptMessages(workspace, [FakeErrorRecord(1), FakeErrorRecord(2), FakeErrorRecord(2)])
+
+        workspace.gather_diagnostics(None)
+
+        self.assertCountEqual([(self._URI_A, 1), (self._URI_B, 2)], workspace.published)
+
+    def test_DiagnosticsOfAnalyzedDocumentAreWithdrawn(self) -> None:
+        """A document whose errors are gone is sent an empty list, even while another document still has some."""
+        workspace = self._createWorkspace()
+        self._scriptMessages(workspace, [FakeErrorRecord(1), FakeErrorRecord(2)])
+        workspace.gather_diagnostics(None)
+
+        # Only b.vhdl reports something now, and a.vhdl is the document that was analyzed.
+        self._scriptMessages(workspace, [FakeErrorRecord(2)])
+        workspace.gather_diagnostics(workspace.sfe_to_document(1))
+
+        self.assertIn((self._URI_A, 0), workspace.published)
+        self.assertIn((self._URI_B, 1), workspace.published)
+
+    def test_DiagnosticsOfAnotherDocumentAreWithdrawn(self) -> None:
+        """Diagnostics published for a document are withdrawn once an analysis no longer reports them."""
+        workspace = self._createWorkspace()
+        self._scriptMessages(workspace, [FakeErrorRecord(1), FakeErrorRecord(2)])
+        workspace.gather_diagnostics(None)
+
+        self._scriptMessages(workspace, [])
+        workspace.gather_diagnostics(None)
+
+        self.assertCountEqual([(self._URI_A, 0), (self._URI_B, 0)], workspace.published)
+
+    def test_UnchangedDiagnosticsAreNotWithdrawn(self) -> None:
+        """A document that still has diagnostics is not sent an empty list on top of them."""
+        workspace = self._createWorkspace()
+        self._scriptMessages(workspace, [FakeErrorRecord(1)])
+        workspace.gather_diagnostics(None)
+
+        self._scriptMessages(workspace, [FakeErrorRecord(1)])
+        workspace.gather_diagnostics(workspace.sfe_to_document(1))
+
+        self.assertEqual([(self._URI_A, 1)], workspace.published)
+
+    def test_RelatedInformationKeepsTheAnalyzedDocument(self) -> None:
+        """A related message names its own file, and does not become the document the round was about."""
+        workspace = self._createWorkspace()
+        self._scriptMessages(
+            workspace,
+            [
+                FakeErrorRecord(1, errorout_memory.Msg_Main),
+                FakeErrorRecord(2, errorout_memory.Msg_Related),
+            ],
+        )
+        workspace.gather_diagnostics(workspace.sfe_to_document(2))
+
+        # a.vhdl carries the diagnostic, b.vhdl only the related location - so b.vhdl has none of its own.
+        self.assertCountEqual([(self._URI_A, 1), (self._URI_B, 0)], workspace.published)
+
+    def test_ClosedDocumentIsNotWithdrawnTwice(self) -> None:
+        """Closing a document withdraws its diagnostics, and the next analysis does not repeat that."""
+        workspace = self._createWorkspace()
+        self._scriptMessages(workspace, [FakeErrorRecord(1)])
+        workspace.gather_diagnostics(None)
+
+        workspace.published.clear()
+        workspace.rm_document(self._URI_A)
+        self._scriptMessages(workspace, [])
+        workspace.gather_diagnostics(None)
+
+        self.assertEqual([], workspace.published)


### PR DESCRIPTION
# Breaking Changes

* ⚠️ `pyGHDL.lsp.document`: `containerName` in a `textDocument/documentSymbol` reply is a **string** - the name of
  the enclosing symbol - where it used to be the whole parent symbol object. A client that read `containerName.name`
  or any other member of that object has to read the value itself instead. See *Bug Fixes*: the old shape never
  conformed to the protocol.


# New Features

* `pyGHDL.lsp.vhdl_ls`:
  * `VhdlLanguageServer.initialize` returns `serverInfo` beside the capabilities:
    `{"name": "ghdl-ls", "version": <pyGHDL version>}`. The reply carried the capabilities alone, so a client
    could neither log which server it had started nor vary its behaviour by server version. `serverInfo` is part
    of the protocol since LSP 3.15.


# Changes

* `pyGHDL.lsp.workspace`:
  * `Workspace.obsolete_doc` skips computing the anti-dependencies when the document being obsoleted is also the
    one analyzed last. That fast path already existed and never ran, because `Workspace._last_linted_doc` was
    never assigned - `git log -S` finds one commit touching it, the rename of `python/` to `pyGHDL/`. It is
    assigned at the end of `Workspace.lint` and `Workspace.apply_changes` again, which removes a walk over every
    unit from the hot path while a file is being typed in.

    Why this is safe is written into the doc-string of `obsolete_doc`: semantic analysis happens in `lint` and
    `apply_changes` alone, so a dependent obsoleted by the previous round can only have come back through an
    analysis of its own - and that would have made *it* the last analyzed document, leaving the guard false.

    **This is the one behavioral change here rather than a repair, and it is a separate commit (`b14b9ff`), so
    it can be dropped on its own if you would rather keep the unconditional walk.**


# Bug Fixes

* `pyGHDL.lsp.document`:
  * ⚠️ `Document.flatten_symbols` sent the whole parent symbol as `containerName` - a dictionary with `kind`,
    `name` and `location` - while
    [`SymbolInformation.containerName`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolInformation)
    is declared `string`. The reply never conformed to the protocol, so a client rendering the flat symbol shape
    displayed an object where a name belongs. It is the enclosing symbol's name now. Three golden reply files had
    the object baked in.
* `pyGHDL.lsp.workspace`:
  * `Workspace.gather_diagnostics` never withdrew the diagnostics of a file whose errors had been fixed, as long
    as any other file still reported one. The method reassigned its own `doc` parameter twice - once when
    attaching related information to a message, and again in the publishing loop:

    ```python
    for sfe, diag in diags.items():
        doc = self.sfe_to_document(sfe)          # the parameter is overwritten
        self.publish_diagnostics(doc.uri, diag)
    if doc is not None and doc._fe not in diags: # so this tests the wrong document
        self.publish_diagnostics(doc.uri, [])
    ```

    By the time the trailing check runs, `doc` is the last file that *had* diagnostics, whose `_fe` is by
    construction in `diags`. The condition is therefore false whenever anything was reported, and no empty list is
    published. A client keeps diagnostics until it is sent new ones, so the corrected errors stay on screen.

    The documents diagnostics were published for are now tracked in `Workspace._diags_set` - a field that was
    created for this and never filled - and every document in it that reports nothing in the current round is sent
    an empty list. That also covers a case the original code did not attempt: a diagnostic disappearing from a file
    other than the one that was analyzed. `Workspace.rm_document` discards its URI from that set, since closing a
    document withdraws its diagnostics there already.


# Known Issues

* `pyGHDL.lsp.vhdl_ls`:
  * `VhdlLanguageServer.dispatcher` still has no entry for two implemented handlers, so those notifications remain
    unreachable. Wiring them changes what the server acts on, which is a decision rather than a repair, so it is
    left out of this pull-request.
* `pyGHDL.lsp`:
  * The classes in this package derive from `object` and carry no type hints, unlike the rest of `pyGHDL`. Not
    touched here - it would bury the four fixes above in a formatting diff.


# Documentation

* The doc-strings of `Workspace.gather_diagnostics`, `Workspace.obsolete_doc` and `Document.flatten_symbols` state
  the rules the code now follows: which documents get an empty list and why, the invariant behind the fast path,
  and that `containerName` is a name. No user-facing documentation covers these internals.


# Unit Tests

* `testsuite/pyunit/lsp/Diagnostics.py` is new: six testcases for what `gather_diagnostics` publishes and
  withdraws. They script the error memory instead of driving *libghdl*, which is what makes the multi-file cases
  reachable at all - the JSON harness can only express what one server run over one directory produces.
  **Three of the six fail without this pull-request**: the analyzed document not being cleared while another file
  has diagnostics, a document that stopped reporting never being cleared, and the related-information
  reassignment.
* The 13 `testsuite/pyunit/lsp/*/replies.json` files gain `serverInfo`; three of them carry the corrected
  `containerName`. They were edited in place rather than regenerated from a server run, so the diff shows the
  behavioural change and not a reordering of keys.


----------
# Related Issues and Pull-Requests

* Reviewed and merged in the fork as [Paebbels/ghdl#48](https://github.com/Paebbels/ghdl/pull/48).
* Independent of [#2936](https://github.com/ghdl/ghdl/pull/2936) (`paebbels/lsp`), which touches the testsuite
  examples and the LSP test driver, not `pyGHDL/lsp/*` and not the golden replies.
