### PR TITLE
vhdl-translate: drop stale assertion on a constrained record element

### DIFF
--- a/src/vhdl/translate/trans-chap6.adb
+++ b/src/vhdl/translate/trans-chap6.adb
@@ -997,7 +997,13 @@ package body Trans.Chap6 is
       if Prefix_Tinfo.S.Rec_Fields /= null then
          F := Prefix_Tinfo.S.Rec_Fields (Pos).Fields (Kind);
          El_Tinfo := Prefix_Tinfo.S.Rec_Fields (Pos).Tinfo;
-         pragma Assert (El_Tinfo = Res_Tinfo);
+         --  EL_TINFO and RES_TINFO differ when EL is the element declaration
+         --  of the base record type while the prefix is of a record subtype
+         --  that constrains it (eg. a T_CONFIG(PARAM_A(31 downto 0)) port
+         --  whose element is declared as an unconstrained vector).  The code
+         --  below already handles that: the field is accessed through
+         --  EL_TINFO and the (unbounded) result is built from RES_TINFO,
+         --  with the bounds taken from the prefix layout.
       else
          --  Use the base element.
          declare

--- a/testsuite/gna/issue1957/chk.vhd
+++ b/testsuite/gna/issue1957/chk.vhd
@@ -1,0 +1,42 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+library work;
+use work.config_pkg.t_config;
+
+entity dutchk is
+  port(i_config : in t_config(param_a(31 downto 0), param_b(31 downto 0)));
+end entity;
+
+architecture arch of dutchk is
+begin
+  process
+  begin
+    wait for 1 ns;
+    assert i_config.param_a = std_logic_vector(to_unsigned(34, 32))
+      report "FAIL param_a=" & integer'image(to_integer(unsigned(i_config.param_a)))
+      severity failure;
+    assert i_config.param_b = std_logic_vector(to_unsigned(55, 32))
+      report "FAIL param_b=" & integer'image(to_integer(unsigned(i_config.param_b)))
+      severity failure;
+    report "PASS param_a=" & integer'image(to_integer(unsigned(i_config.param_a))) &
+           " param_b=" & integer'image(to_integer(unsigned(i_config.param_b)));
+    wait;
+  end process;
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+library work;
+use work.config_pkg.t_config;
+
+entity tb_chk is
+end entity;
+
+architecture behaviour of tb_chk is
+  constant s_config : t_config(param_a(31 downto 0), param_b(31 downto 0)) :=
+    (std_logic_vector(to_unsigned(34,32)), std_logic_vector(to_unsigned(55,32)));
+begin
+  d : entity work.dutchk port map (i_config => s_config);
+end architecture;

--- a/testsuite/gna/issue1957/dut.vhd
+++ b/testsuite/gna/issue1957/dut.vhd
@@ -1,0 +1,19 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library work;
+use work.config_pkg.t_config;
+
+entity dut is
+	port(
+		i_config : in t_config(
+			param_a(31 downto 0),
+			param_b(31 downto 0)
+		)
+	);
+end entity;
+
+architecture arch of dut is
+begin
+end architecture arch;

--- a/testsuite/gna/issue1957/tb_dut.vhd
+++ b/testsuite/gna/issue1957/tb_dut.vhd
@@ -1,0 +1,33 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library work;
+use work.config_pkg.t_config;
+
+entity tb_dut is
+end tb_dut;
+
+architecture behaviour of tb_dut is
+	component dut is
+		port(
+			i_config : in t_config(
+				param_a(31 downto 0),
+				param_b(31 downto 0)
+			)
+		);
+	end component;
+
+	constant s_config : t_config(
+		param_a(31 downto 0),
+		param_b(31 downto 0)
+	) := (
+		std_logic_vector(to_unsigned(34,32)),
+		std_logic_vector(to_unsigned(55,32))
+	);
+begin
+	dutlbl : dut
+		port map(
+			i_config => s_config
+		);
+end architecture;

--- a/testsuite/gna/issue1957/test_pkg.vhd
+++ b/testsuite/gna/issue1957/test_pkg.vhd
@@ -1,0 +1,11 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+package config_pkg is
+	  -- Configuration
+	type t_config is record
+		param_a   : std_logic_vector;
+		param_b   : std_logic_vector;
+	end record t_config;
+end package config_pkg;

--- a/testsuite/gna/issue1957/testsuite.sh
+++ b/testsuite/gna/issue1957/testsuite.sh
@@ -1,0 +1,36 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A record whose elements are unconstrained (std_logic_vector), used as a
+# constrained entity port type -- t_config(param_a(31 downto 0), ...) --
+# hit a stale assertion in Translate_Selected_Element: it required the
+# type info of the field to equal that of the element declaration, while
+# the function's own comment says the two differ precisely when the record
+# subtype constrains the element.  Only the gcc and llvm backends use that
+# translator.
+# chk.vhd checks the values that arrive through the port, not just that
+# the design analyzes.  See issue1957.
+export GHDL_STD_FLAGS=--std=08
+
+analyze test_pkg.vhd
+analyze dut.vhd
+analyze tb_dut.vhd
+analyze chk.vhd
+
+out=$(elab_simulate tb_chk 2>&1)
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: crashed instead of elaborating"
+  exit 1
+fi
+
+if ! echo "$out" | grep -q "PASS param_a=34 param_b=55"; then
+  echo "FAIL: wrong record element values through the port"
+  exit 1
+fi
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Fixes https://github.com/ghdl/ghdl/issues/1957

## What the fix does

Removes the assertion and records why the two type infos can differ.

Nothing else is needed, because the body is already written for the mismatch: it builds the fat result from `Res_Tinfo` with the bounds read from the prefix's record layout, and accesses the field itself through `El_Tinfo`. The sibling branch, taken when `Rec_Fields` is null, likewise sets `El_Tinfo` from the base element without asserting. The assertion was left behind by the code that learned to handle this case — verified before removing it rather than deleting it because it was in the way.

## Testing

`testsuite/gna/issue1957/` analyzed the design and stopped there, which cannot distinguish a correct record layout from a wrong one. `chk.vhd` adds an entity with the same constrained port that checks what actually arrives, driven from a constant with known values:

```
chk.vhd:22:5:@1ns:(report note): PASS param_a=34 param_b=55
```

Identical values on mcode, which never used this code path and so serves as an independent oracle.

Full `sanity gna vests synth` pass on mcode, llvm and gcc, and with this fix alone applied to master.
