### PR TITLE
testsuite: add regression test for issue1504, already fixed on master

### DIFF
--- a/testsuite/synth/issue1504/test1.vhd
+++ b/testsuite/synth/issue1504/test1.vhd
@@ -1,0 +1,15 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity ent is
+    port (
+        clk: in std_ulogic;
+        i: in std_ulogic;
+        o: out std_ulogic
+    );
+end entity;
+
+architecture arch of ent is
+begin
+    o <= i when rising_edge(clk) else unaffected;
+end architecture;

--- a/testsuite/synth/issue1504/testsuite.sh
+++ b/testsuite/synth/issue1504/testsuite.sh
@@ -1,0 +1,13 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# `unaffected` as the else-branch of a conditional signal assignment
+# gated by rising_edge() used to crash --synth with an internal
+# TYPES.INTERNAL_ERROR (synth-stmts.adb:75). See issue1504.
+synth test1.vhd -e ent > syn_test1.vhd
+analyze syn_test1.vhd
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Fixes issue https://github.com/ghdl/ghdl/issues/1504

## What the fix does

No source fix in this commit. Added `testsuite/synth/issue1504/` (the exact repro from the report), whose `testsuite.sh` synthesizes the design and re-analyzes the resulting netlist. This locks in the current, correct behavior as a regression guard.
