### PR TITLE
Ci/time optimisation

### DIFF
--- a/.github/workflows/Build-MSYS2.yml
+++ b/.github/workflows/Build-MSYS2.yml
@@ -87,6 +87,9 @@ jobs:
   Build:
     name: Build GHDL on Windows Server + MSYS2
     runs-on: windows-${{ inputs.windows_version }}
+    # See Build-Ubuntu.yml.  Slowest measured MSYS2 build: 7.5 minutes, but
+    # pacman and the MSYS2 setup make this the heaviest of the three.
+    timeout-minutes: 60
     outputs:
       ghdl_artifact:    ${{ steps.artifact_name.outputs.ghdl_artifact }}
       pacman_artifact:  ${{ steps.artifact_name.outputs.pacman_artifact }}

--- a/.github/workflows/Build-MacOS.yml
+++ b/.github/workflows/Build-MacOS.yml
@@ -69,6 +69,8 @@ jobs:
     name: Build GHDL on '${{ inputs.macos_image }}'
     if: true
     runs-on: ${{ inputs.macos_image }}
+    # See Build-Ubuntu.yml.  Slowest measured macOS build: 3.4 minutes.
+    timeout-minutes: 45
     outputs:
       ghdl_artifact: ${{ steps.artifact_name.outputs.ghdl_artifact }}
 

--- a/.github/workflows/Build-Ubuntu.yml
+++ b/.github/workflows/Build-Ubuntu.yml
@@ -71,6 +71,10 @@ jobs:
     name: Build GHDL on 'ubuntu-${{ inputs.ubuntu_version }}'
     if: true
     runs-on: ubuntu-${{ inputs.ubuntu_version }}
+    # Backstop against a hung step.  Without it a job inherits the 360 minute
+    # default and can hold a runner for six hours.  The slowest legitimate build
+    # measured is gcc/26.04 at 16.2 minutes.
+    timeout-minutes: 45
     outputs:
       ghdl_artifact: ${{ steps.artifact_name.outputs.ghdl_artifact }}
 
@@ -94,7 +98,19 @@ jobs:
           EOF
 
       - name: 🔧 Install dependencies
+        # Normally 33 s (median), 8.7 minutes at the observed worst.  The cap is
+        # what turns an unreachable mirror into a fast, retryable failure.
+        timeout-minutes: 15
         run: |
+          # The runner's mirrorlist puts azure.archive.ubuntu.com first, and that
+          # mirror intermittently stalls instead of failing.  Bound every request
+          # so apt falls through to archive.ubuntu.com instead of hanging.
+          sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'CONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          CONF
+
           APT_ARGS="gcc g++ gnat"
           if ${{ startsWith(inputs.ghdl_backend, 'mcode') }}; then
             APT_ARGS="$APT_ARGS"

--- a/.github/workflows/Build-Ubuntu.yml
+++ b/.github/workflows/Build-Ubuntu.yml
@@ -474,11 +474,14 @@ jobs:
       ghdl_artifact: ${{ needs.Build.outputs.ghdl_artifact }}
       testsuites:    ${{ inputs.testsuites }}
 
+  # Only package images where they can actually be used: on 'master' and on tags.
+  # On a topic branch these images are built, tested and then thrown away, while
+  # holding Linux runners the still-queued build jobs are waiting for.
   Docker:
     uses: ./.github/workflows/Package-Docker.yml
     needs:
       - Build
-    if: inputs.ubuntu_artifact != ''
+    if: inputs.ubuntu_artifact != '' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
     with:
       ubuntu_image:   ubuntu-${{ inputs.ubuntu_version }}
       ghdl_artifact:  ${{ needs.Build.outputs.ghdl_artifact }}

--- a/.github/workflows/Package-Docker.yml
+++ b/.github/workflows/Package-Docker.yml
@@ -123,9 +123,16 @@ jobs:
           printf "Docker image '%s' has %s\n" "${{ steps.build.outputs.ghdl_image }}" "$(docker image inspect ${{ steps.build.outputs.ghdl_image }} --format='{{.Size}}' | numfmt --to=iec --format '%.2f')"
           docker image push ${{ steps.build.outputs.ghdl_image }}
 
-      - name: 🚦 Testing GHDL image
+      # Smoke test only, on purpose.  The full 'testsuites' list has
+      # already been run natively by the 'Test' job, on the very same build artifact
+      # that was just copied into this image.  Running it a second time inside the
+      # container proves nothing new about the image, but used to account for roughly
+      # a third of the pipeline's Linux runner minutes, starving the remaining build
+      # jobs of runners.  'sanity' is enough to prove the image is well-formed.
+      - name: 🚦 Smoke testing GHDL image
+        if: inputs.testsuites != 'none'
         run: |
-          docker container run --rm -v $(pwd):/data ghdl:current /bin/bash -c 'cd /data/testsuite; ./testsuite.sh ${{ inputs.testsuites }}'
+          docker container run --rm -v $(pwd):/data ghdl:current /bin/bash -c 'cd /data/testsuite; ./testsuite.sh sanity'
 
   TestDocker:
     uses: ./.github/workflows/Test-Docker.yml


### PR DESCRIPTION
# CI pipeline time optimisation

Analysis by an AI agent. Three changes to the GitHub Actions pipeline, aimed at the long wall-clock times of the Ubuntu build jobs.

## The measured problem

The starting complaint was that jobs such as `Ubuntu (🐧🟧, llvm, 22.04, sanity gna vests synth vpi vhpi) / Build GHDL on 'ubuntu-22.04'` and its 24.04 counterpart are very slow.

They are not. Those jobs barely do any work — measured on run [32165784522](https://github.com/ghdl/ghdl/actions/runs/32165784522) (branch `bug/issue3315`), the 22.04 one ran for 3.4 minutes (checkout 23 s, `apt install llvm clang` 94 s, `make -j$(nproc)` 76 s, install and sanity ~2 s, artifact upload 4 s) and the 24.04 one for 4.2 minutes. What the Actions UI shows is elapsed wall-clock, which is queue time plus run time, and for those two jobs the queue was 88.2 and 42.9 minutes respectively. Essentially all of the reported slowness is time spent waiting for a runner.

The pipeline dispatches ~100 jobs per push, 60 of them Linux, but the measured peak concurrency of that run was only 10 jobs (5 Linux, 5 Windows, 3 macOS). The 60 Linux jobs added up to 293 Linux job-minutes, so at 5 slots there is at least ~59 minutes of unavoidable serialisation before any scheduling inefficiency is taken into account; the run's actual wall clock was 156 minutes. The way to make the named build jobs finish sooner is therefore not to make them compile faster — there is nothing left to win in 76 seconds of compilation — but to stop spending Linux runner minutes on work that does not need doing.

Breakdown of those 293 Linux job-minutes:

| share | category |
|---|---|
| 35% (103 min) | `Test / Test GHDL` child jobs |
| 33% (98 min) | `Docker / Package GHDL as Docker Image` child jobs |
| 16% (46 min) | `gcc` builds (3 × 12–16 min, they compile GCC 13.3.0 from source) |
| 13% (39 min) | all `mcode` / `llvm` / `llvm-jit` builds combined |

Fixes 1 and 2 target the second row. Fix 3 addresses a separate and larger failure found later: jobs that hang for six hours holding a runner, which no amount of scheduling improvement can compensate for.

## Fix 1 — stop running the whole testsuite a second time inside Docker

### What it does, at a high level

The Docker packaging job used to finish by running the complete testsuite inside the container it had just built. But the `Test` job had already run that exact same testsuite list, natively, against the exact same build artifact that gets copied into the image. So every Ubuntu configuration executed `sanity gna vests synth vpi vhpi` twice on every push, twelve configurations deep — and that duplication, not packaging, is what the 98 minutes / 33% in the table above actually consisted of.

The fix reduces the in-container run to a smoke test. The Docker job's responsibility is to prove that the image is well-formed — that `ghdl` is present, runnable, and finds its libraries — and `sanity` establishes that. Real test coverage is unchanged: `gna`, `vests`, `synth`, `vpi` and `vhpi` still run in the `Test` job against the identical binaries, and the published image is still verified in full by the separate `TestDocker` job.

### How it was fixed

In `.github/workflows/Package-Docker.yml`, the final step of the `Ubuntu` job no longer forwards the `testsuites` input to `testsuite.sh`; it runs `sanity` unconditionally:

```yaml
- name: 🚦 Smoke testing GHDL image
  if: inputs.testsuites != 'none'
  run: |
    docker container run --rm -v $(pwd):/data ghdl:current /bin/bash -c 'cd /data/testsuite; ./testsuite.sh sanity'
```

The `testsuites` input itself is deliberately left alone, because it is also forwarded to the `TestDocker` job, which must keep running the full list against the published image.

The step also gained an `if: inputs.testsuites != 'none'` guard, matching the one the `Test` job is called with in `Build-Ubuntu.yml`. Previously a value of `none` would have been passed through to `testsuite.sh` as if it were a test name, and aborted with `test name 'none' is unknown`.

## Fix 2 — only build Docker images on the refs that keep them

### What it does, at a high level

`Build-Ubuntu.yml` ends with a `Docker` job that does two things: it wraps the GHDL that was just compiled into a Docker image, and it pushes that image to Docker Hub. Only the push is conditional — it is guarded by the `publish` input, which the caller already sets to true for `master` and tags only.

So on a topic branch the second half never runs. The image is built, checked, and then thrown away with the runner. Nothing downstream consumes it and nothing keeps it.

`Build-Ubuntu.yml` is invoked once per backend and Ubuntu version — `mcode`, `llvm`, `llvm-jit` and `gcc`, across 22.04, 24.04 and 26.04, split between the `Ubuntu-fast` and `Ubuntu` matrices in `Pipeline.yml`. That is twelve invocations, and each one contains a `Build` job, a `Test` job and a `Docker` job. So a topic-branch push produces twelve discarded images. On run [32165784522](https://github.com/ghdl/ghdl/actions/runs/32165784522) those twelve `Docker` jobs consumed 98 Linux job-minutes, a third of the entire Linux budget for the run.

**Only the `Docker` job is affected by this fix.** GHDL is still compiled twelve times and still tested twelve times on every push, exactly as before — the `Build` and `Test` jobs are untouched:

| per topic-branch push | before | after |
|---|---|---|
| `Build GHDL` — compiles GHDL | 12 | 12, unchanged |
| `Test GHDL` — runs the full testsuite | 12 | 12, unchanged |
| `Package GHDL as Docker Image` | 12 | 0 |

On `master` and on tags nothing changes at all: all twelve images are still built, tested and pushed to Docker Hub.

Losing a third of the budget would be bad enough, but the scheduling makes it worse than a flat tax. A `Docker` job depends only on its own `Build`, so it becomes runnable the instant that build finishes — and then queues for a runner against the `Build` jobs of *other* matrix entries that have not started yet. With roughly five Linux runners serving sixty Linux jobs, a configuration that happens to build early gets its throwaway `Docker` job into the queue ahead of a configuration that has not begun at all.

That is precisely what happened to `llvm/22.04` in that run. It waited 88.2 minutes for a runner and then built in 3.4 minutes; across the window from +60 to +88 minutes, every Linux slot was held by `Test` and `Docker` jobs belonging to configurations that had already finished building.

Skipping the job on topic branches therefore fixes two things at once: the 98 wasted minutes, and the queue-jumping that pushed the last-scheduled builds furthest back.

### How it was fixed

In `.github/workflows/Build-Ubuntu.yml` the `Docker` job was previously guarded only against a missing artifact:

```yaml
if: inputs.ubuntu_artifact != ''
```

It is now also restricted to the refs where the resulting image is actually kept:

```yaml
if: inputs.ubuntu_artifact != '' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
```

This mirrors the `publish` expression the same job is already called with, with two deliberate differences:

- `publish` also tests `github.event_name != 'pull_request'`. The new condition does not need that test: for a `pull_request` event `github.ref` is `refs/pull/N/merge`, which matches neither arm, so pull requests are skipped regardless.
- `publish` uses `contains(github.ref, 'refs/tags/')`, which would also match a branch whose name merely contains that string. `startsWith` is used here instead.

Releases are unaffected. The two jobs in `Pipeline.yml` that consume this workflow's results, `PublishTag` and the release job, run only for nightly, test and release tags — and every tag ref satisfies the new condition.

## Fix 3 — stop a stalled apt mirror from holding a runner for six hours

### What it does, at a high level

Job [95804002588](https://github.com/ghdl/ghdl/actions/runs/32165027694/job/95804002588) spent 21603 seconds — six hours and three seconds — in its `🔧 Install dependencies` step and was then killed, with the job clocking in at exactly 360.2 minutes. That number is the giveaway: 360 minutes is the GitHub Actions default job timeout. The log ends with `Error: The operation was canceled.`, which is what GitHub prints for a job that hits its maximum execution time as well as for a real cancellation, and which is why this looked at first like an unrelated concurrency cancel.

The trigger is the runner's apt mirrorlist. It puts `azure.archive.ubuntu.com` first, and that mirror intermittently accepts a connection and then never answers. The log shows apt trying it four times for the `InRelease` files, correctly falling through to `archive.ubuntu.com`, then reaching `Ign:15 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages` and stopping there for the rest of the six hours.

What turned a flaky mirror into a six-hour outage is that no workflow in the repository set `timeout-minutes` anywhere — all 14 were checked — so every step inherited the 360-minute job default. This is not a one-off: a second job hung in the same step for the same 360.2 minutes in run [32066707083](https://github.com/ghdl/ghdl/actions/runs/32066707083). Across the nine runs examined that is roughly one in five losing a Linux runner for six hours, out of a pool of about five. It dwarfs both of the fixes above.

### How it was fixed

Two layers, in `.github/workflows/Build-Ubuntu.yml`. The step itself is capped, and apt is told to bound each request instead of blocking indefinitely so it falls through to the working mirror the way it already does for `InRelease`:

```yaml
- name: 🔧 Install dependencies
  timeout-minutes: 15
  run: |
    sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'CONF'
    Acquire::Retries "3";
    Acquire::http::Timeout "30";
    Acquire::https::Timeout "30";
    CONF
    ...
```

15 minutes is chosen against the measured distribution of that step: 33 seconds median, 8.7 minutes at the observed worst.

A job-level backstop then covers any other step that might hang, in all three build workflows — `timeout-minutes: 45` for `Build-Ubuntu.yml` (slowest measured build: gcc/26.04 at 16.2 minutes) and `Build-MacOS.yml` (3.4 minutes), and `60` for `Build-MSYS2.yml` (7.5 minutes measured, but pacman and the MSYS2 setup make it the heaviest of the three).

## Expected effect

The two Docker fixes apply on different refs, and it is worth separating them.

On a topic branch, fix 2 does all the work: it removes all twelve `Docker` jobs, worth roughly 98 of the run's 293 Linux job-minutes, and with them the class of job that was jumping the queue ahead of builds that had not started. On a 5-slot Linux pool that should pull the queue for the `llvm` build jobs down from 45–90 minutes into the 15–25 minute range. Fix 1 contributes nothing here, because the job it trims no longer runs.

On `master` and on tags the reverse holds: fix 2 changes nothing, and fix 1 is what shortens the twelve `Docker` jobs, by cutting each one's in-container test run from the full testsuite down to `sanity`.

Neither fix reduces how much GHDL gets compiled or tested. The saving comes entirely from work that was duplicated or discarded.

Fix 3 does not shorten a healthy run at all. What it does is put a ceiling on an unhealthy one: a stalled mirror now costs 15 minutes and a re-run instead of six hours of a runner that every other queued job is waiting for.

These are estimates, not promises — runner availability varies from run to run — but the measurements underneath them (the duplicated testsuite, and the two 360.2-minute hangs) are solid.

## Deliberately not done

- **Optimising the `llvm` build itself.** It is 76–97 seconds of compilation. There is nothing to win there.
- **Caching the `gcc` builds.** They are the only genuinely long builds at 12–16 minutes each, since they compile GCC 13.3.0 from source every time, but a GCC object tree does not fit the 10 GB per-repository cache limit and the invalidation logic would be fragile.
- **Trimming `vests` from the testsuite list** via the commented-out `testsuites:` knob in `Pipeline.yml`. It would work, but it buys speed by deleting coverage, whereas the changes above buy the same speed by deleting duplication. Worth keeping in reserve.
- **Timeouts on the `Test`, `Docker` and pyGHDL jobs.** Fix 3 covers the three build workflows, where both observed hangs happened. Those other jobs also install dependencies and are still unguarded, so they remain exposed to the same six-hour failure mode; extending the backstop to them is a reasonable follow-up but was kept out of scope here.
