### PR TITLE
testsuite: add regression test for issue1663, already fixed on master

### DIFF
--- a/testsuite/gna/issue1663/tb.vhd
+++ b/testsuite/gna/issue1663/tb.vhd
@@ -1,0 +1,56 @@
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+use IEEE.NUMERIC_STD.ALL;
+
+entity tb is
+end tb;
+
+architecture Behavioral of tb is
+
+constant c_width      : integer := 300;
+constant c_heigth     : integer := 280;
+
+signal test : std_logic_Vector(7 downto 0);
+subtype t_data is std_logic_vector(7 downto 0);
+
+-- type of two dimensional array of data type
+type t_two_dim_array is array(0 to c_heigth-1, 0 to c_width-1) of t_data;
+
+signal i : integer := 0;
+signal j : integer := 0;
+
+signal image : t_two_dim_array := (others => (others => (others => '0')));
+signal nclk	:	std_logic;
+begin
+
+clk_process :process
+begin
+  nclk <= '0';
+  wait for 5 ns;
+  nclk <= '1';
+  wait for 5 ns;
+end process;
+
+
+process(nclk)
+begin
+  if (rising_edge(nclk)) then
+	test <= image(i,j);
+	j <= j + 1;
+	if (j = c_width -1) then
+		j <= 0;
+		i <= i + 1;
+	end if;
+	if (i = c_heigth -1) then
+		i <= 0;
+	end if;
+  end if;
+end process;
+
+process
+begin
+  wait for 100 ns;
+  std.env.finish;
+end process;
+
+end Behavioral;

--- a/testsuite/gna/issue1663/testsuite.sh
+++ b/testsuite/gna/issue1663/testsuite.sh
@@ -1,0 +1,30 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A large 2D array signal (300x280 8-bit elements, an image buffer)
+# combined with --vcd wave dumping used to crash with an internal
+# CONSTRAINT_ERROR (grt-vcd.adb:465 access check failed). The original
+# report read the image from a file via VUnit; this exercises the same
+# large-2D-array + --vcd combination without either dependency. See
+# issue1663.
+export GHDL_STD_FLAGS="--std=08"
+analyze tb.vhd
+
+out=$(elab_simulate tb --vcd=wave.vcd 2>&1)
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: crashed instead of completing"
+  exit 1
+fi
+
+if [ ! -s wave.vcd ]; then
+  echo "FAIL: expected a non-empty wave.vcd to be generated"
+  exit 1
+fi
+
+rm -f wave.vcd
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Fixes issue https://github.com/ghdl/ghdl/issues/1663

## What the fix does

No source fix in this commit. Added `testsuite/gna/issue1663/` (a VUnit-free reconstruction of the repro, preserving the large 2D array + `--vcd` trigger) whose `testsuite.sh` elaborates and simulates the design with `--vcd` and asserts a non-empty wave file is produced with no `GHDL Bug occurred` crash. This locks in the current, correct behavior as a regression guard.
