### PR TITLE
vhdl-translate: allow a bounded actual on an unbounded converted formal

### DIFF
--- a/issue.md
+++ b/issue.md
@@ -1,0 +1,55 @@
+# Issue #1762 — Crash on a type conversion in a port association
+
+https://github.com/ghdl/ghdl/issues/1762
+
+## High-level summary
+
+The design instantiates `reg` with a type conversion on the actual:
+
+```vhdl
+reg : entity work.reg
+  port map (input => bv(s_result), ...);
+```
+
+`input` is an unconstrained `bit_vector` port and `s_result` is a `data_word`, i.e. `unsigned(15 downto 0)`. Elaborating that association crashed the gcc and llvm backends with an internal `ASSERT_FAILURE` in `trans-chap4.adb`. mcode is unaffected: it does not use the `src/vhdl/translate` translator this lives in.
+
+## What is actually wrong in GHDL's implementation
+
+`Elab_Conversion` (`src/vhdl/translate/trans-chap4.adb`) elaborates the conversion. `Elab_In_Conversion` passes the actual as its input and the formal as its output, so here the output is the unconstrained `input` port — unbounded — and the input is the bounded `data_word`. When the output is unbounded the code asserted that the input must be unbounded too:
+
+```ada
+if Out_Tinfo.Type_Mode in Type_Mode_Unbounded then
+   --  The only reason why the output is unbounded is type conversion
+   --  between two unbounded ports.
+   pragma Assert (In_Tinfo.Type_Mode in Type_Mode_Unbounded);
+```
+
+That is not the only reason the output can be unbounded. A conversion between two unbounded ports is one case; an unconstrained formal that takes its constraint from the conversion is another, and that is this design. The premise fails and the assertion fires.
+
+The assertion guards the branch that builds the destination bounds, and with assertions disabled GHDL does not stop — it continues into that branch with the precondition violated.
+
+## What the fix does
+
+Removes the assertion and corrects the comment to state both ways the output can be unbounded.
+
+Nothing else is needed, because the branch already handles a bounded source. `Chap3.Get_Composite_Bounds` returns the bounds from the static layout for a `Type_Mode_Bounded_Arrays` operand, and `Chap7.Translate_Type_Conversion_Array_Bounds` works on Mnodes and types generically. The assumption was over-strict, not the code — checked before removing the assertion rather than deleting it because it was in the way.
+
+## Testing
+
+`testsuite/gna/issue1762/` covers two cases; both crash on master without the fix.
+
+`test.vhd` is the design from the report. It is elaborated and simulated rather than only analyzed, because analysing alone cannot tell a correct conversion from one built on a violated precondition — which is what a `--disable-checks` build does here. `tb.vhd` writes `16#BEEF#` into `r1` and `16#1234#` into `r5` through the converted port and reads them back:
+
+```
+tb.vhd:41:5:@70ns:(report note): PASS a_out=48879 b_out=4660
+```
+
+`conv_range.vhdl` covers what the report's design cannot show. Its conversion targets `bit_vector(data_word'RANGE)`, which has exactly the range of the actual, so it cannot reveal where the bounds of the formal come from. The added case converts an `unsigned(15 downto 0)` actual to a `bit_vector(0 to 15)` target — a different range *and* direction — and checks the value that arrives, read from `'LEFT` to `'RIGHT` so the result does not depend on how the bounds are labelled:
+
+```
+pos(left..right)=1111000000000001 len=16
+```
+
+`16#F001#` is not a palindrome, so a reversal or misalignment would show. The bounds labels themselves are deliberately not asserted: the backends disagree about them for this construct, which is a separate matter from this crash.
+
+Both cases pass on mcode, llvm and gcc, and with this fix alone applied to master. Full `sanity gna vests synth` pass on all three backends.

--- a/src/vhdl/translate/trans-chap4.adb
+++ b/src/vhdl/translate/trans-chap4.adb
@@ -3701,10 +3701,13 @@ package body Trans.Chap4 is
 
       --  Create a copy of SIG_OUT.
       if Out_Tinfo.Type_Mode in Type_Mode_Unbounded then
-         --  The only reason why the output is unbounded is type conversion
-         --  between two unbounded ports.
+         --  The output is unbounded either because both ports are unbounded,
+         --  or because the formal is unconstrained and gets its constraint
+         --  from the conversion (eg 'input => bv(s_result)' on a formal
+         --  declared as BIT_VECTOR).  In the latter case the input is
+         --  bounded; Get_Composite_Bounds then returns the bounds from its
+         --  static layout, so the conversion below works either way.
          --  Need to implicitly convert.
-         pragma Assert (In_Tinfo.Type_Mode in Type_Mode_Unbounded);
          Dest_Sig := Lo2M (New_Selected_Acc_Value (New_Obj (Var_Data),
                                                    Info.Out_Sig_Field),
                            Out_Tinfo, Mode_Signal);

--- a/testsuite/gna/issue1762/conv_range.vhdl
+++ b/testsuite/gna/issue1762/conv_range.vhdl
@@ -1,0 +1,47 @@
+--  The conversion in the report's design targets BIT_VECTOR(DATA_WORD'RANGE),
+--  which has exactly the range of the actual, so it cannot show where the
+--  bounds of the formal come from.  Here the target subtype is deliberately
+--  given a different range and direction from the actual, which makes the
+--  distinction observable -- and which crashes in the same place without the
+--  fix.
+library ieee;
+use ieee.numeric_bit.all;
+
+entity probe_range is
+  port (input : in bit_vector);
+end entity;
+
+architecture behav of probe_range is
+begin
+  process
+    variable s   : string(1 to 16);
+    variable idx : integer;
+  begin
+    wait for 1 ns;
+    --  Walk the vector from 'LEFT to 'RIGHT, so the reported sequence does
+    --  not depend on how the bounds are labelled.  The labels themselves are
+    --  deliberately not checked here: the backends disagree about them for
+    --  this construct, which is a separate matter from this crash.
+    for i in 0 to input'length - 1 loop
+      if input'ascending then idx := input'left + i; else idx := input'left - i; end if;
+      if input (idx) = '1' then s (i + 1) := '1'; else s (i + 1) := '0'; end if;
+    end loop;
+    report "pos(left..right)=" & s & " len=" & integer'image (input'length);
+    wait;
+  end process;
+end architecture;
+
+library ieee;
+use ieee.numeric_bit.all;
+
+entity tb_conv_range is
+end entity;
+
+architecture test of tb_conv_range is
+  subtype data_word is unsigned (15 downto 0);   --  descending
+  subtype bv_asc    is bit_vector (0 to 15);     --  ascending target
+  --  16#F001# is not a palindrome, so a reversal would be visible.
+  signal s_result : data_word := to_unsigned (16#F001#, 16);
+begin
+  u : entity work.probe_range port map (input => bv_asc (s_result));
+end architecture;

--- a/testsuite/gna/issue1762/tb.vhd
+++ b/testsuite/gna/issue1762/tb.vhd
@@ -1,0 +1,45 @@
+library ieee;
+use ieee.numeric_bit.all;
+use work.isa.all;
+
+entity tb_register_bank is
+end entity;
+
+architecture test of tb_register_bank is
+  signal s_result                   : data_word := (others => '0');
+  signal s_select, b_select, a_select : bus_operand := r0;
+  signal clk, write_enable          : bit := '0';
+  signal rst                        : bit := '1';
+  signal a_out, b_out               : data_word;
+
+  procedure wr(signal cl : out bit) is
+  begin
+    cl <= '0'; wait for 10 ns; cl <= '1'; wait for 10 ns; cl <= '0'; wait for 10 ns;
+  end procedure;
+begin
+  dut : entity work.register_bank
+    port map (s_result => s_result, s_select => s_select, b_select => b_select,
+              a_select => a_select, clk => clk, write_enable => write_enable,
+              rst => rst, a_out => a_out, b_out => b_out);
+
+  process
+    variable v : data_word;
+  begin
+    -- write 0xBEEF into r1, 0x1234 into r5
+    write_enable <= '1';
+    s_result <= to_unsigned(16#BEEF#, 16); s_select <= r1; wr(clk);
+    s_result <= to_unsigned(16#1234#, 16); s_select <= r5; wr(clk);
+    write_enable <= '0';
+
+    a_select <= r1; b_select <= r5; wait for 10 ns;
+
+    assert a_out = to_unsigned(16#BEEF#, 16)
+      report "FAIL a_out=" & integer'image(to_integer(a_out)) severity failure;
+    assert b_out = to_unsigned(16#1234#, 16)
+      report "FAIL b_out=" & integer'image(to_integer(b_out)) severity failure;
+
+    report "PASS a_out=" & integer'image(to_integer(a_out)) &
+           " b_out=" & integer'image(to_integer(b_out));
+    wait;
+  end process;
+end architecture;

--- a/testsuite/gna/issue1762/test.vhd
+++ b/testsuite/gna/issue1762/test.vhd
@@ -1,0 +1,111 @@
+library ieee;
+use ieee.numeric_bit.unsigned;
+
+package isa is
+
+    type alu_op is (alu_abus,alu_add,alu_and,alu_neg);
+
+    type cond_op is (cond_no_jump,cond_neg,cond_zero,cond_none);
+
+    type shifter_op is (shifter_noop,shifter_left,shifter_right);
+
+    type bus_operand is ('0','1',neg_one,pc,r0,r1,r2,r3,r4,r5,r6,r7,r8,r9,r10,ac);
+
+    constant data_word_size : natural := 16;
+
+    subtype data_word is unsigned(data_word_size - 1 downto 0);
+
+end package;
+
+
+library ieee;
+use ieee.numeric_bit.all;
+
+entity reg is
+    port(input : in bit_vector;
+         clk : in bit;
+         rst : in bit := '1';
+         output : out bit_vector);
+end entity;
+
+architecture behaviour of reg is
+    signal mem : bit_vector(input'RANGE);
+begin
+
+    changes : process (clk,rst) is
+    begin
+        if rst = '0' then
+            mem <= (others => '0');
+        elsif rising_edge(clk) then
+            mem <= input;
+        end if;
+    end process;
+
+    output <= mem;
+
+end architecture;
+
+
+library ieee;
+use work.isa.all;
+
+entity register_bank is
+    port(s_result : in data_word;
+         s_select, b_select, a_select : in bus_operand;
+         clk, write_enable : in bit;
+         rst : in bit := '1';
+         a_out, b_out : out data_word);
+end entity;
+
+architecture behavioural of register_bank is
+
+    type reg_clocks_t is array (r0 to ac) of bit;
+    signal reg_clocks: reg_clocks_t;
+
+    subtype bv is bit_vector(data_word'RANGE);
+
+    type reg_outputs_t is array (r0 to ac) of bv;
+    signal reg_outputs: reg_outputs_t;
+
+begin
+
+    registers : for i in r0 to ac generate
+        reg : entity work.reg
+                    port map(input => bv(s_result),
+                             clk => reg_clocks(i),
+                             rst => rst,
+                             output => reg_outputs(i));
+    end generate;
+
+    read_process : process (b_select, a_select, clk, rst) is
+
+        procedure assign(signal bus_out : out data_word; reg_select : bus_operand) is
+        begin
+            case reg_select is
+                when '0' | pc => bus_out <= (others => '0');
+                when '1' => bus_out <= (0 => '1',others => '0');
+                when neg_one => bus_out <= (others => '1');
+                when others =>
+                    bus_out <= data_word(reg_outputs(reg_select));
+            end case;
+        end procedure;
+
+    begin
+        assign(a_out, a_select);
+        assign(b_out, b_select);
+    end process;
+
+    write_process : process (s_select, clk, write_enable) is
+        variable enable : bit;
+    begin
+        for i in r0 to ac loop
+            if i = s_select then
+                enable := '1';
+            else
+                enable := '0';
+            end if;
+            reg_clocks(i) <= clk and write_enable and enable;
+        end loop;
+    end process;
+
+end architecture;

--- a/testsuite/gna/issue1762/testsuite.sh
+++ b/testsuite/gna/issue1762/testsuite.sh
@@ -1,0 +1,51 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A conversion function on a port association ("input => bv(s_result)")
+# whose formal is an unconstrained port hit an over-strict assertion in
+# Elab_Conversion: the output is unbounded there while the actual is
+# bounded, which the code assumed could not happen.  Only the gcc and llvm
+# backends use that translator, and only a build with assertions enabled
+# stops on it -- with --disable-checks GHDL silently carried on with a
+# violated precondition, which is why this looked fixed.
+# tb.vhd therefore checks the values that reach the registers, not just
+# that the design analyzes.  See issue1762.
+analyze test.vhd
+analyze tb.vhd
+
+out=$(elab_simulate tb_register_bank 2>&1)
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: crashed instead of elaborating"
+  exit 1
+fi
+
+# 48879 = 16#BEEF#, 4660 = 16#1234#, written through the converted port.
+if ! echo "$out" | grep -q "PASS a_out=48879 b_out=4660"; then
+  echo "FAIL: wrong data through the conversion-function association"
+  exit 1
+fi
+
+# Same crash, but with a conversion target whose range and direction differ
+# from the actual's, which the report's own design cannot distinguish.
+analyze conv_range.vhdl
+
+out=$(elab_simulate tb_conv_range 2>&1)
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: crashed on a conversion to a differently-ranged subtype"
+  exit 1
+fi
+
+# 16#F001# through the conversion, read from 'LEFT to 'RIGHT.
+if ! echo "$out" | grep -q "pos(left..right)=1111000000000001 len=16"; then
+  echo "FAIL: wrong data or length through the differently-ranged conversion"
+  exit 1
+fi
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Fixes https://github.com/ghdl/ghdl/issues/1762

## What the fix does

Removes the assertion and corrects the comment to state both ways the output can be unbounded.

Nothing else is needed, because the branch already handles a bounded source. `Chap3.Get_Composite_Bounds` returns the bounds from the static layout for a `Type_Mode_Bounded_Arrays` operand, and `Chap7.Translate_Type_Conversion_Array_Bounds` works on Mnodes and types generically. The assumption was over-strict, not the code — checked before removing the assertion rather than deleting it because it was in the way.

## Testing

`testsuite/gna/issue1762/` covers two cases; both crash on master without the fix.

`test.vhd` is the design from the report. It is elaborated and simulated rather than only analyzed, because analysing alone cannot tell a correct conversion from one built on a violated precondition — which is what a `--disable-checks` build does here. `tb.vhd` writes `16#BEEF#` into `r1` and `16#1234#` into `r5` through the converted port and reads them back:

```
tb.vhd:41:5:@70ns:(report note): PASS a_out=48879 b_out=4660
```

`conv_range.vhdl` covers what the report's design cannot show. Its conversion targets `bit_vector(data_word'RANGE)`, which has exactly the range of the actual, so it cannot reveal where the bounds of the formal come from. The added case converts an `unsigned(15 downto 0)` actual to a `bit_vector(0 to 15)` target — a different range *and* direction — and checks the value that arrives, read from `'LEFT` to `'RIGHT` so the result does not depend on how the bounds are labelled:

```
pos(left..right)=1111000000000001 len=16
```

`16#F001#` is not a palindrome, so a reversal or misalignment would show. The bounds labels themselves are deliberately not asserted: the backends disagree about them for this construct, which is a separate matter from this crash.

Both cases pass on mcode, llvm and gcc, and with this fix alone applied to master. Full `sanity gna vests synth` pass on all three backends.
