### PR TITLE
testsuite: add regression test for issue2955, already fixed on master

### DIFF
--- a/testsuite/gna/issue2955/dummy.vhd
+++ b/testsuite/gna/issue2955/dummy.vhd
@@ -1,0 +1,23 @@
+library ieee;
+use ieee.numeric_std.all;
+use work.types_pkg.all;
+
+-- Both port declarations below are from the report's "not OK" cases:
+-- a fully unconstrained nested array type, and one with only the outer
+-- dimension constrained (inner "signed" elements left unconstrained).
+entity dummy is
+	generic (
+		g_bit_width : positive;
+		g_num_chnl  : positive
+	);
+	port (
+		i_data  : in  signed_vector;
+		i_data2 : in  signed_vector(0 to g_num_chnl - 1);
+		o_data  : out signed_vector(0 to g_num_chnl - 1)(g_bit_width - 1 downto 0)
+	);
+end entity;
+
+architecture behavioral of dummy is
+begin
+	o_data <= i_data2;
+end architecture;

--- a/testsuite/gna/issue2955/pkg.vhd
+++ b/testsuite/gna/issue2955/pkg.vhd
@@ -1,0 +1,6 @@
+library ieee;
+use ieee.numeric_std.all;
+
+package types_pkg is
+	type signed_vector is array (natural range <>) of signed;
+end package;

--- a/testsuite/gna/issue2955/testsuite.sh
+++ b/testsuite/gna/issue2955/testsuite.sh
@@ -1,0 +1,29 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# An entity port of a nested array type (signed_vector, array of
+# unconstrained signed) left partially or fully unconstrained (only
+# constrained via the actual at instantiation) used to crash
+# analysis/elaboration with an internal ASSERTION_ERROR
+# (synth-vhdl_expr.adb:635). See issue2955.
+export GHDL_STD_FLAGS="--std=08"
+analyze pkg.vhd dummy.vhd top.vhd
+
+out=$(elab_simulate top --fst=waves.fst 2>&1)
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: crashed instead of completing"
+  exit 1
+fi
+
+if ! echo "$out" | grep -q "simulation finished"; then
+  echo "FAIL: expected the simulation to complete"
+  exit 1
+fi
+
+rm -f waves.fst
+clean
+
+echo "Test successful"

--- a/testsuite/gna/issue2955/top.vhd
+++ b/testsuite/gna/issue2955/top.vhd
@@ -1,0 +1,22 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use work.types_pkg.all;
+
+entity top is
+end entity;
+
+architecture a of top is
+	signal s_in  : signed_vector(0 to 3)(7 downto 0);
+	signal s_out : signed_vector(0 to 3)(7 downto 0);
+begin
+	u_dummy : entity work.dummy
+		generic map (g_bit_width => 8, g_num_chnl => 4)
+		port map (i_data => s_in, i_data2 => s_in, o_data => s_out);
+	process
+	begin
+		s_in <= (others => (others => '0'));
+		wait for 10 ns;
+		std.env.finish;
+	end process;
+end architecture;


### PR DESCRIPTION
Fixes issue https://github.com/ghdl/ghdl/issues/2955

## What the fix does

No source fix in this commit. Added `testsuite/gna/issue2955/` (a faithful reconstruction of the report's repro, covering both the fully-unconstrained and outer-only-constrained port shapes in one entity) whose `testsuite.sh` analyzes, elaborates, and simulates the design (with `--fst`, matching the report's wave-dump usage) and asserts it completes normally with no `GHDL Bug occurred`. This locks in the current, correct behavior as a regression guard.
