### PR TITLE
testsuite: add regression test for issue1754, already fixed on master

### DIFF
--- a/testsuite/synth/issue1754/my_entity.vhd
+++ b/testsuite/synth/issue1754/my_entity.vhd
@@ -1,0 +1,15 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity my_entity is
+end;
+
+architecture behaviour of my_entity is
+    type std_logic_vector_array_t is array (natural range <>) of std_logic_vector;
+    type reg_t is record
+        x : std_logic_vector_array_t(15 downto 0)(15 downto 0);
+    end record;
+
+begin
+
+end;

--- a/testsuite/synth/issue1754/testsuite.sh
+++ b/testsuite/synth/issue1754/testsuite.sh
@@ -1,0 +1,15 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A record field typed as an array of unconstrained std_logic_vector
+# elements (a generic array of vectors pattern) used to crash --synth
+# with an internal CONSTRAINT_ERROR (synth-vhdl_context.adb:234) even
+# though the declaration was never used. See issue1754.
+export GHDL_STD_FLAGS="--std=08"
+synth my_entity.vhd -e my_entity > syn_my_entity.vhd
+analyze syn_my_entity.vhd
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Fixes issue https://github.com/ghdl/ghdl/issues/1754

## What the fix does

No source fix in this commit. Added `testsuite/synth/issue1754/` (the exact repro from the report) whose `testsuite.sh` synthesizes the design and re-analyzes the resulting netlist. This locks in the current, correct behavior as a regression guard.