### PR TITLE
grt-avhpi: fix VPI silent NULL on array of unconstrained std_logic_ve…

### DIFF
--- a/src/grt/grt-avhpi.adb
+++ b/src/grt/grt-avhpi.adb
@@ -131,6 +131,7 @@ package body Grt.Avhpi is
                           N_Addr => Avhpi_Get_Address (Ref),
                           N_Type => Ref.Obj.Obj_Type,
                           N_Idx => 0,
+                          N_Bounds => Null_Address,
                           N_Obj => Ref.Obj);
                when VhpiIndexedNameK =>
                   Res := (Kind => AvhpiNameIteratorK,
@@ -138,6 +139,7 @@ package body Grt.Avhpi is
                           N_Addr => Ref.N_Addr,
                           N_Type => Ref.N_Type,
                           N_Idx => 0,
+                          N_Bounds => Ref.N_Bounds,
                           N_Obj => Ref.N_Obj);
                when others =>
                   Error := AvhpiErrorNotImplemented;
@@ -171,11 +173,81 @@ package body Grt.Avhpi is
       Error := AvhpiErrorNotImplemented;
    end Vhpi_Iterator;
 
+   --  Return the address of the per-instance layout of the element of an
+   --  array object whose own (possibly constrained) subtype/type is
+   --  ARR_TYPE and whose bounds -- when ARR_TYPE is itself an unbounded
+   --  object type -- are ARR_BOUNDS (see Object_To_Base_Bounds).
+   --
+   --  This is only meaningful when the array's element is itself
+   --  unbounded (eg. array (natural range <>) of std_logic_vector): the
+   --  element then has no static size of its own, and that size is only
+   --  known from this particular object's own elaborated layout, which --
+   --  for the common case of a fully-constrained array object
+   --  (ARR_BOUNDS = Null_Address) -- is reachable from ARR_TYPE's own
+   --  static Layout field, mirroring the existing Ghdl_Rtik_Subtype_Array
+   --  case of Add_Index but resolving the *element's* size rather than
+   --  the whole array's.
+   --
+   --  Return Null_Address if it cannot be computed (caller must then fail
+   --  loud rather than guess -- see Add_Index's "add_index(3)").
+   function Array_Element_Layout (Ctxt : Rti_Context;
+                                  Arr_Type : Ghdl_Rti_Access;
+                                  Arr_Bounds : Address) return Address
+   is
+      Bt : Ghdl_Rtin_Type_Array_Acc;
+      Bounds : Address;
+      Rng : Ghdl_Range_Ptr;
+   begin
+      Bounds := Arr_Bounds;
+
+      case Arr_Type.Kind is
+         when Ghdl_Rtik_Type_Array =>
+            Bt := To_Ghdl_Rtin_Type_Array_Acc (Arr_Type);
+         when Ghdl_Rtik_Subtype_Array
+           | Ghdl_Rtik_Subtype_Unbounded_Array =>
+            declare
+               St : constant Ghdl_Rtin_Subtype_Composite_Acc :=
+                 To_Ghdl_Rtin_Subtype_Composite_Acc (Arr_Type);
+            begin
+               Bt := To_Ghdl_Rtin_Type_Array_Acc (St.Basetype);
+               if Bounds = Null_Address then
+                  --  Constrained array object (the common case for a
+                  --  u_slv_vector-shaped port): the layout is described
+                  --  by the subtype's own static RTI.
+                  Bounds := Array_Layout_To_Bounds
+                    (Loc_To_Addr (St.Common.Depth, St.Layout, Ctxt));
+               end if;
+            end;
+         when others =>
+            return Null_Address;
+      end case;
+
+      if Bounds = Null_Address then
+         return Null_Address;
+      end if;
+
+      --  Skip the range of each dimension to reach the element's own
+      --  layout, stored right after them.
+      for I in 1 .. Bt.Nbr_Dim loop
+         Extract_Range (Bounds, Get_Base_Type (Bt.Indexes (I - 1)), Rng);
+         if Rng = null then
+            --  Unhandled index type: bounds are not known anymore.
+            return Null_Address;
+         end if;
+      end loop;
+
+      return Bounds;
+   end Array_Element_Layout;
+
    --  OBJ_RTI is the RTI for the base name.
+   --  EL_LAYOUT is the per-instance layout of the element (see
+   --  Array_Element_Layout above); only used, and required non-null, when
+   --  the element's subtype is itself unbounded.
    function Add_Index (Ctxt : Rti_Context;
                        Obj_Base : Address;
                        Obj_Rti : Ghdl_Rtin_Object_Acc;
                        El_Type : Ghdl_Rti_Access;
+                       El_Layout : Address;
                        Off : Ghdl_Index_Type) return Address
    is
       Is_Sig : Boolean;
@@ -238,6 +310,24 @@ package body Grt.Avhpi is
                   El_Size := Sizes.Value;
                end if;
             end;
+         when Ghdl_Rtik_Subtype_Unbounded_Array =>
+            --  The element's subtype is itself unbounded (eg. array
+            --  (natural range <>) of std_logic_vector): its size is not
+            --  static, it is part of the per-instance layout computed by
+            --  Array_Element_Layout and passed in by the caller.
+            if El_Layout = Null_Address then
+               Internal_Error ("add_index(3)");
+            end if;
+            declare
+               Sizes : constant Ghdl_Indexes_Ptr :=
+                 To_Ghdl_Indexes_Ptr (El_Layout);
+            begin
+               if Is_Sig then
+                  El_Size := Sizes.Signal;
+               else
+                  El_Size := Sizes.Value;
+               end if;
+            end;
          when others =>
             Internal_Error ("add_index(2)");
       end case;
@@ -249,6 +339,8 @@ package body Grt.Avhpi is
                                      Error : out AvhpiErrorT)
    is
       El_Type : Ghdl_Rti_Access;
+      El_Layout : Address := Null_Address;
+      El_Bounds : Address := Null_Address;
    begin
       if Iterator.N_Idx = 0 then
          Error := AvhpiErrorIteratorEnd;
@@ -258,16 +350,26 @@ package body Grt.Avhpi is
       El_Type := To_Ghdl_Rtin_Type_Array_Acc
         (Get_Base_Type (Iterator.N_Type)).Element;
 
+      if Is_Unbounded (El_Type) then
+         El_Layout := Array_Element_Layout
+           (Iterator.Ctxt, Iterator.N_Type, Iterator.N_Bounds);
+         if El_Layout /= Null_Address then
+            El_Bounds := Array_Layout_To_Element (El_Layout, El_Type);
+         end if;
+      end if;
+
       Res := (Kind => VhpiIndexedNameK,
               Ctxt => Iterator.Ctxt,
               N_Addr => Iterator.N_Addr,
               N_Type => El_Type,
               N_Idx => 0,
+              N_Bounds => El_Bounds,
               N_Obj => Iterator.N_Obj);
 
       --  Increment Address.
       Iterator.N_Addr := Add_Index
-        (Iterator.Ctxt, Iterator.N_Addr, Iterator.N_Obj, El_Type, 1);
+        (Iterator.Ctxt, Iterator.N_Addr, Iterator.N_Obj, El_Type,
+         El_Layout, 1);
 
       Iterator.N_Idx := Iterator.N_Idx - 1;
       Error := AvhpiErrorOk;
@@ -415,7 +517,14 @@ package body Grt.Avhpi is
             Res := (Kind => VhpiConstDeclK,
                     Ctxt => Ctxt,
                     Obj => To_Ghdl_Rtin_Object_Acc (Rti));
-         when Ghdl_Rtik_Subtype_Array =>
+         when Ghdl_Rtik_Subtype_Array
+           | Ghdl_Rtik_Subtype_Unbounded_Array =>
+            --  Ghdl_Rtik_Subtype_Unbounded_Array is a resolved element of
+            --  an array-of-unconstrained-vector port (eg. array (natural
+            --  range <>) of std_logic_vector): unlike an unresolved
+            --  element, it is always given its own distinct Type_Info,
+            --  so it needs to resolve here too, exactly like a regular
+            --  constrained array subtype.
             declare
                Atype : constant Ghdl_Rtin_Subtype_Composite_Acc :=
                  To_Ghdl_Rtin_Subtype_Composite_Acc (Rti);
@@ -1116,7 +1225,9 @@ package body Grt.Avhpi is
                                      Error : out AvhpiErrorT)
    is
       Base_Type, Atype, El_Type : VhpiHandleT;
+      Arr_Rti : Ghdl_Rti_Access;
       Obj, Addr, Bounds : Address;
+      El_Layout, El_Bounds : Address;
    begin
       --  Default error.
       Error := AvhpiErrorNotImplemented;
@@ -1138,20 +1249,36 @@ package body Grt.Avhpi is
          return;
       end if;
       Obj := Avhpi_Get_Address (Ref);
-      Object_To_Base_Bounds (Avhpi_Get_Rti (Atype), Obj, Addr, Bounds);
+      Arr_Rti := Avhpi_Get_Rti (Atype);
+      Object_To_Base_Bounds (Arr_Rti, Obj, Addr, Bounds);
       if Addr = Null_Address then
          Error := AvhpiErrorBadRel;
          return;
       end if;
+
+      --  When the element's own subtype is unbounded (eg. an array of
+      --  unconstrained std_logic_vector), neither its size nor its
+      --  bounds are static: they are part of the per-instance layout
+      --  reachable from this array object (Arr_Rti/Bounds).
+      El_Layout := Null_Address;
+      El_Bounds := Null_Address;
+      if Is_Unbounded (El_Type.Atype) then
+         El_Layout := Array_Element_Layout (Ref.Ctxt, Arr_Rti, Bounds);
+         if El_Layout /= Null_Address then
+            El_Bounds := Array_Layout_To_Element (El_Layout, El_Type.Atype);
+         end if;
+      end if;
+
       --  Note: the index is a flat index (ie an offset).
       --  TODO: check with length ?
-      Addr := Add_Index (Ref.Ctxt, Addr, Ref.Obj, El_Type.Atype,
+      Addr := Add_Index (Ref.Ctxt, Addr, Ref.Obj, El_Type.Atype, El_Layout,
                          Ghdl_Index_Type (Index));
       Res := (Kind => VhpiIndexedNameK,
               Ctxt => Ref.Ctxt,
               N_Addr => Addr,
               N_Type => El_Type.Atype,
               N_Idx => Ghdl_Index_Type (Index),
+              N_Bounds => El_Bounds,
               N_Obj => Ref.Obj);
    end Indexed_Names_By_Index;
 
@@ -1414,6 +1541,17 @@ package body Grt.Avhpi is
             return Null_Address;
       end case;
    end Avhpi_Get_Address;
+
+   function Avhpi_Get_Bounds (Obj : VhpiHandleT) return Address is
+   begin
+      case Obj.Kind is
+         when VhpiIndexedNameK
+           | AvhpiNameIteratorK =>
+            return Obj.N_Bounds;
+         when others =>
+            return Null_Address;
+      end case;
+   end Avhpi_Get_Bounds;
 
    function Avhpi_Get_Context (Obj : VhpiHandleT) return Rti_Context is
    begin

--- a/src/grt/grt-avhpi.ads
+++ b/src/grt/grt-avhpi.ads
@@ -1007,6 +1007,13 @@ package Grt.Avhpi is
 
    function Avhpi_Get_Address (Obj : VhpiHandleT) return Address;
 
+   --  Bounds of the element of an indexed name, when that element's own
+   --  subtype is unbounded (eg. an array of unconstrained
+   --  std_logic_vector, only fully constrained per elaborated instance).
+   --  Null_Address when the element is bounded (its size/bounds are then
+   --  fully described by its own static RTI) or when OBJ has no bounds.
+   function Avhpi_Get_Bounds (Obj : VhpiHandleT) return Address;
+
    function Avhpi_Get_Context (Obj : VhpiHandleT) return Rti_Context;
 
    function Vhpi_Get_Kind (Obj : VhpiHandleT) return VhpiClassKindT;
@@ -1030,6 +1037,10 @@ private
             N_Addr : Address;
             N_Type : Ghdl_Rti_Access;
             N_Idx : Ghdl_Index_Type;
+            --  Bounds of N_Type, when N_Type is an unbounded subtype
+            --  (element of an array-of-unconstrained-vector object).
+            --  Null_Address otherwise.
+            N_Bounds : Address;
             N_Obj : Ghdl_Rtin_Object_Acc;
          when VhpiSigDeclK
            | VhpiPortDeclK

--- a/src/grt/grt-vcd.adb
+++ b/src/grt/grt-vcd.adb
@@ -421,7 +421,10 @@ package body Grt.Vcd is
 
       case Vhpi_Get_Kind (Sig) is
          when VhpiIndexedNameK =>
-            Bounds := Null_Address;
+            --  Non-null when Sig's own element subtype is unbounded (see
+            --  Avhpi_Get_Bounds / Add_Index's Ghdl_Rtik_Subtype_Unbounded_
+            --  Array case).
+            Bounds := Avhpi_Get_Bounds (Sig);
          when VhpiPortDeclK
             | VhpiSigDeclK
             | VhpiGenericDeclK
@@ -454,6 +457,18 @@ package body Grt.Vcd is
          when Ghdl_Rtik_Type_Array =>
             Arr_Rti := To_Ghdl_Rtin_Type_Array_Acc (Rti);
             Kind := Rti_Array_To_Vcd_Kind (Arr_Rti);
+         when Ghdl_Rtik_Subtype_Unbounded_Array =>
+            --  Only reachable for Sig = VhpiIndexedNameK (a resolved-
+            --  element, eg. std_logic_vector, array-of-unconstrained-
+            --  vector element): Bounds was already set above from
+            --  Avhpi_Get_Bounds (Sig), not recomputed here.
+            declare
+               St : constant Ghdl_Rtin_Subtype_Composite_Acc :=
+                 To_Ghdl_Rtin_Subtype_Composite_Acc (Rti);
+            begin
+               Arr_Rti := To_Ghdl_Rtin_Type_Array_Acc (St.Basetype);
+               Kind := Rti_Array_To_Vcd_Kind (Arr_Rti);
+            end;
          when others =>
             Kind := Vcd_Bad;
       end case;
@@ -478,8 +493,9 @@ package body Grt.Vcd is
          begin
             Extract_Range (Bounds, Idx_Rti, Irange);
          end;
-         --  Do not allow null-array.
-         if Irange.I32.Len = 0 then
+         --  Do not allow unknown bounds (Extract_Range failed, eg. Bounds
+         --  was Null_Address) nor a null-array.
+         if Irange = null or else Irange.I32.Len = 0 then
             Kind := Vcd_Bad;
          end if;
       end if;

--- a/testsuite/vpi/issue3332/mydesign.vhdl
+++ b/testsuite/vpi/issue3332/mydesign.vhdl
@@ -1,0 +1,24 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+package mypkg is
+  -- Resolved element, unconstrained at the type-declaration site (no
+  -- range on std_logic_vector): the element RTI kind is
+  -- Ghdl_Rtik_Subtype_Unbounded_Array, which used to make
+  -- vpi_handle_by_index silently return NULL (no crash, no diagnostic).
+  type t_slv_vector is array (natural range <>) of std_logic_vector;
+end package mypkg;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use work.mypkg.all;
+
+entity myentity is
+  port (
+    sig_o : out t_slv_vector(0 to 1)(4 downto 0) := ("00101", "10101")
+  );
+end entity myentity;
+
+architecture arch of myentity is
+begin
+end architecture arch;

--- a/testsuite/vpi/issue3332/myentity.ref
+++ b/testsuite/vpi/issue3332/myentity.ref
@@ -1,0 +1,4 @@
+sig_o(0) size=5 value=00101
+sig_o(1) size=5 value=10101
+sig_o(0) after write = 11010
+sig_o(1) after write = 10101

--- a/testsuite/vpi/issue3332/testsuite.sh
+++ b/testsuite/vpi/issue3332/testsuite.sh
@@ -1,0 +1,22 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+export GHDL_STD_FLAGS=--std=08
+analyze mydesign.vhdl
+elab myentity
+
+if c_compiler_is_available && ghdl_has_feature myentity vpi; then
+  "$GHDL" --vpi-compile -v "$CC" -c vpi1.c
+  "$GHDL" --vpi-link -v "$CC" -o vpi1.vpi vpi1.o
+
+  add_vpi_path
+
+  simulate myentity --vpi=./vpi1.vpi | tee myentity.out
+  diff_nocr myentity.out myentity.ref
+
+  rm -f vpi1.vpi vpi1.o myentity.out
+fi
+clean
+
+echo "Test successful"

--- a/testsuite/vpi/issue3332/vpi1.c
+++ b/testsuite/vpi/issue3332/vpi1.c
@@ -1,0 +1,110 @@
+#include <stdio.h>
+#include <string.h>
+#include <vpi_user.h>
+
+static vpiHandle do_el0, do_el1;
+static char expected[8];
+
+static PLI_INT32
+cb_delay (p_cb_data cb_data)
+{
+  s_vpi_value val;
+
+  val.format = vpiBinStrVal;
+  vpi_get_value (do_el0, &val);
+  vpi_printf ("sig_o(0) after write = %s\n", val.value.str);
+
+  /* sig_o(1) must be untouched by the sig_o(0) write -- a wrong element
+     stride would show up here instead. */
+  val.format = vpiBinStrVal;
+  vpi_get_value (do_el1, &val);
+  vpi_printf ("sig_o(1) after write = %s\n", val.value.str);
+
+  return 0;
+}
+
+static void
+reg_delay (unsigned cyc)
+{
+  s_cb_data cb;
+  s_vpi_time delay;
+
+  delay.type = vpiSimTime;
+  delay.high = 0;
+  delay.low = cyc;
+
+  cb.reason = cbAfterDelay;
+  cb.cb_rtn = cb_delay;
+  cb.time = &delay;
+  cb.user_data = NULL;
+
+  if (vpi_register_cb (&cb) == NULL)
+    vpi_printf ("cannot register AfterDelay call-back\n");
+}
+
+/* Read and print vpiSize + value for one element of an array-of-
+   unconstrained-vector port. Returns the element handle (or NULL). */
+static vpiHandle
+read_el (vpiHandle arr, const char *name, int idx)
+{
+  vpiHandle el;
+  s_vpi_value val;
+
+  el = vpi_handle_by_index (arr, idx);
+  if (el == NULL) {
+    vpi_printf ("ERROR: vpi_handle_by_index (%s, %d) returned NULL\n", name, idx);
+    return NULL;
+  }
+  val.format = vpiBinStrVal;
+  vpi_get_value (el, &val);
+  vpi_printf ("%s(%d) size=%d value=%s\n", name, idx, vpi_get (vpiSize, el), val.value.str);
+  return el;
+}
+
+static PLI_INT32
+start_of_sim_cb (p_cb_data cb_data)
+{
+  vpiHandle iter, top, sig_o;
+  s_vpi_value val;
+
+  iter = vpi_iterate (vpiModule, NULL);
+  top = vpi_scan (iter);
+
+  sig_o = vpi_handle_by_name ("sig_o", top);
+
+  /* sig_o: t_slv_vector, resolved element -- the silent-NULL case. */
+  do_el0 = read_el (sig_o, "sig_o", 0);
+  do_el1 = read_el (sig_o, "sig_o", 1);
+  if (do_el0 == NULL || do_el1 == NULL)
+    return 0;
+
+  /* Write sig_o(0), checked one time unit later: a vpiNoDelay put is not
+     guaranteed visible to a get in the same callback before simulation
+     time advances. */
+  strcpy (expected, "11010");
+  val.format = vpiBinStrVal;
+  val.value.str = expected;
+  vpi_put_value (do_el0, &val, NULL, vpiNoDelay);
+
+  reg_delay (1);
+
+  return 0;
+}
+
+static void
+my_handle_register (void)
+{
+  s_cb_data cb;
+
+  cb.reason = cbStartOfSimulation;
+  cb.cb_rtn = start_of_sim_cb;
+  cb.user_data = NULL;
+  if (vpi_register_cb (&cb) == NULL)
+    vpi_printf ("cannot register StartOfSimulation call-back\n");
+}
+
+void (*vlog_startup_routines[]) () =
+{
+  my_handle_register,
+  0
+};


### PR DESCRIPTION
Fixes issue https://github.com/ghdl/ghdl/issues/3332

The patch was generated by an AI agent. I cannot provide any guarantee that it is the correct fix. I'll let the maintainers be the judge of that. Feel free to edit, copy or change anything that you deem necessary.

I used a AI agent to investigate the bug, here is his analysis:

> GHDL's VHPI layer (`src/grt/grt-avhpi.adb`) has a lookup table it uses to turn an internal type descriptor into a VPI handle. For an array whose element type is itself an unconstrained, resolved vector (`std_logic_vector` with no range, only given one per elaborated instance), that lookup table is missing an entry. So when `vpi_handle_by_index` tries to resolve the element's subtype, the lookup fails, and the function gives up early and returns NULL — silently, with no error message. Code that doesn't check for NULL just ends up reading or driving nothing.
