### PR TITLE
testsuite: add regression test for issue1522, already fixed on master

### DIFF
--- a/testsuite/synth/issue1522/ent.vhd
+++ b/testsuite/synth/issue1522/ent.vhd
@@ -1,0 +1,23 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity ent is
+	port (int_out : out integer);
+end;
+
+architecture RTL of ent is
+	type int2_array is array (0 to 1) of integer;
+
+	type my_record is record
+		a : int2_array;
+		b : int2_array;
+	end record my_record;
+
+	signal c : unsigned(1 downto 0) := (others => '0');
+
+	constant sym : my_record := (a => (0=>1, 1=>2), b => (0=>2, 1=>2));
+begin
+	int_out <= sym.a(to_integer(c));
+	c <= (others => '0');
+end;

--- a/testsuite/synth/issue1522/testsuite.sh
+++ b/testsuite/synth/issue1522/testsuite.sh
@@ -1,0 +1,14 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# Indexing an array inside a record (with several array members) via a
+# to_integer() conversion used to crash --synth with an internal
+# TYPES.INTERNAL_ERROR (netlists-memories.adb:336) instead of inferring
+# a ROM lookup. See issue1522.
+synth ent.vhd -e ent > syn_ent.vhd
+analyze syn_ent.vhd
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Fixes issue https://github.com/ghdl/ghdl/issues/1522

## What the fix does

No source fix in this commit. Added `testsuite/synth/issue1522/` (the exact repro from the report) whose `testsuite.sh` synthesizes the design and re-analyzes the resulting netlist. This locks in the current, correct behavior as a regression guard.