### PR TITLE
testsuite: add regression test for issue1918, already fixed on master

### DIFF
--- a/testsuite/gna/issue1918/test_pkg.vhd
+++ b/testsuite/gna/issue1918/test_pkg.vhd
@@ -1,0 +1,28 @@
+package test_pkg is
+
+	type value_t is record
+		value : natural;
+	end record;
+
+	type value_array_t is array(natural range<>) of value_t;
+
+	type state_t is record
+		values : value_array_t;
+	end record;
+
+	type state_array_t is array(natural range<>) of state_t;
+
+end test_pkg;
+
+package body test_pkg is
+
+	function to_string(prefix : string; val : state_array_t) return string is
+	begin
+		if val'length = 0 then
+			return "";
+		else
+			return to_string(prefix, val(val'low+1 to val'high));
+		end if;
+	end function;
+
+end package body test_pkg;

--- a/testsuite/gna/issue1918/testsuite.sh
+++ b/testsuite/gna/issue1918/testsuite.sh
@@ -1,0 +1,13 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A recursive function operating on a nested record-containing-
+# unconstrained-array type (state_array_t -> state_t -> value_array_t)
+# used to crash the gcc-backend translator with an internal
+# ASSERT_FAILURE (trans-chap3.adb:60). See issue1918.
+analyze --std=08 -frelaxed-rules test_pkg.vhd
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Fixes issue https://github.com/ghdl/ghdl/issues/1918

## What the fix does

No source fix in this commit. Added `testsuite/gna/issue1918/` (the exact repro from the report) whose `testsuite.sh` analyzes the design and expects success. This locks in the current, correct behavior as a regression guard.
