### PR TITLE
vhdl-sem_expr: record that a function breaking the pure rule is not pure

### DIFF
--- a/src/vhdl/vhdl-sem_expr.adb
+++ b/src/vhdl/vhdl-sem_expr.adb
@@ -5138,6 +5138,12 @@ package body Vhdl.Sem_Expr is
       --  Function.
       if Get_Kind (Subprg) = Iir_Kind_Function_Declaration then
          Error_Pure (Subprg, Obj);
+         --  The function is not pure, whatever it was declared.  Record it,
+         --  like the procedure case below does with Purity_State: the rule
+         --  is only relaxed (a warning by default), so the rest of the
+         --  compiler keeps working on this subprogram and must not assume
+         --  that its result can be computed statically.
+         Set_Pure_Flag (Subprg, False);
          return;
       end if;
 

--- a/testsuite/synth/issue1574/bug_pure.vhdl
+++ b/testsuite/synth/issue1574/bug_pure.vhdl
@@ -1,0 +1,34 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity bug_pure is
+    port (
+        clock : in std_logic;
+        output : out std_logic_vector(7 downto 0)
+    );
+end bug_pure;
+
+architecture bug_arch of bug_pure is
+    type my_enum is (
+        thing1,
+        thing2,
+        thing3
+    );
+
+    signal input : my_enum := thing1;
+
+    function my_enum_func return std_logic_vector is
+    begin
+        case input is
+            when thing1 => return x"00";
+            when others => return x"A0";
+        end case;
+    end my_enum_func;
+begin
+    process (clock)
+    begin
+        if rising_edge(clock) then
+            output <= my_enum_func;
+        end if;
+    end process;
+end bug_arch;

--- a/testsuite/synth/issue1574/testsuite.sh
+++ b/testsuite/synth/issue1574/testsuite.sh
@@ -2,11 +2,23 @@
 
 . ../../testenv.sh
 
-# A function with a case statement containing more than one return
-# statement used to crash --synth with an internal ASSERT_FAILURE
-# (synth-stmts.adb:2055). See issue1574.
+# A function reading a signal from its enclosing architecture, called from
+# a clocked process, crashed --synth with an internal ASSERT_FAILURE
+# (synth-stmts.adb:2055).  The report attributed it to the case statement
+# having more than one return statement, but the maintainer identified the
+# actual cause on the thread: it is the function being impure -- "It is not
+# the number of return statements but the fact the function is impure.
+# Impure functions are not well handled."
+#
+# bug.vhdl is the report's design.  bug_pure.vhdl is the follow-up from the
+# thread ("Still crashes if it's marked as pure instead of impure"), which
+# is the same function declared pure while still reading the signal; GHDL
+# accepts it with a -Wpure warning.  See issue1574.
 synth bug.vhdl -e bug > syn_bug.vhdl
 analyze syn_bug.vhdl
+
+synth bug_pure.vhdl -e bug_pure > syn_bug_pure.vhdl
+analyze syn_bug_pure.vhdl
 
 clean
 


### PR DESCRIPTION
Address the second part of https://github.com/ghdl/ghdl/issues/1574 that was missed previously.

I made a mistake on some of the tickets for which I opened PRs. When letting the AI agent work on it, I didn't realize that it was not looking at the conversations several people has in the thread. Therefore, I asked him to go back and re-analyze the tickets.

## What is actually wrong in GHDL's implementation

A function that reads a signal from an enclosing declarative part breaks the pure rule. `Sem_Check_Pure` (`src/vhdl/vhdl-sem_expr.adb`) detects it and reports it, but for a function it returns without recording anything:

```ada
--  Function.
if Get_Kind (Subprg) = Iir_Kind_Function_Declaration then
   Error_Pure (Subprg, Obj);
   return;
end if;
```

The procedure case a few lines below does record it, with `Set_Purity_State (Subprg, Impure)`. The diagnostic is relaxed — a warning by default (`-Wpure`) — so analysis continues with `Pure_Flag` still set on a function that is demonstrably not pure.

Synthesis then trusts that flag. `Synth_Subprogram_Call` (`src/synth/synth-vhdl_stmts.adb`) decides how to synthesize a call from it:

```ada
--  If the subprogram is not pure, clear the const flag.
if Ctxt /= null and then not Get_Pure_Flag (Imp) then
   Set_Instance_Const (Sub_Inst, False);
end if;
...
if Get_Instance_Const (Sub_Inst) then
   Res := Synth_Static_Subprogram_Call (...);
else
   Res := Synth_Dynamic_Subprogram_Call (...);
end if;
```

With the flag still set, the call takes the static path, which requires the result to be computable at elaboration:

```ada
pragma Assert (Is_Static (C.Ret_Value.Val));
```

The function reads a signal, so its result is not static and the assertion fails. Spelling the same function `impure` clears the flag, takes the dynamic path, and works — which is exactly why only the `pure` spelling crashes.

## What the fix does

Records the violation, mirroring what the procedure case already does: `Set_Pure_Flag (Subprg, False)` next to the existing diagnostic. The function is not pure whatever it was declared, the rule is only relaxed so the rest of the compiler carries on with this subprogram, and nothing downstream should assume its result can be computed statically.

Both spellings then behave identically, which is the point of the thread.

## Testing

`testsuite/synth/issue1574/bug.vhdl` is the report's design. `bug_pure.vhdl` is the follow-up from the thread — the same function declared `pure` while still reading the signal. Both are synthesized and the resulting netlist re-analyzed; the second crashes on master without this fix.

Full `sanity gna vests synth` pass on mcode, llvm and gcc.
