### PR TITLE
Bug/issue1395 follow up

### DIFF
--- a/src/vhdl/translate/trans-chap3.adb
+++ b/src/vhdl/translate/trans-chap3.adb
@@ -730,7 +730,44 @@ package body Trans.Chap3 is
                      Open_Temp;
                      Rng := Bounds_To_Range (Targ, Def, I + 1);
                      if New_Indexes then
+                        --  Stabilize first: Rng is read several times
+                        --  below (Translate_Discrete_Range itself
+                        --  stabilizes internally, but only for its own
+                        --  writes; without stabilizing here first, its
+                        --  underlying address would already have been
+                        --  consumed once we try to read it back).
+                        Rng := Stabilize (Rng);
                         Chap7.Translate_Discrete_Range (Rng, Index);
+
+                        --  Check the bounds of this new index constraint
+                        --  fit within the corresponding index subtype of
+                        --  the unconstrained parent array type (e.g. a
+                        --  STRING's POSITIVE index).  A null range is
+                        --  always compatible, whatever its bounds are
+                        --  (LRM08 5.2.1), so only check non-null ranges.
+                        declare
+                           Parent_Index_Type : constant Iir :=
+                             Get_Index_Type
+                               (Get_Index_Subtype_List (Parent_Type), I);
+                           If_Blk : O_If_Block;
+                           Dummy  : O_Enode;
+                           pragma Unreferenced (Dummy);
+                        begin
+                           Start_If_Stmt
+                             (If_Blk,
+                              New_Compare_Op
+                                (ON_Neq,
+                                 M2E (Range_To_Length (Rng)),
+                                 New_Lit (Ghdl_Index_0),
+                                 Ghdl_Bool_Type));
+                           Dummy := Insert_Scalar_Check
+                             (M2E (Range_To_Left (Rng)), Null_Iir,
+                              Parent_Index_Type, Def);
+                           Dummy := Insert_Scalar_Check
+                             (M2E (Range_To_Right (Rng)), Null_Iir,
+                              Parent_Index_Type, Def);
+                           Finish_If_Stmt (If_Blk);
+                        end;
                      else
                         Gen_Memcpy
                           (M2Addr (Rng),

--- a/src/vhdl/translate/trans-chap3.adb
+++ b/src/vhdl/translate/trans-chap3.adb
@@ -689,6 +689,33 @@ package body Trans.Chap3 is
       end case;
    end Create_Static_Composite_Subtype_Layout;
 
+   --  Check that the bounds of index range RNG are within INDEX_TYPE, the
+   --  index subtype of the array type being constrained (eg the POSITIVE of
+   --  a STRING).  This is needed when the constraint creates new indexes,
+   --  ie when the parent type is unconstrained: the bounds then come from
+   --  the subtype indication and have not been checked anywhere else.
+   --  A null range is compatible with any index subtype (LRM08 5.2.1), so
+   --  it is left alone.
+   procedure Check_Index_Range_Bounds
+     (Rng : Mnode; Index_Type : Iir; Loc : Iir)
+   is
+      If_Blk : O_If_Block;
+      Dummy  : O_Enode;
+      pragma Unreferenced (Dummy);
+   begin
+      Start_If_Stmt
+        (If_Blk,
+         New_Compare_Op (ON_Neq,
+                         M2E (Range_To_Length (Rng)),
+                         New_Lit (Ghdl_Index_0),
+                         Ghdl_Bool_Type));
+      Dummy := Insert_Scalar_Check
+        (M2E (Range_To_Left (Rng)), Null_Iir, Index_Type, Loc);
+      Dummy := Insert_Scalar_Check
+        (M2E (Range_To_Right (Rng)), Null_Iir, Index_Type, Loc);
+      Finish_If_Stmt (If_Blk);
+   end Check_Index_Range_Bounds;
+
    procedure Elab_Composite_Subtype_Layout (Def : Iir; Target : Mnode)
    is
       Tinfo : constant Type_Info_Acc := Get_Info (Def);
@@ -738,36 +765,11 @@ package body Trans.Chap3 is
                         --  consumed once we try to read it back).
                         Rng := Stabilize (Rng);
                         Chap7.Translate_Discrete_Range (Rng, Index);
-
-                        --  Check the bounds of this new index constraint
-                        --  fit within the corresponding index subtype of
-                        --  the unconstrained parent array type (e.g. a
-                        --  STRING's POSITIVE index).  A null range is
-                        --  always compatible, whatever its bounds are
-                        --  (LRM08 5.2.1), so only check non-null ranges.
-                        declare
-                           Parent_Index_Type : constant Iir :=
-                             Get_Index_Type
-                               (Get_Index_Subtype_List (Parent_Type), I);
-                           If_Blk : O_If_Block;
-                           Dummy  : O_Enode;
-                           pragma Unreferenced (Dummy);
-                        begin
-                           Start_If_Stmt
-                             (If_Blk,
-                              New_Compare_Op
-                                (ON_Neq,
-                                 M2E (Range_To_Length (Rng)),
-                                 New_Lit (Ghdl_Index_0),
-                                 Ghdl_Bool_Type));
-                           Dummy := Insert_Scalar_Check
-                             (M2E (Range_To_Left (Rng)), Null_Iir,
-                              Parent_Index_Type, Def);
-                           Dummy := Insert_Scalar_Check
-                             (M2E (Range_To_Right (Rng)), Null_Iir,
-                              Parent_Index_Type, Def);
-                           Finish_If_Stmt (If_Blk);
-                        end;
+                        Check_Index_Range_Bounds
+                          (Rng,
+                           Get_Index_Type
+                             (Get_Index_Subtype_List (Parent_Type), I),
+                           Def);
                      else
                         Gen_Memcpy
                           (M2Addr (Rng),

--- a/testsuite/gna/issue1395/alloc.vhdl
+++ b/testsuite/gna/issue1395/alloc.vhdl
@@ -1,0 +1,16 @@
+--  The constraint of an allocator is elaborated by the same code.
+entity alloc is
+  generic (n : integer := 0);
+end;
+
+architecture arch of alloc is
+  type str_p is access string;
+begin
+  process
+    variable p : str_p;
+  begin
+    p := new string (4 downto n);
+    report integer'image (p'length);
+    wait;
+  end process;
+end;

--- a/testsuite/gna/issue1395/dyn_zero.vhdl
+++ b/testsuite/gna/issue1395/dyn_zero.vhdl
@@ -1,0 +1,18 @@
+-- STRING is `array (POSITIVE range <>) of CHARACTER`, so any index subtype
+-- constraint including 0 is invalid (POSITIVE starts at 1). Here the bound
+-- is not locally static (it comes from a generic), so the violation can
+-- only be caught by a runtime/elaboration-time check, not by a purely
+-- static analysis-time check. See issue1395.
+entity dyn_zero is
+  generic (n : integer := 0);
+end entity;
+
+architecture a of dyn_zero is
+begin
+  process
+    variable s : string(4 downto n);
+  begin
+    report "len=" & integer'image(s'length);
+    wait;
+  end process;
+end architecture;

--- a/testsuite/gna/issue1395/dyn_zero_signal.vhdl
+++ b/testsuite/gna/issue1395/dyn_zero_signal.vhdl
@@ -1,0 +1,18 @@
+-- Same underlying issue as dyn_zero.vhdl (a POSITIVE-indexed STRING with an
+-- index range that includes 0), but a different declaration shape: a
+-- *signal* with a default aggregate value, declared at the architecture
+-- level (not a variable inside a process), and with the generic on the
+-- *left* bound instead of the right. See issue1395.
+entity dyn_zero_signal is
+  generic (g : integer := 4);
+end entity;
+
+architecture arch of dyn_zero_signal is
+  signal str : string (g downto 0) := (others => 'a');
+begin
+  process
+  begin
+    report str;
+    wait;
+  end process;
+end architecture;

--- a/testsuite/gna/issue1395/func_attr.vhdl
+++ b/testsuite/gna/issue1395/func_attr.vhdl
@@ -1,0 +1,29 @@
+--  The original reproducer from the issue: the range of the local string
+--  comes from the attributes of an unconstrained parameter, so it is not
+--  known until the call.  With a BIT_VECTOR(4 downto 0) actual it is
+--  string(4 downto 0), which is outside POSITIVE.
+entity func_attr is
+end;
+
+architecture arch of func_attr is
+begin
+  process
+    function bv2str (bv : bit_vector) return string is
+      variable st_out : string (bv'high downto bv'low);
+    begin
+      for i in bv'range loop
+        if bv (i) = '0' then
+          st_out (i) := '0';
+        else
+          st_out (i) := '1';
+        end if;
+      end loop;
+      return st_out;
+    end function;
+
+    variable bitv : bit_vector (4 downto 0);
+  begin
+    report bv2str (bitv);
+    wait;
+  end process;
+end;

--- a/testsuite/gna/issue1395/ok_ranges.vhdl
+++ b/testsuite/gna/issue1395/ok_ranges.vhdl
@@ -1,0 +1,18 @@
+--  Ranges that must keep working: a null range is compatible with any index
+--  subtype whatever its bounds (LRM08 5.2.1), and an in-range constraint is
+--  of course fine.  Guards against the check rejecting valid designs.
+entity ok_ranges is
+  generic (n : integer := 0);
+end;
+
+architecture arch of ok_ranges is
+  signal null_str  : string (1 to n);          --  null range when n = 0
+  signal valid_str : string (4 downto n + 1);  --  4 downto 1
+begin
+  process
+  begin
+    report "null=" & integer'image (null_str'length)
+      & " valid=" & integer'image (valid_str'length);
+    wait;
+  end process;
+end;

--- a/testsuite/gna/issue1395/testsuite.sh
+++ b/testsuite/gna/issue1395/testsuite.sh
@@ -2,14 +2,41 @@
 
 . ../../testenv.sh
 
+# STRING is "array (POSITIVE range <>) of CHARACTER", so an index constraint
+# that includes 0 is invalid.  The gcc and llvm backends did not check the
+# bounds of a new index constraint against the index subtype of the array
+# being constrained, and accepted e.g. string(4 downto 0) whenever a bound
+# was not locally static.  See issue1395.
+
+# Bounds coming from a generic, on a variable and on a signal.
 analyze dyn_zero.vhdl
 elab_simulate_failure dyn_zero
-
 clean
 
 analyze dyn_zero_signal.vhdl
 elab_simulate_failure dyn_zero_signal
+clean
 
+# The reproducer from the issue itself: the bounds come from the attributes
+# of an unconstrained parameter, and are only known on the call.
+analyze func_attr.vhdl
+elab_simulate_failure func_attr
+clean
+
+# Not a STRING: any array whose index subtype excludes the value.
+analyze user_array.vhdl
+elab_simulate_failure user_array
+clean
+
+# The constraint of an allocator goes through the same code.
+analyze alloc.vhdl
+elab_simulate_failure alloc
+clean
+
+# And the other direction: valid constraints must still elaborate.  A null
+# range is compatible with any index subtype whatever its bounds.
+analyze ok_ranges.vhdl
+elab_simulate ok_ranges
 clean
 
 echo "Test successful"

--- a/testsuite/gna/issue1395/testsuite.sh
+++ b/testsuite/gna/issue1395/testsuite.sh
@@ -1,0 +1,15 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+analyze dyn_zero.vhdl
+elab_simulate_failure dyn_zero
+
+clean
+
+analyze dyn_zero_signal.vhdl
+elab_simulate_failure dyn_zero_signal
+
+clean
+
+echo "Test successful"

--- a/testsuite/gna/issue1395/user_array.vhdl
+++ b/testsuite/gna/issue1395/user_array.vhdl
@@ -1,0 +1,16 @@
+--  Not specific to STRING: any array type with a constrained index subtype
+--  is checked the same way.
+entity user_array is
+  generic (n : integer := 0);
+end;
+
+architecture arch of user_array is
+  type pos_vec is array (positive range <>) of integer;
+  signal s : pos_vec (4 downto n);
+begin
+  process
+  begin
+    report integer'image (s'length);
+    wait;
+  end process;
+end;


### PR DESCRIPTION
# Issue #1395 — follow-up to PR #3346

Analysis by an AI agent.

## What this adds

PR #3346 makes the gcc and llvm backends check the bounds of a new index constraint against the index subtype of the array being constrained, so `string(4 downto 0)` is rejected instead of silently producing a 5-character string. The review asked for two things on top of it:

> It's OK but I would like to rework it a little bit: create a separate subprogram for the check, try to reproduce the error in a different case.

### A separate subprogram for the check

The check was an inline block inside `Elab_Composite_Subtype_Layout`, three levels deep in a loop that is already dense. It is now `Check_Index_Range_Bounds`, declared just before its caller, and the call site is three lines. Behaviour is unchanged.

### The error, reproduced in other cases

The two existing tests both take their bounds from a generic. These are the shapes that were not covered, all of them rejected correctly:

- `func_attr.vhdl` — the reproducer from the issue itself. The range of a local string comes from the attributes of an unconstrained parameter (`string (bv'high downto bv'low)`), so it is only known at the call; passing a `bit_vector (4 downto 0)` makes it `string (4 downto 0)`. This is the case the issue was opened about, and it was the one shape the tests did not exercise.
- `user_array.vhdl` — a user-defined `array (positive range <>) of integer` rather than `STRING`, which shows the check is about the index subtype and not about `STRING` in particular.
- `alloc.vhdl` — the constraint of an allocator (`new string (4 downto n)`), which reaches the same code from a different construct.

And the other direction, which matters more for a check on a path this common: `ok_ranges.vhdl` asserts that valid constraints still elaborate — a null range, which is compatible with any index subtype whatever its bounds (LRM08 5.2.1), and an ordinary in-range constraint. Without it nothing would catch this check becoming over-strict.

## Testing

The extended `testsuite/gna/issue1395` passes on mcode, llvm and gcc.