### PR TITLE
testsuite: add regression test for issue1574, already fixed on master

### DIFF
--- a/testsuite/synth/issue1574/bug.vhdl
+++ b/testsuite/synth/issue1574/bug.vhdl
@@ -1,0 +1,34 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity bug is
+    port (
+        clock : in std_logic;
+        output : out std_logic_vector(7 downto 0)
+    );
+end bug;
+
+architecture bug_arch OF bug is
+    type my_enum is (
+        thing1,
+        thing2,
+        thing3
+    );
+
+    signal input : my_enum := thing1;
+
+    impure function my_enum_func return std_logic_vector is
+    begin
+        case input is
+            when thing1 => return x"00";
+            when others => return x"A0";
+        end case;
+    end my_enum_func;
+begin
+    process (clock)
+    begin
+        if rising_edge(clock) then
+            output <= my_enum_func;
+        end if;
+    end process;
+end bug_arch;

--- a/testsuite/synth/issue1574/testsuite.sh
+++ b/testsuite/synth/issue1574/testsuite.sh
@@ -1,0 +1,13 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A function with a case statement containing more than one return
+# statement used to crash --synth with an internal ASSERT_FAILURE
+# (synth-stmts.adb:2055). See issue1574.
+synth bug.vhdl -e bug > syn_bug.vhdl
+analyze syn_bug.vhdl
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Closes https://github.com/ghdl/ghdl/issues/1574

## What the fix does

No source fix in this commit. Added `testsuite/synth/issue1574/` (the exact repro from the report, renamed `bug.vhdl` for the test directory), whose `testsuite.sh` synthesizes the design and re-analyzes the resulting netlist. This locks in the current, correct behavior as a regression guard.