### PR TITLE
testsuite: add regression test for issue1661, already fixed on master

### DIFF
--- a/testsuite/synth/issue1661/repro.vhdl
+++ b/testsuite/synth/issue1661/repro.vhdl
@@ -1,0 +1,17 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity repro is
+    port (
+        o : out std_logic_vector(7 downto 0)
+    );
+end entity;
+
+architecture rtl of repro is
+    -- integer'image is IIR_PREDEFINED_INTEGER_TO_STRING.
+    constant C_STR : string := integer'image(42);
+    constant C_LEN : natural := C_STR'length;
+begin
+    o <= std_logic_vector(to_unsigned(C_LEN, 8));
+end architecture;

--- a/testsuite/synth/issue1661/testsuite.sh
+++ b/testsuite/synth/issue1661/testsuite.sh
@@ -1,0 +1,24 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# Statically evaluating integer'image (IIR_PREDEFINED_INTEGER_TO_STRING)
+# during --synth's constant folding used to fail with "synth_static_
+# monadic_predefined: unhandled IIR_PREDEFINED_INTEGER_TO_STRING" and
+# then crash with an internal TYPES.INTERNAL_ERROR. The original report
+# hit this via the third-party JSON-for-VHDL library (not reproduced
+# here, as it needs a network fetch); this exercises the same named
+# predefined function directly and self-contained. See issue1661.
+synth repro.vhdl -e repro > syn_repro.vhdl
+analyze syn_repro.vhdl
+
+# "42" has length 2: the folded constant must be std_logic_vector(2), i.e.
+# "00000010".
+if ! grep -q '"00000010"' syn_repro.vhdl; then
+  echo "FAIL: expected the folded length-of-\"42\" constant (2) in the netlist"
+  exit 1
+fi
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Closes https://github.com/ghdl/ghdl/issues/1661

## What the fix does

No source fix in this commit. Added `testsuite/synth/issue1661/` with a minimal, self-contained reproducer that exercises `IIR_PREDEFINED_INTEGER_TO_STRING` directly (`integer'image(42)`, its length fed into a synthesized output), whose `testsuite.sh` synthesizes the design, re-analyzes the resulting netlist, and asserts the correctly folded value appears. This locks in the current, correct behavior as a regression guard.