### PR TITLE
testsuite: cover the record variant of issue1502

### DIFF
--- a/testsuite/synth/issue1502/rec.vhdl
+++ b/testsuite/synth/issue1502/rec.vhdl
@@ -1,0 +1,23 @@
+library ieee; use ieee.std_logic_1164.all;
+package rp is
+  type r_t is record a : std_logic_vector(3 downto 0); b : std_logic; end record;
+  type s_t is record x : std_logic_vector(3 downto 0); y : std_logic; end record;
+  function to_s (v : r_t) return s_t;
+end package;
+package body rp is
+  function to_s (v : r_t) return s_t is
+  begin
+    return (x => v.a, y => v.b);
+  end function;
+end package body;
+
+library ieee; use ieee.std_logic_1164.all; use work.rp.all;
+entity sub is port (i : in s_t; o : out std_logic_vector(3 downto 0)); end entity;
+architecture a of sub is begin o <= i.x when i.y = '1' else (others => '0'); end architecture;
+
+library ieee; use ieee.std_logic_1164.all; use work.rp.all;
+entity rectop is port (ri : in r_t; ro : out std_logic_vector(3 downto 0)); end entity;
+architecture a of rectop is
+begin
+  u : entity work.sub port map (i => to_s(ri), o => ro);
+end architecture;

--- a/testsuite/synth/issue1502/testsuite.sh
+++ b/testsuite/synth/issue1502/testsuite.sh
@@ -2,11 +2,28 @@
 
 . ../../testenv.sh
 
-# A function call producing a record-field-derived array actual for a
-# port association used to crash --synth with an internal ASSERT_FAILURE
-# (synth-expr.adb:830). See issue1502.
+# A conversion function on a port association crashed --synth with an
+# internal ASSERT_FAILURE (synth-expr.adb:830).  The maintainer confirmed
+# the cause on the thread: "Yes, the conversion function is not handled.
+# I will add that."
+#
+# theunit.vhdl is the report's design, whose actual is an array taken from
+# a record field.  rec.vhdl covers the variant a second reporter raised on
+# the same thread -- "I get the same error from synth when using
+# conversion functions for records" -- where the converted value is itself
+# a record.  See issue1502.
 synth theunit.vhdl -e theunit > syn_theunit.vhdl
 analyze syn_theunit.vhdl
+
+# Only synthesized, not re-analyzed: the netlist still refers to the
+# package declaring the record types, which is not part of the netlist.
+export GHDL_STD_FLAGS=--std=08
+out=$(synth rec.vhdl -e rectop 2>&1)
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: crashed on a conversion function returning a record"
+  exit 1
+fi
 
 clean
 


### PR DESCRIPTION
Address the second part of https://github.com/ghdl/ghdl/issues/1502 that was missed previously.

I made a mistake on some of the tickets for which I opened PRs. When letting the AI agent work on it, I didn't realize that it was not looking at the conversations several people has in the thread. Therefore, I asked him to go back and re-analyze the tickets.

## What this commit does

No source fix. `testsuite/synth/issue1502/` covers both shapes from the thread rather than only the original report:

- `theunit.vhdl` — the report's design; synthesized and the netlist re-analyzed.
- `rec.vhdl` — the record-conversion variant; synthesized and checked for the absence of the crash. It is not re-analyzed because the netlist still refers to the package declaring the record types, which synthesis does not emit.

Both pass on mcode, llvm and gcc.
