### PR TITLE
Bug/issue2955 follow up

### DIFF
--- a/src/simul/simul-vhdl_simul.adb
+++ b/src/simul/simul-vhdl_simul.adb
@@ -3598,7 +3598,8 @@ package body Simul.Vhdl_Simul is
    -- PORT is the formal, while SIG is the actual.
    procedure Connect (Dst : Memtyp;
                       Src : Memtyp;
-                      Mode : Connect_Mode) is
+                      Mode : Connect_Mode;
+                      Loc : Node) is
    begin
       pragma Assert (Dst.Typ.Kind = Src.Typ.Kind);
 
@@ -3610,13 +3611,20 @@ package body Simul.Vhdl_Simul is
                Etyp : constant Type_Acc := Dst.Typ.Arr_El;
             begin
                if Len /= Src.Typ.Abound.Len then
-                  raise Internal_Error;
+                  --  The formal and the actual do not have the same length.
+                  --  That is a bound check failure of the association, not
+                  --  an internal error: it happens for instance when the
+                  --  elements of an individual association do not all have
+                  --  the same subtype and the bounds are not locally static,
+                  --  so that Sem cannot report it.
+                  Error_Msg_Exec
+                    (Loc, "length of actual doesn't match length of formal");
                end if;
                for I in 1 .. Len loop
                   Connect ((Etyp, Sig_Index (Dst.Mem, (I - 1) * Etyp.W)),
                            (Src.Typ.Arr_El,
                             Sig_Index (Src.Mem, (I - 1) * Etyp.W)),
-                           Mode);
+                           Mode, Loc);
                end loop;
             end;
             return;
@@ -3628,7 +3636,7 @@ package body Simul.Vhdl_Simul is
                   Connect ((E.Typ, Sig_Index (Dst.Mem, E.Offs.Net_Off)),
                            (Src.Typ.Rec.E (I).Typ,
                             Sig_Index (Src.Mem, E.Offs.Net_Off)),
-                           Mode);
+                           Mode, Loc);
                end;
             end loop;
          when Type_Logic
@@ -3862,7 +3870,7 @@ package body Simul.Vhdl_Simul is
             --  LRM93 12.6.2
             --  A signal is said to be active [...] if one of its source
             --  is active.
-            Connect (To_Memtyp (C.Actual), Form2, Connect_Source);
+            Connect (To_Memtyp (C.Actual), Form2, Connect_Source, C.Assoc);
          end;
       end if;
 
@@ -3893,7 +3901,8 @@ package body Simul.Vhdl_Simul is
             else
                Act2 := Act;
             end if;
-            Connect (To_Memtyp (C.Formal), Act2, Connect_Effective);
+            Connect (To_Memtyp (C.Formal), Act2, Connect_Effective,
+                     C.Assoc);
          end;
       end if;
    end Create_Connect;

--- a/src/vhdl/vhdl-sem_assocs.adb
+++ b/src/vhdl/vhdl-sem_assocs.adb
@@ -953,6 +953,186 @@ package body Vhdl.Sem_Assocs is
       end if;
    end Finish_Individual_Assoc_Array_Subtype;
 
+   --  Subtype that the individual association element EL gives to one
+   --  element of the array.  Null_Iir when it gives none: an open actual, a
+   --  node left over by an earlier error, or an actual whose type is not
+   --  usable here.
+   function Get_Individual_El_Subtype (El : Iir) return Iir
+   is
+      Assoc : constant Iir := Get_Associated_Expr (El);
+      Conv : Iir;
+      Act : Iir;
+      Atype : Iir;
+   begin
+      if Assoc = Null_Iir then
+         return Null_Iir;
+      end if;
+      case Get_Kind (Assoc) is
+         when Iir_Kind_Association_Element_By_Individual =>
+            Atype := Get_Actual_Type (Assoc);
+         when Iir_Kind_Association_Element_By_Expression
+           | Iir_Kind_Association_Element_By_Name =>
+            if Get_Formal_Conversion (Assoc) /= Null_Iir then
+               --  LRM08 5.3.2.2 e) 3) names the *parameter* subtype of the
+               --  conversion as the constraint for an out formal, which is
+               --  not what the conversion node carries here (that is the
+               --  actual side).  Rather than take the wrong one, let this
+               --  association contribute nothing.
+               return Null_Iir;
+            end if;
+            --  LRM08 5.3.2.2 e) 3): with a conversion on the actual, the
+            --  constraint comes from the result type of the function or
+            --  from the type mark.
+            Conv := Get_Actual_Conversion (Assoc);
+            if Conv /= Null_Iir then
+               Atype := Get_Type (Conv);
+            else
+               Act := Get_Actual (Assoc);
+               if Act = Null_Iir or else Is_Error (Act) then
+                  return Null_Iir;
+               end if;
+               Atype := Get_Type (Act);
+            end if;
+         when others =>
+            return Null_Iir;
+      end case;
+      if Atype = Null_Iir or else Is_Error (Atype) then
+         return Null_Iir;
+      end if;
+      if Get_Kind (El) = Iir_Kind_Choice_By_Range then
+         --  The formal part is a slice, so the actual is a slice of the
+         --  array: what it gives is its own element subtype.
+         if Get_Kind (Atype) not in Iir_Kinds_Array_Type_Definition then
+            return Null_Iir;
+         end if;
+         return Get_Element_Subtype (Atype);
+      end if;
+      return Atype;
+   end Get_Individual_El_Subtype;
+
+   --  True when L and R are array subtypes whose bounds are both locally
+   --  static and do not have the same length, at any level: LRM08 5.3.2.2
+   --  makes it an error if the rules yield different index ranges for any
+   --  corresponding array subelement.  Only lengths are compared, like
+   --  Eval_Is_In_Bound does for an association whose formal is constrained;
+   --  bounds that are not locally static are left to the run-time check, and
+   --  a record subelement is not walked into.
+   function Are_Lengths_Static_Mismatch (L, R : Iir) return Boolean
+   is
+      L_Indexes, R_Indexes : Iir_Flist;
+      Nbr : Natural;
+   begin
+      if L = Null_Iir or else R = Null_Iir or else L = R then
+         return False;
+      end if;
+      if Get_Kind (L) not in Iir_Kinds_Array_Type_Definition
+        or else Get_Kind (R) not in Iir_Kinds_Array_Type_Definition
+      then
+         return False;
+      end if;
+      if not Are_Bounds_Locally_Static (L)
+        or else not Are_Bounds_Locally_Static (R)
+      then
+         return False;
+      end if;
+      L_Indexes := Get_Index_Subtype_List (L);
+      R_Indexes := Get_Index_Subtype_List (R);
+      if L_Indexes = Null_Iir_Flist or else R_Indexes = Null_Iir_Flist then
+         return False;
+      end if;
+      Nbr := Get_Nbr_Elements (L_Indexes);
+      if Nbr /= Get_Nbr_Elements (R_Indexes) then
+         return True;
+      end if;
+      for I in 0 .. Nbr - 1 loop
+         if Eval_Discrete_Type_Length (Get_Nth_Element (L_Indexes, I))
+           /= Eval_Discrete_Type_Length (Get_Nth_Element (R_Indexes, I))
+         then
+            return True;
+         end if;
+      end loop;
+      --  Same shape at this level: the elements must match too.
+      return Are_Lengths_Static_Mismatch (Get_Element_Subtype (L),
+                                          Get_Element_Subtype (R));
+   end Are_Lengths_Static_Mismatch;
+
+   --  Walk the whole choice tree of ASSOC, whose actual is an array of
+   --  DIM .. NBR_DIMS remaining dimensions, and collect in REF the element
+   --  subtype the individual associations define.  Every association must
+   --  define the same one, so the first constrained one wins and the others
+   --  are checked against it.  The walk covers the whole tree rather than
+   --  one chain, so that the rows of a multi-dimensional array are checked
+   --  against each other too.
+   procedure Collect_Individual_El_Subtype
+     (Assoc : Iir;
+      Dim : Natural;
+      Nbr_Dims : Natural;
+      Ref : in out Iir;
+      Ref_El : in out Iir)
+   is
+      El : Iir;
+      El_Type : Iir;
+   begin
+      El := Get_Individual_Association_Chain (Assoc);
+      while El /= Null_Iir loop
+         if Dim < Nbr_Dims then
+            Collect_Individual_El_Subtype
+              (Get_Associated_Expr (El), Dim + 1, Nbr_Dims, Ref, Ref_El);
+         else
+            El_Type := Get_Individual_El_Subtype (El);
+            if El_Type /= Null_Iir
+              and then (Get_Kind (El_Type)
+                          in Iir_Kinds_Composite_Type_Definition)
+              and then Get_Constraint_State (El_Type) = Fully_Constrained
+            then
+               if Ref = Null_Iir then
+                  Ref := El_Type;
+                  Ref_El := El;
+               elsif Are_Lengths_Static_Mismatch (Ref, El_Type) then
+                  Error_Msg_Sem
+                    (+El, "element subtype of individual association does "
+                       & "not match the one at %l", +Ref_El);
+               end if;
+            end if;
+         end if;
+         El := Get_Chain (El);
+      end loop;
+   end Collect_Individual_El_Subtype;
+
+   --  The element subtype of the actual built for an individual association
+   --  is not given by the interface: it is defined by the associations, like
+   --  the elements of a record in Finish_Individual_Assoc_Record.  LRM08
+   --  5.3.2.1 has all the elements of an array share one subtype, so they
+   --  must all define the same one.  Without this, ACTUAL_TYPE keeps the
+   --  unconstrained element of the base type although it has just been
+   --  marked as fully constrained, so the bounds of the element are never
+   --  elaborated.
+   procedure Finish_Individual_Assoc_Array_El_Subtype
+     (Actual_Type : Iir; Assoc : Iir)
+   is
+      El_Type : constant Iir := Get_Element_Subtype (Actual_Type);
+      Indexes : constant Iir_Flist := Get_Index_Subtype_List (Actual_Type);
+      Ref : Iir;
+      Ref_El : Iir;
+   begin
+      if Get_Kind (El_Type) not in Iir_Kinds_Composite_Type_Definition
+        or else Get_Constraint_State (El_Type) = Fully_Constrained
+      then
+         return;
+      end if;
+
+      Ref := Null_Iir;
+      Ref_El := Null_Iir;
+      Collect_Individual_El_Subtype
+        (Assoc, 1, Get_Nbr_Elements (Indexes), Ref, Ref_El);
+
+      if Ref /= Null_Iir then
+         --  Element_Subtype is a Ref field: this refers to the subtype of
+         --  the actual without taking ownership of it.
+         Set_Element_Subtype (Actual_Type, Ref);
+      end if;
+   end Finish_Individual_Assoc_Array_El_Subtype;
+
    procedure Finish_Individual_Assoc_Array
      (Actual : Iir; Assoc : Iir; Dim : Natural)
    is
@@ -1070,39 +1250,6 @@ package body Vhdl.Sem_Assocs is
                  (Get_Associated_Expr (El), El_Type);
                El := Get_Chain (El);
             end loop;
-
-            --  If the element is not constrained by the interface, it is
-            --  defined by the individual associations - like the elements of
-            --  a record, cf. Finish_Individual_Assoc_Record.  Take it from
-            --  the first association; they all have the same subtype.
-            --  Without this, ACTUAL_TYPE keeps the unconstrained element of
-            --  the base type although it has just been marked as fully
-            --  constrained, so the bounds of the element are never
-            --  elaborated.
-            if Get_Kind (El_Type) in Iir_Kinds_Composite_Type_Definition
-              and then Get_Constraint_State (El_Type) /= Fully_Constrained
-            then
-               declare
-                  Assoc_Expr : constant Iir := Get_Associated_Expr (Chain);
-                  Assoc_Type : Iir;
-               begin
-                  if (Get_Kind (Assoc_Expr)
-                        = Iir_Kind_Association_Element_By_Individual)
-                  then
-                     Assoc_Type := Get_Actual_Type (Assoc_Expr);
-                  else
-                     Assoc_Type := Get_Type (Get_Actual (Assoc_Expr));
-                  end if;
-                  if Assoc_Type /= Null_Iir
-                    and then (Get_Kind (Assoc_Type)
-                                in Iir_Kinds_Composite_Type_Definition)
-                    and then Get_Constraint_State (Assoc_Type)
-                               = Fully_Constrained
-                  then
-                     Set_Element_Subtype (Actual_Type, Assoc_Type);
-                  end if;
-               end;
-            end if;
          else
             El := Chain;
             while El /= Null_Node loop
@@ -1276,6 +1423,7 @@ package body Vhdl.Sem_Assocs is
                Set_Actual_Type (Assoc, Ntype);
                Set_Actual_Type_Definition (Assoc, Ntype);
                Finish_Individual_Assoc_Array (Assoc, Assoc, 1);
+               Finish_Individual_Assoc_Array_El_Subtype (Ntype, Assoc);
             end if;
          when Iir_Kind_Record_Type_Definition
            | Iir_Kind_Record_Subtype_Definition =>

--- a/testsuite/gna/issue2955/conv.vhd
+++ b/testsuite/gna/issue2955/conv.vhd
@@ -1,0 +1,39 @@
+package p2 is
+  type sv is array (natural range <>) of bit_vector;
+  subtype nib  is bit_vector(3 downto 0);
+  subtype byte is bit_vector(7 downto 0);
+  function w8 (x : nib) return byte;
+end package;
+
+package body p2 is
+  function w8 (x : nib) return byte is
+  begin
+    return x & x;
+  end w8;
+end package body;
+
+use work.p2.all;
+entity dut2 is
+  generic (g : positive);
+  port (o : out sv(0 to g-1));
+end entity;
+architecture a of dut2 is
+begin
+  o(0) <= "0100";
+  o(1) <= "0100";
+end architecture;
+
+use work.p2.all;
+entity tb_conv is end entity;
+architecture a of tb_conv is
+  signal y4 : nib;
+  signal x8 : byte;
+begin
+  u : entity work.dut2 generic map (g => 2)
+      port map (o(0) => y4, w8(o(1)) => x8);
+  process begin
+    wait for 1 ns;
+    report "x8len=" & integer'image(x8'length) & " y4len=" & integer'image(y4'length);
+    wait;
+  end process;
+end architecture;

--- a/testsuite/gna/issue2955/dir.vhd
+++ b/testsuite/gna/issue2955/dir.vhd
@@ -1,0 +1,33 @@
+library ieee; use ieee.std_logic_1164.all; use ieee.numeric_std.all;
+use work.chk_pkg.all;
+
+entity dut_dir is
+  port (i_data : in  signed_vector(0 to 1);
+        o_sum  : out signed(15 downto 0));
+end entity;
+architecture rtl of dut_dir is
+begin
+  o_sum <= resize(i_data(0), 16) + resize(i_data(1), 16);
+end architecture;
+
+library ieee; use ieee.std_logic_1164.all; use ieee.numeric_std.all;
+use work.chk_pkg.all;
+entity tb_dir is end entity;
+architecture rtl of tb_dir is
+  signal a : signed(15 downto 0) := to_signed(3, 16);
+  signal b : signed(0 to 15)     := to_signed(5, 16);
+  signal s : signed(15 downto 0);
+begin
+  --  Same length, opposite direction: legal, and it works.
+  u : entity work.dut_dir
+    port map (i_data(0) => a, i_data(1) => b, o_sum => s);
+
+  process
+  begin
+    wait for 1 ns;
+    assert s = to_signed(8, 16)
+      report "FAIL s=" & integer'image(to_integer(s)) severity failure;
+    report "PASS s=" & integer'image(to_integer(s));
+    wait;
+  end process;
+end architecture;

--- a/testsuite/gna/issue2955/dyn_mismatch.vhd
+++ b/testsuite/gna/issue2955/dyn_mismatch.vhd
@@ -1,0 +1,31 @@
+library ieee; use ieee.std_logic_1164.all; use ieee.numeric_std.all;
+use work.chk_pkg.all;
+
+entity dut_dyn is
+  port (i_data : in  signed_vector(0 to 1);
+        o_sum  : out signed(15 downto 0));
+end entity;
+architecture rtl of dut_dyn is
+begin
+  o_sum <= resize(i_data(0), 16) + resize(i_data(1), 16);
+end architecture;
+
+library ieee; use ieee.std_logic_1164.all; use ieee.numeric_std.all;
+use work.chk_pkg.all;
+entity tb_dyn is end entity;
+architecture rtl of tb_dyn is
+  --  Same mismatch as mismatch.vhd, but through a function call so that the
+  --  bounds are not locally static and analysis cannot see it.
+  function w (n : natural) return natural is
+  begin
+    return n;
+  end function;
+  constant c_w1 : natural := w(16);
+  constant c_w2 : natural := w(8);
+  signal a : signed(c_w1 - 1 downto 0) := to_signed(3, c_w1);
+  signal b : signed(c_w2 - 1 downto 0) := to_signed(5, c_w2);
+  signal s : signed(15 downto 0);
+begin
+  u : entity work.dut_dyn
+    port map (i_data(0) => a, i_data(1) => b, o_sum => s);
+end architecture;

--- a/testsuite/gna/issue2955/gen_mismatch.vhd
+++ b/testsuite/gna/issue2955/gen_mismatch.vhd
@@ -1,0 +1,28 @@
+library ieee; use ieee.std_logic_1164.all; use ieee.numeric_std.all;
+use work.chk_pkg.all;
+entity dut_gen is
+  generic (g_data : signed_vector(0 to 1));
+end entity;
+architecture rtl of dut_gen is
+begin
+  process begin
+    report "g0 len=" & integer'image(g_data(0)'length)
+         & " v=" & integer'image(to_integer(g_data(0)));
+    report "g1 len=" & integer'image(g_data(1)'length)
+         & " v=" & integer'image(to_integer(g_data(1)));
+    wait;
+  end process;
+end architecture;
+
+library ieee; use ieee.std_logic_1164.all; use ieee.numeric_std.all;
+use work.chk_pkg.all;
+entity tb_gen is end entity;
+architecture rtl of tb_gen is
+begin
+  u : entity work.dut_gen
+    --  The two individual associations do not define the same element
+  --  subtype: 8 bits and 16 bits.  Without a check the second value is
+  --  silently truncated to 8 bits and read back as 0.
+  generic map (g_data(0) => to_signed(11, 8),
+                 g_data(1) => to_signed(22, 16));
+end architecture;

--- a/testsuite/gna/issue2955/mismatch.vhd
+++ b/testsuite/gna/issue2955/mismatch.vhd
@@ -1,0 +1,26 @@
+library ieee; use ieee.std_logic_1164.all; use ieee.numeric_std.all;
+use work.chk_pkg.all;
+
+entity dut_mismatch is
+  port (i_data : in  signed_vector(0 to 1);
+        o_sum  : out signed(15 downto 0));
+end entity;
+architecture rtl of dut_mismatch is
+begin
+  o_sum <= resize(i_data(0), 16) + resize(i_data(1), 16);
+end architecture;
+
+library ieee; use ieee.std_logic_1164.all; use ieee.numeric_std.all;
+use work.chk_pkg.all;
+entity tb_mismatch is end entity;
+architecture rtl of tb_mismatch is
+  signal a : signed(15 downto 0) := to_signed(3, 16);
+  signal b : signed(7 downto 0)  := to_signed(5, 8);
+  signal s : signed(15 downto 0);
+begin
+  --  The element of signed_vector is unconstrained, so the two individual
+  --  associations define it -- and they must define the same subtype.
+  --  They do not: 16 bits and 8 bits.
+  u : entity work.dut_mismatch
+    port map (i_data(0) => a, i_data(1) => b, o_sum => s);
+end architecture;

--- a/testsuite/gna/issue2955/slice.vhd
+++ b/testsuite/gna/issue2955/slice.vhd
@@ -1,0 +1,33 @@
+library ieee; use ieee.std_logic_1164.all; use ieee.numeric_std.all;
+use work.chk_pkg.all;
+
+entity dut_slice is
+  port (i_data : in  signed_vector(0 to 1);
+        o_sum  : out signed(15 downto 0));
+end entity;
+architecture rtl of dut_slice is
+begin
+  o_sum <= resize(i_data(0), 16) + resize(i_data(1), 16);
+end architecture;
+
+library ieee; use ieee.std_logic_1164.all; use ieee.numeric_std.all;
+use work.chk_pkg.all;
+entity tb_slice is end entity;
+architecture rtl of tb_slice is
+  signal aa : signed_vector(0 to 1)(15 downto 0)
+    := (to_signed(3, 16), to_signed(5, 16));
+  signal s  : signed(15 downto 0);
+begin
+  --  The formal part is a slice, so the actual is a slice of the array:
+  --  what it gives is its own element subtype, not the array subtype.
+  u : entity work.dut_slice port map (i_data(0 to 1) => aa, o_sum => s);
+
+  process
+  begin
+    wait for 1 ns;
+    assert s = to_signed(8, 16)
+      report "FAIL s=" & integer'image(to_integer(s)) severity failure;
+    report "PASS s=" & integer'image(to_integer(s));
+    wait;
+  end process;
+end architecture;

--- a/testsuite/gna/issue2955/testsuite.sh
+++ b/testsuite/gna/issue2955/testsuite.sh
@@ -10,9 +10,9 @@
 # was marked fully constrained while its element was still unconstrained,
 # so the bounds of the element were never elaborated.
 #
-# repro.vhd is the reporter's own design; chk.vhd checks that the data
-# really crosses the indexed association, since not crashing is not enough
-# to show the element bounds are right.  See issue2955.
+# The element subtype is taken from the individual associations, and LRM08
+# 5.3.2.1 has all the elements of an array share one subtype, so they must
+# all define the same one.  See issue2955.
 export GHDL_STD_FLAGS=--std=08
 
 analyze repro.vhd
@@ -37,6 +37,90 @@ echo "$out"
 
 if ! echo "$out" | grep -q "PASS b=9876 len=16"; then
   echo "FAIL: wrong data or element length through the indexed association"
+  exit 1
+fi
+
+#  Two associations that do not define the same element subtype: rejected
+#  during analysis, since the bounds are locally static.
+out=$(analyze_failure mismatch.vhd 2>&1)
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: crashed instead of reporting the mismatch"
+  exit 1
+fi
+
+if ! echo "$out" | grep -q "element subtype of individual association"; then
+  echo "FAIL: expected the element subtype mismatch error"
+  exit 1
+fi
+
+#  The same on a generic, which is the worst-behaved shape: without the
+#  check the second value is silently truncated and read back as 0, with no
+#  diagnostic and a zero exit status.
+out=$(analyze_failure gen_mismatch.vhd 2>&1)
+echo "$out"
+
+if ! echo "$out" | grep -q "element subtype of individual association"; then
+  echo "FAIL: expected the element subtype mismatch error on a generic"
+  exit 1
+fi
+
+#  The same mismatch with bounds that are not locally static cannot be seen
+#  during analysis.  It must still be an ordinary elaboration error rather
+#  than an internal one.
+analyze dyn_mismatch.vhd
+
+out=$(elab_simulate tb_dyn 2>&1) || true
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: internal error instead of a length mismatch diagnostic"
+  exit 1
+fi
+
+if ! echo "$out" | grep -qE "length of actual doesn't match|bound check failure"; then
+  echo "FAIL: expected a length mismatch diagnostic"
+  exit 1
+fi
+
+#  A slice as the formal part is a single association element, and what it
+#  gives is the element subtype of its own actual, not the array subtype of
+#  it.  This shape is still not fully supported -- gcc and llvm end in a
+#  bound check failure, as they did before -- but it must not be an internal
+#  error, which is what mcode used to answer.
+analyze slice.vhd
+
+out=$(elab_simulate tb_slice 2>&1) || true
+echo "$out"
+
+if echo "$out" | grep -q "GHDL Bug occurred"; then
+  echo "FAIL: internal error on the slice formal association"
+  exit 1
+fi
+
+#  A conversion on the formal part of an out port is legal, and what it
+#  gives is the parameter subtype of the conversion, which is not what the
+#  conversion node carries here -- so such an association must simply be
+#  left out of the comparison rather than compared against the wrong type.
+analyze conv.vhd
+
+out=$(elab_simulate tb_conv 2>&1)
+echo "$out"
+
+if ! echo "$out" | grep -q "x8len=8 y4len=4"; then
+  echo "FAIL: a conversion on the formal part is no longer accepted"
+  exit 1
+fi
+
+#  Same length but opposite direction is legal and must keep working.
+analyze dir.vhd
+
+out=$(elab_simulate tb_dir 2>&1)
+echo "$out"
+
+if ! echo "$out" | grep -q "PASS s=8"; then
+  echo "FAIL: the reversed element association no longer works"
   exit 1
 fi
 


### PR DESCRIPTION
# Issue #2955 follow-up — check that the individual associations agree on the element subtype

Analysis by an AI agent.

## What this is about

PR #3377 was merged with a reservation:

> I think this is OK but there might be missing checks for other elements to have matching bounds.

The merged code takes the element subtype of the synthesized actual from the *first* individual association, on the strength of a comment:

```ada
   --  Take it from the first association; they all have the same subtype.
```

Nothing checks that, and they need not.

## What the LRM requires

LRM08 5.3.2.1: *"An array object is a composite object consisting of elements that have the same subtype."* The formal is one object with one element subtype, so the several associations do not each contribute one — together they must agree.

LRM08 5.3.2.2 e) 3) says where that subtype comes from when the interface does not constrain it (*"the index range is obtained from the object or value denoted by the actual designator"*), and then closes the rule:

> For a given array interface object, or for a given array subelement of an interface object, it is an error if application of the preceding rules yields different index ranges for any corresponding array subelements of the given interface object or given subelement.

That is exactly the missing check, and note *"any corresponding array subelements"*: the rule is recursive.

## What goes wrong without it

Two channels whose actuals are 16 and 8 bits wide, on current master:

| shape | mcode | gcc, llvm |
|---|---|---|
| port, `i_data(0) => a16, i_data(1) => a8` | `TYPES.INTERNAL_ERROR : simul-vhdl_simul.adb:3613` with the bug box | `bound check failure` at elaboration |
| **generic**, `g_data(0) => to_signed(11,8), g_data(1) => to_signed(22,16)` | **no diagnostic at all**: `g_data(1)` reads back as `len=8 v=0`, exit status 0 | `bound check failure` at elaboration |

The generic case is the bad one: the value 22 is silently lost and the run succeeds.

## What this change does

**1. Check the associations against each other** (`Vhdl.Sem_Assocs`). The element subtype is now settled once for the whole actual, by `Finish_Individual_Assoc_Array_El_Subtype`, called from `Finish_Individual_Association1` right after the array walk. It takes the element subtype from the first association that is fully constrained and reports the ones that do not match it:

```
mismatch.vhd:25:55:error: element subtype of individual association does not match the one at line 25:39
```

Settling it once, over the whole choice tree, is what makes a multi-dimensional array work: `Finish_Individual_Assoc_Array` recurses per dimension and reaches the innermost chain once per outer index, so a check placed there compares only the elements of one row against each other. `i_data(0,0)`…`i_data(1,1)` are now all compared.

Three details:

- **A slice formal part gives its own element subtype.** With `i_data(0 to 1) => aa`, the actual is a slice of the array, so `Get_Type (Get_Actual (…))` is the *array* subtype; the merged code installed `signed_vector` as the element subtype of a `signed_vector`. That design is legal and it crashed with an internal error on mcode — `elab-vhdl_objtypes.adb:588`, and `elab-vhdl_insts.adb:651` before #3377 — which it no longer does: mcode now elaborates and simulates it correctly. gcc and llvm still end in a bound check failure there, exactly as they did before, so the shape is not fully supported yet; the remaining half is in the translator, not here.
- **A conversion on the actual defines the constraint**, per LRM08 5.3.2.2 e) 3), so the subtype comes from the conversion rather than from `Get_Actual`, which returns the pre-conversion expression. A conversion on the *formal* is different: the LRM names the conversion's *parameter* subtype there, which is not what the conversion node carries, so such an association is left out of the comparison rather than compared against the wrong type — otherwise `w8(o(1)) => x8`, which works today, would be rejected.
- **`Get_Actual` is not valid on an `Iir_Kind_Association_Element_Open`**, which has an `Open_Actual` instead; the merged code read it unguarded.

Two deliberate limits, both consistent with what GHDL already does elsewhere:

- **Lengths, not index ranges.** The LRM sentence above is about index ranges, so `signed(15 downto 0)` against `signed(0 to 15)` is formally an error. GHDL accepts it today and produces the right result, and the existing check for the constrained case — `Eval_Is_In_Bound` in `Sem_Association_By_Expression`, *"actual constraints don't match formal ones"* — also compares lengths only. Rejecting a direction difference would be a new error on code that works; it is a separate decision for the maintainer, so this check compares lengths, recursively through nested array elements.
- **Locally static bounds only.** Bounds that are not locally static cannot be compared during analysis, exactly as for the neighbouring *"indexes of individual association mismatch"* check. They are left to the run-time check — see (2).

**2. Report the run-time mismatch instead of crashing** (`Simul.Vhdl_Simul`). When the bounds are not locally static the mismatch only shows up while connecting the ports, and `Connect` answered it with `raise Internal_Error`, i.e. GHDL's bug box — where gcc and llvm report a bound check failure. It now reports, with the location of the association:

```
dyn_mismatch.vhd:28:62: length of actual doesn't match length of formal
ghdl:error: error during elaboration
```

## What is still not checked

An interface whose *index* bounds are locally static but whose *element* bounds are not — `sv(0 to 1)(w-1 downto 0)` with `w` a generic — goes down the other branch of `Finish_Individual_Association1` and never reaches this code, so a mismatch there is still only caught at elaboration (cleanly now, see (2)). Widening the check to that branch means giving it an actual subtype to compare against, which is a larger change than this one.

## Testing

`testsuite/gna/issue2955/` keeps the report's design and the data-crossing check, and adds:

- `mismatch.vhd` — two ports of different width: rejected during analysis;
- `gen_mismatch.vhd` — the same on a generic, the silent-data-loss case: rejected during analysis;
- `dyn_mismatch.vhd` — the same mismatch behind a function call, so the bounds are not locally static: a clean elaboration error and no bug box;
- `slice.vhd` — a slice as the formal part: no longer an internal error (it still fails on gcc and llvm, as before, so the test only asserts the absence of the bug box);
- `conv.vhd` — a conversion function on the formal part of an out port: still accepted, still correct;
- `dir.vhd` — same length, opposite direction: still accepted, still correct.

The test fails on master. It passes on mcode, llvm and gcc, and the full `sanity`, `gna` and `synth` suites pass on all three backends.
