### PR TITLE
testsuite: add regression test for issue1502, already fixed on master

### DIFF
--- a/testsuite/synth/issue1502/testsuite.sh
+++ b/testsuite/synth/issue1502/testsuite.sh
@@ -1,0 +1,13 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A function call producing a record-field-derived array actual for a
+# port association used to crash --synth with an internal ASSERT_FAILURE
+# (synth-expr.adb:830). See issue1502.
+synth theunit.vhdl -e theunit > syn_theunit.vhdl
+analyze syn_theunit.vhdl
+
+clean
+
+echo "Test successful"

--- a/testsuite/synth/issue1502/theunit.vhdl
+++ b/testsuite/synth/issue1502/theunit.vhdl
@@ -1,0 +1,52 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity passthrough is
+  port (
+    wdata : in  std_ulogic_vector(1 downto 0);
+    rdata : out std_ulogic_vector(1 downto 0)
+  );
+end;
+
+architecture rtl of passthrough is
+begin
+  rdata <= wdata;
+end;
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity theunit is
+  port (
+    inx   : in    std_ulogic_vector(1 downto 0);
+    utx   : out   std_ulogic_vector(1 downto 0)
+  );
+end;
+
+architecture rtl of theunit is
+  type tdata_t is record
+    hello : std_ulogic_vector(123 downto 0);
+  end record;
+
+  subtype tdatavec_t is std_ulogic_vector(1 downto 0);
+
+  function encodex(u : tdata_t) return std_ulogic_vector is
+    variable ret : tdatavec_t;
+  begin
+    ret(1) := u.hello(101);
+    ret(0) := u.hello(100);
+    return ret;
+  end;
+
+  signal wtdata  : tdata_t;
+
+begin
+  wtdata.hello <= (others => '0');
+
+  ram: entity work.passthrough
+  port map (
+    wdata => encodex(wtdata),
+    rdata => utx
+  );
+end;


### PR DESCRIPTION
Fixes issue https://github.com/ghdl/ghdl/issues/1502

## What the fix does

No source fix in this commit. Added `testsuite/synth/issue1502/` (the exact repro from the report), whose `testsuite.sh` synthesizes the design and re-analyzes the resulting netlist (the standard `testsuite/synth` sanity check: the netlist itself must be valid VHDL). This locks in the current, correct behavior as a regression guard.