### PR TITLE
testsuite: add regression test for issue2037, already fixed on master

### DIFF
--- a/testsuite/synth/issue2037/crc_entity_draft.vhd
+++ b/testsuite/synth/issue2037/crc_entity_draft.vhd
@@ -1,0 +1,47 @@
+library ieee;
+use ieee.numeric_std.all;
+use ieee.std_logic_1164.all;
+
+library ti;
+use ti.crc.all;
+
+entity crc_entity_draft is
+  generic (
+            word_w : integer := 4;
+            crc_w : integer := 32
+          );
+  port (
+         clk : in std_logic;
+         rst : in std_logic;
+         sof : in std_logic;
+         eof : in std_logic;
+         data : in std_logic_vector(word_w - 1 downto 0);
+         crc : out std_logic_vector(crc_w - 1 downto 0)
+       );
+end;
+architecture a_crc_entity_draft of crc_entity_draft is
+  type state_t is (running, idle);
+  signal state : state_t := idle;
+begin
+
+  process(all) is
+    variable t : crc32;
+    variable reg : std_logic_vector(N - 1 downto 0) := (others => '0');
+    variable init : boolean := false;
+  begin
+    if rst then
+      null;
+    elsif rising_edge(clk) then
+      if sof then
+        init := t.initcrc4;
+        reg := t.tablecrc4(data);
+      elsif eof then
+        reg := t.tablecrc4(data);
+        crc <= t.finishcrc4(reg);
+      else
+        reg := t.tablecrc4(data);
+      end if;
+    end if;
+  end process;
+
+end;

--- a/testsuite/synth/issue2037/crc_pkg.vhd
+++ b/testsuite/synth/issue2037/crc_pkg.vhd
@@ -1,0 +1,59 @@
+library ieee;
+use ieee.numeric_std.all;
+use ieee.std_logic_1164.all;
+
+package crc is
+  constant M : integer := 4;
+  constant N : integer := 32;
+
+  type crc32table_t is array (integer range <>) of std_logic_vector(N - 1 downto 0);
+  constant crc32table : crc32table_t (0 to M**2 - 1) := (
+	x"00000000", 	x"105ec76f", 	x"20bd8ede", 	x"30e349b1",
+	x"417b1dbc", 	x"5125dad3", 	x"61c69362", 	x"7198540d",
+	x"82f63b78", 	x"92a8fc17", 	x"a24bb5a6", 	x"b21672c9",
+	x"c38d26c4", 	x"d3d3e1ab", 	x"e330a81a", 	x"f36e6f75"
+);
+
+  type crc32 is protected
+  impure function tablecrc4(a : std_logic_vector) return std_logic_vector;
+  impure function initcrc4 return boolean;
+  impure function finishcrc4(a : std_logic_vector) return std_logic_vector;
+  impure function get return std_logic_vector;
+end protected;
+end package;
+
+package body crc is
+  type crc32 is protected body
+
+  variable crcreg : std_logic_vector(N - 1 downto 0);
+
+  impure function initcrc4 return boolean is
+  begin
+    crcreg := (others => '1');
+    return true;
+  end function;
+
+  impure function finishcrc4(a : std_logic_vector) return std_logic_vector is
+    variable temp : std_logic_vector(a'range) := (others => '1');
+  begin
+    return a xor temp;
+  end function;
+
+
+  impure function tablecrc4(a : std_logic_vector) return std_logic_vector is
+    variable index : std_logic_vector(M - 1 downto 0);
+  begin
+    assert(a'length = M) report "Input of wrong length." severity failure;
+    index := crcreg(M - 1 downto 0)  xor a;
+    crcreg := crcreg srl M;
+    crcreg := crcreg xor crc32table(to_integer(unsigned(index)));
+    return crcreg;
+  end function;
+
+  impure function get return std_logic_vector is
+  begin
+    return crcreg;
+  end function;
+
+  end protected body;
+end package body;

--- a/testsuite/synth/issue2037/testsuite.sh
+++ b/testsuite/synth/issue2037/testsuite.sh
@@ -1,0 +1,31 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A protected-type variable used in a process (inherently not
+# synthesizable hardware) used to crash --synth with an internal
+# TYPES.INTERNAL_ERROR ("synth_concurrent_declaration: cannot handle
+# IIR_KIND_PROTECTED_TYPE_BODY") instead of reporting a clean
+# unsupported-construct error. See issue2037.
+export GHDL_STD_FLAGS="--std=08"
+
+analyze --work=ti crc_pkg.vhd
+analyze crc_entity_draft.vhd
+
+out=$(synth --out=verilog crc_entity_draft 2>&1) || true
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: synth crashed instead of reporting a clean error"
+  exit 1
+fi
+
+if ! echo "$out" | grep -q "protected type variable is not synthesizable"; then
+  echo "FAIL: expected the protected-type-not-synthesizable error"
+  exit 1
+fi
+
+clean ti
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Closes https://github.com/ghdl/ghdl/issues/2037

## What the fix does

No source fix in this commit. Added `testsuite/synth/issue2037/` (the exact repro from the report) whose `testsuite.sh` analyzes the design, attempts `--synth --out=verilog`, and asserts the clean "protected type variable is not synthesizable" error appears with no `GHDL Bug occurred` crash. This locks in the current, correct behavior as a regression guard.