### PR TITLE
Makefile.in: restrict libghdl's gnatlink -R flag to macOS

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -487,10 +487,25 @@ libghdl_name=libghdl-$(libghdl_version)$(SOEXT)
 
 LIBGHDL_GRT_OBJS= pic/grt-cstdio.o pic/grt-cdynload.o
 
+#	gnatlink normally embeds an automatic rpath to the GNAT runtime
+#	(libgnat) directory.  On macOS this duplicates the rpath already
+#	supplied via SHLIB_FLAGS/LDFLAGS and ld rejects it as a "duplicate
+#	LC_RPATH" error (#2806), so -R (disable gnatlink's automatic rpath)
+#	is needed there.  On other platforms SHLIB_FLAGS/LDFLAGS carry no
+#	such rpath, so passing -R everywhere leaves libghdl's shared library
+#	with no working path to libgnat at all when it isn't on the default
+#	linker search path -- which is what makes testsuite/gna/issue2005
+#	fail with undefined GNAT symbols.  Restrict -R to macOS.
+ifeq ($(SOEXT),.dylib)
+LIBGHDL_LARGS_R=-R
+else
+LIBGHDL_LARGS_R=
+endif
+
 lib/$(libghdl_name): $(GRT_SRC_DEPS) $(LIBGHDL_GRT_OBJS) version.ads force
 #	Use -g for gnatlink so that the binder file is not removed.  We need
 #	it for libghdl.a
-	$(GNATMAKE) -I- -aI. -D pic -z libghdl -o $@ -gnat12 $(GNATFLAGS) $(PIC_FLAGS) $(LIBGHDL_INCFLAGS) -bargs -shared -Llibghdl_ -largs -R -g -shared $(SHLIB_FLAGS) $(filter-out -static,$(LDFLAGS)) $(LIBGHDL_GRT_OBJS)
+	$(GNATMAKE) -I- -aI. -D pic -z libghdl -o $@ -gnat12 $(GNATFLAGS) $(PIC_FLAGS) $(LIBGHDL_INCFLAGS) -bargs -shared -Llibghdl_ -largs $(LIBGHDL_LARGS_R) -g -shared $(SHLIB_FLAGS) $(filter-out -static,$(LDFLAGS)) $(LIBGHDL_GRT_OBJS)
 #       On windows, gnatmake (via Osint.Executable_Name) always appends .exe
 #       Adjust.  (Other solution: use gnatmake for compilation and binding,
 #       then use gnatlink directly for linking).

--- a/testsuite/gna/bug0146/testsuite.sh
+++ b/testsuite/gna/bug0146/testsuite.sh
@@ -1,0 +1,37 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+set -x
+
+# libghdl is an Ada shared library, so it needs the GNAT runtime (libgnat)
+# at run time.  gnatlink normally records the path to that runtime in the
+# library itself, but Makefile.in used to defeat that by passing gnatlink's
+# -R on every platform; it is only needed on macOS, where the automatic
+# rpath duplicates the one from LDFLAGS and ld rejects it (#2806).
+# Everywhere else -R just left libghdl with no way to find libgnat unless it
+# happened to sit on the default linker search path -- so libghdl was
+# unusable with a GNAT installed under its own prefix, which is what
+# gna/issue2005 then failed on, with a wall of undefined GNAT symbols.
+
+lib_path="$("$GHDL" --libghdl-library-path)"
+if [ ! -f "$lib_path" ]; then
+    echo "no libghdl"
+    exit 0
+fi
+
+# No ldd on macOS (and it is the one platform that still needs -R).
+if which ldd > /dev/null 2>&1; then
+    if ldd "$lib_path" > deps.txt 2>&1; then
+	if grep "not found" deps.txt > /dev/null; then
+	    echo "error: $lib_path cannot resolve all its dependencies:"
+	    grep "not found" deps.txt
+	    echo "(libghdl was probably linked without a path to the GNAT runtime)"
+	    rm -f deps.txt
+	    exit 1
+	fi
+    fi
+    rm -f deps.txt
+fi
+
+echo "Test successful"


### PR DESCRIPTION
# libghdl cannot find libgnat — gnatlink's `-R` was applied on every platform

Find by the AI agent. Recommendation merge fix and test.

- The test that fails: `testsuite/gna/issue2005`
- Named after **pull request** https://github.com/ghdl/ghdl/pull/2005
- The change that caused it: `b51ed923f` "Makefile.in: use -R for libghdl", for https://github.com/ghdl/ghdl/issues/2806

#2005 is a **pull request**: [Fix include-dir paths returned by cmdline _again_](https://github.com/ghdl/ghdl/pull/2005), by Daniel Gröber, merged March 2022 as commit `55e331585`. It fixed `--libghdl-include-dir` (which should point at a directory *containing* a `ghdl/` subdirectory) versus `--vpi-include-dir` (which should point at the `ghdl/` subdirectory itself), and it added `testsuite/gna/issue2005` to keep them honest.

What that test actually does is compile and link a small C program against `libghdl` using the two paths GHDL reports, in both of the usual styles:

```sh
$CC -I"$incdir" test.c "$($GHDL --libghdl-library-path)"
$CC -I"$incdir" -L"$libdir" test.c -l"$lib"
```

So it is an *include/library path* test. The failure documented here happens at the link step, for a reason that has nothing to do with include paths — the test simply happens to be the only thing in the testsuite that links against `libghdl`, so it is where the breakage surfaces.

## Symptom

`testsuite/gna/issue2005` fails on all three backends (mcode, llvm, gcc) with a wall of undefined GNAT symbols:

```
/usr/bin/ld: warning: libgnat-16.so, needed by .../lib/libghdl-7_0_0_dev.so, not found (try using -rpath or -rpath-link)
/usr/bin/ld: .../lib/libghdl-7_0_0_dev.so: undefined reference to `ada__environment_variables__exists'
/usr/bin/ld: .../lib/libghdl-7_0_0_dev.so: undefined reference to `gnat_E'
... (many more, all GNAT runtime symbols)
```

`testenv.sh` does `set -e` and `testsuite.sh` sources it rather than running it in a subshell, so this really does fail the test rather than being swallowed.

## Root cause

`libghdl-*.so` is an Ada shared library, so it carries a dynamic dependency on GNAT's own runtime — `NEEDED: libgnat-16.so`. (The `ghdl` executable does not: it links the Ada runtime statically, which is why `ghdl` itself runs fine while `libghdl` does not.) Something therefore has to tell the loader where that runtime lives, and normally `gnatlink` does it automatically, by embedding an rpath pointing at the GNAT runtime directory it was built against.

`Makefile.in`'s libghdl rule suppressed exactly that, by passing gnatlink's `-R` ("do not use a run_path_option") unconditionally:

```
lib/$(libghdl_name): $(GRT_SRC_DEPS) $(LIBGHDL_GRT_OBJS) version.ads force
	$(GNATMAKE) ... -largs -R -g -shared $(SHLIB_FLAGS) $(filter-out -static,$(LDFLAGS)) $(LIBGHDL_GRT_OBJS)
```

That `-R` came from `b51ed923f` ("Makefile.in: use -R for libghdl", 2024-12-15, Tristan Gingold), whose commit message is just "For #2806". [Issue #2806](https://github.com/ghdl/ghdl/issues/2806) — "GNA: Issue2005 not working" — is a **macOS** problem: there, gnatlink's automatic rpath duplicates one already supplied through `SHLIB_FLAGS`/`LDFLAGS`, and Apple's `ld` rejects duplicates outright with `ld: duplicate LC_RPATH '.../gnat/lib'`. Suppressing gnatlink's rpath removes the duplicate and fixes macOS. The same commit re-enabled the test on all platforms (`d2a566cb5`, same day), macOS included.

The problem is that the duplicate only exists on macOS, while `-R` was applied everywhere. On other platforms `SHLIB_FLAGS`/`LDFLAGS` carry no rpath to the GNAT runtime, so `-R` does not remove a redundant entry — it removes the *only* entry, and `libghdl.so` is left with no path to its own Ada runtime.

## Why upstream CI never noticed

Whether that matters depends entirely on where libgnat happens to live. With a distribution GNAT it sits in a default linker search directory (`/usr/lib/x86_64-linux-gnu` on Debian/Ubuntu), so the missing rpath costs nothing and everything links. With a GNAT installed under its own prefix it does not, and the missing rpath is fatal. In this sandbox GNAT is at `/home/dalex78/software/gcc/16.2.0`, with the runtime in the compiler-internal `lib/gcc/x86_64-pc-linux-gnu/16.2.0/adalib/` directory, and the failure is immediate.

This is worth stating plainly because it is easy to misread the failure as an environment problem: it is not. The library really is built wrong; a distro GNAT just hides it. Adding that `adalib` directory to `LD_LIBRARY_PATH` makes the test pass, which is a useful confirmation of the diagnosis but not a fix — the module file is right to leave it out, since GNAT's designed mechanism for this is the rpath that `-R` was discarding.

## The fix

`Makefile.in`: restrict `-R` to macOS, matching the platform `#2806` was actually about.

```make
ifeq ($(SOEXT),.dylib)
LIBGHDL_LARGS_R=-R
else
LIBGHDL_LARGS_R=
endif
```

and use `$(LIBGHDL_LARGS_R)` in place of the hard-coded `-R` on the gnatlink line. macOS keeps the behaviour that fixed #2806; everywhere else gnatlink's automatic rpath comes back, and `libghdl.so` can find libgnat again.

Effect on the produced library, same toolchain, before and after:

```
before:  RUNPATH  [<gcc-prefix>/lib64:<llvm-prefix>/lib]
after:   RUNPATH  [<gcc-prefix>/lib64:<gcc-prefix>/lib/gcc/x86_64-pc-linux-gnu/16.2.0/adalib/:<gcc-prefix>/lib64]
```

## The test

`testsuite/gna/bug0146` checks that `libghdl` resolves all of its dynamic dependencies, via `ldd`, and fails with a message that names the culprit:

```
error: .../libghdl-7_0_0_dev.so cannot resolve all its dependencies:
	libgnat-16.so => not found
(libghdl was probably linked without a path to the GNAT runtime)
```

Three notes on the shape of it. It is named `bug0146` because `testsuite/gna/README` reserves `bug0XX` for "bugs not reported", which is the case here — the over-broad `-R` was never filed as an issue, only its macOS counterpart #2806 was. It is a separate directory rather than an addition to `issue2005` so that the two keep their own subjects: `issue2005` is about the include/library paths PR #2005 fixed, this one is about the library being loadable at all. And it skips when `ldd` is absent, which covers macOS — the one platform where `-R` is still applied and where the equivalent check would be `otool -L`.

It follows the portability guidance in `testsuite/gna/README`: no `grep -q` (redirect to `/dev/null` instead), and no pipes into a command that might exit before consuming its input.

## Testing

All three backends were built fresh from this branch (`--disable-checks -O3 -march=native`; the llvm build additionally configured with `--with-backtrace-lib`, as CI does) and put through the full testsuite — sanity, gna, synth, vpi, vhpi, vests. Each backend's suite was run on its own, never two at once on the same tree.

| backend | adalib in libghdl RUNPATH | sanity + gna | synth / vpi / vhpi / vests | gna/issue2005 | gna/bug0146 |
|---|---|---|---|---|---|
| mcode | yes | PASS | PASS | ok | ok |
| llvm | yes | PASS | PASS | ok | ok |
| gcc | yes | PASS | PASS | ok | ok |

**No failures of any kind, on any backend.** That is the notable part: before this fix, `gna/issue2005` failed on all three backends and halted the gna suite, so a fully clean run was not previously obtainable in this environment.

The new test was also checked in the negative direction, which is what makes it a regression test rather than a tautology. Against builds from `origin/master` (no fix), on all three backends: `libghdl` has no adalib entry in its RUNPATH, and both `gna/bug0146` and `gna/issue2005` fail. Against builds from this branch, all three report the adalib entry and both tests pass.

Resulting RUNPATH on the fresh llvm build, for reference:

```
[<gcc-prefix>/lib64:<llvm-prefix>/lib:<gcc-prefix>/lib/gcc/x86_64-pc-linux-gnu/16.2.0/adalib/:<gcc-prefix>/lib64]
```

The first two entries come from the build script's own `-Wl,-rpath` flags; the third is the one gnatlink restores once `-R` is no longer passed, and is the entry that fixes this bug.

Not verifiable here: that macOS still links cleanly. The `ifeq ($(SOEXT),.dylib)` branch keeps `-R` exactly as before on that platform, so #2806 cannot regress, but no macOS machine was available to confirm it.

