### PR TITLE
vhdl-sem_assocs: constrain the element of an individual array associa…

### DIFF
--- a/src/vhdl/vhdl-sem_assocs.adb
+++ b/src/vhdl/vhdl-sem_assocs.adb
@@ -1070,6 +1070,39 @@ package body Vhdl.Sem_Assocs is
                  (Get_Associated_Expr (El), El_Type);
                El := Get_Chain (El);
             end loop;
+
+            --  If the element is not constrained by the interface, it is
+            --  defined by the individual associations - like the elements of
+            --  a record, cf. Finish_Individual_Assoc_Record.  Take it from
+            --  the first association; they all have the same subtype.
+            --  Without this, ACTUAL_TYPE keeps the unconstrained element of
+            --  the base type although it has just been marked as fully
+            --  constrained, so the bounds of the element are never
+            --  elaborated.
+            if Get_Kind (El_Type) in Iir_Kinds_Composite_Type_Definition
+              and then Get_Constraint_State (El_Type) /= Fully_Constrained
+            then
+               declare
+                  Assoc_Expr : constant Iir := Get_Associated_Expr (Chain);
+                  Assoc_Type : Iir;
+               begin
+                  if (Get_Kind (Assoc_Expr)
+                        = Iir_Kind_Association_Element_By_Individual)
+                  then
+                     Assoc_Type := Get_Actual_Type (Assoc_Expr);
+                  else
+                     Assoc_Type := Get_Type (Get_Actual (Assoc_Expr));
+                  end if;
+                  if Assoc_Type /= Null_Iir
+                    and then (Get_Kind (Assoc_Type)
+                                in Iir_Kinds_Composite_Type_Definition)
+                    and then Get_Constraint_State (Assoc_Type)
+                               = Fully_Constrained
+                  then
+                     Set_Element_Subtype (Actual_Type, Assoc_Type);
+                  end if;
+               end;
+            end if;
          else
             El := Chain;
             while El /= Null_Node loop

--- a/testsuite/gna/issue2955/chk.vhd
+++ b/testsuite/gna/issue2955/chk.vhd
@@ -1,0 +1,41 @@
+library ieee; use ieee.std_logic_1164.all; use ieee.numeric_std.all;
+package chk_pkg is
+  type signed_vector is array(natural range <>) of signed;
+end package;
+
+library ieee; use ieee.std_logic_1164.all; use ieee.numeric_std.all;
+use work.chk_pkg.all;
+entity dut_chk is
+  generic (g_bit_width : positive; g_num_chnl : positive);
+  port (i_data : in  signed_vector(0 to g_num_chnl - 1);
+        o_data : out signed_vector(0 to g_num_chnl - 1)(g_bit_width - 1 downto 0));
+end entity;
+architecture rtl of dut_chk is
+begin
+  o_data <= i_data;
+end architecture;
+
+library ieee; use ieee.std_logic_1164.all; use ieee.numeric_std.all;
+use work.chk_pkg.all;
+entity tb_chk2955 is end entity;
+architecture rtl of tb_chk2955 is
+  constant c_w : positive := 16;
+  signal a, b : signed(c_w - 1 downto 0) := (others => '0');
+begin
+  --  Indexed formal association: the element subtype comes from the actual.
+  u : entity work.dut_chk
+    generic map (g_bit_width => c_w, g_num_chnl => 1)
+    port map (i_data(0) => a, o_data(0) => b);
+
+  process
+  begin
+    a <= to_signed(-12345, c_w); wait for 1 ns;
+    assert b = to_signed(-12345, c_w)
+      report "FAIL b=" & integer'image(to_integer(b)) severity failure;
+    a <= to_signed(9876, c_w); wait for 1 ns;
+    assert b = to_signed(9876, c_w)
+      report "FAIL b=" & integer'image(to_integer(b)) severity failure;
+    report "PASS b=" & integer'image(to_integer(b)) & " len=" & integer'image(b'length);
+    wait;
+  end process;
+end architecture;

--- a/testsuite/gna/issue2955/repro.vhd
+++ b/testsuite/gna/issue2955/repro.vhd
@@ -1,0 +1,58 @@
+library ieee;
+use     ieee.std_logic_1164.all;
+use     ieee.numeric_std.all;
+use     ieee.math_real.all;
+
+package dummy_pkg is
+	type signed_vector is array(natural range <>) of signed;
+end package;
+
+library ieee;
+use     ieee.std_logic_1164.all;
+use     ieee.numeric_std.all;
+use     ieee.math_real.all;
+library work;
+use     work.dummy_pkg.all;
+
+entity dummy is
+	generic
+	(
+		g_bit_width : positive;
+		g_num_chnl  : positive
+	);
+	port
+	(
+		i_data : in  signed_vector(0 to g_num_chnl - 1);
+		o_data : out signed_vector(0 to g_num_chnl - 1)(g_bit_width - 1 downto 0)
+	);
+end entity;
+
+architecture rtl of dummy is
+begin
+	o_data <= i_data;
+end architecture;
+
+library ieee;
+use     ieee.std_logic_1164.all;
+use     ieee.numeric_std.all;
+use     ieee.math_real.all;
+library work;
+use     work.dummy_pkg.all;
+
+entity aaa_test_tle is
+end entity;
+
+architecture rtl of aaa_test_tle is
+	constant c_bit_width : positive := 16;
+	constant c_num_chnl  : positive := 1;
+	signal i_data        : signed(c_bit_width - 1 downto 0) := (others => '0');
+	signal o_data        : signed(c_bit_width - 1 downto 0);
+begin
+	i_dut : entity work.dummy
+	generic map (g_bit_width => c_bit_width, g_num_chnl  => c_num_chnl)
+	port map
+	(
+		i_data(0)   => i_data,
+		o_data(0)   => o_data
+	);
+end architecture;

--- a/testsuite/gna/issue2955/testsuite.sh
+++ b/testsuite/gna/issue2955/testsuite.sh
@@ -1,0 +1,45 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A port of a nested array type whose element is unconstrained
+# ("array (natural range <>) of signed", port "signed_vector(0 to N-1)")
+# associated element by element -- "i_data(0) => i_data" -- failed
+# elaboration with a spurious "bound check failure" on the gcc and llvm
+# backends.  The individual association synthesized an actual subtype that
+# was marked fully constrained while its element was still unconstrained,
+# so the bounds of the element were never elaborated.
+#
+# repro.vhd is the reporter's own design; chk.vhd checks that the data
+# really crosses the indexed association, since not crashing is not enough
+# to show the element bounds are right.  See issue2955.
+export GHDL_STD_FLAGS=--std=08
+
+analyze repro.vhd
+
+out=$(elab_simulate aaa_test_tle 2>&1)
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: crashed"
+  exit 1
+fi
+
+if echo "$out" | grep -q "bound check failure"; then
+  echo "FAIL: spurious bound check on the indexed formal association"
+  exit 1
+fi
+
+analyze chk.vhd
+
+out=$(elab_simulate tb_chk2955 2>&1)
+echo "$out"
+
+if ! echo "$out" | grep -q "PASS b=9876 len=16"; then
+  echo "FAIL: wrong data or element length through the indexed association"
+  exit 1
+fi
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Fixes https://github.com/ghdl/ghdl/issues/2955

## What the fix does

Gives the array case the same treatment as the record case: when the element of the interface is not fully constrained, take the element subtype from the individual associations — they all share one — and set it on the synthesized subtype, which makes the `Fully_Constrained` marking true. `Element_Subtype` is a `Ref` field, so this refers to the actual's subtype without transferring ownership.

## Testing

`testsuite/gna/issue2955/repro.vhd` is the reporter's own design, elaborated and simulated. `chk.vhd` drives values across the element-wise association and checks them, because not crashing does not show the element bounds are right:

```
PASS b=9876 len=16
```

Identical on mcode, which accepts the design without the fix and so serves as a reference for the expected values.

The trigger is the unconstrained element, not the generic: with the element constrained in the port declaration the design elaborates on every backend, with or without this fix, whether the index range comes from a generic or a literal.

Full `sanity gna vests synth` pass on mcode, llvm and gcc.
