### PR TITLE
testsuite: add regression test for issue412, already fixed on master

### DIFF
--- a/testsuite/gna/issue412/test.vhdl
+++ b/testsuite/gna/issue412/test.vhdl
@@ -1,0 +1,8 @@
+entity test is
+        generic(
+                type g_t_test
+        );
+        port(
+                if_in  : in  g_t_test
+        );
+end entity;

--- a/testsuite/gna/issue412/testsuite.sh
+++ b/testsuite/gna/issue412/testsuite.sh
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# An entity with a fully generic (unconstrained) "type" generic used to
+# crash the gcc-backend translator with an internal CONSTRAINT_ERROR
+# (trans.adb:1426 access check failed). See issue412.
+analyze --std=08 test.vhdl
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Fixes issue https://github.com/ghdl/ghdl/issues/412

## What the fix does

No source fix in this commit. Added `testsuite/gna/issue412/` (the exact repro from the report) whose `testsuite.sh` analyzes the design and expects success. This locks in the current, correct behavior as a regression guard.
