### PR TITLE
vhdl-translate: compute association bounds in their own environment

### DIFF
--- a/src/vhdl/translate/trans-chap3.adb
+++ b/src/vhdl/translate/trans-chap3.adb
@@ -3757,9 +3757,7 @@ package body Trans.Chap3 is
                                     L_Node : Mnode;
                                     R_Type : Iir;
                                     R_Node : Mnode;
-                                    Loc    : Iir)
-   is
-      Res : O_Enode;
+                                    Loc    : Iir) is
    begin
       case Types_Match (L_Type, R_Type) is
          when True =>
@@ -3769,11 +3767,21 @@ package body Trans.Chap3 is
             Chap6.Gen_Bound_Error (Loc);
             return;
          when Unknown =>
-            Res := Check_Match_Cond (L_Type, Get_Composite_Bounds (L_Node),
-                                     R_Type, Get_Composite_Bounds (R_Node));
-            Chap6.Check_Bound_Error (Res, Loc);
+            Check_Composite_Match_Bounds (L_Type, Get_Composite_Bounds (L_Node),
+                                          R_Type, Get_Composite_Bounds (R_Node),
+                                          Loc);
       end case;
    end Check_Composite_Match;
+
+   procedure Check_Composite_Match_Bounds
+     (L_Type : Iir; L_Bounds : Mnode; R_Type : Iir; R_Bounds : Mnode;
+      Loc : Iir)
+   is
+      Res : O_Enode;
+   begin
+      Res := Check_Match_Cond (L_Type, L_Bounds, R_Type, R_Bounds);
+      Chap6.Check_Bound_Error (Res, Loc);
+   end Check_Composite_Match_Bounds;
 
    procedure Create_Range_From_Array_Attribute_And_Length
      (Array_Attr : Iir; Length : O_Dnode; Res : Mnode)

--- a/src/vhdl/translate/trans-chap3.ads
+++ b/src/vhdl/translate/trans-chap3.ads
@@ -351,6 +351,11 @@ package Trans.Chap3 is
    function Locally_Types_Match (L_Type : Iir; R_Type : Iir)
                                 return Tri_State_Type;
 
+   --  Whether the bounds of L_TYPE and R_TYPE are known to match at analysis
+   --  time.  When Unknown, the check has to be done at run time and the
+   --  bounds of both objects are needed.
+   function Types_Match (L_Type : Iir; R_Type : Iir) return Tri_State_Type;
+
    --  Check bounds of L match bounds of R.
    --  If L_TYPE (resp. R_TYPE) is not a thin composite type, then L_NODE
    --    (resp. R_NODE) are not used (and may be Mnode_Null).
@@ -358,6 +363,15 @@ package Trans.Chap3 is
    --    must designate the object.
    procedure Check_Composite_Match
      (L_Type : Iir; L_Node : Mnode; R_Type : Iir; R_Node : Mnode; Loc : Iir);
+
+   --  Likewise, but with the bounds already extracted from the objects.
+   --  Needed when the bounds of the two operands must be computed in
+   --  different environments (see the direct recursive instantiation case in
+   --  Chap5.Elab_Port_Map_Aspect_Assoc).  Only call it when Types_Match
+   --  returns Unknown.
+   procedure Check_Composite_Match_Bounds
+     (L_Type : Iir; L_Bounds : Mnode; R_Type : Iir; R_Bounds : Mnode;
+      Loc : Iir);
 
    --  Create a subtype range to be stored into RES from length LENGTH, which
    --  is of type INDEX_TYPE.

--- a/src/vhdl/translate/trans-chap5.adb
+++ b/src/vhdl/translate/trans-chap5.adb
@@ -561,9 +561,33 @@ package body Trans.Chap5 is
             --  Check length matches.
             Stabilize (Formal_Sig);
             Stabilize (Actual_Sig);
-            Chap3.Check_Composite_Match (Formal_Type, Formal_Sig,
-                                         Actual_Type, Actual_Sig,
-                                         Assoc);
+            if Chap3.Types_Match (Formal_Type, Actual_Type) = Unknown then
+               --  The check is done at run time, so the bounds of both sides
+               --  are needed.  They must each be computed in their own
+               --  environment: for a direct recursive instantiation the
+               --  formal and the actual environments differ, and the bounds
+               --  of a type that depends on a generic are read from the
+               --  instance.  Stabilize them so that they no longer depend on
+               --  the environment that is current when they are used.
+               declare
+                  Formal_Bounds : Mnode;
+                  Actual_Bounds : Mnode;
+               begin
+                  Formal_Bounds :=
+                    Stabilize (Chap3.Get_Composite_Bounds (Formal_Sig));
+                  Set_Map_Env (Actual_Env);
+                  Actual_Bounds :=
+                    Stabilize (Chap3.Get_Composite_Bounds (Actual_Sig));
+                  Set_Map_Env (Formal_Env);
+                  Chap3.Check_Composite_Match_Bounds
+                    (Formal_Type, Formal_Bounds,
+                     Actual_Type, Actual_Bounds, Assoc);
+               end;
+            else
+               Chap3.Check_Composite_Match (Formal_Type, Formal_Sig,
+                                            Actual_Type, Actual_Sig,
+                                            Assoc);
+            end if;
          end if;
 
          Data := (Actual_Sig => Actual_Sig,

--- a/testsuite/gna/issue1433/example_recursive_instantiation_entity_style.vhd
+++ b/testsuite/gna/issue1433/example_recursive_instantiation_entity_style.vhd
@@ -1,0 +1,43 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity example_recursive_instantiation_entity_style is
+  generic (
+    A_WIDTH : positive;
+    B_WIDTH : positive);
+  port (
+    in_a : in std_logic_vector(A_WIDTH-1 downto 0);
+    in_b : in std_logic_vector(B_WIDTH-1 downto 0));
+end example_recursive_instantiation_entity_style;
+
+
+architecture rtl of example_recursive_instantiation_entity_style is
+begin
+
+  ------------------------------------------------------------------------------
+  -- If A_WIDTH < B_WIDTH, swap the inputs.
+  -- The remainder of this module assumes that A_WIDTH >= B_WIDTH.
+  ------------------------------------------------------------------------------
+  if_gen_a_width_lt_b_width : if (A_WIDTH < B_WIDTH) generate
+  begin
+    assert false
+      report "A_WIDTH=" & integer'image(A_WIDTH) & " < B_WIDTH=" & integer'image(B_WIDTH) & ", so swap them."
+      severity note;
+
+    example_recursive_instantiation_entity_style_i : entity work.example_recursive_instantiation_entity_style
+      generic map (
+        A_WIDTH => B_WIDTH,
+        B_WIDTH => A_WIDTH)
+      port map (
+        in_a => in_b,
+        in_b => in_a);
+  end generate if_gen_a_width_lt_b_width;
+
+  if_gen_a_width_ge_b_width : if (A_WIDTH >= B_WIDTH) generate
+  begin
+    assert false
+      report "Do stuff with A_WIDTH=" & integer'image(A_WIDTH) & " >= B_WIDTH=" & integer'image(B_WIDTH) & "..."
+      severity note;
+  end generate if_gen_a_width_ge_b_width;
+
+end rtl;

--- a/testsuite/gna/issue1433/testsuite.sh
+++ b/testsuite/gna/issue1433/testsuite.sh
@@ -1,0 +1,26 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# An entity that recursively self-instantiates (via "entity
+# library.name" direct instantiation) with swapped generic-specified
+# port widths used to fail with a spurious runtime bound-check error
+# instead of correctly swapping and re-elaborating. See issue1433.
+analyze example_recursive_instantiation_entity_style.vhd
+
+out=$(elab_simulate example_recursive_instantiation_entity_style -gA_WIDTH=2 -gB_WIDTH=3 2>&1)
+echo "$out"
+
+if ! echo "$out" | grep -q "A_WIDTH=2 < B_WIDTH=3, so swap them."; then
+  echo "FAIL: expected the swap-detection message"
+  exit 1
+fi
+
+if ! echo "$out" | grep -q "Do stuff with A_WIDTH=3 >= B_WIDTH=2\.\.\."; then
+  echo "FAIL: expected the recursive instance to run with swapped generics"
+  exit 1
+fi
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Fixes https://github.com/ghdl/ghdl/issues/1433

## What the fix does

Computes the bounds of each side in its own environment and `Stabilize`s them into temporaries, so they no longer depend on whichever environment is current when they are used.

That needs a small refactor of the check itself: `Chap3.Types_Match` becomes visible, and `Chap3.Check_Composite_Match_Bounds` takes bounds that have already been extracted from the objects. `Chap3.Check_Composite_Match` keeps its behaviour and delegates to it.

The new path is taken only when `Types_Match` returns `Unknown`, that is when the check really is deferred to run time. Every other association keeps the previous code, which limits the reach of a change on a path used by every port map.

## Testing

`testsuite/gna/issue1433/` elaborates and simulates the design with `-gA_WIDTH=2 -gB_WIDTH=3` and asserts both expected messages, confirming the swap is detected and the recursive instance runs with the swapped generics:

```
...vhd:23:5:@0ms:(assertion note): A_WIDTH=2 < B_WIDTH=3, so swap them.
...vhd:38:5:@0ms:(assertion note): Do stuff with A_WIDTH=3 >= B_WIDTH=2...
```

Full `sanity gna vests synth` pass on mcode, llvm and gcc, and with this fix alone applied to master.
