### PR TITLE
testsuite: add regression test for issue1496, already fixed on master

### DIFF
--- a/testsuite/synth/issue1496/adder.vhd
+++ b/testsuite/synth/issue1496/adder.vhd
@@ -1,0 +1,16 @@
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.numeric_std.all;
+
+entity adder is
+generic (N: integer := 4);
+port( a,b : in  std_logic_vector(N-1 downto 0);
+      cin : in  std_logic;
+      sum : out std_logic_vector(N-1 downto 0);
+      cout: out std_logic
+      );
+end;
+architecture rtl2008 of adder is
+begin
+  (cout, sum) <= std_logic_vector(unsigned('0' & a) + unsigned('0' & b) + cin);
+end;

--- a/testsuite/synth/issue1496/testsuite.sh
+++ b/testsuite/synth/issue1496/testsuite.sh
@@ -1,0 +1,15 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A target aggregate combining a scalar carry-out with a generic-sized
+# vector sum ((cout, sum) <= std_logic_vector(unsigned('0' & a) + ...))
+# used to crash --synth with an internal TYPES.INTERNAL_ERROR
+# (synth-objtypes.adb:365). See issue1496.
+export GHDL_STD_FLAGS="--std=08"
+synth -gN=4 adder.vhd -e adder > syn_adder.vhd
+analyze syn_adder.vhd
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Fixes issue https://github.com/ghdl/ghdl/issues/1496

## What the fix does

No source fix in this commit. Added `testsuite/synth/issue1496/` (the exact repro from the report) whose `testsuite.sh` synthesizes the design (with `-gN=4`, matching the report) and re-analyzes the resulting netlist. This locks in the current, correct behavior as a regression guard.