### PR TITLE
trans-chap7: report PSL builtins as unsupported in simulation

### DIFF
--- a/src/grt/grt-lib.adb
+++ b/src/grt/grt-lib.adb
@@ -178,6 +178,8 @@ package body Grt.Lib is
             Diag_C ("block already configured");
          when 3 =>
             Diag_C ("bad configuration");
+         when 7 =>
+            Diag_C ("unsupported construct");
          when others =>
             Diag_C ("unknown error code ");
             Diag_C (Integer (Code));

--- a/src/vhdl/translate/trans-chap6.ads
+++ b/src/vhdl/translate/trans-chap6.ads
@@ -62,6 +62,7 @@ package Trans.Chap6 is
    Prg_Err_No_Choice        : constant Natural := 4;
    Prg_Err_Bad_Choice       : constant Natural := 5;
    Prg_Err_Unreach_State    : constant Natural := 6;
+   Prg_Err_Unsupported      : constant Natural := 7;
    procedure Gen_Program_Error (Loc : Iir; Code : Natural);
 
    --  Generate code to emit a failure if COND is TRUE, indicating an

--- a/src/vhdl/translate/trans-chap7.adb
+++ b/src/vhdl/translate/trans-chap7.adb
@@ -5348,6 +5348,21 @@ package body Trans.Chap7 is
                return New_Value (Get_Var (Info.Psl_Finish_Count_Var));
             end;
 
+         when Iir_Kinds_Psl_Builtin =>
+            --  PSL builtin functions (prev, stable, rose, fell, onehot,
+            --  onehot0) are handled for synthesis (src/synth) but are
+            --  not implemented in this translator, which is used for
+            --  ordinary simulation.  Report it instead of ending in
+            --  Error_Kind's internal error, and make the generated code
+            --  stop if it is ever reached: with the mcode backend the
+            --  translation happens while the simulation is already
+            --  running, so without this the assertion would silently be
+            --  evaluated on a made-up value.  See #1530.
+            Error_Msg_Elab
+              (Expr, "PSL builtin function not supported in simulation");
+            Chap6.Gen_Program_Error (Expr, Chap6.Prg_Err_Unsupported);
+            Res := New_Lit (Std_Boolean_False_Node);
+
          when others =>
             Error_Kind ("translate_expression", Expr);
       end case;

--- a/testsuite/gna/issue1530/t.vhd
+++ b/testsuite/gna/issue1530/t.vhd
@@ -1,0 +1,23 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity t is
+end entity;
+
+architecture a of t is
+  signal clk : std_logic := '0';
+  signal x   : std_logic := '0';
+begin
+  clk <= not clk after 5 ns;
+
+  process
+  begin
+    wait for 12 ns;
+    x <= '1';
+    wait for 100 ns;
+    std.env.finish;
+  end process;
+
+  default clock is rising_edge(clk);
+  A1 : assert always stable(x) report "x changed";
+end architecture;

--- a/testsuite/gna/issue1530/testsuite.sh
+++ b/testsuite/gna/issue1530/testsuite.sh
@@ -1,0 +1,51 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# The PSL builtin functions -- stable(), and likewise prev/rose/fell/
+# onehot/onehot0 -- are implemented for --synth but not in the translator
+# used for ordinary simulation, so a design using one of them ended in
+# "translate_expression: cannot handle IIR_KIND_PSL_STABLE" and an
+# internal error instead of a diagnostic.  This is a reduced equivalent
+# of the original, much larger report.
+#
+# The diagnostic now appears, but not at the same point on every backend:
+# gcc and llvm translate while analysing, so it comes out of "ghdl -a" and
+# compilation stops there; the JIT backends (mcode and llvm-jit) translate
+# while the simulation is already being elaborated, so the message appears
+# then and the generated code traps rather than carry on evaluating the
+# assertion on a made-up value.  Either way the point is the same -- a
+# clean diagnostic and no internal error.  See issue1530.
+export GHDL_STD_FLAGS="--std=08 -fpsl"
+
+if "$GHDL" --version | grep -q "JIT code generator"; then
+  analyze t.vhd
+  if out=$(elab_simulate t 2>&1); then
+    echo "$out"
+    echo "UNEXPECTED PASS: PSL builtins now translate for simulation --"
+    echo "update this test to assert the simulation result instead."
+    exit 1
+  fi
+  echo "$out"
+  if ! echo "$out" | grep -q "unsupported construct"; then
+    echo "FAIL: expected the run-time trap on the unsupported construct"
+    exit 1
+  fi
+else
+  out=$(analyze_failure t.vhd 2>&1)
+  echo "$out"
+fi
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: crashed instead of reporting a clean error"
+  exit 1
+fi
+
+if ! echo "$out" | grep -q "PSL builtin function not supported"; then
+  echo "FAIL: expected the clean not-supported diagnostic"
+  exit 1
+fi
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Using a PSL builtin function -- `stable()`, `prev()`, `rose()`, `fell()`, `onehot()`, `onehot0()` -- in a simulated design ended in an internal error:

```
translate_expression: cannot handle IIR_KIND_PSL_STABLE
```

They are implemented for `--synth` but not in `src/vhdl/translate`, so `Translate_Expression` fell through to `Error_Kind`.

Report them instead, and emit a run-time program error before yielding false for the expression.  The trap matters: with mcode the translation happens while the simulation is already being elaborated and the error alone does not stop it, so without it the assertion would go on being evaluated on the made-up value and report a failure at every clock edge.

Fixes part of #1530.
