### PR TITLE
ghdldrv: report two design files compiled to the same object file

### DIFF
--- a/src/ghdldrv/ghdldrv.adb
+++ b/src/ghdldrv/ghdldrv.adb
@@ -336,6 +336,47 @@ package body Ghdldrv is
       Table_Low_Bound => 1,
       Table_Initial => 16);
 
+   --  Object files built from a source file, and the source file each one
+   --  was built from, so that two sources compiled to the same object file
+   --  can be reported.  See Check_Object_Collision.
+   package Objlist is new Tables
+     (Table_Component_Type => String_Acc,
+      Table_Index_Type => Natural,
+      Table_Low_Bound => 1,
+      Table_Initial => 16);
+
+   package Objsrclist is new Tables
+     (Table_Component_Type => String_Acc,
+      Table_Index_Type => Natural,
+      Table_Low_Bound => 1,
+      Table_Initial => 16);
+
+   --  The object file of a design file is named after the *base* name of its
+   --  source file, in the library directory.  So two design files with the
+   --  same base name in different directories (dir1/pkg.vhdl and
+   --  dir2/pkg.vhdl) are both compiled to the same pkg.o: the second
+   --  analysis overwrites the first object file, and the link then either
+   --  fails with a pile of "multiple definition" messages or silently uses
+   --  the wrong object.  Detect it here, where the link list is built, and
+   --  say what is wrong instead of leaving the user with linker errors
+   --  about symbols they never wrote.  See #539 and #1622.
+   procedure Check_Object_Collision (Obj : String; Src : String) is
+   begin
+      for I in Objlist.First .. Objlist.Last loop
+         if Objlist.Table (I).all = Obj
+           and then Objsrclist.Table (I).all /= Src
+         then
+            Error ("'" & Src & "' and '" & Objsrclist.Table (I).all
+                     & "' are both compiled to '" & Obj & "'");
+            Error ("(object files are named after the source file base name;"
+                     & " rename one of these files)");
+            raise Compile_Error;
+         end if;
+      end loop;
+      Objlist.Append (new String'(Obj));
+      Objsrclist.Append (new String'(Src));
+   end Check_Object_Collision;
+
    --  Read a list of files from file FILENAME.
    --  Lines starting with a '#' are ignored (comments)
    --  Lines starting with a '>' are directory lines
@@ -370,6 +411,13 @@ package body Ghdldrv is
       L : Natural;
       File : String_Acc;
    begin
+      if To_Obj then
+         --  Start from an empty state: this may be the second link done by
+         --  this process (libghdl runs several commands in one).
+         Objlist.Init;
+         Objsrclist.Init;
+      end if;
+
       Line (1 .. Filename'Length) := Filename;
       Line (Filename'Length + 1) := Ghdllocal.Nul;
       Stream := fopen (Line'Address, Mode'Address);
@@ -404,6 +452,7 @@ package body Ghdldrv is
                   File := new String'(Dir (1 .. Dir_Len)
                                       & Get_Base_Name (Line (1 .. L))
                                       & Obj_Suffix);
+                  Check_Object_Collision (File.all, Line (1 .. L));
                else
                   File := new String'(Substitute (Line (1 .. L)));
                end if;

--- a/testsuite/gna/issue1622/src/test.vhd
+++ b/testsuite/gna/issue1622/src/test.vhd
@@ -1,0 +1,12 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity something is
+    port(
+        clock: out std_logic
+    );
+end entity;
+
+architecture structural of something is
+begin
+end architecture;

--- a/testsuite/gna/issue1622/tests/test.vhd
+++ b/testsuite/gna/issue1622/tests/test.vhd
@@ -1,0 +1,17 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity other_thing is
+end entity;
+
+architecture structural of other_thing is
+    component something is
+        port(
+            clock: out std_logic
+        );
+    end component;
+
+    signal clock: std_logic;
+begin
+    something_instance: something port map(clock);
+end architecture;

--- a/testsuite/gna/issue1622/testsuite.sh
+++ b/testsuite/gna/issue1622/testsuite.sh
@@ -1,0 +1,38 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# Same defect as issue539, in the shape users hit most often: src/test.vhd
+# and tests/test.vhd are both compiled to test.o, so the link used to fail
+# with "multiple definition" errors.  GHDL now reports the collision.
+# Only the compiled backends (gcc, llvm) write object files; the JIT
+# backends (mcode, llvm-jit) do not and are not affected.  See issue1622.
+if "$GHDL" --version | grep -q "JIT code generator"; then
+  echo "This test needs a backend that writes object files, skipped on a JIT (see issue1622)"
+  exit 0
+fi
+
+export GHDL_STD_FLAGS="--std=08"
+
+analyze src/test.vhd tests/test.vhd
+
+if OUT=$(elab other_thing 2>&1); then
+  echo "$OUT"
+  echo "FAIL: the collision was not reported"
+  exit 1
+fi
+echo "$OUT"
+
+if echo "$OUT" | grep -q "multiple definition"; then
+  echo "FAIL: reached the link and got the raw linker errors"
+  exit 1
+fi
+
+if ! echo "$OUT" | grep -q "are both compiled to"; then
+  echo "FAIL: expected the object file collision diagnostic"
+  exit 1
+fi
+
+clean
+
+echo "Test successful"

--- a/testsuite/gna/issue539/pkg1/pkg.vhd
+++ b/testsuite/gna/issue539/pkg1/pkg.vhd
@@ -1,0 +1,2 @@
+package pkg1 is
+end package pkg1;

--- a/testsuite/gna/issue539/pkg2/pkg.vhd
+++ b/testsuite/gna/issue539/pkg2/pkg.vhd
@@ -1,0 +1,2 @@
+package pkg2 is
+end package pkg2;

--- a/testsuite/gna/issue539/testsuite.sh
+++ b/testsuite/gna/issue539/testsuite.sh
@@ -1,0 +1,39 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# The object file of a design file is named after the base name of its
+# source file, so pkg1/pkg.vhd and pkg2/pkg.vhd are both compiled to
+# pkg.o: the second analysis overwrites the first object file and the
+# link used to fail with a pile of "multiple definition" messages about
+# symbols the user never wrote.  GHDL now says what is wrong instead.
+# Only the compiled backends (gcc, llvm) write object files; the JIT
+# backends (mcode, llvm-jit) do not and are not affected.  See issue539
+# (and the identical issue1622).
+if "$GHDL" --version | grep -q "JIT code generator"; then
+  echo "This test needs a backend that writes object files, skipped on a JIT (see issue539)"
+  exit 0
+fi
+
+"$GHDL" -i pkg1/pkg.vhd pkg2/pkg.vhd top.vhd
+
+if OUT=$("$GHDL" -m top 2>&1); then
+  echo "$OUT"
+  echo "FAIL: the collision was not reported"
+  exit 1
+fi
+echo "$OUT"
+
+if echo "$OUT" | grep -q "multiple definition"; then
+  echo "FAIL: reached the link and got the raw linker errors"
+  exit 1
+fi
+
+if ! echo "$OUT" | grep -q "are both compiled to"; then
+  echo "FAIL: expected the object file collision diagnostic"
+  exit 1
+fi
+
+clean
+
+echo "Test successful"

--- a/testsuite/gna/issue539/top.vhd
+++ b/testsuite/gna/issue539/top.vhd
@@ -1,0 +1,9 @@
+use work.pkg1.all;
+use work.pkg2.all;
+
+entity top is
+end entity;
+
+architecture a of top is
+begin
+end architecture;


### PR DESCRIPTION
The object file of a design file is named after the base name of its source file, so two design files with the same base name in different directories are compiled to the same object file: the second analysis overwrites the first one and the link fails with "multiple definition" errors about symbols the user never wrote.

Detect the collision where the link list is built and report it, as suggested on both issues, instead of leaving the user with the linker errors.  This does not change how object files are named, which is what closing the issues needs.

Fixes part of #539 and #1622.
