### PR TITLE
testsuite: add regression test for issue1235, already fixed on master

### DIFF
--- a/testsuite/synth/issue1235/ent.vhd
+++ b/testsuite/synth/issue1235/ent.vhd
@@ -1,0 +1,25 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity ent is
+    port (
+        clk, ce, valid : in std_logic;
+        got : out std_logic
+    );
+end ent;
+
+architecture a of ent is
+begin
+    process(clk)
+    begin
+        if rising_edge(clk) then
+            got <= '0';
+        end if;
+
+        if rising_edge(clk) and ce = '1' then
+            if valid then
+                got <= '1';
+            end if;
+        end if;
+    end process;
+end a;

--- a/testsuite/synth/issue1235/testsuite.sh
+++ b/testsuite/synth/issue1235/testsuite.sh
@@ -1,0 +1,14 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A process with two separate "if rising_edge(clk) ..." statements
+# (rather than one enclosing if with nested logic) used to crash --synth
+# with an internal ASSERT_FAILURE (netlists.adb:529). See issue1235.
+export GHDL_STD_FLAGS="--std=08"
+synth ent.vhd -e ent > syn_ent.vhd
+analyze syn_ent.vhd
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Closes https://github.com/ghdl/ghdl/issues/1235

## What the fix does

No source fix in this commit. Added `testsuite/synth/issue1235/` (the exact repro from the report) whose `testsuite.sh` synthesizes the design and re-analyzes the resulting netlist. This locks in the current, correct behavior as a regression guard.