### PR TITLE
report running out of memory instead of an internal error or a segfault

### DIFF
--- a/src/ghdldrv/ghdlmain.adb
+++ b/src/ghdldrv/ghdlmain.adb
@@ -701,6 +701,12 @@ package body Ghdlmain is
          Set_Exit_Status (Failure);
       when Exec_Error =>
          Set_Exit_Status (3);
+      when Storage_Error =>
+         --  Ran out of memory (eg elaborating an overly large design).
+         Simple_IO.Put_Line_Err
+           ("ghdl:error: out of memory -- the design requires more "
+            & "memory than is available on this machine");
+         Set_Exit_Status (Failure);
       when E: others =>
          Bug.Disp_Bug_Box (E);
          Set_Exit_Status (2);

--- a/src/grt/grt-cgnatrts.c
+++ b/src/grt/grt-cgnatrts.c
@@ -23,11 +23,21 @@ __gnat_last_chance_handler (void)
   abort ();
 }
 
+/* Defined in grt-errors.adb: report the failure and exit.  Does not
+   return.  Without this, a failed allocation returns a null pointer that
+   the caller stores through straight away, and the simulation dies on
+   SIGSEGV blaming "NULL access dereferenced" -- pointing the user at
+   their design rather than at the machine running out of memory.
+   See #812, #1111 and #2052.  */
+extern void __ghdl_out_of_memory (void);
+
 void *
 __gnat_malloc (size_t size)
 {
   void *res;
   res = malloc (size);
+  if (res == NULL && size != 0)
+    __ghdl_out_of_memory ();
   return res;
 }
 
@@ -40,7 +50,11 @@ __gnat_free (void *ptr)
 void *
 __gnat_realloc (void *ptr, size_t size)
 {
-  return realloc (ptr, size);
+  void *res;
+  res = realloc (ptr, size);
+  if (res == NULL && size != 0)
+    __ghdl_out_of_memory ();
+  return res;
 }
 
 /* Unused imported symbols with gcc 8.1. */

--- a/src/grt/grt-errors.adb
+++ b/src/grt/grt-errors.adb
@@ -63,6 +63,12 @@ package body Grt.Errors is
       Internal_Error ("exit_simulation");
    end Exit_Simulation;
 
+   procedure Out_Of_Memory is
+   begin
+      Error ("out of memory -- the design requires more memory than is "
+               & "available on this machine");
+   end Out_Of_Memory;
+
    procedure Fatal_Error is
    begin
       Maybe_Return_Via_Longjump (-1);

--- a/src/grt/grt-errors.ads
+++ b/src/grt/grt-errors.ads
@@ -98,6 +98,14 @@ package Grt.Errors is
    procedure Info_S (Str : String := "");
    procedure Info_E;
 
+   --  Report a failed memory allocation.  Central point, so that every
+   --  allocation (__ghdl_malloc, and the __gnat_malloc that every "new" in
+   --  grt goes through) calls it instead of handing back a null pointer
+   --  that is dereferenced a few instructions later.
+   procedure Out_Of_Memory;
+   pragma No_Return (Out_Of_Memory);
+   pragma Export (C, Out_Of_Memory, "__ghdl_out_of_memory");
+
    --  Called at end of error message.  Central point for failures.
    procedure Fatal_Error;
    pragma No_Return (Fatal_Error);

--- a/src/grt/grt-lib.adb
+++ b/src/grt/grt-lib.adb
@@ -21,6 +21,7 @@
 --  however invalidate any other reasons why the executable file might be
 --  covered by the GNU Public License.
 
+with System;
 with Grt.Errors; use Grt.Errors;
 with Grt.Errors_Exec; use Grt.Errors_Exec;
 with Grt.Options; use Grt.Options;
@@ -407,9 +408,25 @@ package body Grt.Lib is
    function C_Malloc (Size : Ghdl_Index_Type) return Ghdl_Ptr;
    pragma Import (C, C_Malloc, "malloc");
 
-   function Ghdl_Malloc (Size : Ghdl_Index_Type) return Ghdl_Ptr is
+   --  Report a failed allocation as an ordinary error. Without this the
+   --  null pointer is handed back to the generated code, which dereferences
+   --  it: the simulation then dies on SIGSEGV and blames "NULL access
+   --  dereferenced", pointing the user at their own design instead of at
+   --  the machine running out of memory.  See #812, #1111 and #2052.
+   procedure Check_Alloc (Ptr : Ghdl_Ptr; Size : Ghdl_Index_Type) is
    begin
-      return C_Malloc (Size);
+      if Size /= 0 and then Ptr = Ghdl_Ptr (System.Null_Address) then
+         Out_Of_Memory;
+      end if;
+   end Check_Alloc;
+
+   function Ghdl_Malloc (Size : Ghdl_Index_Type) return Ghdl_Ptr
+   is
+      Res : Ghdl_Ptr;
+   begin
+      Res := C_Malloc (Size);
+      Check_Alloc (Res, Size);
+      return Res;
    end Ghdl_Malloc;
 
    function Ghdl_Malloc0 (Size : Ghdl_Index_Type) return Ghdl_Ptr
@@ -420,9 +437,53 @@ package body Grt.Lib is
       Res : Ghdl_Ptr;
    begin
       Res := C_Malloc (Size);
+      Check_Alloc (Res, Size);
       Memset (Res, 0, Size);
       return Res;
    end Ghdl_Malloc0;
+
+   --  A size is held on 32 bits, so an object of 4 GB or more cannot be
+   --  described.  The generated code computes sizes with wrapping
+   --  arithmetic, and a wrapped size is worse than a large one: elaboration
+   --  asks for a block far too small (0 bytes, for a size that is a multiple
+   --  of 4 GB), gets it, and then writes past it.  The heap is corrupted
+   --  from that point on, and what happens next is up to the C library --
+   --  some carry on until an unrelated allocation fails, some abort with
+   --  "malloc(): unaligned tcache chunk detected".  Report it instead.
+   --  See #2052.
+   procedure Size_Overflow;
+   pragma No_Return (Size_Overflow);
+
+   procedure Size_Overflow is
+   begin
+      Error ("design is too large: a size does not fit on 32 bits, "
+               & "the largest object GHDL can describe is 4 GB");
+   end Size_Overflow;
+
+   function Ghdl_Index_Mul (L : Ghdl_Index_Type; R : Ghdl_Index_Type)
+                           return Ghdl_Index_Type
+   is
+      --  Widen rather than divide: this runs every time an object of an
+      --  unbounded type is created, and a 32 bit division is an order of
+      --  magnitude dearer than a 64 bit multiplication.
+      Res : constant Ghdl_U64 := Ghdl_U64 (L) * Ghdl_U64 (R);
+   begin
+      if Res > Ghdl_U64 (Ghdl_Index_Type'Last) then
+         Size_Overflow;
+      end if;
+      return Ghdl_Index_Type (Res);
+   end Ghdl_Index_Mul;
+
+   function Ghdl_Index_Add (L : Ghdl_Index_Type; R : Ghdl_Index_Type)
+                           return Ghdl_Index_Type
+   is
+      Res : constant Ghdl_Index_Type := L + R;
+   begin
+      if Res < L then
+         Size_Overflow;
+      end if;
+      return Res;
+   end Ghdl_Index_Add;
 
    procedure Ghdl_Free_Mem (Ptr : Ghdl_Ptr)
    is

--- a/src/grt/grt-lib.ads
+++ b/src/grt/grt-lib.ads
@@ -108,6 +108,17 @@ package Grt.Lib is
    --  Allocate and clear SIZE bytes.
    function Ghdl_Malloc0 (Size : Ghdl_Index_Type) return Ghdl_Ptr;
 
+   --  Multiply and add sizes, reporting an overflow instead of wrapping.
+   --  A size is held on 32 bits, so an object of 4 GB or more cannot be
+   --  described: the computation wraps, elaboration then asks for a block
+   --  far too small and writes past it, which silently corrupts the heap.
+   --  The generated code uses these for the size arithmetic it cannot check
+   --  itself.  See #2052.
+   function Ghdl_Index_Mul (L : Ghdl_Index_Type; R : Ghdl_Index_Type)
+                           return Ghdl_Index_Type;
+   function Ghdl_Index_Add (L : Ghdl_Index_Type; R : Ghdl_Index_Type)
+                           return Ghdl_Index_Type;
+
    procedure Ghdl_Free_Mem (Ptr : Ghdl_Ptr);
 
    type Ghdl_Std_Ulogic_Boolean_Array_Type is array (Ghdl_E8 range 0 .. 8)
@@ -168,6 +179,8 @@ private
 
    pragma Export (C, Ghdl_Malloc, "__ghdl_malloc");
    pragma Export (C, Ghdl_Malloc0, "__ghdl_malloc0");
+   pragma Export (C, Ghdl_Index_Mul, "__ghdl_index_mul");
+   pragma Export (C, Ghdl_Index_Add, "__ghdl_index_add");
    pragma Export (C, Ghdl_Free_Mem, "__ghdl_free_mem");
 
    pragma Export (C, Ghdl_I32_Exp_32, "__ghdl_i32_exp_32");

--- a/src/simul/simul-vhdl_compile.adb
+++ b/src/simul/simul-vhdl_compile.adb
@@ -20,6 +20,7 @@ with System;
 with Ada.Unchecked_Conversion;
 
 with Types; use Types;
+with Errorout;
 with Tables;
 with Libraries;
 
@@ -198,9 +199,26 @@ package body Simul.Vhdl_Compile is
 
    procedure Write_Length (Mem : Memory_Ptr; Len : Uns32) is
    begin
-      --  TODO: check ghdl_index_type size ?
       Write_U32 (Mem, Ghdl_U32 (Len));
    end Write_Length;
+
+   --  Sizes and offsets are computed on 64 bits while the design is
+   --  elaborated, but the compiled code holds them in a ghdl_index_type, ie
+   --  on 32 bits.  Report a design that does not fit instead of truncating
+   --  it: a truncated size makes the elaboration code allocate a block far
+   --  too small and then write past it, which corrupts the heap silently.
+   --  Unless checks are disabled, the conversion used to raise
+   --  Constraint_Error, ie the internal-error box.  See #2052.
+   function To_Index (Val : Uns64; Loc : Node) return Uns32 is
+   begin
+      if Val > Uns64 (Uns32'Last) then
+         Error_Msg_Elab
+           (Loc, "design is too large: a size does not fit on 32 bits, "
+              & "the largest object GHDL can describe is 4 GB");
+         raise Errorout.Compilation_Error;
+      end if;
+      return Uns32 (Val);
+   end To_Index;
 
    procedure Write_Bounds (Mem : Memory_Ptr; Bnd : Bound_Type; Btype : Node)
    is
@@ -220,9 +238,11 @@ package body Simul.Vhdl_Compile is
                          Def : Node;
                          Typ : Type_Acc) is
    begin
-      Write_Length (Mem, Uns32 (Typ.Sz));
+      Write_Length (Mem, To_Index (Uns64 (Typ.Sz), Def));
       if Get_Has_Signal_Flag (Def) then
-         Write_Length (Mem + 4, Typ.W * Uns32 (Vhdl_Simul.Sig_Size));
+         Write_Length
+           (Mem + 4,
+            To_Index (Uns64 (Typ.W) * Uns64 (Vhdl_Simul.Sig_Size), Def));
       end if;
    end Write_Size;
 
@@ -393,14 +413,18 @@ package body Simul.Vhdl_Compile is
                --  _OFF
                El_Mem := Add_Field_Offset
                  (Mem, El_Info.Field_Node (Mode_Value));
-               Write_Length (El_Mem, Uns32 (Typ.Rec.E (Idx).Offs.Mem_Off));
+               Write_Length
+                 (El_Mem,
+                  To_Index (Uns64 (Typ.Rec.E (Idx).Offs.Mem_Off), Def));
 
                --  _SIGOFF
                if Get_Has_Signal_Flag (Def) then
                   El_Mem := Add_Field_Offset
                     (Mem, El_Info.Field_Node (Mode_Signal));
-                  Write_Length (El_Mem, (Typ.Rec.E (Idx).Offs.Net_Off
-                                           * Uns32 (Vhdl_Simul.Sig_Size)));
+                  Write_Length
+                    (El_Mem,
+                     To_Index (Uns64 (Typ.Rec.E (Idx).Offs.Net_Off)
+                                 * Uns64 (Vhdl_Simul.Sig_Size), Def));
                end if;
 
                --  _BND (layout)

--- a/src/vhdl/libghdl/libghdl_synth.adb
+++ b/src/vhdl/libghdl/libghdl_synth.adb
@@ -23,6 +23,7 @@ with Name_Table;
 with Types_Utils;
 
 with Bug;
+with Simple_IO;
 
 with Netlists.Errors;
 with Netlists.Disp_Common;
@@ -126,6 +127,11 @@ package body Libghdl_Synth is
    exception
       when Option_Error
         | Errorout.Compilation_Error =>
+         return No_Module;
+      when Storage_Error =>
+         Simple_IO.Put_Line_Err
+           ("ghdl:error: out of memory -- the design requires more "
+            & "memory than is available on this machine");
          return No_Module;
       when E: others =>
          --  Avoid possible issues with exceptions...

--- a/src/vhdl/translate/ortho_front.adb
+++ b/src/vhdl/translate/ortho_front.adb
@@ -37,6 +37,7 @@ with Errorout; use Errorout;
 with Errorout.Console;
 with Vhdl.Errors; use Vhdl.Errors;
 with Bug;
+with Simple_IO;
 with Options; use Options;
 
 package body Ortho_Front is
@@ -692,6 +693,11 @@ package body Ortho_Front is
          end if;
          return False;
       when Option_Error =>
+         return False;
+      when Storage_Error =>
+         Simple_IO.Put_Line_Err
+           ("ghdl:error: out of memory -- the design requires more "
+            & "memory than is available on this machine");
          return False;
       when E: others =>
          Bug.Disp_Bug_Box (E);

--- a/src/vhdl/translate/trans-chap3.adb
+++ b/src/vhdl/translate/trans-chap3.adb
@@ -1206,10 +1206,9 @@ package body Trans.Chap3 is
          El_Size := Get_Subtype_Size (El_Type, Mnode_Null, Kind);
       end if;
 
-      --  Compute size.
-      Size := New_Dyadic_Op
-        (ON_Mul_Ov,
-         El_Size,
+      --  Compute size (reported if it reaches 4 GB, see #2052).
+      Size := Gen_Index_Mul
+        (El_Size,
          Get_Bounds_Length (Layout_To_Bounds (Layout), Def));
 
       --  Set size.
@@ -1666,8 +1665,7 @@ package body Trans.Chap3 is
                end if;
 
                New_Assign_Stmt (New_Obj (Off_Var),
-                                New_Dyadic_Op (ON_Add_Ov,
-                                               New_Obj_Value (Off_Var),
+                                Gen_Index_Add (New_Obj_Value (Off_Var),
                                                El_Size));
             end if;
          end;
@@ -2994,7 +2992,7 @@ package body Trans.Chap3 is
          if Dim = 1 then
             Res := Dim_Length;
          else
-            Res := New_Dyadic_Op (ON_Mul_Ov, Res, Dim_Length);
+            Res := Gen_Index_Mul (Res, Dim_Length);
          end if;
       end loop;
       return Res;
@@ -3373,8 +3371,8 @@ package body Trans.Chap3 is
                   Bounds1 := Bounds;
                   El_Sz := Get_Subtype_Size (El_Type, Mnode_Null, Kind);
                end if;
-               return New_Dyadic_Op
-                 (ON_Mul_Ov, Chap3.Get_Bounds_Length (Bounds1, Atype), El_Sz);
+               return Gen_Index_Mul
+                 (Chap3.Get_Bounds_Length (Bounds1, Atype), El_Sz);
             end;
          when Type_Mode_Unbounded_Record =>
             return New_Value (Sizes_To_Size (Layout_To_Sizes (Bounds), Kind));

--- a/src/vhdl/translate/trans-chap9.adb
+++ b/src/vhdl/translate/trans-chap9.adb
@@ -2816,8 +2816,7 @@ package body Trans.Chap9 is
         (New_Obj (Var_Inst),
          Gen_Alloc
            (Alloc_System,
-            New_Dyadic_Op (ON_Mul_Ov,
-                           New_Value_Selected_Acc_Value
+            Gen_Index_Mul (New_Value_Selected_Acc_Value
                              (New_Obj (Range_Ptr),
                               Iter_Type_Info.B.Range_Length),
                            New_Lit (Get_Scope_Size (Info.Block_Scope))),

--- a/src/vhdl/translate/trans-helpers2.adb
+++ b/src/vhdl/translate/trans-helpers2.adb
@@ -123,6 +123,26 @@ package body Trans.Helpers2 is
       New_Procedure_Call (Constr);
    end Gen_Memcpy;
 
+   function Gen_Index_Mul (L : O_Enode; R : O_Enode) return O_Enode
+   is
+      Constr : O_Assoc_List;
+   begin
+      Start_Association (Constr, Ghdl_Index_Mul);
+      New_Association (Constr, L);
+      New_Association (Constr, R);
+      return New_Function_Call (Constr);
+   end Gen_Index_Mul;
+
+   function Gen_Index_Add (L : O_Enode; R : O_Enode) return O_Enode
+   is
+      Constr : O_Assoc_List;
+   begin
+      Start_Association (Constr, Ghdl_Index_Add);
+      New_Association (Constr, L);
+      New_Association (Constr, R);
+      return New_Function_Call (Constr);
+   end Gen_Index_Add;
+
    function Gen_Alloc
      (Kind : Allocation_Kind; Size : O_Enode; Ptype : O_Tnode) return O_Enode
    is

--- a/src/vhdl/translate/trans-helpers2.ads
+++ b/src/vhdl/translate/trans-helpers2.ads
@@ -33,6 +33,12 @@ package Trans.Helpers2 is
 
    procedure Gen_Memcpy (Dest : O_Enode; Src : O_Enode; Length : O_Enode);
 
+   --  Size arithmetic that reports an overflow instead of wrapping: sizes
+   --  are held on 32 bits, and a wrapped size makes elaboration allocate a
+   --  block far too small and then write past it.  See #2052.
+   function Gen_Index_Mul (L : O_Enode; R : O_Enode) return O_Enode;
+   function Gen_Index_Add (L : O_Enode; R : O_Enode) return O_Enode;
+
    --  Allocate SIZE bytes aligned on the biggest alignment and return a
    --  pointer of type PTYPE.
    function Gen_Alloc

--- a/src/vhdl/translate/trans_decls.ads
+++ b/src/vhdl/translate/trans_decls.ads
@@ -186,6 +186,8 @@ package Trans_Decls is
    Ghdl_Deref : O_Dnode;
    Ghdl_Malloc : O_Dnode;
    Ghdl_Malloc0 : O_Dnode;
+   Ghdl_Index_Mul : O_Dnode;
+   Ghdl_Index_Add : O_Dnode;
    Ghdl_Free_Mem : O_Dnode;
    Ghdl_Real_Exp : O_Dnode;
    Ghdl_I32_Exp : O_Dnode;

--- a/src/vhdl/translate/trans_link.adb
+++ b/src/vhdl/translate/trans_link.adb
@@ -65,6 +65,10 @@ package body Trans_Link is
            Grt.Lib.Ghdl_Malloc'Address);
       Def (Trans_Decls.Ghdl_Malloc0,
            Grt.Lib.Ghdl_Malloc0'Address);
+      Def (Trans_Decls.Ghdl_Index_Mul,
+           Grt.Lib.Ghdl_Index_Mul'Address);
+      Def (Trans_Decls.Ghdl_Index_Add,
+           Grt.Lib.Ghdl_Index_Add'Address);
       Def (Trans_Decls.Ghdl_Free_Mem,
            Grt.Lib.Ghdl_Free_Mem'Address);
 

--- a/src/vhdl/translate/translation.adb
+++ b/src/vhdl/translate/translation.adb
@@ -635,6 +635,30 @@ package body Translation is
       New_Interface_Decl (Interfaces, Param, Wki_Length, Ghdl_Index_Type);
       Finish_Subprogram_Decl (Interfaces, Ghdl_Malloc0);
 
+      --  function __ghdl_index_mul (l : ghdl_index_type;
+      --                               r : ghdl_index_type)
+      --     return ghdl_index_type;
+      Start_Function_Decl
+        (Interfaces, Get_Identifier ("__ghdl_index_mul"), O_Storage_External,
+         Ghdl_Index_Type);
+      New_Interface_Decl (Interfaces, Param, Get_Identifier ("l"),
+                          Ghdl_Index_Type);
+      New_Interface_Decl (Interfaces, Param, Get_Identifier ("r"),
+                          Ghdl_Index_Type);
+      Finish_Subprogram_Decl (Interfaces, Ghdl_Index_Mul);
+
+      --  function __ghdl_index_add (l : ghdl_index_type;
+      --                               r : ghdl_index_type)
+      --     return ghdl_index_type;
+      Start_Function_Decl
+        (Interfaces, Get_Identifier ("__ghdl_index_add"), O_Storage_External,
+         Ghdl_Index_Type);
+      New_Interface_Decl (Interfaces, Param, Get_Identifier ("l"),
+                          Ghdl_Index_Type);
+      New_Interface_Decl (Interfaces, Param, Get_Identifier ("r"),
+                          Ghdl_Index_Type);
+      Finish_Subprogram_Decl (Interfaces, Ghdl_Index_Add);
+
       --  procedure __ghdl_free_mem (ptr : ghdl_ptr_type);
       Start_Procedure_Decl
         (Interfaces, Get_Identifier ("__ghdl_free_mem"), O_Storage_External);

--- a/testsuite/gna/issue1111/example.vhd
+++ b/testsuite/gna/issue1111/example.vhd
@@ -1,0 +1,12 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity example is
+  generic (
+    VEC_WIDTH : positive);
+end example;
+
+architecture behavioral of example is
+  signal vec : std_logic_vector(VEC_WIDTH-1 downto 0);
+begin
+end behavioral;

--- a/testsuite/gna/issue1111/testsuite.sh
+++ b/testsuite/gna/issue1111/testsuite.sh
@@ -1,0 +1,65 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A std_logic_vector sized from a generic near INTEGER'HIGH.  It needs
+# 2**31 signals, ie 16 GB of signal storage, so elaboration must fail -- the
+# point is that it fails with a clean diagnostic instead of GHDL's
+# internal-error box.  Which diagnostic depends on what gives way first: the
+# backends that describe the object report that its size does not fit on 32
+# bits, the others run out of memory.  Both are clean errors.
+#
+# Elaboration runs under a virtual-memory cap so that the failure is quick
+# and cannot disturb the machine.  Where the cap goes depends on the
+# backend: the JIT backends (mcode, llvm-jit) allocate the design in
+# "ghdl -e" itself, while gcc and llvm only allocate when the elaborated
+# executable runs -- and their "ghdl -e" runs the code generator and the
+# linker, whose own memory use depends on the toolchain of the machine.
+# Capping those made this test pass on some CI runners and fail on others,
+# so they are kept out of the cap.
+#
+# Shells that cannot limit virtual memory (eg macOS) skip the check rather
+# than run unbounded.
+export GHDL_STD_FLAGS="--std=08"
+
+analyze example.vhd
+
+W=-gVEC_WIDTH=2147483647
+
+if ! ( ulimit -v 2000000 ) 2>/dev/null; then
+  echo "skipped: this shell cannot limit virtual memory (ulimit -v)"
+  clean
+  echo "Test successful"
+  exit 0
+fi
+
+if "$GHDL" --version | grep -q "JIT code generator"; then
+  out=$( ( ulimit -v 2000000; elab_simulate example $W 2>&1 ) ) || true
+else
+  elab example
+  out=$( ( ulimit -v 2000000; simulate example $W 2>&1 ) ) || true
+fi
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: reported an internal error instead of running out of memory"
+  exit 1
+fi
+
+if ! echo "$out" | grep -qE "out of memory|too large"; then
+  case "$out" in
+    *error*|*Error*)
+      echo "FAIL: expected the size-overflow or out-of-memory diagnostic"
+      exit 1
+      ;;
+    *)
+      #  Nothing failed at all: the shell accepted "ulimit -v" but the
+      #  limit is not enforced, so the design was never short of memory.
+      echo "skipped: the virtual-memory cap is not enforced here"
+      ;;
+  esac
+fi
+
+clean
+
+echo "Test successful"

--- a/testsuite/gna/issue2052/ovf.vhd
+++ b/testsuite/gna/issue2052/ovf.vhd
@@ -1,0 +1,18 @@
+--  The same 32-bit size overflow as repro.vhd, with nothing to allocate:
+--  "big" is 2**30 integers, ie 2**32 bytes, and no object of that subtype
+--  is declared.  Only its layout is computed, so the design needs no memory
+--  at all and every backend reaches the diagnostic in a few milliseconds.
+entity ovf is
+  generic (n : natural := 2**30);
+end ovf;
+
+architecture a of ovf is
+  type row is array (natural range <>) of integer;
+  subtype big is row (0 to n - 1);
+begin
+  process
+  begin
+    report "elaborated";
+    wait;
+  end process;
+end a;

--- a/testsuite/gna/issue2052/repro.vhd
+++ b/testsuite/gna/issue2052/repro.vhd
@@ -1,0 +1,57 @@
+library ieee;
+use ieee.numeric_std.all;
+use ieee.std_logic_1164.all;
+
+entity repro is
+  generic(
+    width : integer := 8
+         );
+end;
+architecture a of repro is
+  subtype byte is std_logic_vector(width - 1 downto 0);
+  type ram is array(integer range <>) of byte;
+  type bank is array(integer range<>) of ram;
+
+  --  2**16 x 2**16 bytes, ie 2**35 bytes of signal value: far more than the
+  --  4 GB a size can express.  The size computation used to wrap, so
+  --  __ghdl_malloc0 was asked for 0 bytes and elaboration wrote past the
+  --  block it got back; the overflow is now reported.  See issue2052.
+  signal mem : bank
+  (2**16-1 downto 0)
+  (2**16-1 downto 0);
+  signal index : unsigned(32-1 downto 0) := (others => '0');
+
+  function read(memx : bank; indexx : unsigned) return byte is
+  begin
+    return memx
+    (to_integer(indexx(31 downto 16)))
+    (to_integer(indexx(15 downto 0)));
+  end function;
+
+  procedure write(signal memx : inout bank; indexx : unsigned; value : byte) is
+  begin
+    memx
+    (to_integer(indexx(31 downto 16)))
+    (to_integer(indexx(15 downto 0)))
+    <= value;
+  end procedure;
+
+  signal clk,rst : std_logic := '1';
+  constant clk_period : time := 10 ns;
+begin
+
+  clk <= not clk after clk_period/2;
+  rst <= '1', '0' after clk_period*5;
+
+  process (all) is
+  begin
+    if rising_edge(clk) then
+      index <= index + "1";
+      write(mem, index, std_logic_vector(index(byte'range)));
+      if index > "0" then
+        report "Wrote to memory the value " & to_hstring(read(mem, index - "1"));
+      end if;
+    end if;
+  end process;
+
+end;

--- a/testsuite/gna/issue2052/testsuite.sh
+++ b/testsuite/gna/issue2052/testsuite.sh
@@ -1,0 +1,92 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A nested array signal of 2**16 x 2**16 bytes: 2**35 bytes, far more than
+# the 4 GB a size can express.  Sizes are computed on 32 bits, so the
+# computation wrapped and __ghdl_malloc0 was asked for 0 bytes; elaboration
+# got a valid empty block and wrote past it.  Valgrind called it "Invalid
+# write of size 1 [...] 0 bytes after a block of size 0", and what happened
+# next was up to the C library -- an unrelated allocation failing later, or
+# "malloc(): unaligned tcache chunk detected".  Either the overflow is now
+# reported, or the design runs out of memory first; both are clean errors,
+# and neither is an internal error box.
+#
+# Elaboration runs under a virtual-memory cap so that the failure is quick
+# and cannot disturb the machine.  Where the cap goes depends on the
+# backend: the JIT backends (mcode, llvm-jit) allocate the design in
+# "ghdl -e" itself, while gcc and llvm only allocate when the elaborated
+# executable runs -- and their "ghdl -e" runs the code generator and the
+# linker, whose own memory use depends on the toolchain of the machine.
+# Capping those made this test pass on some CI runners and fail on others,
+# so they are kept out of the cap.
+#
+# Shells that cannot limit virtual memory (eg macOS) skip the check rather
+# than run unbounded.
+export GHDL_STD_FLAGS="--std=08"
+
+analyze repro.vhd
+
+if ! ( ulimit -v 2000000 ) 2>/dev/null; then
+  echo "skipped: this shell cannot limit virtual memory (ulimit -v)"
+  clean
+  echo "Test successful"
+  exit 0
+fi
+
+if "$GHDL" --version | grep -q "JIT code generator"; then
+  out=$( ( ulimit -v 2000000; elab_simulate repro 2>&1 ) ) || true
+else
+  elab repro
+  out=$( ( ulimit -v 2000000; simulate repro 2>&1 ) ) || true
+fi
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: reported an internal error instead of running out of memory"
+  exit 1
+fi
+
+if ! echo "$out" | grep -qE "out of memory|too large"; then
+  case "$out" in
+    *error*|*Error*)
+      echo "FAIL: expected the size-overflow or out-of-memory diagnostic"
+      exit 1
+      ;;
+    *)
+      #  Nothing failed at all: the shell accepted "ulimit -v" but the
+      #  limit is not enforced, so the design was never short of memory.
+      echo "skipped: the virtual-memory cap is not enforced here"
+      ;;
+  esac
+fi
+
+#  The same overflow with nothing to allocate: only the layout of an
+#  oversized subtype is computed, so this needs no memory, no virtual-memory
+#  cap and nothing to skip.  Every backend must report the size, and the
+#  error must be reported rather than raised: the JIT backends compute the
+#  layout while elaborating (simul-vhdl_compile.adb) and the others in the
+#  generated code (__ghdl_index_mul).
+analyze ovf.vhd
+
+if "$GHDL" --version | grep -q "JIT code generator"; then
+  out=$( elab_simulate ovf 2>&1 ) || true
+else
+  elab ovf
+  out=$( simulate ovf 2>&1 ) || true
+fi
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: reported an internal error instead of the oversized design"
+  exit 1
+fi
+
+if ! echo "$out" | grep -q "too large"; then
+  echo "FAIL: expected the size-overflow diagnostic"
+  exit 1
+fi
+
+clean
+
+echo "Test successful"

--- a/testsuite/gna/issue812/cosim_test.vhd
+++ b/testsuite/gna/issue812/cosim_test.vhd
@@ -1,0 +1,16 @@
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.numeric_std.all;
+use IEEE.std_logic_unsigned.all;
+
+entity cosim_test is
+end cosim_test;
+
+architecture rtl of cosim_test is
+
+type ram_type is array(0 to (2**28)-1) of std_logic_vector(127 downto 0);
+signal ram : ram_type := (others => (others => '0'));
+
+begin
+
+end rtl;

--- a/testsuite/gna/issue812/testsuite.sh
+++ b/testsuite/gna/issue812/testsuite.sh
@@ -1,0 +1,74 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A 2**28 x 128-bit array signal: about 34e9 scalar signals, far more than
+# any machine can hold (see the issue thread).  Elaboration must fail; the
+# point is how -- a failed allocation reported as such, instead of GHDL's
+# internal-error box.
+#
+# The gcc and llvm backends never get that far: the initial value of the
+# signal is built in a stack temporary, so the generated DECL_ELAB has a
+# 32 GB stack frame (llvm even warns about it while analysing) and the
+# executable dies on stack overflow before allocating anything.  That is a
+# different limitation from the one fixed here, so on those backends this
+# test only checks that analysis still succeeds.  See issue812.
+#
+# Elaboration runs under a virtual-memory cap so that the failure is quick
+# and cannot disturb the machine.  Where the cap goes depends on the
+# backend: the JIT backends (mcode, llvm-jit) allocate the design in
+# "ghdl -e" itself, while gcc and llvm only allocate when the elaborated
+# executable runs -- and their "ghdl -e" runs the code generator and the
+# linker, whose own memory use depends on the toolchain of the machine.
+# Capping those made this test pass on some CI runners and fail on others,
+# so they are kept out of the cap.
+#
+# Shells that cannot limit virtual memory (eg macOS) skip the check rather
+# than run unbounded.
+export GHDL_STD_FLAGS="--std=08 -fsynopsys"
+
+analyze cosim_test.vhd
+
+if ! "$GHDL" --version | grep -q "JIT code generator"; then
+  clean
+  echo "Test successful"
+  exit 0
+fi
+
+if ! ( ulimit -v 2000000 ) 2>/dev/null; then
+  echo "skipped: this shell cannot limit virtual memory (ulimit -v)"
+  clean
+  echo "Test successful"
+  exit 0
+fi
+
+if "$GHDL" --version | grep -q "JIT code generator"; then
+  out=$( ( ulimit -v 2000000; elab_simulate cosim_test 2>&1 ) ) || true
+else
+  elab cosim_test
+  out=$( ( ulimit -v 2000000; simulate cosim_test 2>&1 ) ) || true
+fi
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: reported an internal error instead of running out of memory"
+  exit 1
+fi
+
+if ! echo "$out" | grep -qE "out of memory|too large"; then
+  case "$out" in
+    *error*|*Error*)
+      echo "FAIL: expected the size-overflow or out-of-memory diagnostic"
+      exit 1
+      ;;
+    *)
+      #  Nothing failed at all: the shell accepted "ulimit -v" but the
+      #  limit is not enforced, so the design was never short of memory.
+      echo "skipped: the virtual-memory cap is not enforced here"
+      ;;
+  esac
+fi
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
A design that needs more memory than the machine has did not say so. With mcode, Storage_Error escaped into the "GHDL Bug occurred" box; with gcc and llvm, the simulation stored through the null pointer a failed allocation returned and died on SIGSEGV, which grt reported as "NULL access dereferenced" -- blaming the user's design.

Add Grt.Errors.Out_Of_Memory (exported as __ghdl_out_of_memory) and call it from the grt allocation entry points: __gnat_malloc and __gnat_realloc, which every "new" in grt goes through, and __ghdl_malloc / __ghdl_malloc0, which the generated code calls.  Catch Storage_Error in the driver, the synthesis entry point and the translation front end for the mcode side.

Fixes part of #812, #1111 and #2052.