### PR TITLE
issue742: add a regression test for the nested unconstrained array constant

### DIFF
--- a/testsuite/gna/issue742/crash.vhdl
+++ b/testsuite/gna/issue742/crash.vhdl
@@ -1,0 +1,19 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity crashing_entity is
+end crashing_entity;
+
+architecture crashing_arch of crashing_entity is
+
+  type byte_array is array (natural range <>) of std_logic_vector(7 downto 0);
+  type message_array is array (natural range <>) of byte_array;
+
+  constant messages : message_array := (
+    (X"00", X"00"),
+    (X"00", X"00")
+  );
+
+begin
+
+end crashing_arch;

--- a/testsuite/gna/issue742/test_pkg.vhdl
+++ b/testsuite/gna/issue742/test_pkg.vhdl
@@ -1,0 +1,72 @@
+----------------------------------------------------------------------------
+-- File: test_pkg.vhd
+-- Project:
+-- Description: MWE for function recursion
+--
+--
+-- Author: Greg Davey
+-- Data modified: 01/26/2019
+-- Version: 1.0
+----------------------------------------------------------------------------
+library ieee;
+    use ieee.std_logic_1164.all;
+    use ieee.numeric_std.all;
+    use ieee.fixed_pkg.all;
+
+package test_pkg is
+    type t_sl_array is array(natural range <>) of std_logic;
+    type t_slv_array is array(natural range <>) of std_logic_vector;
+    type t_sf_array is array (natural range <>) of sfixed;
+
+    type t_complex_sfixed is record
+        i : sfixed;
+        q : sfixed;
+    end record;
+
+    type t_csf_array is array (natural range <>) of t_complex_sfixed;
+
+    type t_cfixed_row_vector is array(positive range <>) of t_complex_sfixed;
+
+    function to_string         (data      : t_complex_sfixed)    return string;
+
+    function to_string         (data      : t_cfixed_row_vector) return string;
+
+    --impure function do_something (samples : integer; ret_type : sfixed) return t_sf_array;
+
+end package;
+
+
+package body test_pkg is
+    --return the string representation of a complex number
+    function to_string (
+        data : t_complex_sfixed)
+        return string is
+
+    begin
+        return "(" & real'image(to_real(data.i)) & " + " & real'image(to_real(data.q)) & "i)";
+    end function;
+
+
+    --return the string representation of a complex row vector
+    function to_string (
+        data : t_cfixed_row_vector)
+        return string is
+    begin
+        if (data'length > 1) then
+            return to_string(data(data'low to data'high - 1)) & ", " & to_string(data(data'high));
+        else
+            return to_string(data(data'low));
+        end if;
+    end function;
+
+
+    ----check unconstrained return type
+    --impure function do_something (samples : integer; ret_type : sfixed) return t_sf_array is
+    --    variable init_array      : t_sf_array(0 to samples - 1)(ret_type'left downto ret_type'right) := (others => (others => '0'));
+    --begin
+    --    for i in 0 to (samples - 1) loop
+    --        init_array(i)   := to_sfixed(1.0 / real(1+i), ret_type);
+    --    end loop;
+    --    return init_array;
+    --end function;
+end package body;

--- a/testsuite/gna/issue742/testsuite.sh
+++ b/testsuite/gna/issue742/testsuite.sh
@@ -1,0 +1,18 @@
+#! /bin/sh
+
+. ../../testenv.sh
+
+export GHDL_STD_FLAGS=--std=08
+
+# The original report: a package with a recursive to_string over an array of
+# records whose elements are unbounded (sfixed).
+analyze test_pkg.vhdl
+
+# The reduction posted on the issue: a constant of a nested unconstrained
+# array type, whose element subtype is only known from the aggregate.
+analyze crash.vhdl
+elab_simulate crashing_entity
+
+clean
+
+echo "Test successful"


### PR DESCRIPTION
Closes #742

The report was filed as a recursive-function crash, but the reduction posted on the thread by julian-becker shows it is not: a constant of an unconstrained array whose element subtype is itself unconstrained was enough to reach Error_Kind in Get_Composite_Type_Layout (trans-chap3.adb:49), because the element subtype had neither a layout of its own nor a Subtype_Owner to borrow one from.

Both the reduction and the reporter's original test_pkg.vhdl analyse cleanly on master today, so this adds only the two reproducers as a regression test.
