### PR TITLE
ghdldrv: give each design file its own object file

### DIFF
--- a/libraries/Makefile.inc
+++ b/libraries/Makefile.inc
@@ -369,19 +369,19 @@ $(IEEE19_DIR)/ieee-obj19.cf: $(ANALYZE_DEP) $(IEEE19_SRCS) $(SYNOPSYS19_SRCS) $(
 
 ANALYZE_STD=$(GHDL) --bootstrap-standard $(GHDL_FLAGS)
 
-$(STD87_DIR)/std_standard.o: $(GHDL) std.v87
+$(STD87_DIR)/std_standard.vhdl.o: $(GHDL) std.v87
 	cd $(STD87_DIR); $(ANALYZE_STD) --std=87
 
-$(STD93_DIR)/std_standard.o: $(GHDL) std.v93
+$(STD93_DIR)/std_standard.vhdl.o: $(GHDL) std.v93
 	cd $(STD93_DIR); $(ANALYZE_STD) --std=93
 
-$(STD08_DIR)/std_standard.o: $(GHDL) std.v08
+$(STD08_DIR)/std_standard.vhdl.o: $(GHDL) std.v08
 	cd $(STD08_DIR); $(ANALYZE_STD) --std=08
 
-$(STD19_DIR)/std_standard.o: $(GHDL) std.v19
+$(STD19_DIR)/std_standard.vhdl.o: $(GHDL) std.v19
 	cd $(STD19_DIR); $(ANALYZE_STD) --std=19
 
-libs.vhdl.standard: $(STD87_DIR)/std_standard.o \
- $(STD93_DIR)/std_standard.o \
- $(STD08_DIR)/std_standard.o \
- $(STD19_DIR)/std_standard.o
+libs.vhdl.standard: $(STD87_DIR)/std_standard.vhdl.o \
+ $(STD93_DIR)/std_standard.vhdl.o \
+ $(STD08_DIR)/std_standard.vhdl.o \
+ $(STD19_DIR)/std_standard.vhdl.o

--- a/src/ghdldrv/ghdldrv.adb
+++ b/src/ghdldrv/ghdldrv.adb
@@ -351,15 +351,13 @@ package body Ghdldrv is
       Table_Low_Bound => 1,
       Table_Initial => 16);
 
-   --  The object file of a design file is named after the *base* name of its
-   --  source file, in the library directory.  So two design files with the
-   --  same base name in different directories (dir1/pkg.vhdl and
-   --  dir2/pkg.vhdl) are both compiled to the same pkg.o: the second
-   --  analysis overwrites the first object file, and the link then either
-   --  fails with a pile of "multiple definition" messages or silently uses
-   --  the wrong object.  Detect it here, where the link list is built, and
-   --  say what is wrong instead of leaving the user with linker errors
-   --  about symbols they never wrote.  See #539 and #1622.
+   --  Two design files of a library are not supposed to share an object
+   --  file anymore, as Ghdllocal.Get_Object_Prefix identifies each one by
+   --  the name of its source file and a number.  Only that number may
+   --  collide.  Keep checking it here, where the link list is built:
+   --  otherwise one object file overwrites the other and the link either
+   --  fails with a pile of "multiple definition" messages or silently
+   --  uses the wrong object.  See #539 and #1622.
    procedure Check_Object_Collision (Obj : String; Src : String) is
    begin
       for I in Objlist.First .. Objlist.Last loop
@@ -368,7 +366,7 @@ package body Ghdldrv is
          then
             Error ("'" & Src & "' and '" & Objsrclist.Table (I).all
                      & "' are both compiled to '" & Obj & "'");
-            Error ("(object files are named after the source file base name;"
+            Error ("(the object file is named after the source file;"
                      & " rename one of these files)");
             raise Compile_Error;
          end if;
@@ -449,9 +447,9 @@ package body Ghdldrv is
                Filelist.Append (File);
             else
                if To_Obj then
-                  File := new String'(Dir (1 .. Dir_Len)
-                                      & Get_Base_Name (Line (1 .. L))
-                                      & Obj_Suffix);
+                  File := new String'
+                    (Get_Object_Prefix (Dir (1 .. Dir_Len), Line (1 .. L))
+                       & Obj_Suffix);
                   Check_Object_Collision (File.all, Line (1 .. L));
                else
                   File := new String'(Substitute (Line (1 .. L)));
@@ -475,7 +473,7 @@ package body Ghdldrv is
    begin
       Dir := Get_Library_Directory (Get_Library (File));
       Name := Get_Design_File_Filename (File);
-      return Image (Dir) & Get_Base_Name (Image (Name)) & Obj_Suffix;
+      return Get_Object_Prefix (Image (Dir), Image (Name)) & Obj_Suffix;
    end Get_Object_Filename;
 
    procedure Add_Argument (Inst : in out Instance; Arg : String_Acc) is
@@ -1184,7 +1182,7 @@ package body Ghdldrv is
               String'(Get_Machine_Path_Prefix & Get_Directory_Separator
                       & "std" & Get_Directory_Separator
                       & Get_Version_Path & Get_Directory_Separator
-                      & "std_standard" & Obj_Suffix);
+                      & "std_standard.vhdl" & Obj_Suffix);
             P := P + 1;
             Args (P) := Std_File;
          else

--- a/src/ghdldrv/ghdllocal.adb
+++ b/src/ghdldrv/ghdllocal.adb
@@ -593,6 +593,47 @@ package body Ghdllocal is
       return Filename (First .. Last);
    end Get_Base_Name;
 
+   --  A short number identifying the source file among the files of a
+   --  library.  This is a hash (fnv-1a) of the file name as it was written
+   --  on the command line: its relative path, its name and its extension,
+   --  which together are unique in a library.  It is computed on the path
+   --  as written, so it doesn't change when relative sources are moved.
+   function Get_File_Number (File : String) return String
+   is
+      Hash : Uns32 := 16#811c_9dc5#;
+      Img : String (1 .. 5);
+      Val : Uns32;
+   begin
+      for I in File'Range loop
+         Hash := Hash xor Uns32 (Character'Pos (File (I)));
+         Hash := Hash * 16#0100_0193#;
+      end loop;
+
+      --  Five decimal digits are enough to tell apart the files of a
+      --  design; Ghdldrv.Check_Object_Collision reports the rest.
+      Val := Hash mod 100_000;
+      for I in reverse Img'Range loop
+         Img (I) := Character'Val (Character'Pos ('0') + Val mod 10);
+         Val := Val / 10;
+      end loop;
+      return Img;
+   end Get_File_Number;
+
+   function Get_Object_Prefix (Dir : String; File : String) return String
+   is
+      Pos : constant Natural := Get_Basename_Pos (File);
+      --  The name of the source file, extension included.
+      Name : constant String := File (Pos + 1 .. File'Last);
+   begin
+      if Pos < File'First then
+         --  No directory: the name is enough to identify the file within
+         --  the library.  This is also the case of std_standard.
+         return Dir & Name;
+      else
+         return Dir & Name & '-' & Get_File_Number (File);
+      end if;
+   end Get_Object_Prefix;
+
    function Append_Suffix
      (File : String; Suffix : String; In_Work : Boolean := True)
      return String_Acc
@@ -600,8 +641,11 @@ package body Ghdllocal is
       use Name_Table;
    begin
       if In_Work then
-         return new String'(Image (Libraries.Work_Directory)
-                              & Get_Base_Name (File) & Suffix);
+         declare
+            Dir : constant String := Image (Libraries.Work_Directory);
+         begin
+            return new String'(Get_Object_Prefix (Dir, File) & Suffix);
+         end;
       else
          return new String'(File & Suffix);
       end if;

--- a/src/ghdldrv/ghdllocal.ads
+++ b/src/ghdldrv/ghdllocal.ads
@@ -92,8 +92,16 @@ package Ghdllocal is
    --  path (PATH).
    function Is_Basename (Pathname : String) return Boolean;
 
+   --  Return the path of the object file of source file FILE in library
+   --  directory DIR, without its suffix.  Two design files of a library
+   --  never share it: the object file keeps the name of the source file,
+   --  its extension included, and a unique number is added when
+   --  FILE has a directory part. See #539 and #1622.
+   function Get_Object_Prefix (Dir : String; File : String) return String;
+
    --  Build a filename based on FILE. If IN_WORK is true, the result is
-   --  the concatenation of the workdir, the basename of FILE and SUFFIX.
+   --  the object file name of FILE in the workdir (see Get_Object_Prefix)
+   --  with SUFFIX.
    --  If IN_WORK is false, the result is the concatenation of FILE and SUFFIX.
    function Append_Suffix
      (File : String; Suffix : String; In_Work : Boolean := True)

--- a/testsuite/gna/issue1622/testsuite.sh
+++ b/testsuite/gna/issue1622/testsuite.sh
@@ -3,8 +3,10 @@
 . ../../testenv.sh
 
 # Same defect as issue539, in the shape users hit most often: src/test.vhd
-# and tests/test.vhd are both compiled to test.o, so the link used to fail
-# with "multiple definition" errors.  GHDL now reports the collision.
+# and tests/test.vhd were both compiled to test.o, so the link failed with
+# "multiple definition" errors.  The object file now keeps the name and
+# the extension of the source file, followed by a number identifying its
+# directory.
 # Only the compiled backends (gcc, llvm) write object files; the JIT
 # backends (mcode, llvm-jit) do not and are not affected.  See issue1622.
 if "$GHDL" --version | grep -q "JIT code generator"; then
@@ -15,24 +17,39 @@ fi
 export GHDL_STD_FLAGS="--std=08"
 
 analyze src/test.vhd tests/test.vhd
+elab_simulate other_thing
 
-if OUT=$(elab other_thing 2>&1); then
-  echo "$OUT"
-  echo "FAIL: the collision was not reported"
-  exit 1
-fi
-echo "$OUT"
-
-if echo "$OUT" | grep -q "multiple definition"; then
-  echo "FAIL: reached the link and got the raw linker errors"
-  exit 1
-fi
-
-if ! echo "$OUT" | grep -q "are both compiled to"; then
-  echo "FAIL: expected the object file collision diagnostic"
+if [ "$(ls test.vhd-*.o 2> /dev/null | wc -l)" -ne 2 ]; then
+  echo "FAIL: expected an object file for each test.vhd"
+  ls
   exit 1
 fi
 
 clean
+
+# The number is computed on the path as it is written, so a directory
+# that is not below the directory of analysis is not a special case: the
+# vhdl libraries of ghdl itself are analyzed as '../../src/ieee/...vhdl'.
+# Check a '..' path and an absolute path each get their own object file,
+# and that a source without any directory keeps a plain name (that one is
+# how std_standard is compiled).
+mkdir -p build
+"$GHDL" -a --std=08 --workdir=build ../issue1622/src/test.vhd
+"$GHDL" -a --std=08 --workdir=build "$(pwd)/tests/test.vhd"
+if [ "$(ls build/test.vhd-*.o 2> /dev/null | wc -l)" -ne 2 ]; then
+  echo "FAIL: expected an object file for each path"
+  ls build
+  exit 1
+fi
+rm -rf build
+
+mkdir -p build
+(cd src; "$GHDL" -a --std=08 --workdir=../build test.vhd)
+if [ ! -f build/test.vhd.o ]; then
+  echo "FAIL: a source without a directory must keep a plain object name"
+  ls build
+  exit 1
+fi
+rm -rf build
 
 echo "Test successful"

--- a/testsuite/gna/issue539/ext/pkg.vhd
+++ b/testsuite/gna/issue539/ext/pkg.vhd
@@ -1,0 +1,2 @@
+package pkg3 is
+end package pkg3;

--- a/testsuite/gna/issue539/ext/pkg.vhdl
+++ b/testsuite/gna/issue539/ext/pkg.vhdl
@@ -1,0 +1,2 @@
+package pkg4 is
+end package pkg4;

--- a/testsuite/gna/issue539/ext/top_ext.vhd
+++ b/testsuite/gna/issue539/ext/top_ext.vhd
@@ -1,0 +1,9 @@
+use work.pkg3.all;
+use work.pkg4.all;
+
+entity top_ext is
+end entity;
+
+architecture a of top_ext is
+begin
+end architecture;

--- a/testsuite/gna/issue539/testsuite.sh
+++ b/testsuite/gna/issue539/testsuite.sh
@@ -2,11 +2,13 @@
 
 . ../../testenv.sh
 
-# The object file of a design file is named after the base name of its
-# source file, so pkg1/pkg.vhd and pkg2/pkg.vhd are both compiled to
-# pkg.o: the second analysis overwrites the first object file and the
-# link used to fail with a pile of "multiple definition" messages about
-# symbols the user never wrote.  GHDL now says what is wrong instead.
+# The object file of a design file used to be named after the *base* name
+# of its source file, in the library directory, so pkg1/pkg.vhd and
+# pkg2/pkg.vhd were both compiled to pkg.o: the second analysis
+# overwrote the first object file and the link failed with a pile of
+# "multiple definition" messages about symbols the user never wrote.
+# The object file now keeps the name and the extension of the source
+# file, followed by a number identifying its directory.
 # Only the compiled backends (gcc, llvm) write object files; the JIT
 # backends (mcode, llvm-jit) do not and are not affected.  See issue539
 # (and the identical issue1622).
@@ -16,21 +18,34 @@ if "$GHDL" --version | grep -q "JIT code generator"; then
 fi
 
 "$GHDL" -i pkg1/pkg.vhd pkg2/pkg.vhd top.vhd
+"$GHDL" -m top
+run ./top
 
-if OUT=$("$GHDL" -m top 2>&1); then
-  echo "$OUT"
-  echo "FAIL: the collision was not reported"
-  exit 1
-fi
-echo "$OUT"
-
-if echo "$OUT" | grep -q "multiple definition"; then
-  echo "FAIL: reached the link and got the raw linker errors"
+# One object file per source, not one for both.
+if [ "$(ls pkg.vhd-*.o 2> /dev/null | wc -l)" -ne 2 ]; then
+  echo "FAIL: expected an object file for each pkg.vhd"
+  ls
   exit 1
 fi
 
-if ! echo "$OUT" | grep -q "are both compiled to"; then
-  echo "FAIL: expected the object file collision diagnostic"
+"$GHDL" --clean
+if ls pkg.vhd-*.o > /dev/null 2>&1; then
+  echo "FAIL: --clean left the object files behind"
+  exit 1
+fi
+
+clean
+
+# Two sources of the same directory that differ only by their extension
+# are in the same case: example.vhd and example.vht, reported by
+# Mercotui on issue539.  The extension is part of the object file name.
+"$GHDL" -i ext/pkg.vhd ext/pkg.vhdl ext/top_ext.vhd
+"$GHDL" -m top_ext
+run ./top_ext
+
+if ! ls pkg.vhd-*.o > /dev/null 2>&1 || ! ls pkg.vhdl-*.o > /dev/null 2>&1; then
+  echo "FAIL: the extension must be part of the object file name"
+  ls
   exit 1
 fi
 


### PR DESCRIPTION
Closes #539 
Closes #1622 

# Issues #539 and #1622 — object files collide when two sources share a base name

Analysis by an AI agent.

## What was left open

Both issues report the same thing: with the gcc or llvm backend, `ghdl -a` writes an object file named after the source file's *base* name into the library directory, so two design files with the same base name overwrite each other's object file, and the link fails with a wall of "multiple definition" messages about symbols the user never wrote.

The previous change ([#3383](https://github.com/ghdl/ghdl/pull/3383)) only implemented the sanity check tgingold had considered ("Maybe I should add code to detect this situation"), and left the naming open, because the thread has three proposals for it:

- a hash of the full file path, Mercotui on #539 — tgingold: *"Adding a hash would prevent from moving files"*;
- a unique number per object file, tgingold on #1622: *"A fix could be to append a unique number to each object file"*;
- mirroring the source directory under the object directory, jpf91 on #1622: *"`src/test.vhd` => `obj/mylib/src/test.o`"*.

## What the fix does

An object file has to be told apart from another by everything that tells the two source files apart, and `Ghdllocal.Get_Object_Prefix` now names it after the source file itself: its name, its **extension**, and a **number** identifying its directory.

```
src/test.vhd   ->  test.vhd-23236.o
tests/test.vhd ->  test.vhd-50195.o
ext/pkg.vhd    ->  pkg.vhd-66865.o
ext/pkg.vhdl   ->  pkg.vhdl-59879.o
top.vhd        ->  top.vhd.o
```

All of them stay directly in the library directory, as they always have.

- The **extension** is what closes the case Mercotui reported on #539: `example.vhd` and `example.vht` are two different files of the *same* directory, so nothing about the directory can separate them.
- The **number** is tgingold's proposal from #1622. It is a hash (fnv-1a, five decimal digits) of the file name as it was written on the command line — its relative path, its name and its extension, which together are unique within a library. A source file given without any directory has nothing to disambiguate and keeps a plain object file name.

Three places name an object file and all three go through that one function: `Ghdllocal.Append_Suffix`, which names the object (and asm, and post) file of an analysis and is also what `--clean` and `--remove` delete; `Ghdldrv.Get_Object_Filename`, used by `--gen-makefile`, by `-f`, and by `Missing_Object_File`, which is how `-m` decides to recompile; and `Ghdldrv.Add_File_List`, which turns the file list written at elaboration into the object files handed to the linker.

Because the library file records the file name as it was given on the command line (`file "/home/u/proj/" "src/test.vhd"`), analysis and link derive the same name from the same string, and nothing new has to be stored in the library.

`Check_Object_Collision` from #3383 stays, now as a backstop for a collision of that number rather than as the general case.

## Why this hash is not the hash tgingold rejected

Mercotui proposed hashing the **full file path**, and tgingold's objection was *"Adding a hash would prevent from moving files"* — an absolute path changes when the project is moved, so every object file would be renamed and recompiled.

This number is computed on the path **as it was written on the command line**, which is relative in the case that matters. `../../src/ieee/numeric_std.vhdl` hashes the same wherever the project sits, and so does `src/test.vhd`. Only a source given by an absolute path gets a number that moves with it, and it is then no worse off than the design file itself, which the library records by that same absolute path.

## Why not mirror the source directory under the object directory

That was implemented first, and then dropped, for two reasons found while testing it:

- The library directory is the current directory by default. Mirroring then puts the object files **inside the user's source subdirectories** — `ghdl -m top` in a project without `--workdir` scatters `.o` files across `src/`, `tests/` and so on. Only a build directory makes the mirror look like jpf91's example.
- It does not close #539 anyway. `example.vhd` and `example.vht` are in the same directory, so they still need the extension, and a source whose directory cannot be mirrored — an absolute path, or one with a `..` component, which is how the vhdl libraries of ghdl itself are analyzed (`../../src/ieee/numeric_std.vhdl`) — still needs a number. The mirror was a third mechanism on top of the two that are actually needed.

`install.vhdllib` also copies `$(LIBDST_DIR)/$$d/*`, one flat directory at a time, so mirroring the object files of the standard libraries into subdirectories would have meant not installing them at all.

The one thing the mirror gave that this does not is jpf91's other point: with mirrored names, a makefile wildcard rule can derive the source of an object. `--gen-makefile` still emits a correct explicit rule per file, but `test.vhd-23236.o` cannot be turned back into `src/test.vhd` by a pattern.

## Things to know before merging

- **Every object file is renamed**, once: `test.o` becomes `test.vhd-23236.o`, and `std_standard.o` becomes `std_standard.vhdl.o`. The two places that spell the latter out — `Ghdldrv.Link` and the `libs.vhdl.standard` targets in `libraries/Makefile.inc` — were updated.
- **Upgrading is handled but leaves litter.** `-m` recompiles the files whose object is not at the new name (`Missing_Object_File` looks it up through the same function), and the link list only contains the new names, so a stale `pkg.o` from an older GHDL is never linked in — but it is not deleted either, and `--clean` will not remove it.
- The number is five decimal digits. Two files that collide on it are reported by `Check_Object_Collision`, not silently mislinked.
- `Ghdllocal.Get_Base_Name` no longer has any caller: object naming was its only use.

## Testing

- `testsuite/gna/issue539` — the reporter's `pkg1/pkg.vhd` + `pkg2/pkg.vhd`, through `ghdl -i` and `ghdl -m`, run, asserting there is one object file per source and that `--clean` removes them; then Mercotui's case, `ext/pkg.vhd` + `ext/pkg.vhdl`, analyzed, linked and run, asserting the extension is what separates them.
- `testsuite/gna/issue1622` — the reporter's `src/test.vhd` + `tests/test.vhd`, analyzed, elaborated and run, asserting one object file per source; then a `..` path and an absolute path, asserting each gets its own; then a source analyzed without any directory, asserting it keeps a plain object file name (that is how `std_standard` is compiled).

Both skip on the JIT backends, which write no object files.

Full `gna` (1139 tests), `sanity` and `synth` suites pass on all four backend variants: llvm, gcc, mcode and llvm-jit.
