### PR TITLE
trans: put the layout of a slice actual in the instance, not in a global

### DIFF
--- a/src/vhdl/translate/trans-chap3.ads
+++ b/src/vhdl/translate/trans-chap3.ads
@@ -75,13 +75,6 @@ package Trans.Chap3 is
    procedure Elab_Type_Declaration (Decl : Iir);
    procedure Elab_Subtype_Declaration (Decl : Iir_Subtype_Declaration);
 
-   --  Elaborate the layout (bounds/length/size) of a composite subtype
-   --  whose declaration was translated with With_Vars => True but whose
-   --  layout variable wasn't elaborated as part of a normal object/type
-   --  declaration (e.g. an anonymous subtype translated on demand from
-   --  Chap4.Translate_Association_Subprogram). No-op for a static type.
-   procedure Elab_Composite_Subtype_Layout (Def : Iir);
-
    --  Builders.
    --  A complex type is a type whose size is not locally static.
    --

--- a/src/vhdl/translate/trans-chap4.adb
+++ b/src/vhdl/translate/trans-chap4.adb
@@ -3127,7 +3127,6 @@ package body Trans.Chap4 is
       Mark2, Mark3      : Id_Mark_Type;
       Inter_List        : O_Inter_List;
       In_Type, Out_Type : Iir;
-      In_Fresh, Out_Fresh : Boolean;
       In_Info, Out_Info : Type_Info_Acc;
       El_List           : O_Element_List;
       Stmt_Info         : Block_Info_Acc;
@@ -3168,20 +3167,11 @@ package body Trans.Chap4 is
       --  Add interface name and a unique number in case of individual assoc.
       Push_Identifier_Prefix (Mark3, Get_Identifier (Inter), Num);
 
-      --  Handle anonymous subtypes.
-      --  These types may be touched here for the first time (this
-      --  formal/actual conversion may be the only place they're ever
-      --  referenced, e.g. the anonymous subtype of a slice actual used
-      --  only as a formal-conversion argument): With_Vars must be True
-      --  so their composite-layout variable actually gets allocated,
-      --  and (since Translate_Anonymous_Subtype_Definition is a no-op
-      --  when the type was already translated elsewhere) an explicit
-      --  elaboration is needed below for whichever of the two was
-      --  freshly created here, once this subprogram's own scope (which
-      --  bounds expressions like a generic-derived width need to
-      --  resolve against) is set up. See #3088/#827.
-      Out_Fresh := Get_Info (Out_Type) = null;
-      In_Fresh := Get_Info (In_Type) = null;
+      --  Handle anonymous subtypes.  Both are referenced below, so their
+      --  layout variable must exist.  For an instantiation it has already
+      --  been created, in the instance (see the CONVS record built by
+      --  Chap9.Translate_Component_Instantiation_Statement); for a block
+      --  header there is no such record, and a global one is created here.
       Chap3.Translate_Anonymous_Subtype_Definition (Out_Type, True);
       Chap3.Translate_Anonymous_Subtype_Definition (In_Type, True);
       Out_Info := Get_Info (Out_Type);
@@ -3308,15 +3298,6 @@ package body Trans.Chap4 is
                               Stmt_Info.Block_Parent_Field,
                               Get_Info (Block).Block_Scope'Access);
       end if;
-
-      --  Record which type(s) were freshly translated above: Elab_Conversion
-      --  (the true elaboration-time counterpart of this subprogram, which
-      --  runs once per instance before this subprogram body ever executes)
-      --  needs to elaborate their layout before it relies on it -- doing it
-      --  here instead would be too late, since this subprogram's body only
-      --  runs later, on demand, each time the conversion is invoked.
-      Conv_Info.Out_Fresh := Out_Fresh;
-      Conv_Info.In_Fresh := In_Fresh;
 
       --  Read signal value.
       case Mode is
@@ -3665,23 +3646,6 @@ package body Trans.Chap4 is
       Var_Data : O_Dnode;
       Data     : Elab_Signal_Data;
    begin
-      --  Elaborate the layout of whichever of IN_TYPE/OUT_TYPE was an
-      --  anonymous subtype only ever referenced through this conversion
-      --  association (e.g. the anonymous subtype of a slice actual):
-      --  Translate_Association_Subprogram allocated its layout variable
-      --  (with With_Vars => True) but couldn't fill it in, since at
-      --  translation time there's no instance/scope yet to resolve
-      --  bounds expressions (such as a generic-derived width) against.
-      --  This is the true elaboration-time counterpart, running once per
-      --  instance before anything below needs the real bounds. See
-      --  #3088/#827.
-      if Info.Out_Fresh and then Is_Composite (Out_Tinfo) then
-         Chap3.Elab_Composite_Subtype_Layout (Out_Type);
-      end if;
-      if Info.In_Fresh and then Is_Composite (In_Tinfo) then
-         Chap3.Elab_Composite_Subtype_Layout (In_Type);
-      end if;
-
       --  Allocate data for the subprogram.
       Var_Data := Create_Temp (Info.Record_Ptr_Type);
       New_Assign_Stmt

--- a/src/vhdl/translate/trans-chap5.adb
+++ b/src/vhdl/translate/trans-chap5.adb
@@ -614,6 +614,20 @@ package body Trans.Chap5 is
             Chap9.Gen_Port_Init_Driving (Formal_Sig, Formal_Type, Init_Node);
          end if;
       else
+         --  A formal conversion allocates its result from the bounds of the
+         --  actual, but unlike an actual conversion -- which translates the
+         --  name of the actual, and that elaborates its subtype -- nothing
+         --  has elaborated them at that point.  Do it here, in the
+         --  environment of the actual.  Only a slice needs it: any other
+         --  name has its subtype elaborated with its declaration.
+         if Get_Formal_Conversion (Assoc) /= Null_Iir
+           and then Get_Kind (Actual) = Iir_Kind_Slice_Name
+         then
+            Set_Map_Env (Actual_Env);
+            Chap3.Elab_Array_Subtype (Actual_Type);
+            Set_Map_Env (Formal_Env);
+         end if;
+
          if Get_Actual_Conversion (Assoc) /= Null_Iir then
             Chap4.Elab_In_Conversion (Assoc, Formal, Actual_Sig);
             Set_Map_Env (Formal_Env);

--- a/src/vhdl/translate/trans-chap9.adb
+++ b/src/vhdl/translate/trans-chap9.adb
@@ -252,7 +252,12 @@ package body Trans.Chap9 is
                   Act_Type : constant Iir := Get_Type (Get_Actual (Assoc));
                   Form_Conv : constant Iir := Get_Formal_Conversion (Assoc);
                   Formal : constant Iir := Get_Formal (Assoc);
-                  Need_Actual : constant Boolean := Act_Conv /= Null_Iir
+                  --  The conversion subprogram references the subtype of
+                  --  the actual whichever side the conversion is on: it
+                  --  converts the actual to the formal, or the formal to
+                  --  the actual.
+                  Need_Actual : constant Boolean :=
+                    (Act_Conv /= Null_Iir or else Form_Conv /= Null_Iir)
                     and then Is_Anonymous_Type_Definition (Act_Type);
                   Need_Formal : constant Boolean := Form_Conv /= Null_Iir
                     and then Is_Anonymous_Type_Definition (Get_Type (Formal));

--- a/src/vhdl/translate/trans.ads
+++ b/src/vhdl/translate/trans.ads
@@ -1189,13 +1189,6 @@ package Trans is
       Out_Val_Field       : O_Fnode;
       Record_Type         : O_Tnode;
       Record_Ptr_Type     : O_Tnode;
-      --  True if the corresponding type (formal's or actual's) was
-      --  translated for the first time here (an anonymous subtype only
-      --  ever referenced through this conversion), and therefore needs
-      --  its layout elaborated here too, once per instance, instead of
-      --  by whatever code normally elaborates a named/pre-existing type.
-      In_Fresh            : Boolean;
-      Out_Fresh           : Boolean;
    end record;
 
    type Direct_Driver_Type is record

--- a/testsuite/gna/issue827/blk.vhd
+++ b/testsuite/gna/issue827/blk.vhd
@@ -1,0 +1,29 @@
+--  Same conversion, on the port map of a block header: that one has no
+--  instance to hold the layout of the slice.
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use std.env.finish;
+
+entity blk is
+  generic (w : positive := 4);
+end blk;
+
+architecture behav of blk is
+  signal s : std_ulogic_vector (15 downto 0);
+begin
+  b : block
+    port (p : out unsigned (w - 1 downto 0));
+    port map (std_ulogic_vector(p) => s (w - 1 downto 0));
+  begin
+    p <= (others => '1');
+  end block;
+
+  process
+  begin
+    wait for 1 ns;
+    assert s (3 downto 0) = "1111"
+      report "bad s: " & to_string (s) severity failure;
+    finish;
+  end process;
+end architecture;

--- a/testsuite/gna/issue827/multi.vhd
+++ b/testsuite/gna/issue827/multi.vhd
@@ -1,0 +1,56 @@
+--  Two instances of the same architecture, with a different generic: the
+--  layout of the slice actual must be per-instance, not shared.
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity sub is
+  generic (w : positive);
+  port (o : out unsigned (w - 1 downto 0));
+end sub;
+
+architecture behav of sub is
+begin
+  o <= (others => '1');
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity top is
+  generic (w : positive);
+  port (q : out std_ulogic_vector (15 downto 0));
+end top;
+
+architecture behav of top is
+begin
+  inst : entity work.sub
+    generic map (w => w)
+    port map (std_ulogic_vector(o) => q (w - 1 downto 0));
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use std.env.finish;
+
+entity multi is
+end multi;
+
+architecture behav of multi is
+  signal q1 : std_ulogic_vector (15 downto 0);
+  signal q2 : std_ulogic_vector (15 downto 0);
+begin
+  t1 : entity work.top generic map (w => 4) port map (q => q1);
+  t2 : entity work.top generic map (w => 12) port map (q => q2);
+
+  process
+  begin
+    wait for 1 ns;
+    assert q1 (3 downto 0) = "1111"
+      report "bad q1: " & to_string (q1) severity failure;
+    assert q2 (11 downto 0) = "111111111111"
+      report "bad q2: " & to_string (q2) severity failure;
+    finish;
+  end process;
+end architecture;

--- a/testsuite/gna/issue827/testsuite.sh
+++ b/testsuite/gna/issue827/testsuite.sh
@@ -6,11 +6,26 @@
 # actual is a slice with generic-dependent bounds used to raise
 # ASSERTION_ERROR at trans-chap3.adb:60 with the gcc and llvm backends:
 # the anonymous subtype of the slice is only ever reached through that
-# conversion, so its layout variable was never elaborated.  mcode was
-# not affected.  See issue827 (and the identical issue3088).
+# conversion, so its layout variable was never created.  mcode was not
+# affected.  See issue827 (and the identical issue3088).
 export GHDL_STD_FLAGS="--std=08"
 analyze ent.vhd tb.vhd
 elab_simulate tb
+
+clean
+
+# That layout must be a variable of the instance, not a global one: with
+# two instances of the same architecture and a different generic, sharing
+# it made the conversion use the bounds of the other instance.
+analyze multi.vhd
+elab_simulate multi
+
+clean
+
+# Same conversion on the port map of a block header, which has no
+# instance record to put that layout in.
+analyze blk.vhd
+elab_simulate blk
 
 clean
 


### PR DESCRIPTION
# PR #3384 follow-up — the layout of a slice actual must live in the instance

Analysis by an AI agent.

## The review comment

On [#3384](https://github.com/ghdl/ghdl/pull/3384) (merged), tgingold wrote:

> I don't think new flags in info have to be added, but fine for now.

The flags are `In_Fresh` and `Out_Fresh`, added to `Assoc_Conv_Info` in `trans.ads`. `Translate_Association_Subprogram` recorded in them which of the two association types it had just translated, so that `Elab_Conversion` knew whose layout to elaborate. He is right that they should not be there — and for a stronger reason than tidiness: they were the visible symptom of the layout variable being created in the wrong place.

## What the flags were hiding

#3384 fixed the crash by translating both types with `With_Vars => True`, so that the composite-layout variable of the slice's anonymous subtype actually gets allocated. But `Create_Var` allocates into `Inst_Build`, the instance factory that is *currently pushed*, and `Translate_Association_Subprograms` is called from `Translate_Block_Subprograms`, where no factory is pushed at all. `Create_Var` then falls into its `Global` branch and returns a `Create_Global_Var`.

So the layout of the slice was one global, shared by every instance of the architecture. It is visible in the object file:

```
$ ghdl -a multi.vhd && ghdl -e multi && nm *.o | grep STL
0000000000000000 B work__top__ARCH__behav__inst__CONVOUT__o__U0__STL
```

`B` is writable, uninitialised data — one instance of it for the whole program, whereas the other `STL` symbols in that design are `R`/`r`, read-only static layouts that are the same for every instance and can be shared. Each instance overwrites it at elaboration, the last one wins, and the conversion subprogram — which reads it at *run* time, on every call — then works with the bounds of whichever instance elaborated last. With two instances of the same architecture and a different generic:

```
./multi:error: bound check failure at multi.vhd:30
```

That is on current master, with the gcc and llvm backends. One instance hides it completely, which is why the tests added by #3384 pass.

## What the fix does

`Chap9.Translate_Component_Instantiation_Statement` already builds a record in the instance for exactly this purpose — the `__CONVS` record, whose comment reads *"When conversions are used, the subtype of the actual (or of the formal for formal conversions) may not be yet translated. This can happen if the name is a slice. We need to translate it and create variables in the instance because it will be referenced by the conversion subprogram."* That is the machinery that was missing its case, not machinery that had to be invented.

1. **`trans-chap9.adb`** — the subtype of the actual was only created for an *actual* conversion, although the conversion subprogram references it whichever side the conversion is on: an actual conversion converts the actual to the formal, a formal conversion converts the formal to the actual. `Need_Actual` now covers both. The variable is created inside `Push_Instance_Factory (Info.Block_Scope'Access)`, so it becomes a field of the instantiation's record instead of a global, and the `B` symbol above disappears.

2. **`trans-chap5.adb`** — the elaboration of those bounds no longer needs to be remembered, it can be asked for where it is missing. `Elab_Port_Map_Aspect_Assoc` elaborates the subtype of a slice actual before the conversion allocates its result, in the environment of the actual. Only the formal-conversion path needs it: on the actual-conversion path `Elab_Conversion` translates the name of the actual (`Chap6.Translate_Signal_Name` of its input), and `Translate_Slice_Name_Init` elaborates the subtype as a side effect, before the bounds are used. On the formal-conversion path the actual is not the input but the destination, its name is only translated *after* the conversion has been elaborated, and nothing else does it.

3. **`trans-chap4.adb`, `trans.ads`, `trans-chap3.ads`** — revert to their exact pre-#3384 content, except that `Translate_Anonymous_Subtype_Definition` keeps `With_Vars => True`. Both flags and the `Elab_Composite_Subtype_Layout` export are gone.

The condition used in chap5 is `Get_Kind (Actual) = Iir_Kind_Slice_Name`, re-derived from the tree at elaboration rather than stored at translation. Testing the type instead would not work: `Is_Anonymous_Type_Definition` is also true of an ordinary port subtype indication such as `std_logic_vector(bit_count - 1 downto 0)`, whose layout belongs to the entity's instance and must not be re-elaborated from the instantiating block.

## Why `With_Vars => True` stays

Dropping it re-raises `ASSERTION_ERROR : trans-chap3.adb:60`, for a shape #3384 fixed and had no test for: the port map of a **block header**. `Translate_Association_Subprograms` is called there with the header as `Stmt`, `Get_Info (Hdr)` carries no scope, and there is no instantiation statement, hence no `__CONVS` record to put the layout in. The global created from chap4 is the fallback for that case, and is the pre-existing behaviour, so the block-header path is unchanged by this patch. `blk.vhd` now covers it.

Note also that the asymmetry between formal and actual is real and not an oversight: a formal that is a slice must have a locally static range (`range expression must be locally static`), so only the actual side can have generic-dependent bounds, and only the actual side needs a per-instance layout.

## Testing

`testsuite/gna/issue827` gains two designs:

- `multi.vhd` — two instances of the same architecture with `w => 4` and `w => 12`. Fails on master (`bound check failure`), passes with the fix.
- `blk.vhd` — the same conversion on the port map of a block header, the shape that has no instance record.

Full `gna` (1139 tests), `sanity` and `synth` suites, all four backend variants, all successful:

| backend | gna | sanity | synth |
| --- | --- | --- | --- |
| llvm | ok | ok | ok |
| gcc | ok | ok | ok |
| mcode | ok | ok | ok |
| llvm-jit | ok | ok | ok |

mcode and llvm-jit were not affected by the shared layout, as they were not affected by the original crash either, although they do run the same `src/vhdl/translate` front end — they report `static elaboration, <backend> JIT code generator` and translate the whole design in one pass rather than one unit at a time. The two designs are run on all four regardless.
