### PR TITLE
fix llvm/gcc backend accepting 0-inclusive STRING index bounds

### DIFF
--- a/src/vhdl/translate/trans-chap3.adb
+++ b/src/vhdl/translate/trans-chap3.adb
@@ -730,7 +730,44 @@ package body Trans.Chap3 is
                      Open_Temp;
                      Rng := Bounds_To_Range (Targ, Def, I + 1);
                      if New_Indexes then
+                        --  Stabilize first: Rng is read several times
+                        --  below (Translate_Discrete_Range itself
+                        --  stabilizes internally, but only for its own
+                        --  writes; without stabilizing here first, its
+                        --  underlying address would already have been
+                        --  consumed once we try to read it back).
+                        Rng := Stabilize (Rng);
                         Chap7.Translate_Discrete_Range (Rng, Index);
+
+                        --  Check the bounds of this new index constraint
+                        --  fit within the corresponding index subtype of
+                        --  the unconstrained parent array type (e.g. a
+                        --  STRING's POSITIVE index).  A null range is
+                        --  always compatible, whatever its bounds are
+                        --  (LRM08 5.2.1), so only check non-null ranges.
+                        declare
+                           Parent_Index_Type : constant Iir :=
+                             Get_Index_Type
+                               (Get_Index_Subtype_List (Parent_Type), I);
+                           If_Blk : O_If_Block;
+                           Dummy  : O_Enode;
+                           pragma Unreferenced (Dummy);
+                        begin
+                           Start_If_Stmt
+                             (If_Blk,
+                              New_Compare_Op
+                                (ON_Neq,
+                                 M2E (Range_To_Length (Rng)),
+                                 New_Lit (Ghdl_Index_0),
+                                 Ghdl_Bool_Type));
+                           Dummy := Insert_Scalar_Check
+                             (M2E (Range_To_Left (Rng)), Null_Iir,
+                              Parent_Index_Type, Def);
+                           Dummy := Insert_Scalar_Check
+                             (M2E (Range_To_Right (Rng)), Null_Iir,
+                              Parent_Index_Type, Def);
+                           Finish_If_Stmt (If_Blk);
+                        end;
                      else
                         Gen_Memcpy
                           (M2Addr (Rng),

--- a/testsuite/gna/issue1395/dyn_zero.vhdl
+++ b/testsuite/gna/issue1395/dyn_zero.vhdl
@@ -1,0 +1,18 @@
+-- STRING is `array (POSITIVE range <>) of CHARACTER`, so any index subtype
+-- constraint including 0 is invalid (POSITIVE starts at 1). Here the bound
+-- is not locally static (it comes from a generic), so the violation can
+-- only be caught by a runtime/elaboration-time check, not by a purely
+-- static analysis-time check. See issue1395.
+entity dyn_zero is
+  generic (n : integer := 0);
+end entity;
+
+architecture a of dyn_zero is
+begin
+  process
+    variable s : string(4 downto n);
+  begin
+    report "len=" & integer'image(s'length);
+    wait;
+  end process;
+end architecture;

--- a/testsuite/gna/issue1395/dyn_zero_signal.vhdl
+++ b/testsuite/gna/issue1395/dyn_zero_signal.vhdl
@@ -1,0 +1,18 @@
+-- Same underlying issue as dyn_zero.vhdl (a POSITIVE-indexed STRING with an
+-- index range that includes 0), but a different declaration shape: a
+-- *signal* with a default aggregate value, declared at the architecture
+-- level (not a variable inside a process), and with the generic on the
+-- *left* bound instead of the right. See issue1395.
+entity dyn_zero_signal is
+  generic (g : integer := 4);
+end entity;
+
+architecture arch of dyn_zero_signal is
+  signal str : string (g downto 0) := (others => 'a');
+begin
+  process
+  begin
+    report str;
+    wait;
+  end process;
+end architecture;

--- a/testsuite/gna/issue1395/testsuite.sh
+++ b/testsuite/gna/issue1395/testsuite.sh
@@ -1,0 +1,15 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+analyze dyn_zero.vhdl
+elab_simulate_failure dyn_zero
+
+clean
+
+analyze dyn_zero_signal.vhdl
+elab_simulate_failure dyn_zero_signal
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
https://github.com/ghdl/ghdl/issues/1395