### PR TITLE
testsuite: add regression test for issue2079, already fixed on master

### DIFF
--- a/testsuite/synth/issue2079/ent.vhdl
+++ b/testsuite/synth/issue2079/ent.vhdl
@@ -1,0 +1,34 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity ent is
+	generic (
+		WIDTH : positive := 32;
+		DEPTH : positive := 256
+	);
+	port (
+		clk: in std_logic;
+
+		write_enable: in std_logic;
+		write_address: in natural range 0 to DEPTH-1;
+		input: in std_logic_vector(WIDTH-1 downto 0);
+
+		read_address: in natural range 0 to DEPTH-1;
+		output: out std_logic_vector(WIDTH-1 downto 0)
+	);
+end entity;
+
+architecture a of ent is
+begin
+	proc: process(clk)
+		type memory_t is array(0 to DEPTH-1) of std_logic_vector(WIDTH-1 downto 0);
+		variable memory : memory_t;
+	begin
+		output <= memory(read_address);
+
+		if write_enable = '1' then
+			memory(write_address) := input;
+		end if;
+	end process;
+end architecture;

--- a/testsuite/synth/issue2079/testsuite.sh
+++ b/testsuite/synth/issue2079/testsuite.sh
@@ -1,0 +1,28 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A memory with an async (unclocked) write port used to crash --synth
+# with an internal ASSERTION_ERROR (netlists-memories.adb:2057) instead
+# of a clean diagnostic. See issue2079.
+export GHDL_STD_FLAGS="--std=08"
+
+# Use the helper from testenv.sh rather than calling $GHDL directly: it
+# already assembles the flag variables, which have to stay unquoted so
+# they split into separate arguments.
+out=$(synth ent.vhdl -e 2>&1) || true
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: synth crashed instead of reporting a clean error"
+  exit 1
+fi
+
+if ! echo "$out" | grep -q "latch infered"; then
+  echo "FAIL: expected a clean latch-inference error"
+  exit 1
+fi
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Fixes issue https://github.com/ghdl/ghdl/issues/2079

## What the fix does

No source fix in this commit. Added `testsuite/synth/issue2079/` (the exact repro from the report) whose `testsuite.sh` attempts `--synth`, expects it to fail, and asserts the clean "latch infered" error appears with no `GHDL Bug occurred` crash. This locks in the current, correct behavior as a regression guard.
