### PR TITLE
testsuite: add regression test for issue1946, already fixed on master

### DIFF
--- a/testsuite/synth/issue1946/circuit.vhd
+++ b/testsuite/synth/issue1946/circuit.vhd
@@ -1,0 +1,22 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity circuit is
+    port (
+        clk : std_logic;
+        sig : out std_logic
+    );
+end entity;
+
+architecture rtl of circuit is
+begin
+    process (clk)
+    begin
+        if falling_edge(clk) then
+            -- assertion failure only as long as this branch exists
+        elsif rising_edge(clk) then
+            -- assertion failure only when assignment is here
+            sig <= '1';
+        end if;
+    end process;
+end architecture;

--- a/testsuite/synth/issue1946/testsuite.sh
+++ b/testsuite/synth/issue1946/testsuite.sh
@@ -1,0 +1,20 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A process with a falling_edge branch containing no statements, followed
+# by an elsif rising_edge branch that does have a signal assignment, used
+# to crash --synth with an internal ASSERT_FAILURE
+# (netlists-memories.adb:2575). See issue1946.
+export GHDL_STD_FLAGS="--std=08"
+out=$(synth circuit.vhd -e circuit 2>&1)
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: synth crashed"
+  exit 1
+fi
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Closes https://github.com/ghdl/ghdl/issues/1946

## What the fix does

No source fix in this commit. Added `testsuite/synth/issue1946/` (the repro from the report, with an output port so the assignment isn't optimized away) whose `testsuite.sh` synthesizes the design and asserts no `GHDL Bug occurred` crash. (The resulting netlist references a synth-internal `gate_mdff` primitive, which isn't meant to be re-analyzed as standalone VHDL, so this test checks for successful, crash-free synthesis rather than re-analyzing the netlist — unlike the simpler `testsuite/synth/issueNNNN` tests elsewhere in this pass.) This locks in the current, correct behavior as a regression guard.
