### PR TITLE
testsuite: add regression test for issue1110, already fixed on master

### DIFF
--- a/testsuite/synth/issue1110/ent.vhd
+++ b/testsuite/synth/issue1110/ent.vhd
@@ -1,0 +1,25 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity ent is
+	port (
+		clk : in std_logic;
+		i : in std_logic_vector(7 downto 0);
+		o : out std_logic_vector(7 downto 0)
+	);
+end;
+
+architecture a of ent is
+	signal a : std_logic_vector(7 downto 0) := x"42";
+	signal b : std_logic_vector(7 downto 0) := a;
+begin
+	process(clk)
+	begin
+		if rising_edge(clk) then
+			a <= i;
+			b <= a;
+		end if;
+	end process;
+
+	o <= b;
+end;

--- a/testsuite/synth/issue1110/testsuite.sh
+++ b/testsuite/synth/issue1110/testsuite.sh
@@ -1,0 +1,28 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A signal's initialization value naming another signal (b's init value
+# is "a", itself initialized to x"42") used to crash --synth's netlist
+# display with an internal TYPES.INTERNAL_ERROR
+# (netlists-disp_vhdl.adb:361) instead of resolving it to that signal's
+# constant initial value. See issue1110.
+out=$(synth ent.vhd -e ent 2>&1)
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: synth crashed"
+  exit 1
+fi
+
+# Both n9 (a's init driver) and n10 (b's init driver) must be resolved to
+# the constant "01000010" (x"42").
+count=$(echo "$out" | grep -c '"01000010"')
+if [ "$count" -ne 2 ]; then
+  echo "FAIL: expected the x\"42\" init value resolved twice (a and b), got $count"
+  exit 1
+fi
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Closes https://github.com/ghdl/ghdl/issues/1110

## What the fix does

No source fix in this commit. Added `testsuite/synth/issue1110/` (the exact repro from the report) whose `testsuite.sh` synthesizes the design and asserts the constant `x"42"` init value appears resolved twice (once for `a`, once for `b`), with no `GHDL Bug occurred` crash. This locks in the current, correct behavior as a regression guard.
