### PR TITLE
CI: bound dependency installation so a stalled mirror cannot burn 6 h…

### DIFF
--- a/.github/workflows/Build-MSYS2.yml
+++ b/.github/workflows/Build-MSYS2.yml
@@ -87,9 +87,7 @@ jobs:
   Build:
     name: Build GHDL on Windows Server + MSYS2
     runs-on: windows-${{ inputs.windows_version }}
-    # See Build-Ubuntu.yml.  Slowest measured MSYS2 build: 7.5 minutes, but
-    # pacman and the MSYS2 setup make this the heaviest of the three.
-    timeout-minutes: 60
+    timeout-minutes: 30
     outputs:
       ghdl_artifact:    ${{ steps.artifact_name.outputs.ghdl_artifact }}
       pacman_artifact:  ${{ steps.artifact_name.outputs.pacman_artifact }}

--- a/.github/workflows/Build-MSYS2.yml
+++ b/.github/workflows/Build-MSYS2.yml
@@ -87,6 +87,9 @@ jobs:
   Build:
     name: Build GHDL on Windows Server + MSYS2
     runs-on: windows-${{ inputs.windows_version }}
+    # See Build-Ubuntu.yml.  Slowest measured MSYS2 build: 7.5 minutes, but
+    # pacman and the MSYS2 setup make this the heaviest of the three.
+    timeout-minutes: 60
     outputs:
       ghdl_artifact:    ${{ steps.artifact_name.outputs.ghdl_artifact }}
       pacman_artifact:  ${{ steps.artifact_name.outputs.pacman_artifact }}

--- a/.github/workflows/Build-MacOS.yml
+++ b/.github/workflows/Build-MacOS.yml
@@ -69,6 +69,8 @@ jobs:
     name: Build GHDL on '${{ inputs.macos_image }}'
     if: true
     runs-on: ${{ inputs.macos_image }}
+    # See Build-Ubuntu.yml.  Slowest measured macOS build: 3.4 minutes.
+    timeout-minutes: 45
     outputs:
       ghdl_artifact: ${{ steps.artifact_name.outputs.ghdl_artifact }}
 

--- a/.github/workflows/Build-MacOS.yml
+++ b/.github/workflows/Build-MacOS.yml
@@ -69,8 +69,7 @@ jobs:
     name: Build GHDL on '${{ inputs.macos_image }}'
     if: true
     runs-on: ${{ inputs.macos_image }}
-    # See Build-Ubuntu.yml.  Slowest measured macOS build: 3.4 minutes.
-    timeout-minutes: 45
+    timeout-minutes: 30
     outputs:
       ghdl_artifact: ${{ steps.artifact_name.outputs.ghdl_artifact }}
 

--- a/.github/workflows/Build-Ubuntu.yml
+++ b/.github/workflows/Build-Ubuntu.yml
@@ -71,10 +71,7 @@ jobs:
     name: Build GHDL on 'ubuntu-${{ inputs.ubuntu_version }}'
     if: true
     runs-on: ubuntu-${{ inputs.ubuntu_version }}
-    # Backstop against a hung step.  Without it a job inherits the 360 minute
-    # default and can hold a runner for six hours.  The slowest legitimate build
-    # measured is gcc/26.04 at 16.2 minutes.
-    timeout-minutes: 45
+    timeout-minutes: 30
     outputs:
       ghdl_artifact: ${{ steps.artifact_name.outputs.ghdl_artifact }}
 
@@ -98,17 +95,13 @@ jobs:
           EOF
 
       - name: 🔧 Install dependencies
-        # Normally 33 s (median), 8.7 minutes at the observed worst.  The cap is
-        # what turns an unreachable mirror into a fast, retryable failure.
-        timeout-minutes: 15
+        timeout-minutes: 10
         run: |
-          # The runner's mirrorlist puts azure.archive.ubuntu.com first, and that
-          # mirror intermittently stalls instead of failing.  Bound every request
-          # so apt falls through to archive.ubuntu.com instead of hanging.
+          # Reduce waiting time for a potentially hanging 'azure.archive.ubuntu.com'
           sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'CONF'
-          Acquire::Retries "3";
-          Acquire::http::Timeout "30";
-          Acquire::https::Timeout "30";
+          Acquire::Retries "20";
+          Acquire::http::Timeout "15";
+          Acquire::https::Timeout "15";
           CONF
 
           APT_ARGS="gcc g++ gnat"

--- a/.github/workflows/Build-Ubuntu.yml
+++ b/.github/workflows/Build-Ubuntu.yml
@@ -71,6 +71,10 @@ jobs:
     name: Build GHDL on 'ubuntu-${{ inputs.ubuntu_version }}'
     if: true
     runs-on: ubuntu-${{ inputs.ubuntu_version }}
+    # Backstop against a hung step.  Without it a job inherits the 360 minute
+    # default and can hold a runner for six hours.  The slowest legitimate build
+    # measured is gcc/26.04 at 16.2 minutes.
+    timeout-minutes: 45
     outputs:
       ghdl_artifact: ${{ steps.artifact_name.outputs.ghdl_artifact }}
 
@@ -94,7 +98,19 @@ jobs:
           EOF
 
       - name: 🔧 Install dependencies
+        # Normally 33 s (median), 8.7 minutes at the observed worst.  The cap is
+        # what turns an unreachable mirror into a fast, retryable failure.
+        timeout-minutes: 15
         run: |
+          # The runner's mirrorlist puts azure.archive.ubuntu.com first, and that
+          # mirror intermittently stalls instead of failing.  Bound every request
+          # so apt falls through to archive.ubuntu.com instead of hanging.
+          sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'CONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          CONF
+
           APT_ARGS="gcc g++ gnat"
           if ${{ startsWith(inputs.ghdl_backend, 'mcode') }}; then
             APT_ARGS="$APT_ARGS"


### PR DESCRIPTION
Follow up on https://github.com/ghdl/ghdl/pull/3354

## Answering their apt question

> I don't see how azure.archive.ubuntu.com is skipped and a second or third is tried." 

It's visible in the log you pasted, via the item numbers. `Ign:2 http://azure.archive.ubuntu.com/ubuntu jammy InRelease` appears four times, then the same item 2 reappears as `Hit:2 https://archive.ubuntu.com/ubuntu jammy InRelease` — the mirror method exhausted azure and fell through. The hang is the case where that fallback didn't happen: `Ign:15 … jammy-updates/main amd64 Packages` and then six hours of nothing.

Two admissions I owe them. Those four attempts imply `Acquire::Retries` is already 3 in the runner image, so my `Acquire::Retries "3"` line is probably a no-op. And I cannot explain why the default 120 s `Acquire::http::Timeout` didn't fire — which means my `"30"` may not help either. The apt block is speculative; only `timeout-minutes` provably bounds the failure.