### PR TITLE
netlists-memories: reject an unclocked write port as a RAM write port

### DIFF
--- a/src/synth/netlists-memories.adb
+++ b/src/synth/netlists-memories.adb
@@ -1797,6 +1797,15 @@ package body Netlists.Memories is
       Inst : Instance;
       N : Net;
       Inp : Input;
+
+      --  Whether the chain from INSERT to the signal goes through a
+      --  register (Dff/Idff/Mdff/Midff).  A write port with no register
+      --  at all in its chain has no clock to synthesize a write-port gate
+      --  with (there is no asynchronous/unclocked write-port gate kind),
+      --  and would otherwise imply an invalid combinational feedback loop
+      --  (elements not written would have to combinationally hold their
+      --  previous value).  See #1722.
+      Has_Clock : Boolean := False;
    begin
       --  For each gate of the chain, starting from LAST and going forward
       --  until the signal.
@@ -1817,6 +1826,10 @@ package body Netlists.Memories is
                      --  There must be only one such gate per stage.
                      return No_Instance;
                   end if;
+                  if Get_Id (Inst) = Id_Dff or else Get_Id (Inst) = Id_Idff
+                  then
+                     Has_Clock := True;
+                  end if;
                   N := Get_Output (Inst, 0);
                when Id_Mdff
                  | Id_Midff =>
@@ -1826,6 +1839,7 @@ package body Netlists.Memories is
                         --  There must be only one such gate per stage.
                         return No_Instance;
                      end if;
+                     Has_Clock := True;
                      N := Get_Output (Inst, 0);
                   else
                      --  Ignore.
@@ -1835,6 +1849,17 @@ package body Netlists.Memories is
                   null;
                when Id_Isignal
                   | Id_Signal =>
+                  if not Has_Clock then
+                     --  Unclocked write port: there is no netlist gate
+                     --  kind to represent an asynchronous memory write,
+                     --  and (as this would be a combinational read of a
+                     --  signal's own previous value for the elements not
+                     --  written) it isn't valid combinational hardware
+                     --  either.  Reject this signal as a RAM candidate;
+                     --  it is reported as an ordinary unhandled signal
+                     --  assignment (combinational loop) instead.
+                     return No_Instance;
+                  end if;
                   return Inst;
                when others =>
                   return No_Instance;

--- a/testsuite/synth/issue1722/fifo.vhd
+++ b/testsuite/synth/issue1722/fifo.vhd
@@ -1,0 +1,79 @@
+library ieee ;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity fifo is
+generic(
+    DEPTH    : integer := 256;
+    WDTH     : integer := 16;
+    TRESHOLD : integer := 32
+);
+port(
+    reset   : in std_logic;
+    clk     : in std_logic;
+
+    data_in    : in std_logic_vector(WDTH-1 downto 0);
+    data_out   : out std_logic_vector(WDTH-1 downto 0);
+    empty      : out std_logic;
+    full       : out std_logic;
+    half_full  : out std_logic;
+    wr         : in std_logic;
+    rd         : in std_logic
+);
+end entity;
+
+architecture ar_fifo of fifo is
+    type rcells_memory_t is array(0 to DEPTH-1) of std_logic_vector(WDTH-1 downto 0);
+    signal rcells_memory : rcells_memory_t;
+    signal write_ptr  : integer range 0 to DEPTH-1 :=0;
+    signal read_ptr   : integer range 0 to DEPTH-1 :=0;
+    signal data_count : integer :=0;
+    signal full_sig   : std_logic :='0';
+    signal empty_sig   : std_logic :='0';
+begin
+
+    empty <= empty_sig;
+    full  <= full_sig;
+    half_full  <= '1' when data_count >= TRESHOLD else '0';
+    empty_sig <= '1' when data_count = 0 else '0';
+    full_sig <= '1' when data_count = DEPTH-1 else '0';
+
+    process(clk, reset)
+    begin
+        if reset = '0' then
+            data_count <= 0;
+        elsif clk'event and clk = '1' then
+            if wr = '1' and rd = '0'  and data_count /= DEPTH then
+                data_count <= data_count + 1;
+            elsif rd = '1' and wr = '0' and data_count /= 0 then
+                data_count <= data_count - 1;
+            end if;
+        end if;
+    end process;
+
+
+    process(clk, reset)
+    begin
+        if reset = '0' then
+            write_ptr <= 0;
+        elsif clk'event and clk = '1' then
+            if wr = '1' and full_sig = '0' then
+                write_ptr <= (write_ptr + 1) mod (DEPTH-1);
+            end if;
+        end if;
+    end process;
+    rcells_memory(write_ptr) <= data_in;
+
+    process(clk, reset)
+    begin
+        if reset = '0' then
+            read_ptr <= 0;
+        elsif clk'event and clk = '1' then
+            if rd = '1' and empty_sig = '0' then
+                read_ptr <= (read_ptr + 1) mod (DEPTH-1);
+            end if;
+        end if;
+    end process;
+    data_out <= rcells_memory(read_ptr);
+
+end architecture ar_fifo;

--- a/testsuite/synth/issue1722/testsuite.sh
+++ b/testsuite/synth/issue1722/testsuite.sh
@@ -1,0 +1,38 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# A memory array written by a plain concurrent (unclocked) signal
+# assignment -- rcells_memory(write_ptr) <= data_in; -- was accepted as a
+# RAM write port and routed through the synchronous Id_Mem_Wr_Sync gate
+# with no clock connected, which crashed --synth's netlist display with
+# ASSERTION_ERROR at netlists.adb:886.
+#
+# An unclocked write port is no longer accepted as a RAM write port, so
+# the array is synthesized as ordinary combinational dyn_insert/extract
+# logic instead: no crash, and no "found RAM" note either, since the
+# design does not describe a RAM.  See issue1722.
+export GHDL_STD_FLAGS="--std=08"
+
+synth fifo.vhd -e fifo > syn_fifo.vhdl 2>&1
+
+if grep -q "Id_Mem_Wr_Sync\|ASSERTION_ERROR\|GHDL Bug occurred" syn_fifo.vhdl; then
+  echo "FAIL: unexpected crash/error output"
+  cat syn_fifo.vhdl
+  exit 1
+fi
+
+if grep -q "found RAM" syn_fifo.vhdl; then
+  echo "FAIL: the unclocked write is still inferred as a RAM"
+  exit 1
+fi
+
+if ! grep -q "entity fifo is" syn_fifo.vhdl; then
+  echo "FAIL: no netlist was produced"
+  cat syn_fifo.vhdl
+  exit 1
+fi
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Synthesizing a memory array written by a plain concurrent -- unclocked -- signal assignment crashed:

  raised ADA.ASSERTIONS.ASSERTION_ERROR : netlists.adb:886

Validate_RAM_Simple walks the chain from the write gate to the signal and steps over Dff/Idff/Mdff/Midff gates, but never requires one to be there. A chain with no register at all still validated, so Create_RAM_Ports built an Id_Mem_Wr_Sync gate whose clock input stayed No_Net, and Disp_Memory then called Get_Net_Parent on it.

There is no asynchronous write-port gate to use instead, and this pattern is not memory-shaped hardware anyway: with no register in the chain the elements the write does not select would have to combinationally hold their previous value.  So reject it, and let it be synthesized as the ordinary dyn_insert/dyn_extract logic it describes.

Fixes #1722.