### PR TITLE
testsuite: add regression test for issue1636, already fixed on master

### DIFF
--- a/testsuite/synth/issue1636/asym_test.vhd
+++ b/testsuite/synth/issue1636/asym_test.vhd
@@ -1,0 +1,33 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity asym_test is
+  port (
+    clk_i  : in  std_logic;
+    dat_i  : in  std_logic_vector(15 downto 0);
+    addr_i : in  std_logic_vector(3 downto 0);
+    dat_o : out std_logic_vector(15 downto 0)
+  );
+end asym_test;
+
+architecture arch of asym_test is
+
+  type   reg_file_t is array (15 downto 0) of std_logic_vector(15 downto 0);
+  signal reg_file : reg_file_t;
+
+begin
+
+  process(clk_i)
+  begin
+    if rising_edge(clk_i) then
+        reg_file(to_integer(unsigned(addr_i)))(15 downto 1) <= dat_i(15 downto 1);
+    end if;
+  end process;
+
+  process(addr_i, reg_file)
+  begin
+      dat_o <= reg_file(to_integer(unsigned(addr_i)));
+  end process;
+
+end arch;

--- a/testsuite/synth/issue1636/testsuite.sh
+++ b/testsuite/synth/issue1636/testsuite.sh
@@ -1,0 +1,13 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A partial (bit 0 excluded) write to a memory word used to crash
+# --synth with an internal ASSERT_FAILURE (netlists-builders.adb:1266)
+# instead of splitting the memory by write pattern. See issue1636.
+synth asym_test.vhd -e asym_test > syn_asym_test.vhd
+analyze syn_asym_test.vhd
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Fixes issue https://github.com/ghdl/ghdl/issues/1636

## What the fix does

No source fix in this commit. Added `testsuite/synth/issue1636/` (the exact repro from the report) whose `testsuite.sh` synthesizes the design and re-analyzes the resulting netlist. This locks in the current, correct behavior as a regression guard.