### PR TITLE
vhdl-sem_stmts: skip invalid choices when filling aggregate-target array

### DIFF
--- a/src/vhdl/vhdl-sem_stmts.adb
+++ b/src/vhdl/vhdl-sem_stmts.adb
@@ -123,14 +123,24 @@ package body Vhdl.Sem_Stmts is
    begin
       El := Chain;
       while El /= Null_Iir loop
-         Ass := Get_Associated_Expr (El);
-         if Get_Kind (Ass) = Iir_Kind_Aggregate then
-            Fill_Array_From_Aggregate_Associated
-              (Get_Association_Choices_Chain (Ass), Nbr, Arr);
-         else
-            Arr (Nbr) := Ass;
-            Nbr := Nbr + 1;
-         end if;
+         case Get_Kind (El) is
+            when Iir_Kind_Choice_By_Range
+              | Iir_Kind_Choice_By_Others =>
+               --  Already reported as an error by Check_Aggregate_Target,
+               --  which (unlike here) does not count these choices in NBR.
+               --  ARR is sized to that count, so they must be skipped here
+               --  too, or NBR overruns ARR'Last.
+               null;
+            when others =>
+               Ass := Get_Associated_Expr (El);
+               if Get_Kind (Ass) = Iir_Kind_Aggregate then
+                  Fill_Array_From_Aggregate_Associated
+                    (Get_Association_Choices_Chain (Ass), Nbr, Arr);
+               else
+                  Arr (Nbr) := Ass;
+                  Nbr := Nbr + 1;
+               end if;
+         end case;
          El := Get_Chain (El);
       end loop;
    end Fill_Array_From_Aggregate_Associated;

--- a/testsuite/gna/issue2227/test.vhdl
+++ b/testsuite/gna/issue2227/test.vhdl
@@ -1,0 +1,25 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity test is
+end test;
+
+architecture rtl of test is
+
+  signal a : character;
+  signal b : character;
+  signal c : character;
+  signal k : string(1 to 5);
+begin
+  process
+    variable  y : string(1 to 8);
+  begin
+    y := "abcdefgh";
+    (1 => a, 2 => b, 3 => c, 4 to 8 => k) <= y;
+    wait for 1 ns;
+    report a & " " & b & " " & c &  " " & k;
+    report a & b & c & k;
+    wait;
+  end process;
+end rtl;

--- a/testsuite/gna/issue2227/testsuite.sh
+++ b/testsuite/gna/issue2227/testsuite.sh
@@ -1,0 +1,29 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# The assignment target aggregate uses a discrete-range choice
+# ("4 to 8 => k"), which LRM93 8.4 disallows for a target -- Check_Target
+# correctly rejects it. But Fill_Array_From_Aggregate_Associated (which
+# fills an array sized by the *valid* choice count) used to walk every
+# choice unconditionally, overrunning that array and crashing with an
+# internal CONSTRAINT_ERROR (index check failed) right after the correct
+# error was already reported. See issue2227.
+export GHDL_STD_FLAGS="--std=08"
+
+out=$(analyze_failure test.vhdl 2>&1)
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: analysis crashed instead of reporting a clean error"
+  exit 1
+fi
+
+if ! echo "$out" | grep -q "discrete range choice not allowed for target"; then
+  echo "FAIL: expected the discrete-range-choice error"
+  exit 1
+fi
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Fixes https://github.com/ghdl/ghdl/issues/2227
