### PR TITLE
llvm: support llvm 23

### DIFF
--- a/configure
+++ b/configure
@@ -327,6 +327,7 @@ if test $backend = llvm -o $backend = llvm_jit; then
        check_version 20. $llvm_version ||
        check_version 21. $llvm_version ||
        check_version 22. $llvm_version ||
+       check_version 23. $llvm_version ||
        false; then
     echo "Debugging is enabled with llvm $llvm_version"
   else

--- a/src/ortho/llvm6/llvm-cbindings.cpp
+++ b/src/ortho/llvm6/llvm-cbindings.cpp
@@ -1747,7 +1747,8 @@ start_subprogram_body(ODnodeSubprg *Func)
         ParamsArr.push_back(Inter->Dtype->Dbg);
     }
 
-    DITypeRefArray Params = DBuilder->getOrCreateTypeArray(ParamsArr);
+    //  llvm 23 renamed DITypeRefArray to DITypeArray; 'auto' spells both.
+    auto Params = DBuilder->getOrCreateTypeArray(ParamsArr);
     Ty = DBuilder->createSubroutineType(Params);
 
 #if LLVM_VERSION_MAJOR >= 8


### PR DESCRIPTION
# macOS CI broken — "Unhandled version llvm 23.1.0"

https://github.com/ghdl/ghdl/actions/runs/33720771239/job/100539330848

Analysis by an AI agent.

## High-level summary

The macOS llvm job has been failing at the configure step with `Unhandled version llvm 23.1.0`. No commit broke it: the job installs llvm from Homebrew without pinning a version, and Homebrew moved the `llvm` formula to 23.1.0. GHDL's `configure` only accepted up to `22.`, so it stopped at its own version gate.

Enabling 23 in that gate is not sufficient on its own. llvm 23 removed `DITypeRefArray`, so `src/ortho/llvm6/llvm-cbindings.cpp` no longer compiles against it, and a configure-only change would have moved the CI failure from configure to the build.

## Root cause 1 — the configure version gate

`configure` has an explicit list of accepted llvm versions, one `check_version` per release:

```sh
       check_version 21. $llvm_version ||
       check_version 22. $llvm_version ||
       false; then
    echo "Debugging is enabled with llvm $llvm_version"
  else
    echo "Unhandled version llvm $llvm_version"
    exit 1
```

`check_version` is a prefix match with `.` rewritten to `v`, so `check_version 23.` tests `^23v` against `23v1v0`. The list was last extended by 2baf7858d ("tentatively enable llvm 22.x"), which is also the last commit to touch `configure` for this; none of the recent commits on master touch `configure` or `.github/workflows/Build-MacOS.yml`. The job runs a bare `brew install llvm coreutils` with no version, so the break arrived with Homebrew, not with a GHDL change, and would have hit whichever commit ran next.

## Root cause 2 — DITypeRefArray removed in llvm 23

With the gate opened, the build fails instead:

```
llvm-cbindings.cpp:1750:5: error: 'DITypeRefArray' was not declared in this scope
 1750 |     DITypeRefArray Params = DBuilder->getOrCreateTypeArray(ParamsArr);
llvm-cbindings.cpp:1751:41: error: 'Params' was not declared in this scope
```

`DIBuilder::getOrCreateTypeArray` returned `DITypeRefArray` up to llvm 22 and returns `DITypeArray` in llvm 23; the old name is gone from `llvm/IR/DebugInfoMetadata.h`. Only the debug-info path in `Start_Subprogram_Body` names that type.

This is the whole of GHDL's exposure to the llvm API bump. The Ada side (`ortho_llvm.ads`, `ortho_llvm.adb`) imports GHDL's own C++ wrappers — `ortho_llvm_init`, `Set_Optimization_Level` and so on, all defined in `llvm-cbindings.cpp` — rather than llvm's C API directly, so `llvm-cbindings.cpp` is the single file that can break on a new llvm.

## What the fix does

`configure` gains `check_version 23.`, in the same form as the surrounding lines.

`llvm-cbindings.cpp` spells the type `auto`:

```cpp
    //  llvm 23 renamed DITypeRefArray to DITypeArray; 'auto' spells both.
    auto Params = DBuilder->getOrCreateTypeArray(ParamsArr);
    Ty = DBuilder->createSubroutineType(Params);
```

`auto` was preferred over `#if LLVM_VERSION_MAJOR >= 23` because the variable only feeds `createSubroutineType`, whose parameter type tracks the same rename, so nothing else needs to know the spelling — and it will survive the next rename without another guard. Every other `LLVM_VERSION_MAJOR` guard in the file is open-ended (`>= N` or `< N`, the highest being `>= 18`) with no exact-match or upper-bounded arm, so llvm 23 otherwise takes exactly the same code paths as 22.

## Testing performed

**The version gate, against a real llvm 23.1.0 `llvm-config`.** Master's `configure` reproduces the CI failure exactly:

```
Unhandled version llvm 23.1.0
```

and with the fix it passes:

```
Debugging is enabled with llvm 23.1.0
```

**A full GHDL built against llvm 23.1.0.** `configure --with-llvm-config=.../llvm/23.1.0/bin/llvm-config` followed by `make` and `make install` completes with zero errors, and the result reports:

```
GHDL 7.0.0-dev (tarball) [Dunoon edition]
 Compiled with GNAT Version: 16.2.0
 llvm 23.1.0 code generator
```

So the fix is verified where it matters: the two things that broke — the gate and the compilation of `llvm-cbindings.cpp` — are both cleared, and nothing else in llvm 23 breaks the build or the link.

**Backward compatibility.** `llvm-cbindings.cpp` also compiles against the headers of llvm 22.1.8 and 18.1.8 with zero errors, so `auto` is right for old and new alike.

**No regression.** Full `sanity gna synth vpi vhpi vests` against all three backends — mcode, llvm (built against 23.1.0) and gcc 15.3.0 — all built with checks enabled (`-gnata`).

A first attempt at this used the upstream prebuilt release `LLVM-23.1.0-Linux-X64`, which turned out to be unusable on this machine: it needs glibc 2.32/2.33/2.34 and this is Debian 11 with glibc 2.31, so its `llvm-config` would not execute. Its *headers* were still good enough to prove the compile failure and the fix; the full build above used an llvm 23.1.0 built from source instead (`module load llvm/23.1.0`).

## Separate matter: the bump will happen again

`.github/workflows/Build-MacOS.yml` installs llvm with an unpinned `brew install llvm`, so the next Homebrew major will break master the same way, on whatever commit happens to be pushed at the time. Two options, neither taken here because both are policy calls for the maintainer:

- pin the formula (`brew install llvm@23`), making CI reproducible and moving llvm upgrades to a deliberate commit;
- keep it unpinned and accept the red run as the signal to enable the next version, which is what has happened for 21, 22 and now 23.
