### PR TITLE
vhdl-sem_assocs: direction of a formal sliced in several parts

### DIFF
--- a/src/simul/simul-vhdl_elab.adb
+++ b/src/simul/simul-vhdl_elab.adb
@@ -888,12 +888,22 @@ package body Simul.Vhdl_Elab is
          Formal := Inter;
       end if;
       Synth_Object_Name (Port_Inst, Formal, Formal_Base, Typ, Off);
+      if Formal_Base = No_Valtyp then
+         --  The formal is in error (eg: a slice whose direction doesn't match
+         --  the one of the port).
+         return;
+      end if;
       Typ := Unshare (Typ, Global_Pool'Access);
       Formal_Sig := Formal_Base.Val.S;
       Formal_Ep := (Formal_Sig, Off, Typ);
 
       Synth_Object_Name
         (Assoc_Inst, Get_Actual (Assoc), Actual_Base, Typ, Off);
+      if Actual_Base = No_Valtyp then
+         --  The actual is in error (eg: a slice whose direction doesn't match
+         --  the one of the port).
+         return;
+      end if;
       Typ := Unshare (Typ, Global_Pool'Access);
       Actual_Sig := Actual_Base.Val.S;
       Actual_Ep := (Actual_Sig, Off, Typ);
@@ -966,6 +976,11 @@ package body Simul.Vhdl_Elab is
          Formal := Inter;
       end if;
       Formal_Ep := Compute_Sub_Signal (Port_Inst, Formal);
+      if Formal_Ep.Base = No_Signal_Index then
+         --  The formal is in error (eg: a slice whose direction doesn't match
+         --  the one of the port).
+         return;
+      end if;
 
       Actual_Ep := (No_Signal_Index, No_Value_Offsets, null);
 

--- a/src/synth/synth-vhdl_insts.adb
+++ b/src/synth/synth-vhdl_insts.adb
@@ -1075,6 +1075,13 @@ package body Synth.Vhdl_Insts is
          Synth_Individual_Formal
            (Syn_Inst, Inter_Typ, Get_Formal (Iassoc), Typ, Offs);
 
+         if Typ = null then
+            --  The formal is in error (eg: a slice whose direction doesn't
+            --  match the one of the port).
+            Value_Offset_Tables.Free (Els);
+            return No_Net;
+         end if;
+
          --   2. synth expression
          V := Synth_Single_Input_Assoc
            (Syn_Inst, Typ, Syn_Inst, Get_Actual (Iassoc), Iassoc);
@@ -1175,6 +1182,13 @@ package body Synth.Vhdl_Insts is
          --   1. compute type and offset
          Synth_Individual_Formal
            (Syn_Inst, Inter_Typ, Get_Formal (Iassoc), Typ, Offs);
+
+         if Typ = null then
+            --  The formal is in error (eg: a slice whose direction doesn't
+            --  match the one of the port).
+            Release_Expr_Pool (Marker);
+            exit;
+         end if;
 
          --   2. Extract the value.
          O := Build_Extract (Get_Build (Syn_Inst), Port, Offs.Net_Off, Typ.W);

--- a/src/vhdl/vhdl-sem_assocs.adb
+++ b/src/vhdl/vhdl-sem_assocs.adb
@@ -1159,7 +1159,6 @@ package body Vhdl.Sem_Assocs is
          declare
             Index_Constraint : Iir;
             Index_Subtype_Constraint : Iir;
-            Indiv_Assoc : Iir;
             Dir : Direction_Type;
          begin
             --  Create an index subtype.
@@ -1183,21 +1182,7 @@ package body Vhdl.Sem_Assocs is
             Set_Range_Constraint (Actual_Index, Index_Subtype_Constraint);
             Set_Type_Staticness (Actual_Index, Locally);
 
-            --  LRM08 5.3.2.2 Index constraints and discrete ranges
-            --  e) 2) If the subtype index range is undefed, and the interface
-            --  object or subelement [...] is associated by a single
-            --  association element in which the formal designator is a slice
-            --  name, then the direction of the index range of the object is
-            --  that of the corresponding index subtype of the interface
-            --  object.
-            Indiv_Assoc := Get_Individual_Association_Chain (Assoc);
-            if Get_Chain (Indiv_Assoc) = Null_Iir
-              and then Get_Kind (Indiv_Assoc) = Iir_Kind_Choice_By_Range
-            then
-               Dir := Get_Direction (Get_Choice_Range (Indiv_Assoc));
-            else
-               Dir := Get_Direction (Index_Constraint);
-            end if;
+            Dir := Get_Direction (Index_Constraint);
             Set_Direction (Index_Subtype_Constraint, Dir);
 
             --  For ownership purpose, the bounds must be copied otherwise

--- a/testsuite/gna/issue1687/ok.vhdl
+++ b/testsuite/gna/issue1687/ok.vhdl
@@ -1,0 +1,18 @@
+use work.pack_RC_Add_n_F.all;
+
+--  The design of ent.vhdl with the formal designator written ascending,
+--  which is the direction LRM08 5.3.2.2 e) 2) gives the unconstrained
+--  formal A.  The actual stays 'downto': an association only has to match
+--  on length.
+entity RC_Add_n_F_ok is
+    generic(n : natural := 4);
+    port(A, B : in bit_vector(n-1 downto 0); Cin: in bit; Sum: out bit_vector(n-1 downto 0); Cout: out bit);
+end RC_Add_n_F_ok;
+
+architecture Arch_RC_Add_n_F_ok of RC_Add_n_F_ok is
+    signal result: bit_vector(n downto 0);
+begin
+    result <= RC_Add_n(A(0 to 3) => A(3 downto 0), B => B, Cin => Cin);
+    Sum <= result(n-1 downto 0);
+    Cout <= result(n);
+end Arch_RC_Add_n_F_ok;

--- a/testsuite/gna/issue1687/testsuite.sh
+++ b/testsuite/gna/issue1687/testsuite.sh
@@ -2,8 +2,39 @@
 
 . ../../testenv.sh
 
+# ent.vhdl calls RC_Add_n, whose formal A is an unconstrained bit_vector,
+# with a single slice as the formal designator:
+#
+#   result <= RC_Add_n(A(3 downto 0) => A(3 downto 0), B => B, Cin => Cin);
+#
+# LRM08 5.3.2.2 e) 2) gives the index range of an interface object that is
+# associated by a slice name -- or by more than one association element --
+# the direction of the corresponding index subtype of its base type.  For
+# bit_vector that is 'natural', so the object is ascending and this
+# 'downto' slice of it is an error (LRM08 8.5).  Written 'A(0 to 3) => ...'
+# it is accepted.
+#
+# This is the same rule as in issue2765 and issue2688.  The test expected
+# a failure until a93226f23 made a single slice give its own direction to
+# the object, which is the behaviour that has been removed again.
 analyze pkg.vhdl ent.vhdl
-elab_simulate rc_add_n_f
+
+out=$(elab_simulate_failure rc_add_n_f 2>&1)
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: crashed instead of reporting the slice direction error"
+  exit 1
+fi
+
+if ! echo "$out" | grep -q "slice direction doesn't match"; then
+  echo "FAIL: expected the slice direction error"
+  exit 1
+fi
+
+# The same call with the formal designator written ascending is legal.
+analyze ok.vhdl
+elab_simulate rc_add_n_f_ok
 
 clean
 

--- a/testsuite/gna/issue2688/bad.vhdl
+++ b/testsuite/gna/issue2688/bad.vhdl
@@ -1,0 +1,37 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+--  The formal is sliced in two parts that do not have the same direction,
+--  so there is no direction to give to the unconstrained port: the slices
+--  are reported, and GHDL used to crash right after the error.
+entity bad is
+    port (
+        aclk    : in  std_logic;
+        aresetn : in  std_logic;
+        wvalid  : in  std_logic;
+        wready  : out std_logic;
+        wdata   : in  std_logic_vector(31 downto 0);
+        wstrb   : in  std_logic_vector( 3 downto 0)
+    );
+end entity bad;
+
+architecture struct of bad is
+    signal bi_wvalid, bi_wready : std_logic;
+    signal bi_wdata : std_logic_vector(31 downto 0);
+    signal bi_wstrb : std_logic_vector( 3 downto 0);
+begin
+
+    w_skid : entity work.skid_buffer_in
+    port map(
+        aclk    => aclk,
+        aresetn => aresetn,
+        r_valid => wvalid,
+        r_ready => wready,
+        r_data(35 downto 0) => wstrb & wdata,
+        c_valid => bi_wvalid,
+        c_ready => bi_wready,
+        c_data(35 downto 32) => bi_wstrb,
+        c_data(0 to 31)      => bi_wdata
+    );
+
+end architecture struct;

--- a/testsuite/gna/issue2688/inst.vhdl
+++ b/testsuite/gna/issue2688/inst.vhdl
@@ -1,0 +1,36 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity inst is
+    port (
+        aclk    : in  std_logic;
+        aresetn : in  std_logic;
+        wvalid  : in  std_logic;
+        wready  : out std_logic;
+        wdata   : in  std_logic_vector(31 downto 0);
+        wstrb   : in  std_logic_vector( 3 downto 0)
+    );
+end entity inst;
+
+architecture struct of inst is
+    constant data_bytes : natural := 4;
+    signal bi_wvalid, bi_wready   : std_logic;
+    signal bi_wdata : std_logic_vector(data_bytes*8-1 downto 0);
+    signal bi_wstrb : std_logic_vector(data_bytes-1   downto 0);
+begin
+
+    w_skid : entity work.skid_buffer_in
+    port map(
+        aclk    => aclk,
+        aresetn => aresetn,
+        r_valid => wvalid,
+        r_ready => wready,
+        r_data  => wstrb & wdata,
+        c_valid => bi_wvalid,
+        c_ready => bi_wready,
+        c_data(wdata'length+wstrb'high downto wdata'length) => bi_wstrb,
+        c_data(wdata'high downto 0) => bi_wdata
+    );
+
+end architecture struct;

--- a/testsuite/gna/issue2688/inst2.vhdl
+++ b/testsuite/gna/issue2688/inst2.vhdl
@@ -1,0 +1,36 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity inst2 is
+    port (
+        aclk    : in  std_logic;
+        aresetn : in  std_logic;
+        wvalid  : in  std_logic;
+        wready  : out std_logic;
+        wdata   : in  std_logic_vector(31 downto 0);
+        wstrb   : in  std_logic_vector( 3 downto 0)
+    );
+end entity inst2;
+
+architecture struct of inst2 is
+    constant data_bytes : natural := 4;
+    signal bi_wvalid, bi_wready   : std_logic;
+    signal bi_wdata : std_logic_vector(data_bytes*8-1 downto 0);
+    signal bi_wstrb : std_logic_vector(data_bytes-1   downto 0);
+begin
+
+    w_skid : entity work.skid_buffer_in
+    port map(
+        aclk    => aclk,
+        aresetn => aresetn,
+        r_valid => wvalid,
+        r_ready => wready,
+        r_data(wdata'length+wstrb'high downto 0)  => wstrb & wdata,
+        c_valid => bi_wvalid,
+        c_ready => bi_wready,
+        c_data(wdata'length+wstrb'high downto wdata'length) => bi_wstrb,
+        c_data(wdata'high downto 0) => bi_wdata
+    );
+
+end architecture struct;

--- a/testsuite/gna/issue2688/inst3.vhdl
+++ b/testsuite/gna/issue2688/inst3.vhdl
@@ -1,0 +1,31 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity inst3 is
+    port (
+        aclk    : in  std_logic;
+        aresetn : in  std_logic;
+        wvalid  : in  std_logic;
+        wready  : out std_logic
+    );
+end entity inst3;
+
+architecture struct of inst3 is
+    constant data_bytes : natural := 4;
+    signal bi_wvalid, bi_wready : std_logic;
+    signal bi_wblob : std_logic_vector(data_bytes*9-1 downto 0);
+    constant left  : std_logic_vector(data_bytes-1   downto 0) := (others => '1');
+    constant right : std_logic_vector(data_bytes*8-1 downto 0) := (others => '1');
+begin
+    w_skid : entity work.skid_buffer_in
+    port map(
+        aclk    => aclk,
+        aresetn => aresetn,
+        r_valid => wvalid,
+        r_ready => wready,
+        r_data  => left & right,
+        c_valid => bi_wvalid,
+        c_ready => bi_wready,
+        c_data  => bi_wblob
+    );
+end architecture struct;

--- a/testsuite/gna/issue2688/ok.vhdl
+++ b/testsuite/gna/issue2688/ok.vhdl
@@ -1,0 +1,41 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+--  The same port map as inst2, with the slices written ascending.  LRM08
+--  5.3.2.2 e) 2) gives a formal that is constrained by its association --
+--  by one slice or by several -- the direction of the index subtype of its
+--  base type, 'natural' here, hence 'to'.  So this is the shape that is
+--  legal, for the single slice of r_data as well as for the two of c_data.
+entity ok is
+    port (
+        aclk    : in  std_logic;
+        aresetn : in  std_logic;
+        wvalid  : in  std_logic;
+        wready  : out std_logic;
+        wdata   : in  std_logic_vector(31 downto 0);
+        wstrb   : in  std_logic_vector( 3 downto 0)
+    );
+end entity ok;
+
+architecture struct of ok is
+    constant data_bytes : natural := 4;
+    signal bi_wvalid, bi_wready   : std_logic;
+    signal bi_wdata : std_logic_vector(data_bytes*8-1 downto 0);
+    signal bi_wstrb : std_logic_vector(data_bytes-1   downto 0);
+begin
+
+    w_skid : entity work.skid_buffer_in
+    port map(
+        aclk    => aclk,
+        aresetn => aresetn,
+        r_valid => wvalid,
+        r_ready => wready,
+        r_data(0 to wdata'length+wstrb'high)  => wstrb & wdata,
+        c_valid => bi_wvalid,
+        c_ready => bi_wready,
+        c_data(0 to wdata'high) => bi_wdata,
+        c_data(wdata'length to wdata'length+wstrb'high) => bi_wstrb
+    );
+
+end architecture struct;

--- a/testsuite/gna/issue2688/skid.vhdl
+++ b/testsuite/gna/issue2688/skid.vhdl
@@ -1,0 +1,53 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity skid_buffer_in is
+    port (
+        aclk    : in  std_logic;
+        aresetn : in  std_logic;
+        r_valid : in  std_logic;
+        r_ready : out std_logic;
+        r_data  : in  std_logic_vector;
+        c_valid : out std_logic;
+        c_ready : in  std_logic;
+        c_data  : out std_logic_vector
+    );
+end entity skid_buffer_in;
+
+architecture rtl of skid_buffer_in is
+    constant data_width : natural := r_data'length;
+    signal b_data  : std_logic_vector(r_data'range);
+    signal b_valid : std_logic;
+begin
+
+    skid : process(aclk, aresetn)
+    begin
+        if (aresetn = '0') then
+            r_ready <= '0';
+            b_data  <= (others => '0');
+            b_valid <= '0';
+        elsif rising_edge(aclk) then
+            if c_ready then
+                b_valid <= '0';
+            end if;
+            if (r_valid and r_ready) = '1' then
+                if c_ready = '0' then
+                    b_data <= r_data;
+                end if;
+                b_valid <= not c_ready;
+                r_ready <= c_ready;
+            else
+                r_ready <= c_ready or not b_valid;
+            end if;
+        end if;
+    end process skid;
+
+    with to_bit(b_valid) select c_data <=
+        r_data when '0',
+        b_data when '1';
+    with to_bit(b_valid) select c_valid <=
+        r_valid and r_ready when '0',
+        '1' when '1';
+
+end architecture rtl;

--- a/testsuite/gna/issue2688/testsuite.sh
+++ b/testsuite/gna/issue2688/testsuite.sh
@@ -1,0 +1,114 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+# Five shapes of the same port map, all taken from the issue2688 thread.
+export GHDL_STD_FLAGS="--std=08"
+
+analyze skid.vhdl
+
+# 1. The original report: the actual for the unconstrained formal r_data is
+#    a concatenation of two *signals*, so it is not a globally static
+#    expression.  Per LRM08 6.5.6.3 that makes the port equivalent to an
+#    anonymous signal of the formal's subtype, which is unconstrained --
+#    illegal.  This used to end in an internal error naming
+#    IIR_KIND_CONCATENATION_OPERATOR; it is now a clean diagnostic.
+out=$(analyze_failure inst.vhdl 2>&1)
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: analysis crashed instead of reporting a clean error"
+  exit 1
+fi
+
+if ! echo "$out" | grep -q "form of expression for unbounded inertial"; then
+  echo "FAIL: expected the unbounded-inertial-association error"
+  exit 1
+fi
+
+# 2. The same port map with the concatenation of two *constants*, which is
+#    globally static and therefore legal.  It used to fail on the gcc and
+#    llvm backends and work on mcode; it works everywhere now.
+analyze inst3.vhdl
+elab_simulate inst3
+
+# 3. The variant where the unconstrained formals are constrained by slices
+#    in the port map itself, which is what the reporter tried next.  c_data
+#    is sliced in two parts, so LRM08 5.3.2.2 e) 2) gives its index range
+#    the direction of the index subtype of the base type ('to' for
+#    natural), and the 'downto' slices of the port map are an error.  What
+#    was wrong is what came after: GHDL raised CONSTRAINT_ERROR right after
+#    printing the message, both when elaborating and under --synth.
+#
+#    The backends differ on when they report it (elaboration for mcode and
+#    llvm-jit, run time for gcc and llvm), so check the message rather than
+#    the exit status.
+analyze inst2.vhdl
+
+out=$(elab_simulate inst2 2>&1) || true
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: crashed after reporting the slice direction error"
+  exit 1
+fi
+
+if ! echo "$out" | grep -q "slice direction doesn't match"; then
+  echo "FAIL: expected the slice direction error"
+  exit 1
+fi
+
+out=$(synth inst2 2>&1) || true
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: --synth crashed after reporting the slice direction error"
+  exit 1
+fi
+
+if ! echo "$out" | grep -q "slice direction doesn't match"; then
+  echo "FAIL: expected the slice direction error from --synth"
+  exit 1
+fi
+
+# 4. The same design with the multi-part formal written ascending, which is
+#    the direction the rule gives it.  This is the shape that works.
+analyze ok.vhdl
+elab_simulate ok
+
+synth ok > syn_ok.vhdl
+rm -f syn_ok.vhdl
+
+# 5. Slices that do not agree on a direction: same error, and again no
+#    crash after it.
+analyze bad.vhdl
+
+out=$(elab_simulate bad 2>&1) || true
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: crashed after reporting the slice direction error"
+  exit 1
+fi
+
+if ! echo "$out" | grep -q "slice direction doesn't match"; then
+  echo "FAIL: expected the slice direction error"
+  exit 1
+fi
+
+out=$(synth bad 2>&1) || true
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: --synth crashed after reporting the slice direction error"
+  exit 1
+fi
+
+if ! echo "$out" | grep -q "slice direction doesn't match"; then
+  echo "FAIL: expected the slice direction error from --synth"
+  exit 1
+fi
+
+clean
+
+echo "Test successful"

--- a/testsuite/gna/issue2765/ok.vhdl
+++ b/testsuite/gna/issue2765/ok.vhdl
@@ -1,0 +1,28 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+--  The design of top.vhdl with the slice written ascending, which is the
+--  direction LRM08 5.3.2.2 e) 2) gives the formal.  This is the shape that
+--  is legal, and the slice of a 'downto' actual by an ascending formal is
+--  fine: an association only has to match on length.
+entity handle_ok is
+    port (data_i : in std_ulogic_vector);
+end;
+
+architecture arch of handle_ok is
+begin
+end;
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity top_ok is
+    port (count_i : in std_ulogic_vector(5 downto 0));
+end;
+
+architecture arch of top_ok is
+begin
+    handle : entity work.handle_ok port map (
+        data_i(0 to 5) => count_i
+    );
+end;

--- a/testsuite/gna/issue2765/testsuite.sh
+++ b/testsuite/gna/issue2765/testsuite.sh
@@ -2,8 +2,57 @@
 
 . ../../testenv.sh
 
+# The reported design constrains an unconstrained formal with a single
+# 'downto' slice in the port map:
+#
+#   data_i(5 downto 0) => count_i
+#
+# LRM08 5.3.2.2 e) 2) gives the index range of such an object the direction
+# of the corresponding index subtype of the base type of the interface
+# object -- 'natural' for a std_ulogic_vector, hence 'to' -- whenever the
+# object is associated by more than one association element or by a single
+# one whose formal designator is a slice name.  The object is therefore
+# ascending and this 'downto' slice of it is an error (LRM08 8.5).
+#
+# GHDL used to take the direction of the slice instead, which accepted the
+# design, and this test used to run it.  That was the non-conformant half of
+# a93226f23; the other half, not crashing after the error, is what #2765 was
+# really about and is still checked below.  See also issue2688, where the
+# same rule applies to a formal sliced in several parts.
 analyze top.vhdl
-elab_simulate top
+
+out=$(elab_simulate top 2>&1) || true
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: crashed after reporting the slice direction error"
+  exit 1
+fi
+
+if ! echo "$out" | grep -q "slice direction doesn't match"; then
+  echo "FAIL: expected the slice direction error"
+  exit 1
+fi
+
+out=$(synth top 2>&1) || true
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: --synth crashed after reporting the slice direction error"
+  exit 1
+fi
+
+if ! echo "$out" | grep -q "slice direction doesn't match"; then
+  echo "FAIL: expected the slice direction error from --synth"
+  exit 1
+fi
+
+# The same design written ascending is legal and must keep working.
+analyze ok.vhdl
+elab_simulate top_ok
+
+synth top_ok > syn_top_ok.vhdl
+rm -f syn_top_ok.vhdl
 
 clean
 


### PR DESCRIPTION
The index range of an unconstrained formal that a port map constrains through individual associations took its direction from the slice only when there was a single association element, and from the index subtype of the interface object otherwise -- 'natural', hence 'to'.  So a formal sliced in several parts was built as a 'to' object, and the 'downto' slices that constrained it were then rejected:

  d : entity work.sub port map (o(3 downto 2) => ha, o(1 downto 0) => la);
  error: slice direction doesn't match index direction

As designs are written 'downto' almost everywhere, this made slicing an unconstrained formal in more than one part unusable.  Take the direction from the slices when they all agree, which is what commit a93226f23 already did for a single slice.  Indexed names have no direction and don't take part; slices that disagree keep the direction of the index subtype and are still reported.

That error left a null type behind, and three places used it without checking, raising CONSTRAINT_ERROR right after the message.  Stop on the erroneous association in each of them instead.

Closes #2688.